### PR TITLE
adding user list

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
@@ -45,9 +45,9 @@ public class PluginConfiguration : BasePluginConfiguration
     public string ClientList { get; set; } = "Android TV, Kodi";
 
     /// <summary>
-    /// Gets or sets the list of users to auto skip for.
+    /// Gets or sets the list of users to ignore.
     /// </summary>
-    public string UserList { get; set; } = string.Empty;
+    public string UserIgnoreList { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets a value indicating whether to scan for intros during a scheduled task.

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
@@ -45,6 +45,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public string ClientList { get; set; } = "Android TV, Kodi";
 
     /// <summary>
+    /// Gets or sets the list of users to auto skip for.
+    /// </summary>
+    public string UserList { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to scan for intros during a scheduled task.
     /// </summary>
     public bool AutoDetectIntros { get; set; } = false;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -446,10 +446,9 @@
                             </details>
 
                             <div class="fieldDescription">
-                                auto skip will be enabled for the selected clients and users.<br />
-                                Note:<br />
-                                - The device list will select kodi by defaults, any other device will need to be selected manually.<br />
-                                - The user list will select automatically any new user.
+                                The Auto Skip Client List will determine the clients that auto skip, it will apply to <strong>all</strong> enabled users.<br />
+                                Any new users are enabled by default.<br />
+                                Please disable any users that should not skip automatically.
                             </div>
                             <br /><br />
                         </div>

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -357,7 +357,7 @@
                             </label>
 
                             <div class="fieldDescription">
-                                If checked, intros will be automatically skipped for <strong>all</strong> clients and users
+                                If checked, intros will be automatically skipped for <strong>all</strong> clients and users.
                                  Individual clients can override this from the player settings popup (gear icon).<br />
                                 If you access Jellyfin through a reverse proxy, it must be configured to proxy websockets.<br />
                             </div>

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -778,7 +778,7 @@
                 "MaxParallelism",
                 "SelectedLibraries",
                 "ClientList",
-                "UserList",
+                "UserIgnoreList",
                 "AnalysisPercent",
                 "AnalysisLengthLimit",
                 "MinimumIntroDuration",
@@ -936,7 +936,6 @@
             }
 
             function updateListUsers(textField, container, users) {
-                // Create a comma-separated list of user IDs from the unchecked checkboxes
                 textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:not(:checked)'))
                     .map(checkbox => users.find(user => user.Name === checkbox.nextElementSibling.textContent).Id)
                     .join(', ');

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -357,7 +357,7 @@
                             </label>
 
                             <div class="fieldDescription">
-                                If checked, intros will be automatically skipped for <strong>all</strong> clients.
+                                If checked, intros will be automatically skipped for <strong>all</strong> clients and users
                                  Individual clients can override this from the player settings popup (gear icon).<br />
                                 If you access Jellyfin through a reverse proxy, it must be configured to proxy websockets.<br />
                             </div>
@@ -393,7 +393,7 @@
                             </label>
 
                             <div class="fieldDescription">
-                                If checked, credits will be automatically skipped for <strong>all</strong> clients.
+                                If checked, credits will be automatically skipped for <strong>all</strong> clients and users.
                                  Individual clients can override this from the player settings popup (gear icon).<br />
                                 If you access Jellyfin through a reverse proxy, it must be configured to proxy websockets.<br />
                             </div>

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -427,13 +427,32 @@
                             Failed to add skip button to web interface. See <a href="https://github.com/intro-skipper/intro-skipper/wiki/Troubleshooting#skip-button-is-not-visible" target="_blank" rel="noopener noreferrer">troubleshooting guide</a> for the most common issues.
                         </div>
 
-                        <details id="AutoSkipClientList" style="padding-bottom: 1em;">
-                            <summary>Auto Skip Client List</summary>
-                            <br />
-                            <div class="checkboxList paperList" style="padding:.5em 1em" id="autoSkipCheckboxes"></div>
-                            <label class="inputLabel" for="ClientList"></label>
-                            <input id="ClientList" type="hidden" is="emby-input" />
-                        </details>
+                        <div id="AutoSkipLists">
+                            <div style="margin-bottom: 0.5em;">
+                                Auto Skip Lists:
+                            </div>
+                            <details id="AutoSkipClientList">
+                                <summary>Auto Skip Client List</summary>
+                                <div class="checkboxList paperList" style="padding:.5em 1em" id="autoSkipClientCheckboxes"></div>
+                                <label class="inputLabel" for="ClientList"></label>
+                                <input id="ClientList" type="hidden" is="emby-input" />
+                            </details>
+
+                            <details id="AutoSkipUserList">
+                                <summary>Auto Skip User List</summary>
+                                <div class="checkboxList paperList" style="padding:.5em 1em; margin-bottom: 0;" id="autoSkipUserCheckboxes"></div>
+                                <label class="inputLabel" for="UserList"></label>
+                                <input id="UserList" type="hidden" is="emby-input" />
+                            </details>
+
+                            <div class="fieldDescription">
+                                auto skip will be enabled for the selected clients and users.<br />
+                                Note:<br />
+                                - The device list will select android tv and kodi by defaults, any other device will need to be selected manually.<br />
+                                - The user list will select automatically any new user.
+                            </div>
+                            <br /><br />
+                        </div>
 
                         <div id="SkipButtonSettings">
 
@@ -759,6 +778,7 @@
                 "MaxParallelism",
                 "SelectedLibraries",
                 "ClientList",
+                "UserList",
                 "AnalysisPercent",
                 "AnalysisLengthLimit",
                 "MinimumIntroDuration",
@@ -829,7 +849,9 @@
             var librariesContainer = document.querySelector("div.folderAccessListContainer");
             var skipFirstEpisode = document.querySelector("div#divSkipFirstEpisode");
             var secondsOfIntroStartToPlay = document.querySelector("div#divSecondsOfIntroStartToPlay");
-            var autoSkipClientList = document.getElementById("AutoSkipClientList");
+            var autoSkipList = document.querySelector("div#AutoSkipLists");
+            var autoSkipClientList = autoSkipList.querySelector("details#AutoSkipClientList");
+            var autoSkipUserList = autoSkipList.querySelector("details#AutoSkipUserList");
             var secondsOfCreditsStartToPlay = document.querySelector("div#divSecondsOfCreditsStartToPlay");
             var autoSkipNotificationText = document.querySelector("div#divAutoSkipNotificationText");
             var autoSkipCredits = document.querySelector("input#AutoSkipCredits");
@@ -849,19 +871,19 @@
 
             function skipButtonVisibleText() {
                 if (autoSkip.checked && autoSkipCredits.checked) {
-                    autoSkipClientList.style.display = 'none';
+                    autoSkipList.style.display = 'none';
                     skipButtonVisibleLabel.textContent = "Button unavailable due to auto skip";
                 } else if (autoSkip.checked) {
-                    autoSkipClientList.style.display = 'unset';
-                    autoSkipClientList.style.width = '100%';
+                    autoSkipList.style.display = 'unset';
+                    autoSkipList.style.width = '100%';
                     skipButtonVisibleLabel.textContent = "Show skip credit button";
                 } else if (autoSkipCredits.checked) {
-                    autoSkipClientList.style.display = 'unset';
-                    autoSkipClientList.style.width = '100%';
+                    autoSkipList.style.display = 'unset';
+                    autoSkipList.style.width = '100%';
                     skipButtonVisibleLabel.textContent = "Show skip intro button";
                 } else {
-                    autoSkipClientList.style.display = 'unset';
-                    autoSkipClientList.style.width = '100%';
+                    autoSkipList.style.display = 'unset';
+                    autoSkipList.style.width = '100%';
                     skipButtonVisibleLabel.textContent = "Show skip intro / credit button";
                 }
                 skipButtonVisibleChanged()
@@ -913,6 +935,13 @@
                     .join(', ');
             }
 
+            function updateListUsers(textField, container, users) {
+                // Create a comma-separated list of user IDs from the unchecked checkboxes
+                textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:not(:checked)'))
+                    .map(checkbox => users.find(user => user.Name === checkbox.nextElementSibling.textContent).Id)
+                    .join(', ');
+            }
+
             function generateCheckboxList(items, containerId, textFieldId) {
                 const container = document.getElementById(containerId);
                 const textField = document.getElementById(textFieldId);
@@ -933,10 +962,36 @@
                 });
             }
 
+            function generateCheckboxListUsers(items, containerId, textFieldId) {
+                const container = document.getElementById(containerId);
+                const textField = document.getElementById(textFieldId);
+                const checkedItems = textField.value ? textField.value.split(', ') : [];
+
+                container.innerHTML = items.map(item => {
+                    const isChecked = !checkedItems.includes(item.Id) ? 'checked' : '';
+                    return '<label class="emby-checkbox-label">' +
+                        '<input type="checkbox" is="emby-checkbox" ' + isChecked + '>' +
+                        '<span class="checkboxLabel">' + item.Name + '</span>' +
+                        '</label>';
+                }).join('');
+
+
+                container.addEventListener('change', event => {
+                    if (event.target.type === 'checkbox') {
+                        updateListUsers(textField, container, items);
+                    }
+                });
+            }
+
             async function generateAutoSkipClientList() {
                 const response = await getJson("Devices");
                 const devices = [...new Set(response.Items.map(item => item.AppName))];
-                generateCheckboxList(devices, 'autoSkipCheckboxes', 'ClientList');
+                generateCheckboxList(devices, 'autoSkipClientCheckboxes', 'ClientList');
+            }
+
+            async function generateAutoSkipUserList() {
+                const response = await getJson("Users");
+                generateCheckboxListUsers(response, 'autoSkipUserCheckboxes', 'UserList');
             }
 
             async function populateLibraries() {
@@ -1347,6 +1402,7 @@
                         autoSkipCreditsChanged();
                         persistSkipChanged();
                         generateAutoSkipClientList();
+                        generateAutoSkipUserList();
 
                         Dashboard.hideLoadingMsg();
                     });

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -448,7 +448,7 @@
                             <div class="fieldDescription">
                                 auto skip will be enabled for the selected clients and users.<br />
                                 Note:<br />
-                                - The device list will select android tv and kodi by defaults, any other device will need to be selected manually.<br />
+                                - The device list will select kodi by defaults, any other device will need to be selected manually.<br />
                                 - The user list will select automatically any new user.
                             </div>
                             <br /><br />

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -441,8 +441,8 @@
                             <details id="AutoSkipUserList">
                                 <summary>Auto Skip User List</summary>
                                 <div class="checkboxList paperList" style="padding:.5em 1em; margin-bottom: 0;" id="autoSkipUserCheckboxes"></div>
-                                <label class="inputLabel" for="UserList"></label>
-                                <input id="UserList" type="hidden" is="emby-input" />
+                                <label class="inputLabel" for="UserIgnoreList"></label>
+                                <input id="UserIgnoreList" type="hidden" is="emby-input" />
                             </details>
 
                             <div class="fieldDescription">
@@ -990,7 +990,7 @@
 
             async function generateAutoSkipUserList() {
                 const response = await getJson("Users");
-                generateCheckboxListUsers(response, 'autoSkipUserCheckboxes', 'UserList');
+                generateCheckboxListUsers(response, 'autoSkipUserCheckboxes', 'UserIgnoreList');
             }
 
             async function populateLibraries() {

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkip.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkip.cs
@@ -40,7 +40,7 @@ public class AutoSkip(
     private Timer _playbackTimer = new(1000);
     private Dictionary<string, bool> _sentSeekCommand = [];
     private HashSet<string> _clientList = [];
-    private HashSet<Guid> _userList = [];
+    private HashSet<Guid> _userIgnoreList = [];
 
     private void AutoSkipChanged(object? sender, BasePluginConfiguration e)
     {
@@ -49,7 +49,7 @@ public class AutoSkip(
         var newState = configuration.AutoSkip || (configuration.SkipButtonVisible && _clientList.Count > 0);
         _logger.LogDebug("Setting playback timer enabled to {NewState}", newState);
         _playbackTimer.Enabled = newState;
-        _userList = new HashSet<Guid>(configuration.UserList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse));
+        _userIgnoreList = new HashSet<Guid>(configuration.UserIgnoreList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse));
     }
 
     private void UserDataManager_UserDataSaved(object? sender, UserDataSaveEventArgs e)
@@ -107,7 +107,7 @@ public class AutoSkip(
 
     private void PlaybackTimer_Elapsed(object? sender, ElapsedEventArgs e)
     {
-        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkip || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase) && !_userList.Contains(s.UserId))))
+        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkip || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase) && !_userIgnoreList.Contains(s.UserId))))
         {
             var deviceId = session.DeviceId;
             var itemId = session.NowPlayingItem.Id;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkip.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkip.cs
@@ -40,6 +40,7 @@ public class AutoSkip(
     private Timer _playbackTimer = new(1000);
     private Dictionary<string, bool> _sentSeekCommand = [];
     private HashSet<string> _clientList = [];
+    private HashSet<Guid> _userList = [];
 
     private void AutoSkipChanged(object? sender, BasePluginConfiguration e)
     {
@@ -48,6 +49,7 @@ public class AutoSkip(
         var newState = configuration.AutoSkip || (configuration.SkipButtonVisible && _clientList.Count > 0);
         _logger.LogDebug("Setting playback timer enabled to {NewState}", newState);
         _playbackTimer.Enabled = newState;
+        _userList = new HashSet<Guid>(configuration.UserList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse));
     }
 
     private void UserDataManager_UserDataSaved(object? sender, UserDataSaveEventArgs e)
@@ -105,7 +107,7 @@ public class AutoSkip(
 
     private void PlaybackTimer_Elapsed(object? sender, ElapsedEventArgs e)
     {
-        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkip || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase))))
+        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkip || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase) && !_userList.Contains(s.UserId))))
         {
             var deviceId = session.DeviceId;
             var itemId = session.NowPlayingItem.Id;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkipCredits.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkipCredits.cs
@@ -40,7 +40,7 @@ public class AutoSkipCredits(
     private Timer _playbackTimer = new(1000);
     private Dictionary<string, bool> _sentSeekCommand = [];
     private HashSet<string> _clientList = [];
-    private HashSet<Guid> _userList = [];
+    private HashSet<Guid> _userIgnoreList = [];
 
     private void AutoSkipCreditChanged(object? sender, BasePluginConfiguration e)
     {
@@ -49,7 +49,7 @@ public class AutoSkipCredits(
         var newState = configuration.AutoSkipCredits || (configuration.SkipButtonVisible && _clientList.Count > 0);
         _logger.LogDebug("Setting playback timer enabled to {NewState}", newState);
         _playbackTimer.Enabled = newState;
-        _userList = new HashSet<Guid>(configuration.UserList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse));
+        _userIgnoreList = new HashSet<Guid>(configuration.UserIgnoreList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse));
     }
 
     private void UserDataManager_UserDataSaved(object? sender, UserDataSaveEventArgs e)
@@ -107,7 +107,7 @@ public class AutoSkipCredits(
 
     private void PlaybackTimer_Elapsed(object? sender, ElapsedEventArgs e)
     {
-        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkipCredits || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase) && !_userList.Contains(s.UserId))))
+        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkipCredits || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase) && !_userIgnoreList.Contains(s.UserId))))
         {
             var deviceId = session.DeviceId;
             var itemId = session.NowPlayingItem.Id;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkipCredits.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkipCredits.cs
@@ -40,6 +40,7 @@ public class AutoSkipCredits(
     private Timer _playbackTimer = new(1000);
     private Dictionary<string, bool> _sentSeekCommand = [];
     private HashSet<string> _clientList = [];
+    private HashSet<Guid> _userList = [];
 
     private void AutoSkipCreditChanged(object? sender, BasePluginConfiguration e)
     {
@@ -48,6 +49,7 @@ public class AutoSkipCredits(
         var newState = configuration.AutoSkipCredits || (configuration.SkipButtonVisible && _clientList.Count > 0);
         _logger.LogDebug("Setting playback timer enabled to {NewState}", newState);
         _playbackTimer.Enabled = newState;
+        _userList = new HashSet<Guid>(configuration.UserList.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(Guid.Parse));
     }
 
     private void UserDataManager_UserDataSaved(object? sender, UserDataSaveEventArgs e)
@@ -105,7 +107,7 @@ public class AutoSkipCredits(
 
     private void PlaybackTimer_Elapsed(object? sender, ElapsedEventArgs e)
     {
-        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkipCredits || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase))))
+        foreach (var session in _sessionManager.Sessions.Where(s => Plugin.Instance!.Configuration.AutoSkipCredits || (Plugin.Instance!.Configuration.SkipButtonVisible && _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase) && !_userList.Contains(s.UserId))))
         {
             var deviceId = session.DeviceId;
             var itemId = session.NowPlayingItem.Id;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e4687bc4-74ec-40a8-afe6-e673f4f0b624)
From issue #126
it auto select every new user for the enabled clients.

## Summary by Sourcery

Add functionality to manage an auto skip user list alongside the existing client list, enabling automatic skipping of intros and credits for all users by default, with the option to disable specific users. Update the configuration interface to support these changes.

New Features:
- Introduce an auto skip user list feature that allows users to be automatically selected for skipping intros and credits, similar to the existing client list functionality.

Enhancements:
- Update the configuration page to include options for managing both auto skip client and user lists, providing a more comprehensive control over the auto skip feature.