### PR TITLE
Add an option to wipe movie timestamps

### DIFF
--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -1409,7 +1409,7 @@
                 }
 
                 // erase all intro/credits timestamps
-                function eraseTimestamps(mode) {
+                function eraseTimestamps(mode, isEpisode = null) {
                     const lower = mode.toLocaleLowerCase();
                     const title = "Confirm timestamp erasure";
                     const body = "Are you sure you want to erase all previously discovered " + mode.toLocaleLowerCase() + " timestamps?";
@@ -1420,7 +1420,12 @@
                             return;
                         }
 
-                        fetchWithAuth("Intros/EraseTimestamps?mode=" + mode + "&eraseCache=" + eraseCacheChecked, "POST", null);
+                        // Let C default to null rather than trying to ensure cast consistency
+                        if (isEpisode != null) {
+                            fetchWithAuth("Intros/EraseTimestamps?mode=" + mode + "&isEpisode=" + isEpisode + "&eraseCache=" + eraseCacheChecked, "POST", null);
+                        } else {
+                            fetchWithAuth("Intros/EraseTimestamps?mode=" + mode + "&eraseCache=" + eraseCacheChecked, "POST", null);
+                        }
 
                         Dashboard.alert(mode + " timestamps erased");
                         document.getElementById("eraseModeCacheCheckbox").checked = false;

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -709,6 +709,9 @@
                                         <br />
 
                                         <button is="emby-button" class="button-submit emby-button" id="btnErasePreviewTimestamps">Erase all preview timestamps (globally)</button>
+                                        <br />
+
+                                        <button is="emby-button" class="button-submit emby-button" id="btnEraseMovieTimestamps">Erase all movie timestamps (globally)</button>
                                     </div>
                                     <div>
                                         <input type="checkbox" id="eraseModeCacheCheckbox" style="margin-left: 10px" />
@@ -758,6 +761,7 @@
                 var btnEraseRecapTimestamps = document.querySelector("button#btnEraseRecapTimestamps");
                 var btnEraseCreditTimestamps = document.querySelector("button#btnEraseCreditTimestamps");
                 var btnErasePreviewTimestamps = document.querySelector("button#btnErasePreviewTimestamps");
+                var btnEraseMovieTimestamps = document.querySelector("button#btnEraseMovieTimestamps");
 
                 // all plugin configuration fields that can be get or set with .value (i.e. strings or numbers).
                 var configurationFields = [
@@ -1409,8 +1413,7 @@
                 }
 
                 // erase all intro/credits timestamps
-                function eraseTimestamps(mode, isEpisode = null) {
-                    const lower = mode.toLocaleLowerCase();
+                function eraseTimestamps(mode) {
                     const title = "Confirm timestamp erasure";
                     const body = "Are you sure you want to erase all previously discovered " + mode.toLocaleLowerCase() + " timestamps?";
                     const eraseCacheChecked = document.getElementById("eraseModeCacheCheckbox").checked;
@@ -1420,14 +1423,25 @@
                             return;
                         }
 
-                        // Let C default to null rather than trying to ensure cast consistency
-                        if (isEpisode != null) {
-                            fetchWithAuth("Intros/EraseTimestamps?mode=" + mode + "&isEpisode=" + isEpisode + "&eraseCache=" + eraseCacheChecked, "POST", null);
-                        } else {
-                            fetchWithAuth("Intros/EraseTimestamps?mode=" + mode + "&eraseCache=" + eraseCacheChecked, "POST", null);
-                        }
+                        fetchWithAuth("Intros/EraseTimestamps?mode=" + mode + "&eraseCache=" + eraseCacheChecked, "POST", null);
 
                         Dashboard.alert(mode + " timestamps erased");
+                        document.getElementById("eraseModeCacheCheckbox").checked = false;
+                    });
+                }
+
+                function eraseMovieTimestamps() {
+                    const title = "Confirm timestamp erasure";
+                    const body = "Are you sure you want to erase all previously discovered movie timestamps?";
+
+                    Dashboard.confirm(body, title, (result) => {
+                        if (!result) {
+                            return;
+                        }
+
+                        fetchWithAuth("Intros/EraseMovieTimestamps", "POST", null);
+
+                        Dashboard.alert("Movie timestamps erased");
                         document.getElementById("eraseModeCacheCheckbox").checked = false;
                     });
                 }
@@ -1503,6 +1517,10 @@
                 });
                 btnErasePreviewTimestamps.addEventListener("click", (e) => {
                     eraseTimestamps("Preview");
+                    e.preventDefault();
+                });
+                btnEraseMovieTimestamps.addEventListener("click", (e) => {
+                    eraseMovieTimestamps();
                     e.preventDefault();
                 });
                 btnSeasonEraseTimestamps.addEventListener("click", () => {

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -11,6 +11,7 @@ using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Manager;
+using Jellyfin.Extensions;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
@@ -227,16 +228,17 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     /// Erases all previously discovered introduction timestamps.
     /// </summary>
     /// <param name="mode">Mode.</param>
+    /// <param name="isEpisode">True if item is television episode.</param>
     /// <param name="eraseCache">Erase cache.</param>
     /// <response code="204">Operation successful.</response>
     /// <returns>No content.</returns>
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPost("Intros/EraseTimestamps")]
-    public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false)
+    public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool? isEpisode = null, [FromQuery] bool eraseCache = false)
     {
         using var db = new IntroSkipperDbContext(Plugin.Instance!.DbPath);
         var segments = await db.DbSegment
-            .Where(s => s.Type == mode)
+            .Where(s => s.Type == mode && (isEpisode == null || Plugin.Instance!.GetItem(s.ToSegment().EpisodeId) is Episode == isEpisode))
             .ToListAsync()
             .ConfigureAwait(false);
 


### PR DESCRIPTION
This will expand removal operations to cover blanket removal by media type.

## Summary by Sourcery

New Features:
- Add a button to erase all movie timestamps globally in the configuration page.