### PR TITLE
All platforms ship with ffmpeg

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
@@ -61,7 +61,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets a value indicating whether analysis will use Chromaprint to determine fingerprints.
     /// </summary>
-    public bool UseChromaprint { get; set; } = true;
+    public bool WithChromaprint { get; set; } = true;
 
     // ===== EDL handling =====
 

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -798,7 +798,6 @@
                 "AnalyzeSeasonZero",
                 "SelectAllLibraries",
                 "RegenerateEdlFiles",
-                "UseChromaprint",
                 "CacheFingerprints",
                 "AutoSkip",
                 "AutoSkipCredits",

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -271,20 +271,6 @@
                             <br />
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
-                                    <input id="UseChromaprint" type="checkbox" is="emby-checkbox" />
-                                    <span>Chromaprint analysis</span>
-                                </label>
-
-                                <div class="fieldDescription">
-                                    If checked, analysis will use Chromaprint to compare episode audio and identify intros.
-                                    <br />
-                                    <strong>WARNING: Disabling this option may result in incomplete or innaccurate analysis!</strong>
-                                    <br />
-                                </div>
-                            </div>
-
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label class="emby-checkbox-label">
                                     <input id="CacheFingerprints" type="checkbox" is="emby-checkbox" />
                                     <span>Cache episode fingerprints</span>
                                 </label>

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -61,7 +61,7 @@ public class BaseItemAnalyzerTask
     {
         var ffmpegValid = FFmpegWrapper.CheckFFmpegVersion();
         // Assert that ffmpeg with chromaprint is installed
-        if (Plugin.Instance!.Configuration.UseChromaprint && !ffmpegValid)
+        if (Plugin.Instance!.Configuration.WithChromaprint && !ffmpegValid)
         {
             throw new FingerprintException(
                 "Analysis terminated! Chromaprint is not enabled in the current ffmpeg. If Jellyfin is running natively, install jellyfin-ffmpeg5. If Jellyfin is running in a container, upgrade to version 10.8.0 or newer.");
@@ -211,7 +211,7 @@ public class BaseItemAnalyzerTask
             new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>())
         };
 
-        if (first.IsAnime && Plugin.Instance!.Configuration.UseChromaprint)
+        if (first.IsAnime && Plugin.Instance!.Configuration.WithChromaprint)
         {
             analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }
@@ -221,7 +221,7 @@ public class BaseItemAnalyzerTask
             analyzers.Add(new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()));
         }
 
-        if (!first.IsAnime && Plugin.Instance!.Configuration.UseChromaprint)
+        if (!first.IsAnime && Plugin.Instance!.Configuration.WithChromaprint)
         {
             analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }


### PR DESCRIPTION
This is no longer necessary as a workaround for ffmpeg without chromaprint.

## Summary by Sourcery

Remove the Chromaprint analysis option from the configuration page as it is no longer necessary, simplifying the user interface.

Enhancements:
- Remove the Chromaprint analysis option from the configuration page, simplifying the user interface.