### PR TITLE
README.md - add install instructions for jellyfin-ffmpeg on Gentoo Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://manifest.intro-skipper.org/manifest.json
   * `linuxserver/jellyfin` 10.10.z container: preinstalled
   * Debian Linux based native installs: provided by the `jellyfin-ffmpeg7` package
   * MacOS native installs: build ffmpeg with chromaprint support ([instructions](https://github.com/intro-skipper/intro-skipper/wiki/Custom-FFMPEG-(MacOS)))
+  * Gentoo Linux native installs: enable xarblu-overlay and install media-video/jellyfin-ffmpeg
 
 ## Limitations
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add installation instructions for jellyfin-ffmpeg on Gentoo Linux to the README.