### PR TITLE
Restore Analyzed state for tracking

### DIFF
--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -33,7 +33,7 @@ public class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMediaFile
             throw new NotImplementedException("mode must equal Credits");
         }
 
-        var episodesWithoutIntros = analysisQueue.Where(e => !e.IsAnalyzed).ToList();
+        var episodesWithoutIntros = analysisQueue.Where(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed).ToList();
 
         var searchStart = 0.0;
 
@@ -57,7 +57,7 @@ public class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMediaFile
                 continue;
             }
 
-            episode.IsAnalyzed = true;
+            episode.SetAnalyzed(mode, EpisodeState.Analyzed);
             await Plugin.Instance!.UpdateTimestampAsync(credit, mode).ConfigureAwait(false);
             searchStart = episode.Duration - credit.Start + _config.MinimumCreditsDuration;
         }

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -47,7 +47,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
             return analysisQueue;
         }
 
-        var episodesWithoutIntros = analysisQueue.Where(e => !e.IsAnalyzed).ToList();
+        var episodesWithoutIntros = analysisQueue.Where(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed).ToList();
 
         foreach (var episode in episodesWithoutIntros)
         {
@@ -67,7 +67,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
                 continue;
             }
 
-            episode.IsAnalyzed = true;
+            episode.SetAnalyzed(mode, EpisodeState.Analyzed);
             await Plugin.Instance!.UpdateTimestampAsync(skipRange, mode).ConfigureAwait(false);
         }
 

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -35,10 +36,10 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
         AnalysisMode mode,
         CancellationToken cancellationToken)
     {
-        // Episodes that were not analyzed.
-        var episodeAnalysisQueue = analysisQueue.Where(e => !e.IsAnalyzed).ToList();
+        // Episodes that were not analyzed or have a fingerprint cache.
+        var episodeAnalysisQueue = analysisQueue.Where(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed || File.Exists(FFmpegWrapper.GetFingerprintCachePath(e, mode))).ToList();
 
-        if (episodeAnalysisQueue.Count <= 1)
+        if (analysisQueue.Count <= 1 || episodeAnalysisQueue.Any(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed))
         {
             return analysisQueue;
         }
@@ -50,6 +51,13 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
 
         // Cache of all fingerprints for this season.
         var fingerprintCache = new Dictionary<Guid, uint[]>();
+
+        // Ensure at least two fingerprints are present.
+        if (episodeAnalysisQueue.Count == 1)
+        {
+            episodeAnalysisQueue.AddRange(analysisQueue
+                .Where(episode => Math.Abs(episode.EpisodeNumber - episodeAnalysisQueue[0].EpisodeNumber) <= 1));
+        }
 
         // Compute fingerprints for all episodes in the season
         foreach (var episode in episodeAnalysisQueue)
@@ -151,7 +159,7 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
             // If an intro is found for this episode, adjust its times and save it else add it to the list of episodes without intros.
             if (seasonIntros.TryGetValue(currentEpisode.EpisodeId, out var intro))
             {
-                currentEpisode.IsAnalyzed = true;
+                currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
                 await Plugin.Instance!.UpdateTimestampAsync(intro, mode).ConfigureAwait(false);
             }
         }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -39,7 +39,7 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
         // Episodes that were not analyzed or have a fingerprint cache.
         var episodeAnalysisQueue = analysisQueue.Where(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed || File.Exists(FFmpegWrapper.GetFingerprintCachePath(e, mode))).ToList();
 
-        if (analysisQueue.Count <= 1 || episodeAnalysisQueue.Any(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed))
+        if (analysisQueue.Count <= 1 || !episodeAnalysisQueue.Any(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed))
         {
             return analysisQueue;
         }

--- a/IntroSkipper/Data/EpisodeState.cs
+++ b/IntroSkipper/Data/EpisodeState.cs
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only.
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// State of an episode.
+/// </summary>
+public enum EpisodeState
+{
+    /// <summary>
+    /// Episode has not been analyzed.
+    /// </summary>
+    NotAnalyzed,
+
+    /// <summary>
+    /// Episode has been analyzed.
+    /// </summary>
+    Analyzed,
+
+    /// <summary>
+    /// Episode has been analyzed but no segments were found.
+    /// </summary>
+    NoSegments,
+}

--- a/IntroSkipper/Data/QueuedEpisode.cs
+++ b/IntroSkipper/Data/QueuedEpisode.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only.
 
 using System;
+using System.Collections.Generic;
 
 namespace IntroSkipper.Data;
 
@@ -10,6 +11,8 @@ namespace IntroSkipper.Data;
 /// </summary>
 public class QueuedEpisode
 {
+    private readonly EpisodeState[] _isAnalyzed = new EpisodeState[Enum.GetValues(typeof(AnalysisMode)).Length];
+
     /// <summary>
     /// Gets or sets the series name.
     /// </summary>
@@ -19,6 +22,11 @@ public class QueuedEpisode
     /// Gets or sets the season number.
     /// </summary>
     public int SeasonNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the episode number.
+    /// </summary>
+    public int EpisodeNumber { get; set; }
 
     /// <summary>
     /// Gets or sets the episode id.
@@ -34,6 +42,11 @@ public class QueuedEpisode
     /// Gets or sets the series id.
     /// </summary>
     public Guid SeriesId { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this media has been already analyzed.
+    /// </summary>
+    public IReadOnlyList<EpisodeState> IsAnalyzed => _isAnalyzed;
 
     /// <summary>
     /// Gets or sets the full path to episode.
@@ -56,11 +69,6 @@ public class QueuedEpisode
     public bool IsMovie { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether an episode has been analyzed.
-    /// </summary>
-    public bool IsAnalyzed { get; set; }
-
-    /// <summary>
     /// Gets or sets the timestamp (in seconds) to stop searching for an introduction at.
     /// </summary>
     public int IntroFingerprintEnd { get; set; }
@@ -74,4 +82,24 @@ public class QueuedEpisode
     /// Gets or sets the total duration of this media file (in seconds).
     /// </summary>
     public int Duration { get; set; }
+
+    /// <summary>
+    /// Sets a value indicating whether this media has been already analyzed.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="value">Value to set.</param>
+    public void SetAnalyzed(AnalysisMode mode, EpisodeState value)
+    {
+        _isAnalyzed[(int)mode] = value;
+    }
+
+    /// <summary>
+    /// Sets a value indicating whether this media has been already analyzed.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    /// <returns>Value of the analyzed mode.</returns>
+    public EpisodeState GetAnalyzed(AnalysisMode mode)
+    {
+        return _isAnalyzed[(int)mode];
+    }
 }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -233,6 +233,7 @@ namespace IntroSkipper.Manager
                 SeasonNumber = episode.AiredSeasonNumber ?? 0,
                 SeriesId = episode.SeriesId,
                 SeasonId = episode.SeasonId,
+                EpisodeNumber = episode.IndexNumber ?? 0,
                 EpisodeId = episode.Id,
                 Name = episode.Name,
                 IsAnime = isAnime,
@@ -302,33 +303,51 @@ namespace IntroSkipper.Manager
         /// This is done to ensure that we don't analyze items that were deleted between the call to GetMediaItems() and popping them from the queue.
         /// </summary>
         /// <param name="candidates">Queued media items.</param>
-        /// <param name="modes">Analysis mode.</param>
+        /// <param name="modes">Analysis modes.</param>
         /// <returns>Media items that have been verified to exist in Jellyfin and in storage.</returns>
-        internal (IReadOnlyList<QueuedEpisode> QueuedEpisodes, IReadOnlyCollection<AnalysisMode> RequiredModes)
-            VerifyQueue(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes)
+        internal IReadOnlyList<QueuedEpisode> VerifyQueue(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes)
         {
-            var verified = new List<QueuedEpisode>();
-            var requiredModes = new HashSet<AnalysisMode>();
+            if (candidates == null || candidates.Count == 0)
+            {
+                return [];
+            }
 
-            var episodeIds = Plugin.Instance!.GetEpisodeIds(candidates[0].SeasonId);
+            var verified = new List<QueuedEpisode>(candidates.Count);
+            var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+            var episodeIds = plugin.GetEpisodeIds(candidates[0].SeasonId);
 
             foreach (var candidate in candidates)
             {
                 try
                 {
-                    var path = Plugin.Instance!.GetItemPath(candidate.EpisodeId);
-                    if (!File.Exists(path))
+                    var path = plugin.GetItemPath(candidate.EpisodeId);
+
+                    if (string.IsNullOrEmpty(path) || !File.Exists(path))
                     {
+                        _logger.LogDebug("Skipping {Name} ({Id}): file not found", candidate.Name, candidate.EpisodeId);
                         continue;
                     }
 
                     verified.Add(candidate);
 
+                    var hasSegments = plugin.GetTimestamps(candidate.EpisodeId);
+
                     foreach (var mode in modes)
                     {
-                        if (!episodeIds.TryGetValue(mode, out var ids) || !ids.Contains(candidate.EpisodeId) || Plugin.Instance!.AnalyzeAgain)
+                        if (episodeIds.TryGetValue(mode, out var ids) && ids.Contains(candidate.EpisodeId))
                         {
-                            requiredModes.Add(mode);
+                            if (hasSegments.TryGetValue(mode, out _))
+                            {
+                                candidate.SetAnalyzed(mode, EpisodeState.Analyzed);
+                            }
+                            else if (!plugin.AnalyzeAgain)
+                            {
+                                candidate.SetAnalyzed(mode, EpisodeState.NoSegments);
+                            }
+                        }
+                        else
+                        {
+                            candidate.SetAnalyzed(mode, EpisodeState.NotAnalyzed);
                         }
                     }
                 }
@@ -342,7 +361,7 @@ namespace IntroSkipper.Manager
                 }
             }
 
-            return (verified, requiredModes);
+            return verified;
         }
     }
 }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -345,10 +345,6 @@ namespace IntroSkipper.Manager
                                 candidate.SetAnalyzed(mode, EpisodeState.NoSegments);
                             }
                         }
-                        else
-                        {
-                            candidate.SetAnalyzed(mode, EpisodeState.NotAnalyzed);
-                        }
                     }
                 }
                 catch (Exception ex)

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
-using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
@@ -37,6 +36,7 @@ public class BaseItemAnalyzerTask(
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+    private readonly bool _ffmpegValid = FFmpegWrapper.CheckFFmpegVersion();
 
     /// <summary>
     /// Analyze all media items on the server.
@@ -76,6 +76,14 @@ public class BaseItemAnalyzerTask(
                 "No libraries selected for analysis. Please visit the plugin settings to configure.");
         }
 
+        if (!_ffmpegValid)
+        {
+            _logger.LogInformation(
+                "Skipping Chromaprint analysis! Chromaprint is not enabled in the current ffmpeg. " +
+                "If Jellyfin is running natively, install jellyfin-ffmpeg7. " +
+                "If Jellyfin is running in a container, upgrade to version 10.10.0 or newer.");
+        }
+
         int totalProcessed = 0;
         var options = new ParallelOptions
         {
@@ -87,7 +95,7 @@ public class BaseItemAnalyzerTask(
         {
             var updateMediaSegments = false;
 
-            var (episodes, requiredModes) = queueManager.VerifyQueue(season.Value, modes);
+            var episodes = queueManager.VerifyQueue(season.Value, modes);
             if (episodes.Count == 0)
             {
                 return;
@@ -96,20 +104,15 @@ public class BaseItemAnalyzerTask(
             try
             {
                 var firstEpisode = episodes[0];
-                if (modes.Count != requiredModes.Count)
-                {
-                    Interlocked.Add(ref totalProcessed, episodes.Count * (modes.Count - requiredModes.Count));
-                    progress.Report((double)totalProcessed / totalQueued * 100);
-                }
 
-                foreach (var mode in requiredModes)
+                foreach (var mode in modes)
                 {
                     ct.ThrowIfCancellationRequested();
                     int analyzed = await AnalyzeItemsAsync(
                         episodes,
                         mode,
                         ct).ConfigureAwait(false);
-                    Interlocked.Add(ref totalProcessed, analyzed);
+                    Interlocked.Add(ref totalProcessed, episodes.Count);
 
                     updateMediaSegments = analyzed > 0 || updateMediaSegments;
                     progress.Report((double)totalProcessed / totalQueued * 100);
@@ -157,20 +160,20 @@ public class BaseItemAnalyzerTask(
         AnalysisMode mode,
         CancellationToken cancellationToken)
     {
+        if (!items.Any(e => e.GetAnalyzed(mode) == EpisodeState.NotAnalyzed))
+        {
+            return 0;
+        }
+
         var first = items[0];
         if (!first.IsMovie && first.SeasonNumber == 0 && !_config.AnalyzeSeasonZero)
         {
             return 0;
         }
 
-        // Reset the IsAnalyzed flag for all items
-        foreach (var item in items)
-        {
-            item.IsAnalyzed = false;
-        }
-
-        // Get the analyzer action for the current mode
-        var action = Plugin.Instance!.GetAnalyzerAction(first.SeasonId, mode);
+        var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+        var action = plugin.GetAnalyzerAction(first.SeasonId, mode);
 
         _logger.LogInformation(
             "[Mode: {Mode}] Analyzing {Count} files from {Name} season {Season}",
@@ -179,45 +182,27 @@ public class BaseItemAnalyzerTask(
             first.SeriesName,
             first.SeasonNumber);
 
-        // Create a list of analyzers to use for the current mode
+        // Create analyzers list
         var analyzers = new List<IMediaFileAnalyzer>();
 
+        // Add analyzers based on conditions
         if (action is AnalyzerAction.Chapter or AnalyzerAction.Default)
         {
             analyzers.Add(new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()));
         }
 
-        if (first.IsAnime &&
-            mode is not (AnalysisMode.Recap or AnalysisMode.Preview) &&
-            action is AnalyzerAction.Default or AnalyzerAction.Chromaprint)
+        if (first.IsAnime && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
         {
-            // Assert that ffmpeg with chromaprint is installed
-            if (!FFmpegWrapper.CheckFFmpegVersion())
-            {
-                throw new FingerprintException(
-                    "Analysis terminated! Chromaprint is not enabled in the current ffmpeg. If Jellyfin is running natively, install jellyfin-ffmpeg7. If Jellyfin is running in a container, upgrade to version 10.10.0 or newer.");
-            }
-
             analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }
 
-        if (mode is AnalysisMode.Credits &&
-            action is AnalyzerAction.Default or AnalyzerAction.BlackFrame)
+        if (mode is AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.BlackFrame)
         {
             analyzers.Add(new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()));
         }
 
-        if (!first.IsAnime && !first.IsMovie &&
-            mode is not (AnalysisMode.Recap or AnalysisMode.Preview) &&
-            action is AnalyzerAction.Default or AnalyzerAction.Chromaprint)
+        if (!first.IsAnime && !first.IsMovie && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
         {
-            // Assert that ffmpeg with chromaprint is installed
-            if (!FFmpegWrapper.CheckFFmpegVersion())
-            {
-                throw new FingerprintException(
-                    "Analysis terminated! Chromaprint is not enabled in the current ffmpeg. If Jellyfin is running natively, install jellyfin-ffmpeg7. If Jellyfin is running in a container, upgrade to version 10.10.0 or newer.");
-            }
-
             analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }
 
@@ -232,6 +217,6 @@ public class BaseItemAnalyzerTask(
         // Set the episode IDs for the analyzed items
         await Plugin.Instance!.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId)).ConfigureAwait(false);
 
-        return items.Count(i => i.IsAnalyzed);
+        return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve analysis of episodes by adding an Analyzed state for tracking and enhancing Chromaprint analysis. Add a check for FFmpeg/Chromaprint compatibility and skip analysis if not available. Update the queue management to verify episodes and handle existing fingerprints.

New Features:
- Track episode analysis state to avoid re-analyzing already processed episodes.

Tests:
- Verify that the fingerprint cache is checked before analysis.