### PR TITLE
allow users to override the URL

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -258,7 +258,7 @@ public class PluginConfiguration : BasePluginConfiguration
     public ProcessPriorityClass ProcessPriority { get; set; } = ProcessPriorityClass.BelowNormal;
 
     /// <summary>
-    /// Gets or sets the ManifestUrl, e.g. for mainland China.
+    /// Gets or sets a value indicating whether the ManifestUrl is self-managed, e.g. for mainland China.
     /// </summary>
-    public string ManifestUrl { get; set; } = "https://manifest.intro-skipper.org/manifest.json";
+    public bool OverideManifestUrl { get; set; }
 }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -260,5 +260,5 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets a value indicating whether the ManifestUrl is self-managed, e.g. for mainland China.
     /// </summary>
-    public bool OverideManifestUrl { get; set; }
+    public bool OverrideManifestUrl { get; set; }
 }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -248,12 +248,17 @@ public class PluginConfiguration : BasePluginConfiguration
     public string AutoSkipCreditsNotificationText { get; set; } = "Credits skipped";
 
     /// <summary>
-    /// Gets or sets the number of threads for an ffmpeg process.
+    /// Gets or sets the number of threads for a ffmpeg process.
     /// </summary>
     public int ProcessThreads { get; set; }
 
     /// <summary>
-    /// Gets or sets the relative priority for an ffmpeg process.
+    /// Gets or sets the relative priority for a ffmpeg process.
     /// </summary>
     public ProcessPriorityClass ProcessPriority { get; set; } = ProcessPriorityClass.BelowNormal;
+
+    /// <summary>
+    /// Gets or sets the ManifestUrl, e.g. for mainland China.
+    /// </summary>
+    public string ManifestUrl { get; set; } = "https://manifest.intro-skipper.org/manifest.json";
 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -565,7 +565,6 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             pattern = @"<script src=""configurationpage\?name=skip-intro-button\.js.*<\/script>";
             if (!Regex.IsMatch(contents, pattern, RegexOptions.IgnoreCase))
             {
-                _logger.LogInformation("nothing todo bye!");
                 return;
             }
 

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -467,7 +467,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 pluginRepositories.RemoveAll(repo => repo.Url != null && oldRepos.Contains(repo.Url));
 
                 // Add repository only if it does not exit and the OverideManifestUrl Option is activated
-                if (!pluginRepositories.Exists(repo => repo.Url == "https://manifest.intro-skipper.org/manifest.json") && Instance!.Configuration.OverideManifestUrl)
+                if (!pluginRepositories.Exists(repo => repo.Url == "https://manifest.intro-skipper.org/manifest.json") && Instance!.Configuration.OverrideManifestUrl)
                 {
                     // Add the new repository to the list
                     pluginRepositories.Add(new RepositoryInfo

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -92,8 +92,6 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         XmlSerializationHelper.MigrateXML(_introPath);
         XmlSerializationHelper.MigrateXML(_creditsPath);
 
-        MigrateRepoUrl(serverConfiguration);
-
         var oldConfigFile = Path.Join(applicationPaths.PluginConfigurationsPath, "ConfusedPolarBear.Plugin.IntroSkipper.xml");
 
         if (File.Exists(oldConfigFile))
@@ -123,6 +121,8 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 _logger.LogWarning("Something stupid happend: {Exception}", ex);
             }
         }
+
+        MigrateRepoUrl(serverConfiguration);
 
         // TODO: remove when https://github.com/jellyfin/jellyfin-meta/discussions/30 is complete
         try
@@ -467,13 +467,13 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 pluginRepositories.RemoveAll(repo => repo.Url != null && oldRepos.Contains(repo.Url));
 
                 // Add repository only if it does not exit
-                if (!pluginRepositories.Exists(repo => repo.Url == "https://manifest.intro-skipper.org/manifest.json") && !pluginRepositories.Exists(repo => repo.Url != null && repo.Url.StartsWith("https://raw.githubusercontent.com/intro-skipper/intro-skipper/10.", StringComparison.OrdinalIgnoreCase)))
+                if (!pluginRepositories.Exists(repo => repo.Url == Instance!.Configuration.ManifestUrl))
                 {
                     // Add the new repository to the list
                     pluginRepositories.Add(new RepositoryInfo
                     {
                         Name = "intro skipper (automatically migrated by plugin)",
-                        Url = "https://manifest.intro-skipper.org/manifest.json",
+                        Url = Instance!.Configuration.ManifestUrl,
                         Enabled = true,
                     });
                 }
@@ -565,6 +565,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             pattern = @"<script src=""configurationpage\?name=skip-intro-button\.js.*<\/script>";
             if (!Regex.IsMatch(contents, pattern, RegexOptions.IgnoreCase))
             {
+                _logger.LogInformation("nothing todo bye!");
                 return;
             }
 

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -466,14 +466,14 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 // remove all old plugins
                 pluginRepositories.RemoveAll(repo => repo.Url != null && oldRepos.Contains(repo.Url));
 
-                // Add repository only if it does not exit
-                if (!pluginRepositories.Exists(repo => repo.Url == Instance!.Configuration.ManifestUrl))
+                // Add repository only if it does not exit and the OverideManifestUrl Option is activated
+                if (!pluginRepositories.Exists(repo => repo.Url == "https://manifest.intro-skipper.org/manifest.json") && Instance!.Configuration.OverideManifestUrl)
                 {
                     // Add the new repository to the list
                     pluginRepositories.Add(new RepositoryInfo
                     {
                         Name = "intro skipper (automatically migrated by plugin)",
-                        Url = Instance!.Configuration.ManifestUrl,
+                        Url = "https://manifest.intro-skipper.org/manifest.json",
                         Enabled = true,
                     });
                 }


### PR DESCRIPTION
… when added manually

intro-skipper.org is not available for use in mainland China

## Summary by Sourcery

Improve the plugin configuration by adding a new option to manage the repository URL manually and correct spelling errors in the codebase.

Enhancements:
- Ensure repository URL is only overridden when the OverideManifestUrl option is activated.
- Correct spelling errors in variable names and comments.