### PR TITLE
Zero and reset remaining intro time

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -227,7 +227,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets the amount of intro to play (in seconds).
     /// </summary>
-    public int RemainingSecondsOfIntro { get; set; } = 2;
+    public int RemainingSecondsOfIntro { get; set; };
 
     /// <summary>
     /// Gets or sets the amount of intro at start to play (in seconds).

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -227,7 +227,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets the amount of intro to play (in seconds).
     /// </summary>
-    public int RemainingSecondsOfIntro { get; set; };
+    public int RemainingSecondsOfIntro { get; set; }
 
     /// <summary>
     /// Gets or sets the amount of intro at start to play (in seconds).

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -1612,7 +1612,7 @@
                     fetchWithAuth("Episode/" + lhsId + "/Timestamps", "POST", JSON.stringify(newLhs));
                     fetchWithAuth("Episode/" + rhsId + "/Timestamps", "POST", JSON.stringify(newRhs));
 
-                    Dashboard.alert("New introduction timestamps saved");
+                    Dashboard.alert("New segment timestamps saved");
                 });
                 document.addEventListener("keydown", keyDown);
                 windowHashInterval = setInterval(checkWindowHash, 2500);

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -935,6 +935,8 @@
 
                 persistSkip.addEventListener("change", persistSkipChanged);
 
+                var remainingSecondsOfIntro = document.getElementById("RemainingSecondsOfIntro")
+
                 async function pluginSkipSettingChanged() {
                     if (pluginSkip.checked) {
                         serverSkipSettings.style.display = "unset";
@@ -944,6 +946,7 @@
                         autoSkip.checked = false;
                         skipButtonVisible.checked = false;
                         persistSkip.checked = false;
+                        remainingSecondsOfIntro.value = 0;
                     }
                 }
 


### PR DESCRIPTION
## Summary by Sourcery

Reset the remaining intro time to zero when the plugin skip setting is changed and remove the default value for the RemainingSecondsOfIntro property in the PluginConfiguration class.

Bug Fixes:
- Reset the remaining intro time to zero when the plugin skip setting is changed.

Enhancements:
- Remove the default value for the RemainingSecondsOfIntro property in the PluginConfiguration class.