### PR TITLE
Don't restrict chapter lengths

### DIFF
--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -27,14 +27,6 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
     private readonly ILogger<ChapterAnalyzer> _logger = logger;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
 
-    private readonly Dictionary<AnalysisMode, Func<(double Min, double Max)>> _durationBounds = new()
-    {
-        [AnalysisMode.Introduction] = () => (_config.MinimumIntroDuration, _config.MaximumIntroDuration),
-        [AnalysisMode.Credits] = () => (_config.MinimumCreditsDuration, _config.MaximumCreditsDuration),
-        [AnalysisMode.Recap] = () => (_config.MinimumRecapDuration, _config.MaximumRecapDuration),
-        [AnalysisMode.Preview] = () => (_config.MinimumPreviewDuration, _config.MaximumPreviewDuration)
-    };
-
     /// <inheritdoc />
     public async Task<IReadOnlyList<QueuedEpisode>> AnalyzeMediaFiles(
         IReadOnlyList<QueuedEpisode> analysisQueue,
@@ -104,14 +96,18 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         }
 
         var reversed = mode == AnalysisMode.Credits || mode == AnalysisMode.Preview;
-        var boundsFunc = _durationBounds.GetValueOrDefault(mode) ?? throw new ArgumentOutOfRangeException(nameof(mode));
+        Dictionary<AnalysisMode, Func<(double Min, double Max)>> durationBounds = new()
+        {
+            [AnalysisMode.Introduction] = () => (_config.MinimumIntroDuration, _config.MaximumIntroDuration),
+            [AnalysisMode.Credits] = () => (_config.MinimumCreditsDuration, _config.MaximumCreditsDuration),
+            [AnalysisMode.Recap] = () => (_config.MinimumRecapDuration, _config.MaximumRecapDuration),
+            [AnalysisMode.Preview] = () => (_config.MinimumPreviewDuration, _config.MaximumPreviewDuration)
+        };
+        var boundsFunc = durationBounds.GetValueOrDefault(mode) ?? throw new ArgumentOutOfRangeException(nameof(mode));
         var bounds = boundsFunc(); // Call the function to get the values
-        var maximumDuration = mode == AnalysisMode.Credits && episode.IsMovie
-            ? _config.MaximumMovieCreditsDuration
-            : bounds.Max;
         var (minDuration, maxDuration) = _config.FullLengthChapters
             ? (1, episode.Duration - 1)
-            : (bounds.Min, maximumDuration);
+            : (bounds.Min, mode == AnalysisMode.Credits && episode.IsMovie ? _config.MaximumMovieCreditsDuration : bounds.Max);
 
         // Check all chapters
         for (int i = reversed ? count - 1 : 0; reversed ? i >= 0 : i < count; i += reversed ? -1 : 1)

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -95,8 +95,12 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
             return null;
         }
 
+        var creditDuration = episode.IsMovie ? _config.MaximumMovieCreditsDuration : _config.MaximumCreditsDuration;
         var reversed = mode == AnalysisMode.Credits;
-        var (minDuration, maxDuration) = (1, episode.Duration - 1);
+        var (minDuration, maxDuration) = _config.FullLengthChapters ?
+            (1, episode.Duration - 1) : reversed
+            ? (_config.MinimumCreditsDuration, creditDuration)
+            : (_config.MinimumIntroDuration, _config.MaximumIntroDuration);
 
         // Check all chapters
         for (int i = reversed ? count - 1 : 0; reversed ? i >= 0 : i < count; i += reversed ? -1 : 1)

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -94,12 +94,8 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         {
             return null;
         }
-
-        var creditDuration = episode.IsMovie ? _config.MaximumMovieCreditsDuration : _config.MaximumCreditsDuration;
         var reversed = mode == AnalysisMode.Credits;
-        var (minDuration, maxDuration) = reversed
-            ? (1, creditDuration)
-            : (1, _config.MaximumIntroDuration);
+        var (minDuration, maxDuration) = (1, episode.Duration - 1);
 
         // Check all chapters
         for (int i = reversed ? count - 1 : 0; reversed ? i >= 0 : i < count; i += reversed ? -1 : 1)

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -99,7 +99,9 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         Dictionary<AnalysisMode, Func<(double Min, double Max)>> durationBounds = new()
         {
             [AnalysisMode.Introduction] = () => (_config.MinimumIntroDuration, _config.MaximumIntroDuration),
-            [AnalysisMode.Credits] = () => (_config.MinimumCreditsDuration, _config.MaximumCreditsDuration),
+            [AnalysisMode.Credits] = () => (_config.MinimumCreditsDuration, episode.IsMovie
+                ? _config.MaximumMovieCreditsDuration
+                : _config.MaximumCreditsDuration),
             [AnalysisMode.Recap] = () => (_config.MinimumRecapDuration, _config.MaximumRecapDuration),
             [AnalysisMode.Preview] = () => (_config.MinimumPreviewDuration, _config.MaximumPreviewDuration)
         };
@@ -107,7 +109,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         var bounds = boundsFunc(); // Call the function to get the values
         var (minDuration, maxDuration) = _config.FullLengthChapters
             ? (1, episode.Duration - 1)
-            : (bounds.Min, mode == AnalysisMode.Credits && episode.IsMovie ? _config.MaximumMovieCreditsDuration : bounds.Max);
+            : (bounds.Min, bounds.Max);
 
         // Check all chapters
         for (int i = reversed ? count - 1 : 0; reversed ? i >= 0 : i < count; i += reversed ? -1 : 1)

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -94,6 +94,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         {
             return null;
         }
+
         var reversed = mode == AnalysisMode.Credits;
         var (minDuration, maxDuration) = (1, episode.Duration - 1);
 

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -98,8 +98,8 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         var creditDuration = episode.IsMovie ? _config.MaximumMovieCreditsDuration : _config.MaximumCreditsDuration;
         var reversed = mode == AnalysisMode.Credits;
         var (minDuration, maxDuration) = reversed
-            ? (_config.MinimumCreditsDuration, creditDuration)
-            : (_config.MinimumIntroDuration, _config.MaximumIntroDuration);
+            ? (1, creditDuration)
+            : (1, _config.MaximumIntroDuration);
 
         // Check all chapters
         for (int i = reversed ? count - 1 : 0; reversed ? i >= 0 : i < count; i += reversed ? -1 : 1)

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -109,7 +109,7 @@ public class PluginConfiguration : BasePluginConfiguration
     public int AnalysisLengthLimit { get; set; } = 10;
 
     /// <summary>
-    /// Gets or sets whether to use the minimum and maximum duration for chapters.
+    /// Gets or sets a value indicating whether to use the minimum and maximum duration for chapters.
     /// </summary>
     public bool FullLengthChapters { get; set; } = true;
 
@@ -132,6 +132,26 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the upper limit (in seconds) on the length of each episode's audio track that will be analyzed when searching for ending credits.
     /// </summary>
     public int MaximumCreditsDuration { get; set; } = 450;
+
+    /// <summary>
+    /// Gets or sets the minimum length of similar audio that will be considered a recap.
+    /// </summary>
+    public int MinimumRecapDuration { get; set; } = 15;
+
+    /// <summary>
+    /// Gets or sets the maximum length of similar audio that will be considered a recap.
+    /// </summary>
+    public int MaximumRecapDuration { get; set; } = 120;
+
+    /// <summary>
+    /// Gets or sets the minimum length of similar audio that will be considered a preview.
+    /// </summary>
+    public int MinimumPreviewDuration { get; set; } = 15;
+
+    /// <summary>
+    /// Gets or sets the maximum length of similar audio that will be considered a preview.
+    /// </summary>
+    public int MaximumPreviewDuration { get; set; } = 120;
 
     /// <summary>
     /// Gets or sets the upper limit (in seconds) on the length of a movie segment that will be analyzed when searching for ending credits.

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -109,6 +109,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public int AnalysisLengthLimit { get; set; } = 10;
 
     /// <summary>
+    /// Gets or sets whether to use the minimum and maximum duration for chapters.
+    /// </summary>
+    public bool FullLengthChapters { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the minimum length of similar audio that will be considered an introduction.
     /// </summary>
     public int MinimumIntroDuration { get; set; } = 15;

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -134,6 +134,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public int MaximumCreditsDuration { get; set; } = 450;
 
     /// <summary>
+    /// Gets or sets the upper limit (in seconds) on the length of a movie segment that will be analyzed when searching for ending credits.
+    /// </summary>
+    public int MaximumMovieCreditsDuration { get; set; } = 900;
+
+    /// <summary>
     /// Gets or sets the minimum length of similar audio that will be considered a recap.
     /// </summary>
     public int MinimumRecapDuration { get; set; } = 15;
@@ -152,11 +157,6 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the maximum length of similar audio that will be considered a preview.
     /// </summary>
     public int MaximumPreviewDuration { get; set; } = 120;
-
-    /// <summary>
-    /// Gets or sets the upper limit (in seconds) on the length of a movie segment that will be analyzed when searching for ending credits.
-    /// </summary>
-    public int MaximumMovieCreditsDuration { get; set; } = 900;
 
     /// <summary>
     /// Gets or sets the minimum percentage of a frame that must consist of black pixels before it is considered a black frame.

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -185,25 +185,25 @@
                                     <div class="fieldDescription">Segments longer than this duration will not be considered movie credits.</div>
                                 </div>
 
-                                <div class="inputContainer">
+                                <div class="inputContainer" id="MinimumRecapDurationContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="MinimumRecapDuration"> Minimum recap duration (in seconds) </label>
                                     <input id="MinimumRecapDuration" type="number" is="emby-input" min="1" />
                                     <div class="fieldDescription">Segments which are shorter than this duration will not be considered a recap.</div>
                                 </div>
 
-                                <div class="inputContainer">
+                                <div class="inputContainer" id="MaximumRecapDurationContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="MaximumRecapDuration"> Maximum recap duration (in seconds) </label>
                                     <input id="MaximumRecapDuration" type="number" is="emby-input" min="1" />
                                     <div class="fieldDescription">Segments which are longer than this duration will not be considered a recap.</div>
                                 </div>
 
-                                <div class="inputContainer">
+                                <div class="inputContainer" id="MinimumPreviewDurationContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="MinimumPreviewDuration"> Minimum preview duration (in seconds) </label>
                                     <input id="MinimumPreviewDuration" type="number" is="emby-input" min="1" />
                                     <div class="fieldDescription">Segments which are shorter than this duration will not be considered a preview.</div>
                                 </div>
 
-                                <div class="inputContainer">
+                                <div class="inputContainer" id="MaximumPreviewDurationContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="MaximumPreviewDuration"> Maximum preview duration (in seconds) </label>
                                     <input id="MaximumPreviewDuration" type="number" is="emby-input" min="1" />
                                     <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
@@ -920,10 +920,10 @@
 
                 selectAllLibraries.addEventListener("change", selectAllLibrariesChanged);
 
-                const minimumRecapDuration = document.getElementById("MinimumRecapDuration");
-                const maximumRecapDuration = document.getElementById("MaximumRecapDuration");
-                const minimumPreviewDuration = document.getElementById("MinimumPreviewDuration");
-                const maximumPreviewDuration = document.getElementById("MaximumPreviewDuration");
+                const minimumRecapDuration = document.getElementById("MinimumRecapDurationContainer");
+                const maximumRecapDuration = document.getElementById("MaximumRecapDurationContainer");
+                const minimumPreviewDuration = document.getElementById("MinimumPreviewDurationContainer");
+                const maximumPreviewDuration = document.getElementById("MaximumPreviewDurationContainer");
 
                 // Hide or show durations for segments that are exclusively analyzed by chapters
                 function fullLengthChaptersChanged() {

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -148,6 +148,13 @@
                                 </p>
                                 <br />
 
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label class="emby-checkbox-label">
+                                        <input id="FullLengthChapters" type="checkbox" is="emby-checkbox" />
+                                        <span>Ignore duration limits for chapters</span>
+                                    </label>
+                                </div>
+
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="MinimumIntroDuration"> Minimum introduction duration (in seconds) </label>
                                     <input id="MinimumIntroDuration" type="number" is="emby-input" min="1" />
@@ -803,7 +810,7 @@
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "PersistSkipButton", "SkipButtonEnabled"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "PersistSkipButton", "SkipButtonEnabled"];
 
                 // visualizer elements
                 const analyzerActionsSection = document.querySelector("div#analyzerActionsSection");

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -179,6 +179,12 @@
                                     <div class="fieldDescription">Segments or similar sounding audio which is longer than this duration will not be considered credits.</div>
                                 </div>
 
+                                <div class="inputContainer" id="movieCreditsDuration">
+                                    <label class="inputLabel inputLabelUnfocused" for="MaximumMovieCreditsDuration"> Maximum movie credits duration (in seconds) </label>
+                                    <input id="MaximumMovieCreditsDuration" type="number" is="emby-input" min="1" />
+                                    <div class="fieldDescription">Segments longer than this duration will not be considered movie credits.</div>
+                                </div>
+
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="MinimumRecapDuration"> Minimum recap duration (in seconds) </label>
                                     <input id="MinimumRecapDuration" type="number" is="emby-input" min="1" />
@@ -201,12 +207,6 @@
                                     <label class="inputLabel inputLabelUnfocused" for="MaximumPreviewDuration"> Maximum preview duration (in seconds) </label>
                                     <input id="MaximumPreviewDuration" type="number" is="emby-input" min="1" />
                                     <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
-                                </div>
-
-                                <div class="inputContainer" id="movieCreditsDuration">
-                                    <label class="inputLabel inputLabelUnfocused" for="MaximumMovieCreditsDuration"> Maximum movie credits duration (in seconds) </label>
-                                    <input id="MaximumMovieCreditsDuration" type="number" is="emby-input" min="1" />
-                                    <div class="fieldDescription">Segments longer than this duration will not be considered movie credits.</div>
                                 </div>
 
                                 <div class="inputContainer" id="excludeSeries">
@@ -812,11 +812,11 @@
                     "MaximumIntroDuration",
                     "MinimumCreditsDuration",
                     "MaximumCreditsDuration",
+                    "MaximumMovieCreditsDuration",
                     "MinimumRecapDuration",
                     "MaximumRecapDuration",
                     "MinimumPreviewDuration",
                     "MaximumPreviewDuration",
-                    "MaximumMovieCreditsDuration",
                     "ProcessPriority",
                     "ProcessThreads",
                     // playback
@@ -881,6 +881,7 @@
                 const skipFirstEpisode = document.getElementById("divSkipFirstEpisode");
                 const secondsOfIntroStartToPlay = document.getElementById("divSecondsOfIntroStartToPlay");
                 const autoSkipClientList = document.querySelector("div.AutoSkipClientListContainer");
+                const fullLengthChapters = document.getElementById("FullLengthChapters");
                 const movieCreditsDuration = document.getElementById("movieCreditsDuration");
 
                 function skipButtonVisibleChanged() {
@@ -918,6 +919,28 @@
                 }
 
                 selectAllLibraries.addEventListener("change", selectAllLibrariesChanged);
+
+                const minimumRecapDuration = document.getElementById("MinimumRecapDuration");
+                const maximumRecapDuration = document.getElementById("MaximumRecapDuration");
+                const minimumPreviewDuration = document.getElementById("MinimumPreviewDuration");
+                const maximumPreviewDuration = document.getElementById("MaximumPreviewDuration");
+
+                // Hide or show durations for segments that are exclusively analyzed by chapters
+                function fullLengthChaptersChanged() {
+                    if (fullLengthChapters.checked) {
+                        minimumRecapDuration.style.display = "none";
+                        maximumRecapDuration.style.display = "none";
+                        minimumPreviewDuration.style.display = "none";
+                        maximumPreviewDuration.style.display = "none";
+                    } else {
+                        minimumRecapDuration.style.display = "unset";
+                        maximumRecapDuration.style.display = "unset";
+                        minimumPreviewDuration.style.display = "unset";
+                        maximumPreviewDuration.style.display = "unset";
+                    }
+                }
+
+                fullLengthChapters.addEventListener("change", fullLengthChaptersChanged);
 
                 function updateList(textField, container) {
                     textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
@@ -1494,6 +1517,7 @@
 
                         populateLibraries();
                         selectAllLibrariesChanged();
+                        fullLengthChaptersChanged();
                         autoSkipChanged();
                         persistSkipChanged();
                         generateAutoSkipTypeList();

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -179,6 +179,30 @@
                                     <div class="fieldDescription">Segments or similar sounding audio which is longer than this duration will not be considered credits.</div>
                                 </div>
 
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="MinimumRecapDuration"> Minimum recap duration (in seconds) </label>
+                                    <input id="MinimumRecapDuration" type="number" is="emby-input" min="1" />
+                                    <div class="fieldDescription">Segments which are shorter than this duration will not be considered a recap.</div>
+                                </div>
+
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="MaximumRecapDuration"> Maximum recap duration (in seconds) </label>
+                                    <input id="MaximumRecapDuration" type="number" is="emby-input" min="1" />
+                                    <div class="fieldDescription">Segments which are longer than this duration will not be considered a recap.</div>
+                                </div>
+
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="MinimumPreviewDuration"> Minimum preview duration (in seconds) </label>
+                                    <input id="MinimumPreviewDuration" type="number" is="emby-input" min="1" />
+                                    <div class="fieldDescription">Segments which are shorter than this duration will not be considered a preview.</div>
+                                </div>
+
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="MaximumPreviewDuration"> Maximum preview duration (in seconds) </label>
+                                    <input id="MaximumPreviewDuration" type="number" is="emby-input" min="1" />
+                                    <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
+                                </div>
+
                                 <div class="inputContainer" id="movieCreditsDuration">
                                     <label class="inputLabel inputLabelUnfocused" for="MaximumMovieCreditsDuration"> Maximum movie credits duration (in seconds) </label>
                                     <input id="MaximumMovieCreditsDuration" type="number" is="emby-input" min="1" />
@@ -788,6 +812,10 @@
                     "MaximumIntroDuration",
                     "MinimumCreditsDuration",
                     "MaximumCreditsDuration",
+                    "MinimumRecapDuration",
+                    "MaximumRecapDuration",
+                    "MinimumPreviewDuration",
+                    "MaximumPreviewDuration",
                     "MaximumMovieCreditsDuration",
                     "ProcessPriority",
                     "ProcessThreads",

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -754,9 +754,11 @@
                                         <input type="checkbox" id="eraseModeCacheCheckbox" style="margin-left: 10px" />
                                         <label for="eraseModeCacheCheckbox" style="margin-left: 5px">Erase global cached fingerprint files</label>
                                     </div>
-                                    <div>
-                                        <button is="emby-button" class="button-submit emby-button" id="btnRebuildDatabase">Rebuild database</button>
-                                    </div>
+                                </div>
+                                <div>
+                                  <p>
+                                    <button is="emby-button" class="button-submit emby-button" id="btnRebuildDatabase">Rebuild database</button>
+                                  </p>
                                 </div>
                             </details>
 

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -757,7 +757,7 @@
                                 </div>
                                 <div>
                                   <p>
-                                    <button is="emby-button" class="button-submit emby-button" id="btnRebuildDatabase">Rebuild database</button>
+                                    <button is="emby-button" class="button-submit block emby-button" id="btnRebuildDatabase">Rebuild database</button>
                                   </p>
                                 </div>
                             </details>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -185,29 +185,31 @@
                                     <div class="fieldDescription">Segments longer than this duration will not be considered movie credits.</div>
                                 </div>
 
-                                <div class="inputContainer" id="MinimumRecapDurationContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="MinimumRecapDuration"> Minimum recap duration (in seconds) </label>
-                                    <input id="MinimumRecapDuration" type="number" is="emby-input" min="1" />
-                                    <div class="fieldDescription">Segments which are shorter than this duration will not be considered a recap.</div>
-                                </div>
+                                <div id="RecapPreviewDurations">
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="MinimumRecapDuration"> Minimum recap duration (in seconds) </label>
+                                        <input id="MinimumRecapDuration" type="number" is="emby-input" min="1" />
+                                        <div class="fieldDescription">Segments which are shorter than this duration will not be considered a recap.</div>
+                                    </div>
 
-                                <div class="inputContainer" id="MaximumRecapDurationContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="MaximumRecapDuration"> Maximum recap duration (in seconds) </label>
-                                    <input id="MaximumRecapDuration" type="number" is="emby-input" min="1" />
-                                    <div class="fieldDescription">Segments which are longer than this duration will not be considered a recap.</div>
-                                </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="MaximumRecapDuration"> Maximum recap duration (in seconds) </label>
+                                        <input id="MaximumRecapDuration" type="number" is="emby-input" min="1" />
+                                        <div class="fieldDescription">Segments which are longer than this duration will not be considered a recap.</div>
+                                    </div>
 
-                                <div class="inputContainer" id="MinimumPreviewDurationContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="MinimumPreviewDuration"> Minimum preview duration (in seconds) </label>
-                                    <input id="MinimumPreviewDuration" type="number" is="emby-input" min="1" />
-                                    <div class="fieldDescription">Segments which are shorter than this duration will not be considered a preview.</div>
-                                </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="MinimumPreviewDuration"> Minimum preview duration (in seconds) </label>
+                                        <input id="MinimumPreviewDuration" type="number" is="emby-input" min="1" />
+                                        <div class="fieldDescription">Segments which are shorter than this duration will not be considered a preview.</div>
+                                    </div>
 
-                                <div class="inputContainer" id="MaximumPreviewDurationContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="MaximumPreviewDuration"> Maximum preview duration (in seconds) </label>
-                                    <input id="MaximumPreviewDuration" type="number" is="emby-input" min="1" />
-                                    <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
-                                </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="MaximumPreviewDuration"> Maximum preview duration (in seconds) </label>
+                                        <input id="MaximumPreviewDuration" type="number" is="emby-input" min="1" />
+                                        <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
+                                    </div>
+                              </div>
 
                                 <div class="inputContainer" id="excludeSeries">
                                     <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
@@ -920,23 +922,14 @@
 
                 selectAllLibraries.addEventListener("change", selectAllLibrariesChanged);
 
-                const minimumRecapDuration = document.getElementById("MinimumRecapDurationContainer");
-                const maximumRecapDuration = document.getElementById("MaximumRecapDurationContainer");
-                const minimumPreviewDuration = document.getElementById("MinimumPreviewDurationContainer");
-                const maximumPreviewDuration = document.getElementById("MaximumPreviewDurationContainer");
+                const recapPreviewDurations = document.getElementById("RecapPreviewDurations");
 
                 // Hide or show durations for segments that are exclusively analyzed by chapters
                 function fullLengthChaptersChanged() {
                     if (fullLengthChapters.checked) {
-                        minimumRecapDuration.style.display = "none";
-                        maximumRecapDuration.style.display = "none";
-                        minimumPreviewDuration.style.display = "none";
-                        maximumPreviewDuration.style.display = "none";
+                        recapPreviewDurations.style.display = "none";
                     } else {
-                        minimumRecapDuration.style.display = "unset";
-                        maximumRecapDuration.style.display = "unset";
-                        minimumPreviewDuration.style.display = "unset";
-                        maximumPreviewDuration.style.display = "unset";
+                        recapPreviewDurations.style.display = "unset";
                     }
                 }
 


### PR DESCRIPTION
Setting a value of 1 for the minimum ensures it is a valid segment, but the assumption is that chapters are intentional segments and not estimates. Setting a value of 1 less than the length ensures the chapter isn't simply the entire video

## Summary by Sourcery

Add an option to ignore duration limits for chapters.

New Features:
- Added a checkbox to the configuration page to allow users to ignore duration limits for chapters.

Tests:
- Updated tests to reflect the new configuration option.