### PR TITLE
Improve Anime Detection

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Manager/QueueManager.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Manager/QueueManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using ConfusedPolarBear.Plugin.IntroSkipper.Data;
 using Jellyfin.Data.Enums;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -186,7 +187,8 @@ public class QueueManager(ILogger<QueueManager> logger, ILibraryManager libraryM
 
         var isAnime = seasonEpisodes.FirstOrDefault()?.IsAnime ??
             (pluginInstance.GetItem(episode.SeriesId) is Series series &&
-            series.Tags.Concat(series.Genres).Any(tag => tag.Equals("anime", StringComparison.OrdinalIgnoreCase)));
+                (series.Tags.Contains("anime", StringComparison.OrdinalIgnoreCase) ||
+                series.Genres.Contains("anime", StringComparison.OrdinalIgnoreCase)));
 
         // Limit analysis to the first X% of the episode and at most Y minutes.
         // X and Y default to 25% and 10 minutes.

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Manager/QueueManager.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Manager/QueueManager.cs
@@ -184,6 +184,10 @@ public class QueueManager(ILogger<QueueManager> logger, ILibraryManager libraryM
             return;
         }
 
+        var isAnime = seasonEpisodes.FirstOrDefault()?.IsAnime ??
+            (pluginInstance.GetItem(episode.SeriesId) is Series series &&
+            series.Tags.Concat(series.Genres).Any(tag => tag.Equals("anime", StringComparison.OrdinalIgnoreCase)));
+
         // Limit analysis to the first X% of the episode and at most Y minutes.
         // X and Y default to 25% and 10 minutes.
         var duration = TimeSpan.FromTicks(episode.RunTimeTicks ?? 0).TotalSeconds;
@@ -200,7 +204,7 @@ public class QueueManager(ILogger<QueueManager> logger, ILibraryManager libraryM
             SeriesId = episode.SeriesId,
             EpisodeId = episode.Id,
             Name = episode.Name,
-            IsAnime = episode.GetInheritedTags().Contains("anime", StringComparer.OrdinalIgnoreCase),
+            IsAnime = isAnime,
             Path = episode.Path,
             Duration = Convert.ToInt32(duration),
             IntroFingerprintEnd = Convert.ToInt32(fingerprintDuration),


### PR DESCRIPTION
Enhanced anime detection to use both genres and tags for identifying animes. Previously, detection relied solely on tags, which worked only with TMDb metadata.