### PR TITLE
Skip / delay analysis based on type

### DIFF
--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -232,6 +232,6 @@ public class BaseItemAnalyzerTask(
         // Set the episode IDs for the analyzed items
         await Plugin.Instance!.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId)).ConfigureAwait(false);
 
-        return items.Where(i => i.IsAnalyzed).Count();
+        return items.Count(i => i.IsAnalyzed);
     }
 }

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -119,7 +119,12 @@ namespace IntroSkipper.Services
             if (_config.AutoDetectIntros &&
                 itemChangeEventArgs.Item is { LocationType: not LocationType.Virtual } item)
             {
-                Guid? id = item is Episode episode ? episode.SeasonId : (item is Movie movie ? movie.Id : null);
+                Guid? id = item switch
+                {
+                    Episode episode => episode.SeasonId,
+                    Movie movie => movie.Id,
+                    _ => null
+                };
 
                 if (id.HasValue)
                 {

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -166,7 +166,7 @@ namespace IntroSkipper.Services
             }
             else if (AutomaticTaskState == TaskState.Idle)
             {
-                _logger.LogDebug("Media Library changed, analyzis will start soon!");
+                _logger.LogDebug("Media Library changed, analysis will start soon!");
                 _queueTimer.Change(TimeSpan.FromSeconds(60), Timeout.InfiniteTimeSpan);
             }
         }

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -129,7 +129,14 @@ namespace IntroSkipper.Services
                 if (id.HasValue)
                 {
                     _seasonsToAnalyze.Add(id.Value);
-                    StartTimer();
+                    if (itemChangeEventArgs.UpdateReason == 0)
+                    {
+                        StartTimer(120);
+                    }
+                    else
+                    {
+                        StartTimer();
+                    }
                 }
             }
         }
@@ -158,7 +165,7 @@ namespace IntroSkipper.Services
         /// <summary>
         /// Start timer to debounce analyzing.
         /// </summary>
-        private void StartTimer()
+        private void StartTimer(int delay = 60)
         {
             if (AutomaticTaskState == TaskState.Running)
             {
@@ -167,7 +174,7 @@ namespace IntroSkipper.Services
             else if (AutomaticTaskState == TaskState.Idle)
             {
                 _logger.LogDebug("Media Library changed, analysis will start soon!");
-                _queueTimer.Change(TimeSpan.FromSeconds(60), Timeout.InfiniteTimeSpan);
+                _queueTimer.Change(TimeSpan.FromSeconds(delay), Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -111,6 +111,11 @@ namespace IntroSkipper.Services
         /// <param name="itemChangeEventArgs">The <see cref="ItemChangeEventArgs"/>.</param>
         private void OnItemChanged(object? sender, ItemChangeEventArgs itemChangeEventArgs)
         {
+            if (itemChangeEventArgs.UpdateReason == ItemUpdateType.ImageUpdate)
+            {
+                return;
+            }
+
             if (_config.AutoDetectIntros &&
                 itemChangeEventArgs.Item is { LocationType: not LocationType.Virtual } item)
             {

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -128,15 +128,10 @@ namespace IntroSkipper.Services
 
                 if (id.HasValue)
                 {
+                    var delay = itemChangeEventArgs.UpdateReason == 0 ? 120 : 60;
+
                     _seasonsToAnalyze.Add(id.Value);
-                    if (itemChangeEventArgs.UpdateReason == 0)
-                    {
-                        StartTimer(120);
-                    }
-                    else
-                    {
-                        StartTimer();
-                    }
+                    StartTimer(delay);
                 }
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Enhance the analysis process by skipping updates for ImageUpdate types and introducing a delay parameter in the StartTimer method. Refactor the OnItemChanged method to use a switch expression for cleaner code and improve logging for better clarity.

Enhancements:
- Add condition to skip analysis for ImageUpdate type in OnItemChanged method.
- Refactor OnItemChanged method to use switch expression for determining item ID.
- Modify StartTimer method to accept an optional delay parameter with a default value of 60 seconds.
- Improve logging message in StartTimer method for clarity.