### PR TITLE
Hide player config when it’s locked by server

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/UserInterfaceConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/UserInterfaceConfiguration.cs
@@ -12,7 +12,7 @@ namespace ConfusedPolarBear.Plugin.IntroSkipper.Configuration;
 /// <param name="autoSkip">Auto Skip Intro.</param>
 /// <param name="autoSkipCredits">Auto Skip Credits.</param>
 /// <param name="clientList">Auto Skip Clients.</param>
-public class UserInterfaceConfiguration(bool visible, string introText, string creditsText, bool autoSkip, bool autoSkipCredits)
+public class UserInterfaceConfiguration(bool visible, string introText, string creditsText, bool autoSkip, bool autoSkipCredits, string clientList)
 {
     /// <summary>
     /// Gets or sets a value indicating whether to show the skip intro button.
@@ -40,7 +40,7 @@ public class UserInterfaceConfiguration(bool visible, string introText, string c
     public bool AutoSkipCredits { get; set; } = autoSkipCredits;
 
     /// <summary>
-    /// Gets or sets a value indicating client to auto skip for.
+    /// Gets or sets a value indicating clients to auto skip for.
     /// </summary>
-    public bool ClientList { get; set; } = clientList;
+    public string ClientList { get; set; } = clientList;
 }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/UserInterfaceConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/UserInterfaceConfiguration.cs
@@ -11,6 +11,7 @@ namespace ConfusedPolarBear.Plugin.IntroSkipper.Configuration;
 /// <param name="creditsText">Skip button end credits text.</param>
 /// <param name="autoSkip">Auto Skip Intro.</param>
 /// <param name="autoSkipCredits">Auto Skip Credits.</param>
+/// <param name="clientList">Auto Skip Clients.</param>
 public class UserInterfaceConfiguration(bool visible, string introText, string creditsText, bool autoSkip, bool autoSkipCredits)
 {
     /// <summary>
@@ -37,4 +38,9 @@ public class UserInterfaceConfiguration(bool visible, string introText, string c
     /// Gets or sets a value indicating whether auto skip credits.
     /// </summary>
     public bool AutoSkipCredits { get; set; } = autoSkipCredits;
+
+    /// <summary>
+    /// Gets or sets a value indicating client to auto skip for.
+    /// </summary>
+    public bool ClientList { get; set; } = clientList;
 }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/UserInterfaceConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/UserInterfaceConfiguration.cs
@@ -9,7 +9,9 @@ namespace ConfusedPolarBear.Plugin.IntroSkipper.Configuration;
 /// <param name="visible">Skip button visibility.</param>
 /// <param name="introText">Skip button intro text.</param>
 /// <param name="creditsText">Skip button end credits text.</param>
-public class UserInterfaceConfiguration(bool visible, string introText, string creditsText)
+/// <param name="autoSkip">Auto Skip Intro.</param>
+/// <param name="autoSkipCredits">Auto Skip Credits.</param>
+public class UserInterfaceConfiguration(bool visible, string introText, string creditsText, bool autoSkip, bool autoSkipCredits)
 {
     /// <summary>
     /// Gets or sets a value indicating whether to show the skip intro button.
@@ -25,4 +27,14 @@ public class UserInterfaceConfiguration(bool visible, string introText, string c
     /// Gets or sets the text to display in the skip intro button in end credits mode.
     /// </summary>
     public string SkipButtonEndCreditsText { get; set; } = creditsText;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether auto skip intro.
+    /// </summary>
+    public bool AutoSkip { get; set; } = autoSkip;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether auto skip credits.
+    /// </summary>
+    public bool AutoSkipCredits { get; set; } = autoSkipCredits;
 }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
@@ -303,8 +303,18 @@ const introSkipper = {
         localStorage.setItem('introskipperOption', option);
         this.d(`Introskipper option selected and saved: ${option}`);
     },
-    injectIntroSkipperOptions(actionSheet) {
+    isAutoSkipLocked(config) {
+        const isAutoSkip = config.AutoSkip && config.AutoSkipCredits;
+        const isAutoSkipClient = new Set(config.ClientList.split(',')).has(ApiClient.appName());
+        return isAutoSkip || (config.SkipButtonVisible && isAutoSkipClient);
+    },
+    async injectIntroSkipperOptions(actionSheet) {
         if (!this.skipButton) return;
+        const config = await this.secureFetch("Intros/UserInterfaceConfiguration");
+        if (this.isAutoSkipLocked(config)) {
+            this.d("Auto skip enforced by server");
+            return;
+        }
         const statsButton = actionSheet.querySelector('[data-id="stats"]');
         if (!statsButton) return;
         const menuItem = this.createButton(statsButton, 'introskipperMenu',

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
@@ -223,6 +223,7 @@ public class SkipIntroController : ControllerBase
             config.SkipButtonIntroText,
             config.SkipButtonEndCreditsText,
             config.AutoSkip,
-            config.AutoSkipCredits);
+            config.AutoSkipCredits,
+            config.ClientList);
     }
 }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
@@ -221,6 +221,8 @@ public class SkipIntroController : ControllerBase
         return new UserInterfaceConfiguration(
             config.SkipButtonVisible,
             config.SkipButtonIntroText,
-            config.SkipButtonEndCreditsText);
+            config.SkipButtonEndCreditsText,
+            config.AutoSkip,
+            config.AutoSkipCredits);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add server-side control to lock auto-skip settings in the Intro Skipper plugin, preventing client-side changes when the server enforces specific configurations. Extend the configuration class to support new auto-skip properties and client-specific settings.

New Features:
- Introduce the ability to lock auto-skip functionality based on server configuration, preventing users from changing auto-skip settings when enforced by the server.

Enhancements:
- Extend the UserInterfaceConfiguration class to include new properties for auto-skip settings and client-specific configurations.