### PR TITLE
Add button to recreate db

### DIFF
--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -714,6 +714,9 @@
                                         <input type="checkbox" id="eraseModeCacheCheckbox" style="margin-left: 10px" />
                                         <label for="eraseModeCacheCheckbox" style="margin-left: 5px">Erase global cached fingerprint files</label>
                                     </div>
+                                    <div>
+                                        <button is="emby-button" class="button-submit emby-button" id="btnRebuildDatabase">Rebuild database</button>
+                                    </div>
                                 </div>
                                 <br />
                                 <br />
@@ -758,6 +761,7 @@
                 var btnEraseRecapTimestamps = document.querySelector("button#btnEraseRecapTimestamps");
                 var btnEraseCreditTimestamps = document.querySelector("button#btnEraseCreditTimestamps");
                 var btnErasePreviewTimestamps = document.querySelector("button#btnErasePreviewTimestamps");
+                var btnRebuildDatabase = document.querySelector("button#btnRebuildDatabase");
 
                 // all plugin configuration fields that can be get or set with .value (i.e. strings or numbers).
                 var configurationFields = [
@@ -1503,6 +1507,9 @@
                 btnErasePreviewTimestamps.addEventListener("click", (e) => {
                     eraseTimestamps("Preview");
                     e.preventDefault();
+                });
+                btnRebuildDatabase.addEventListener("click", () => {
+                    fetchWithAuth("Intros/RebuildDatabase", "POST", null);
                 });
                 btnSeasonEraseTimestamps.addEventListener("click", () => {
                     Dashboard.confirm("Are you sure you want to erase all timestamps for this season?", "Confirm timestamp erasure", (result) => {

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -252,6 +252,20 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     }
 
     /// <summary>
+    /// Rebuilds the database.
+    /// </summary>
+    /// <response code="204">Database rebuilt.</response>
+    /// <returns>No content.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpPost("Intros/RebuildDatabase")]
+    public ActionResult RebuildDatabase()
+    {
+        using var db = new IntroSkipperDbContext(Plugin.Instance!.DbPath);
+        db.RebuildDatabase();
+        return NoContent();
+    }
+
+    /// <summary>
     /// Gets the user interface configuration.
     /// </summary>
     /// <response code="200">UserInterfaceConfiguration returned.</response>


### PR DESCRIPTION
## Summary by Sourcery

Add functionality to rebuild the database through a new button in the configuration page, which triggers a new API endpoint to perform the database rebuild while preserving existing valid data.

New Features:
- Introduce a new button in the configuration page to allow users to rebuild the database.

Enhancements:
- Add a new method to the database context to rebuild the database while preserving valid segments and season information.