### PR TITLE
10.10.2

### DIFF
--- a/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
+++ b/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
@@ -44,8 +44,9 @@ namespace IntroSkipper.Manager
                         var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null, true).ConfigureAwait(false);
                         await Task.WhenAll(existingSegments.Select(s => _mediaSegmentManager.DeleteSegmentAsync(s.Id))).ConfigureAwait(false);
                     }
-                    catch (Exception )
+                    catch (Exception vs)
                     {
+                        _logger.LogError(vs, "GetSegmentsAsync failed. 10.10.1 compatibility enabled.");
                         var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null).ConfigureAwait(false);
                         await Task.WhenAll(existingSegments.Select(s => _mediaSegmentManager.DeleteSegmentAsync(s.Id))).ConfigureAwait(false);
                     }

--- a/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
+++ b/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
@@ -39,8 +39,16 @@ namespace IntroSkipper.Manager
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
-                    var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null, true).ConfigureAwait(false);
-                    await Task.WhenAll(existingSegments.Select(s => _mediaSegmentManager.DeleteSegmentAsync(s.Id))).ConfigureAwait(false);
+                    try
+                    {
+                        var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null, true).ConfigureAwait(false);
+                        await Task.WhenAll(existingSegments.Select(s => _mediaSegmentManager.DeleteSegmentAsync(s.Id))).ConfigureAwait(false);
+                    }
+                    catch (Exception )
+                    {
+                        var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null).ConfigureAwait(false);
+                        await Task.WhenAll(existingSegments.Select(s => _mediaSegmentManager.DeleteSegmentAsync(s.Id))).ConfigureAwait(false);
+                    }
 
                     var newSegments = await _segmentProvider.GetMediaSegments(new MediaSegmentGenerationRequest { ItemId = episode.EpisodeId }, cancellationToken).ConfigureAwait(false);
 

--- a/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
+++ b/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
@@ -39,7 +39,7 @@ namespace IntroSkipper.Manager
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
-                    var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null).ConfigureAwait(false);
+                    var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null, true).ConfigureAwait(false);
                     await Task.WhenAll(existingSegments.Select(s => _mediaSegmentManager.DeleteSegmentAsync(s.Id))).ConfigureAwait(false);
 
                     var newSegments = await _segmentProvider.GetMediaSegments(new MediaSegmentGenerationRequest { ItemId = episode.EpisodeId }, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add a try-catch block to handle exceptions when fetching existing media segments, ensuring fallback to a secondary method if the primary method fails.