### PR TITLE
exclude series

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -28,6 +28,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public string SelectedLibraries { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the comma separated list of series names to exclude from analysis.
+    /// </summary>
+    public string ExcludeSeries { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets a value indicating whether all libraries should be analyzed.
     /// </summary>
     public bool SelectAllLibraries { get; set; } = true;

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -178,6 +178,12 @@
                                     <div class="fieldDescription">Segments longer than this duration will not be considered movie credits.</div>
                                 </div>
 
+                                <div class="inputContainer" id="excludeSeries">
+                                    <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
+                                    <input id="ExcludeSeries" type="text" is="emby-input" />
+                                    <div class="fieldDescription">Exclude series from analysis. Enter a comma-separated list of series names to exclude.</div>
+                                </div>
+
                                 <br />
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
@@ -763,6 +769,7 @@
                     // analysis
                     "MaxParallelism",
                     "SelectedLibraries",
+                    "ExcludeSeries",
                     "ClientList",
                     "AnalysisPercent",
                     "AnalysisLengthLimit",

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -238,7 +238,7 @@ namespace IntroSkipper.Manager
                 IsAnime = isAnime,
                 Path = episode.Path,
                 Duration = (int)duration,
-                IntroFingerprintEnd = (int)(duration - fingerprintDuration),
+                IntroFingerprintEnd = (int)fingerprintDuration,
                 CreditsFingerprintStart = (int)(duration - maxCreditsDuration),
             });
 
@@ -271,8 +271,8 @@ namespace IntroSkipper.Manager
                 EpisodeId = movie.Id,
                 Name = movie.Name,
                 Path = movie.Path,
-                Duration = Convert.ToInt32(duration),
-                CreditsFingerprintStart = Convert.ToInt32(duration - pluginInstance.Configuration.MaximumMovieCreditsDuration),
+                Duration = (int)duration,
+                CreditsFingerprintStart = (int)(duration - pluginInstance.Configuration.MaximumMovieCreditsDuration),
                 IsMovie = true
             });
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new feature to exclude specific series from analysis by adding an 'ExcludeSeries' configuration option. Enhance error handling in the QueueLibraryContents method with try-catch blocks and error logging. Update the configuration page to allow users to specify series to exclude from analysis.

New Features:
- Add functionality to exclude specific series from analysis by introducing a new configuration option 'ExcludeSeries'.

Enhancements:
- Improve error handling in the QueueLibraryContents method by adding try-catch blocks and logging errors.

Documentation:
- Update configuration page to include a new input field for excluding series from analysis.