### PR TITLE
Add skipping last episode minus the episode

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
@@ -164,6 +164,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool SkipFirstEpisode { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether the introduction in the last episode of a season should be ignored.
+    /// </summary>
+    public bool SkipLastEpisode { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets a value indicating whether the skip button should be displayed for the duration of the intro.
     /// </summary>
     public bool PersistSkipButton { get; set; } = true;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -375,6 +375,18 @@
                             <br />
                         </div>
 
+                        <div id="divSkipLastEpisode" class="checkboxContainer checkboxContainer-withDescription">
+                            <label class="emby-checkbox-label">
+                                <input id="SkipLastEpisode" type="checkbox" is="emby-checkbox" />
+                                <span>Play intro for last episode of a season</span>
+                            </label>
+
+                            <div class="fieldDescription">
+                                If checked, auto skip will play the introduction of the last episode in a season.<br />
+                            </div>
+                            <br />
+                        </div>
+
                         <div id="divSecondsOfIntroStartToPlay" class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="SecondsOfIntroStartToPlay">
                                 Intro skip delay (in seconds)
@@ -418,7 +430,7 @@
 
                             <div class="fieldDescription">
                                 If checked, a skip button will be displayed according to the settings below, while
-                                 clients selected in the Auto Skip Client List will skip <strong>automatically</strong>.
+                                clients selected in the Auto Skip Client List will skip <strong>automatically</strong>.
                                 <br />
                             </div>
                         </div>
@@ -817,6 +829,7 @@
                 "AutoSkip",
                 "AutoSkipCredits",
                 "SkipFirstEpisode",
+                "SkipLastEpisode",
                 "PersistSkipButton",
                 "SkipButtonVisible"
             ]
@@ -850,6 +863,7 @@
             var selectAllLibraries = document.querySelector("input#SelectAllLibraries");
             var librariesContainer = document.querySelector("div.folderAccessListContainer");
             var skipFirstEpisode = document.querySelector("div#divSkipFirstEpisode");
+            var skipLastEpisode = document.querySelector("div#divSkipLastEpisode");
             var secondsOfIntroStartToPlay = document.querySelector("div#divSecondsOfIntroStartToPlay");
             var autoSkipClientList = document.getElementById("AutoSkipClientList");
             var secondsOfCreditsStartToPlay = document.querySelector("div#divSecondsOfCreditsStartToPlay");
@@ -892,10 +906,12 @@
             function autoSkipChanged() {
                 if (autoSkip.checked) {
                     skipFirstEpisode.style.display = 'unset';
+                    skipLastEpisode.style.display = 'unset';
                     autoSkipNotificationText.style.display = 'unset';
                     secondsOfIntroStartToPlay.style.display = 'unset';
                 } else {
                     skipFirstEpisode.style.display = 'none';
+                    skipLastEpisode.style.display = 'none';
                     autoSkipNotificationText.style.display = 'none';
                     secondsOfIntroStartToPlay.style.display = 'none';
                 }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkip.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Services/AutoSkip.cs
@@ -87,8 +87,14 @@ public class AutoSkip(
             return;
         }
 
-        // If this is the first episode in the season, and SkipFirstEpisode is false, pretend that we've already sent the seek command for this playback session.
+        // If this is the first episode in the season, and SkipFirstEpisode is true, pretend that we've already sent the seek command for this playback session.
         if (Plugin.Instance!.Configuration.SkipFirstEpisode && episodeNumber == 1)
+        {
+            newState = true;
+        }
+
+        // If this is the last episode in the season, and SkipLastEpisode is true, pretend that we've already sent the seek command for this playback session.
+        if (Plugin.Instance!.Configuration.SkipLastEpisode && episodeNumber == 1)
         {
             newState = true;
         }


### PR DESCRIPTION
Needs to determine if the current episode is the last episode, but this fills in all the UI and stuff

## Summary by Sourcery

Add a feature to optionally skip the introduction for the last episode of a season, updating the configuration UI to include a new checkbox for this setting and modifying the logic to respect this new configuration.

New Features:
- Introduce a new configuration option to skip the introduction for the last episode of a season, allowing users to choose whether to play or skip intros for the final episode.

Enhancements:
- Update the configuration page to include a new checkbox for skipping the last episode's intro, providing users with a clear option to enable or disable this feature.