### PR TITLE
fix ignore list configuration

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -928,6 +928,8 @@
             // when the fingerprint visualizer opens, populate show names
             async function visualizerToggled() {
                 if (!visualizer.open) {
+                    ignorelistSection.style.display = "none";
+                    saveIgnoreListSeasonButton.style.display = "none";
                     return;
                 }
 


### PR DESCRIPTION
fix ignore list configuration still show when reopen the Manage Timestamps & Fingerprints and the user can click on apply to series and by that send a bad request

fix for #281