### PR TITLE
add missing Migration for EpisodeIds

### DIFF
--- a/IntroSkipper/Migrations/20241123113631_AddEpisodeIdsColumn.Designer.cs
+++ b/IntroSkipper/Migrations/20241123113631_AddEpisodeIdsColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IntroSkipper.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IntroSkipper.Migrations
 {
     [DbContext(typeof(IntroSkipperDbContext))]
-    partial class IntroSkipperDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241123113631_AddEpisodeIdsColumn")]
+    partial class AddEpisodeIdsColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/IntroSkipper/Migrations/20241123113631_AddEpisodeIdsColumn.cs
+++ b/IntroSkipper/Migrations/20241123113631_AddEpisodeIdsColumn.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IntroSkipper.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEpisodeIdsColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EpisodeIds",
+                table: "DbSeasonInfo",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: string.Empty);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EpisodeIds",
+                table: "DbSeasonInfo");
+        }
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a migration to introduce the 'EpisodeIds' column to the 'DbSeasonInfo' table, ensuring it is non-nullable with a default empty string value. Update the Entity Framework Core version annotation to 8.0.11.

New Features:
- Add a new column 'EpisodeIds' to the 'DbSeasonInfo' table in the database schema.

Enhancements:
- Update the Entity Framework Core product version annotation from '8.0.10' to '8.0.11'.