### PR TITLE
A more consistent layout (almost)

### DIFF
--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -518,6 +518,18 @@
                                     <br />
                                     <div class="inlineForm">
                                         <div class="inputContainer">
+                                            <label class="inputLabel inputLabelUnfocused" for="recapStart">Recap Start</label>
+                                            <input type="text" id="editLeftRecapEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
+                                            <input type="number" id="editLeftRecapEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
+                                        </div>
+                                        <div class="inputContainer">
+                                            <label class="inputLabel inputLabelUnfocused" for="recapEnd">Recap End</label>
+                                            <input type="text" id="editLeftRecapEpisodeEndDisplay" class="emby-input custom-time-input" readonly />
+                                            <input type="number" id="editLeftRecapEpisodeEndEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
+                                        </div>
+                                    </div>
+                                    <div class="inlineForm">
+                                        <div class="inputContainer">
                                             <label class="inputLabel inputLabelUnfocused" for="introStart">Intro Start</label>
                                             <input type="text" id="editLeftIntroEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
                                             <input type="number" id="editLeftIntroEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
@@ -542,18 +554,6 @@
                                     </div>
                                     <div class="inlineForm">
                                         <div class="inputContainer">
-                                            <label class="inputLabel inputLabelUnfocused" for="recapStart">Recap Start</label>
-                                            <input type="text" id="editLeftRecapEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
-                                            <input type="number" id="editLeftRecapEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
-                                        </div>
-                                        <div class="inputContainer">
-                                            <label class="inputLabel inputLabelUnfocused" for="recapEnd">Recap End</label>
-                                            <input type="text" id="editLeftRecapEpisodeEndDisplay" class="emby-input custom-time-input" readonly />
-                                            <input type="number" id="editLeftRecapEpisodeEndEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
-                                        </div>
-                                    </div>
-                                    <div class="inlineForm">
-                                        <div class="inputContainer">
                                             <label class="inputLabel inputLabelUnfocused" for="previewStart">Preview Start</label>
                                             <input type="text" id="editLeftPreviewEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
                                             <input type="number" id="editLeftPreviewEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
@@ -568,6 +568,18 @@
                                     <div id="rightEpisodeEditor">
                                         <h4 style="margin: 0" id="editRightEpisodeTitle"></h4>
                                         <br />
+                                        <div class="inlineForm">
+                                            <div class="inputContainer">
+                                                <label class="inputLabel inputLabelUnfocused" for="recapStart">Recap Start</label>
+                                                <input type="text" id="editRightRecapEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
+                                                <input type="number" id="editRightRecapEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
+                                            </div>
+                                            <div class="inputContainer">
+                                                <label class="inputLabel inputLabelUnfocused" for="recapEnd">Recap End</label>
+                                                <input type="text" id="editRightRecapEpisodeEndDisplay" class="emby-input custom-time-input" readonly />
+                                                <input type="number" id="editRightRecapEpisodeEndEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
+                                            </div>
+                                        </div>
                                         <div class="inlineForm">
                                             <div class="inputContainer">
                                                 <label class="inputLabel inputLabelUnfocused" for="introStart">Intro Start</label>
@@ -590,18 +602,6 @@
                                                 <label class="inputLabel inputLabelUnfocused" for="creditsEnd">Credits End</label>
                                                 <input type="text" id="editRightCreditEpisodeEndDisplay" class="emby-input custom-time-input" readonly />
                                                 <input type="number" id="editRightCreditEpisodeEndEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
-                                            </div>
-                                        </div>
-                                        <div class="inlineForm">
-                                            <div class="inputContainer">
-                                                <label class="inputLabel inputLabelUnfocused" for="recapStart">Recap Start</label>
-                                                <input type="text" id="editRightRecapEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
-                                                <input type="number" id="editRightRecapEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
-                                            </div>
-                                            <div class="inputContainer">
-                                                <label class="inputLabel inputLabelUnfocused" for="recapEnd">Recap End</label>
-                                                <input type="text" id="editRightRecapEpisodeEndDisplay" class="emby-input custom-time-input" readonly />
-                                                <input type="number" id="editRightRecapEpisodeEndEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
                                             </div>
                                         </div>
                                         <div class="inlineForm">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -461,6 +461,14 @@
                                     <br />
 
                                     <div id="analyzerActionsContainer">
+                                        <label for="actionRecap" style="margin-right: 1.5em; display: inline-block">
+                                            <span>Recap analysis</span>
+                                            <select is="emby-select" id="actionRecap" class="emby-select-withcolor emby-select">
+                                                <option value="Default">Default</option>
+                                                <option value="Chapter">Chapter</option>
+                                                <option value="None">None</option>
+                                            </select>
+                                        </label>
                                         <label for="actionIntro" style="margin-right: 1.5em; display: inline-block">
                                             <span>Introduction analysis</span>
                                             <select is="emby-select" id="actionIntro" class="emby-select-withcolor emby-select">
@@ -471,20 +479,12 @@
                                             </select>
                                         </label>
                                         <label for="actionCredits" style="margin-right: 1.5em; display: inline-block">
-                                            <span>Credits analysis</span>
+                                            <span>Credits (Outro) analysis</span>
                                             <select is="emby-select" id="actionCredits" class="emby-select-withcolor emby-select">
                                                 <option value="Default">Default</option>
                                                 <option value="Chapter">Chapter</option>
                                                 <option value="Chromaprint">Chromaprint</option>
                                                 <option value="BlackFrame">BlackFrame</option>
-                                                <option value="None">None</option>
-                                            </select>
-                                        </label>
-                                        <label for="actionRecap" style="margin-right: 1.5em; display: inline-block">
-                                            <span>Recap analysis</span>
-                                            <select is="emby-select" id="actionRecap" class="emby-select-withcolor emby-select">
-                                                <option value="Default">Default</option>
-                                                <option value="Chapter">Chapter</option>
                                                 <option value="None">None</option>
                                             </select>
                                         </label>
@@ -542,12 +542,12 @@
                                     </div>
                                     <div class="inlineForm">
                                         <div class="inputContainer">
-                                            <label class="inputLabel inputLabelUnfocused" for="creditsStart">Credits Start</label>
+                                            <label class="inputLabel inputLabelUnfocused" for="creditsStart">Credits (Outro) Start</label>
                                             <input type="text" id="editLeftCreditEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
                                             <input type="number" id="editLeftCreditEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
                                         </div>
                                         <div class="inputContainer">
-                                            <label class="inputLabel inputLabelUnfocused" for="creditsEnd">Credits End</label>
+                                            <label class="inputLabel inputLabelUnfocused" for="creditsEnd">Credits (Outro) End</label>
                                             <input type="text" id="editLeftCreditEpisodeEndDisplay" class="emby-input custom-time-input" readonly />
                                             <input type="number" id="editLeftCreditEpisodeEndEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
                                         </div>
@@ -594,12 +594,12 @@
                                         </div>
                                         <div class="inlineForm">
                                             <div class="inputContainer">
-                                                <label class="inputLabel inputLabelUnfocused" for="creditsStart">Credits Start</label>
+                                                <label class="inputLabel inputLabelUnfocused" for="creditsStart">Credits (Outro) Start</label>
                                                 <input type="text" id="editRightCreditEpisodeStartDisplay" class="emby-input custom-time-input" readonly />
                                                 <input type="number" id="editRightCreditEpisodeStartEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
                                             </div>
                                             <div class="inputContainer">
-                                                <label class="inputLabel inputLabelUnfocused" for="creditsEnd">Credits End</label>
+                                                <label class="inputLabel inputLabelUnfocused" for="creditsEnd">Credits (Outro) End</label>
                                                 <input type="text" id="editRightCreditEpisodeEndDisplay" class="emby-input custom-time-input" readonly />
                                                 <input type="number" id="editRightCreditEpisodeEndEdit" class="emby-input custom-time-input" style="display: none" step="any" min="0" />
                                             </div>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -705,7 +705,7 @@
                                         <button is="emby-button" class="button-submit emby-button" id="btnEraseRecapTimestamps">Erase all recap timestamps (globally)</button>
                                         <br />
 
-                                        <button is="emby-button" class="button-submit emby-button" id="btnEraseCreditTimestamps">Erase all end credits timestamps (globally)</button>
+                                        <button is="emby-button" class="button-submit emby-button" id="btnEraseCreditTimestamps">Erase all credits (outro) timestamps (globally)</button>
                                         <br />
 
                                         <button is="emby-button" class="button-submit emby-button" id="btnErasePreviewTimestamps">Erase all preview timestamps (globally)</button>


### PR DESCRIPTION
This creates a layout closer to the upstream options, but a little more geared at the specific placement in typical shows.

Most shows are
Recap
Intro
Outro
Preview

This doesn't technically align with how the settings are presented (hence the "almost") but does sort the settings by how a user is likely to expect when editing without reading the labels.

## Summary by Sourcery

Enhancements:
- Reorganize the layout of the configuration page to better align with typical show structures, placing 'Recap' sections before 'Intro' and 'Outro' sections.