### PR TITLE
Snap to Keyframe

### DIFF
--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -67,6 +67,13 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
                 continue;
             }
 
+            if (_config.SnapToKeyframe)
+            {
+                var adjustedEnd = ChromaprintAnalyzer.SnapToNearestKeyframe(episode, skipRange.End);
+                _logger.LogDebug("Snapped end {End} of segment to nearest keyframe: {Keyframe}", skipRange.End, adjustedEnd);
+                skipRange.End = adjustedEnd;
+            }
+
             episode.SetAnalyzed(mode, EpisodeState.Analyzed);
             await Plugin.Instance!.UpdateTimestampAsync(skipRange, mode).ConfigureAwait(false);
         }

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -69,9 +69,11 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
 
             if (_config.SnapToKeyframe)
             {
-                var adjustedEnd = ChromaprintAnalyzer.SnapToNearestKeyframe(episode, skipRange.End);
-                _logger.LogDebug("Snapped end {End} of segment to nearest keyframe: {Keyframe}", skipRange.End, adjustedEnd);
-                skipRange.End = adjustedEnd;
+                skipRange.End = ChromaprintAnalyzer.SnapToNearestKeyframe(episode, skipRange.End - _config.RemainingSecondsOfIntro);
+            }
+            else
+            {
+                skipRange.End -= _config.RemainingSecondsOfIntro;
             }
 
             episode.SetAnalyzed(mode, EpisodeState.Analyzed);
@@ -103,20 +105,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         }
 
         var reversed = mode == AnalysisMode.Credits || mode == AnalysisMode.Preview;
-        Dictionary<AnalysisMode, Func<(double Min, double Max)>> durationBounds = new()
-        {
-            [AnalysisMode.Introduction] = () => (_config.MinimumIntroDuration, _config.MaximumIntroDuration),
-            [AnalysisMode.Credits] = () => (_config.MinimumCreditsDuration, episode.IsMovie
-                ? _config.MaximumMovieCreditsDuration
-                : _config.MaximumCreditsDuration),
-            [AnalysisMode.Recap] = () => (_config.MinimumRecapDuration, _config.MaximumRecapDuration),
-            [AnalysisMode.Preview] = () => (_config.MinimumPreviewDuration, _config.MaximumPreviewDuration)
-        };
-        var boundsFunc = durationBounds.GetValueOrDefault(mode) ?? throw new ArgumentOutOfRangeException(nameof(mode));
-        var bounds = boundsFunc(); // Call the function to get the values
-        var (minDuration, maxDuration) = _config.FullLengthChapters
-            ? (1, episode.Duration - 1)
-            : (bounds.Min, bounds.Max);
+        var (minDuration, maxDuration) = GetBounds(mode, episode);
 
         // Check all chapters
         for (int i = reversed ? count - 1 : 0; reversed ? i >= 0 : i < count; i += reversed ? -1 : 1)
@@ -185,5 +174,27 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         }
 
         return null;
+    }
+
+    private (double Min, double Max) GetBounds(AnalysisMode mode, QueuedEpisode episode)
+    {
+        ArgumentNullException.ThrowIfNull(episode);
+
+        if (_config.FullLengthChapters)
+        {
+            // Leave 1 second buffer at start and end
+            return (1, episode.Duration - 1);
+        }
+
+        // Map analysis mode to duration bounds
+        return mode switch
+            {
+                AnalysisMode.Introduction => (_config.MinimumIntroDuration, _config.MaximumIntroDuration),
+                AnalysisMode.Credits => (_config.MinimumCreditsDuration,
+                    episode.IsMovie ? _config.MaximumMovieCreditsDuration : _config.MaximumCreditsDuration),
+                AnalysisMode.Recap => (_config.MinimumRecapDuration, _config.MaximumRecapDuration),
+                AnalysisMode.Preview => (_config.MinimumPreviewDuration, _config.MaximumPreviewDuration),
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Unsupported analysis mode: {mode}")
+            };
     }
 }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -159,8 +159,9 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
             // If an intro is found for this episode, adjust its times and save it else add it to the list of episodes without intros.
             if (seasonIntros.TryGetValue(currentEpisode.EpisodeId, out var intro))
             {
+                var adjustedIntro = AdjustIntroTimes(currentEpisode, intro);
                 currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await Plugin.Instance!.UpdateTimestampAsync(intro, mode).ConfigureAwait(false);
+                await Plugin.Instance!.UpdateTimestampAsync(adjustedIntro, mode).ConfigureAwait(false);
             }
         }
 
@@ -387,6 +388,11 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
             AdjustIntroBasedOnSilence(episode, originalIntro, originalIntroEnd);
         }
 
+        if (_config.SnapToKeyframe)
+        {
+            originalIntro.End = SnapToNearestKeyframe(episode, originalIntro.End);
+        }
+
         _logger.LogTrace(
             "{Name} adjusted intro: {Start} - {End}",
             episode.Name,
@@ -459,6 +465,31 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
     private static bool IsTimeWithinRange(double time, TimeRange range)
     {
         return range.Start < time && time < range.End;
+    }
+
+    /// <summary>
+    /// Snaps a timestamp to the nearest keyframe, preferring keyframes before the timestamp.
+    /// </summary>
+    /// <param name="episode">Episode to search.</param>
+    /// <param name="time">Time to snap to nearest keyframe.</param>
+    /// <returns>The nearest keyframe or original time if no suitable keyframe found.</returns>
+    public static double SnapToNearestKeyframe(QueuedEpisode episode, double time)
+    {
+        var duration = episode.Duration;
+        if (time > duration - 2)
+        {
+            return duration;
+        }
+
+        var searchRange = new TimeRange(time - 3, time + 1);
+        var keyframes = FFmpegWrapper.DetectKeyFrames(episode, searchRange);
+
+        // Prefer keyframes before the time, otherwise take the first keyframe after
+        return keyframes
+            .OrderBy(kf => kf > time + 0.01) // Frames before time first (false before true)
+            .ThenBy(kf => Math.Abs(kf - time)) // Then by closest to target time
+            .DefaultIfEmpty(time)
+            .First();
     }
 
     /// <summary>

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -390,7 +390,11 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
 
         if (_config.SnapToKeyframe)
         {
-            originalIntro.End = SnapToNearestKeyframe(episode, originalIntro.End);
+            originalIntro.End = SnapToNearestKeyframe(episode, originalIntro.End - _config.RemainingSecondsOfIntro);
+        }
+        else
+        {
+            originalIntro.End -= _config.RemainingSecondsOfIntro;
         }
 
         _logger.LogTrace(
@@ -475,13 +479,17 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
     /// <returns>The nearest keyframe or original time if no suitable keyframe found.</returns>
     public static double SnapToNearestKeyframe(QueuedEpisode episode, double time)
     {
+        var config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
         var duration = episode.Duration;
-        if (time > duration - 2)
+        // If the time is within the configured threshold of the end, return the duration
+        if (time > duration - config.EndSnapThreshold)
         {
             return duration;
         }
 
-        var searchRange = new TimeRange(time - 3, time + 1);
+        var searchRange = new TimeRange(
+            time - config.KeyframeWindowBefore,
+            time + config.KeyframeWindowAfter);
         var keyframes = FFmpegWrapper.DetectKeyFrames(episode, searchRange);
 
         // Prefer keyframes before the time, otherwise take the first keyframe after

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -150,7 +150,23 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets a value indicating whether to snap the end of a segm to the nearest keyframe.
     /// </summary>
-    public bool SnapToKeyframe { get; set; }
+    public bool SnapToKeyframe { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets window in seconds to snap segments to the end of the episode.
+    /// This gets applied at the very end.
+    /// </summary>
+    public double EndSnapThreshold { get; set; } = 2.0;
+
+    /// <summary>
+    /// Gets or sets the number of seconds to search before segment end to find a keyframe.
+    /// </summary>
+    public double KeyframeWindowBefore { get; set; } = 3.0;
+
+    /// <summary>
+    /// Gets or sets the number of seconds to search after segment end to find a keyframe.
+    /// </summary>
+    public double KeyframeWindowAfter { get; set; } = 1.0;
 
     /// <summary>
     /// Gets or sets the regular expression used to detect introduction chapters.
@@ -295,20 +311,4 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether movies should be analyzed.
     /// </summary>
     public bool AnalyzeMovies { get; set; }
-
-    /// <summary>
-    /// Gets or sets window in seconds to snap segments to the end of the episode.
-    /// This gets applied at the very end.
-    /// </summary>
-    public double EndSnapThreshold { get; set; } = 2.0;
-
-    /// <summary>
-    /// Gets or sets the number of seconds to search before segment end to find a keyframe.
-    /// </summary>
-    public double KeyframeWindowBefore { get; set; } = 3.0;
-
-    /// <summary>
-    /// Gets or sets the number of seconds to search after segment end to find a keyframe.
-    /// </summary>
-    public double KeyframeWindowAfter { get; set; } = 1.0;
 }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -148,6 +148,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public int BlackFrameMinimumPercentage { get; set; } = 85;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to snap the end of a segm to the nearest keyframe.
+    /// </summary>
+    public bool SnapToKeyframe { get; set; }
+
+    /// <summary>
     /// Gets or sets the regular expression used to detect introduction chapters.
     /// </summary>
     public string ChapterAnalyzerIntroductionPattern { get; set; } =

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -297,18 +297,18 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AnalyzeMovies { get; set; }
 
     /// <summary>
-    /// Gets or sets window in seconds to snap chapters to the start or end of the episode.
+    /// Gets or sets window in seconds to snap segments to the end of the episode.
     /// This gets applied at the very end.
     /// </summary>
     public double EndSnapThreshold { get; set; } = 2.0;
 
     /// <summary>
-    /// Gets or sets the number of seconds to search before a keyframe.
+    /// Gets or sets the number of seconds to search before segment end to find a keyframe.
     /// </summary>
     public double KeyframeWindowBefore { get; set; } = 3.0;
 
     /// <summary>
-    /// Gets or sets the number of seconds to search after a keyframe.
+    /// Gets or sets the number of seconds to search after segment end to find a keyframe.
     /// </summary>
     public double KeyframeWindowAfter { get; set; } = 1.0;
 }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -295,4 +295,20 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether movies should be analyzed.
     /// </summary>
     public bool AnalyzeMovies { get; set; }
+
+    /// <summary>
+    /// Gets or sets window in seconds to snap chapters to the start or end of the episode.
+    /// This gets applied at the very end.
+    /// </summary>
+    public double EndSnapThreshold { get; set; } = 2.0;
+
+    /// <summary>
+    /// Gets or sets the number of seconds to search before a keyframe.
+    /// </summary>
+    public double KeyframeWindowBefore { get; set; } = 3.0;
+
+    /// <summary>
+    /// Gets or sets the number of seconds to search after a keyframe.
+    /// </summary>
+    public double KeyframeWindowAfter { get; set; } = 1.0;
 }

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -208,8 +208,20 @@
                                         <input id="MaximumPreviewDuration" type="number" is="emby-input" min="1" />
                                         <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
                                     </div>
-                              </div>
+                                </div>
 
+                                <br />
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label class="emby-checkbox-label">
+                                        <input id="SnapToKeyframe" type="checkbox" is="emby-checkbox" />
+                                        <span>Snap segment end to nearest keyframe</span>
+                                    </label>
+
+
+                                    <div class="fieldDescription">When enabled, this option will snap the end of a segment to the nearest keyframe.</div>
+                                </div>
+
+                                <br />
                                 <div class="inputContainer" id="excludedSeries">
                                     <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
                                     <input id="ExcludeSeries" type="text" is="emby-input" />
@@ -795,7 +807,7 @@
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe"];
 
                 // visualizer elements
                 const analyzeMovies = document.getElementById("AnalyzeMovies");

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -221,6 +221,24 @@
                                     <div class="fieldDescription">When enabled, this option will snap the end of a segment to the nearest keyframe.</div>
                                 </div>
 
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowBefore"> Keyframe search range before </label>
+                                    <input id="KeyframeWindowBefore" type="number" is="emby-input" min="0" />
+                                    <div class="fieldDescription">Number of seconds to search before a keyframe.</div>
+                                </div>
+
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowAfter"> Keyframe search range after </label>
+                                    <input id="KeyframeWindowAfter" type="number" is="emby-input" min="0" />
+                                    <div class="fieldDescription">Number of seconds to search after a keyframe.</div>
+                                </div>
+
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="EndSnapThreshold"> Episode end snap threshold </label>
+                                    <input id="EndSnapThreshold" type="number" is="emby-input" min="0" />
+                                    <div class="fieldDescription">Number of seconds to snap the end of a segment to the episode end.</div>
+                                </div>
+
                                 <br />
                                 <div class="inputContainer" id="excludedSeries">
                                     <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
@@ -406,7 +424,7 @@
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="RemainingSecondsOfIntro"> Segment playback duration (in seconds) </label>
                                     <input id="RemainingSecondsOfIntro" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Seconds of segment ending that should be played. Defaults to 2.</div>
+                                    <div class="fieldDescription">Seconds of segment ending that should be played. Defaults to 0.</div>
                                 </div>
 
                                 <div id="divAutoSkipNotificationText" class="inputContainer">
@@ -777,6 +795,9 @@
                     // analysis
                     "MaxParallelism",
 					"SelectedLibraries",
+                    "KeyframeWindowBefore",
+                    "KeyframeWindowAfter",
+                    "EndSnapThreshold",
                     "ExcludeSeries",
                     "ClientList",
                     "AnalysisPercent",

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -224,13 +224,13 @@
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowBefore"> Keyframe search range before </label>
                                     <input id="KeyframeWindowBefore" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Number of seconds to search before a keyframe.</div>
+                                    <div class="fieldDescription">Number of seconds to search before segment end to find a keyframe.</div>
                                 </div>
 
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowAfter"> Keyframe search range after </label>
                                     <input id="KeyframeWindowAfter" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Number of seconds to search after a keyframe.</div>
+                                    <div class="fieldDescription">Number of seconds to search after segment end to find a keyframe.</div>
                                 </div>
 
                                 <div class="inputContainer">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -214,29 +214,30 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
                                         <input id="SnapToKeyframe" type="checkbox" is="emby-checkbox" />
-                                        <span>Snap segment end to nearest keyframe</span>
+                                        <span>Enable keyframe snapping for smooth playback transitions</span>
                                     </label>
 
-
-                                    <div class="fieldDescription">When enabled, this option will snap the end of a segment to the nearest keyframe.</div>
+                                    <div class="fieldDescription">When enabled, segment endpoints will be adjusted to the nearest video keyframe for smoother playback transitions during skipping.</div>
                                 </div>
 
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowBefore"> Keyframe search range before </label>
-                                    <input id="KeyframeWindowBefore" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Number of seconds to search before segment end to find a keyframe.</div>
-                                </div>
+                                <div id="snapSettings">
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowBefore"> Keyframe search window (before) </label>
+                                        <input id="KeyframeWindowBefore" type="number" is="emby-input" min="0" />
+                                        <div class="fieldDescription">Maximum number of seconds to look backwards from a segment endpoint to find a suitable keyframe. A larger window increases the chance of finding an optimal keyframe.</div>
+                                    </div>
 
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowAfter"> Keyframe search range after </label>
-                                    <input id="KeyframeWindowAfter" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Number of seconds to search after segment end to find a keyframe.</div>
-                                </div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="KeyframeWindowAfter"> Keyframe search window (after) </label>
+                                        <input id="KeyframeWindowAfter" type="number" is="emby-input" min="0" />
+                                        <div class="fieldDescription">Maximum number of seconds to look forward from a segment endpoint to find a suitable keyframe. A larger window increases the chance of finding an optimal keyframe.</div>
+                                    </div>
 
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="EndSnapThreshold"> Episode end snap threshold </label>
-                                    <input id="EndSnapThreshold" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Number of seconds to snap the end of a segment to the episode end.</div>
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="EndSnapThreshold"> End credits snap threshold </label>
+                                        <input id="EndSnapThreshold" type="number" is="emby-input" min="0" />
+                                        <div class="fieldDescription">If the end of a credits segment is within this many seconds of the episode end, it will be automatically extended to the episode end. Set to 0 to disable.</div>
+                                    </div>
                                 </div>
 
                                 <br />
@@ -857,6 +858,7 @@
                 const btnUpdateTimestamps = document.querySelector("button#btnUpdateTimestamps");
                 const timeContainer = document.querySelector("span#timestampContainer");
                 const fingerprintVisualizer = document.getElementById("fingerprintVisualizer");
+                const snapSettings = document.getElementById("snapSettings");
 
                 let windowHashInterval = 0;
 
@@ -867,6 +869,7 @@
                 const librariesContainer = document.querySelector("div.folderAccessListContainer");
                 const autoSkipClientList = document.querySelector("div.AutoSkipClientListContainer");
                 const fullLengthChapters = document.getElementById("FullLengthChapters");
+                const snapToKeyframe = document.getElementById("SnapToKeyframe");
                 const globalTimestamps = document.getElementById("GlobalTimestamps");
                 const btnEraseGlobalTimestamps = document.getElementById("btnEraseGlobalTimestamps");
 
@@ -960,6 +963,16 @@
                         serverSkipSettings.style.display = "none";
                     }
                 }
+
+                async function snapSettingsVisible() {
+                    if (snapToKeyframe.checked) {
+                        snapSettings.style.display = "unset";
+                    } else {
+                        snapSettings.style.display = "none";
+                    }
+                }
+
+                snapToKeyframe.addEventListener("change", snapSettingsVisible);
 
                 async function pluginSkipSettingChanged() {
                     if (!pluginSkip.checked) {
@@ -1479,6 +1492,7 @@
                         generateAutoSkipTypeList();
                         generateAutoSkipClientList();
                         pluginSkipSettingVisible();
+                        snapSettingsVisible();
                         globalTimestampChanged();
 
                         Dashboard.hideLoadingMsg();

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -12,11 +12,13 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
+using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Controllers;
 
@@ -26,9 +28,10 @@ namespace IntroSkipper.Controllers;
 [Authorize]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
-public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateManager) : ControllerBase
+public class SkipIntroController(IMediaSegmentManager mediaSegmentManager, ILoggerFactory loggerFactory) : ControllerBase
 {
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
+    private readonly ILoggerFactory _loggerFactory = loggerFactory;
 
     /// <summary>
     /// Returns the timestamps of the introduction in a television episode. Responses are in API version 1 format.
@@ -102,7 +105,8 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
 
             if (episode is not null)
             {
-                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync([episode], cancellationToken).ConfigureAwait(false);
+                var mediaSegmentUpdateManager = new MediaSegmentUpdateManager(_mediaSegmentManager, _loggerFactory.CreateLogger<MediaSegmentUpdateManager>());
+                await mediaSegmentUpdateManager.UpdateMediaSegmentsAsync([episode], cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -185,8 +189,6 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     {
         var timestamps = Plugin.Instance!.GetTimestamps(id);
         var intros = new Dictionary<AnalysisMode, Intro>();
-        var runTime = TimeSpan.FromTicks(Plugin.Instance!.GetItem(id)?.RunTimeTicks ?? 0).TotalSeconds;
-        var config = Plugin.Instance.Configuration;
 
         foreach (var (mode, timestamp) in timestamps)
         {
@@ -197,11 +199,6 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
 
             // Create new Intro to avoid mutating the original stored in dictionary
             var segment = new Intro(timestamp);
-
-            // Calculate intro end time
-            segment.IntroEnd = runTime > 0 && runTime < segment.IntroEnd + 1
-                ? runTime
-                : segment.IntroEnd - config.RemainingSecondsOfIntro;
 
             intros[mode] = segment;
         }

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -12,13 +12,11 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
-using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Controllers;
 
@@ -28,10 +26,9 @@ namespace IntroSkipper.Controllers;
 [Authorize]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
-public class SkipIntroController(IMediaSegmentManager mediaSegmentManager, ILoggerFactory loggerFactory) : ControllerBase
+public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateManager) : ControllerBase
 {
-    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
-    private readonly ILoggerFactory _loggerFactory = loggerFactory;
+    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
 
     /// <summary>
     /// Returns the timestamps of the introduction in a television episode. Responses are in API version 1 format.
@@ -105,8 +102,7 @@ public class SkipIntroController(IMediaSegmentManager mediaSegmentManager, ILogg
 
             if (episode is not null)
             {
-                var mediaSegmentUpdateManager = new MediaSegmentUpdateManager(_mediaSegmentManager, _loggerFactory.CreateLogger<MediaSegmentUpdateManager>());
-                await mediaSegmentUpdateManager.UpdateMediaSegmentsAsync([episode], cancellationToken).ConfigureAwait(false);
+                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync([episode], cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -12,6 +12,7 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
+using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -25,15 +26,17 @@ namespace IntroSkipper.Controllers;
 /// Initializes a new instance of the <see cref="VisualizationController"/> class.
 /// </remarks>
 /// <param name="logger">Logger.</param>
-/// <param name="mediaSegmentUpdateManager">Media Segment Update Manager.</param>
+/// <param name="mediaSegmentManager">Media segment manager.</param>
+/// <param name="loggerFactory">Logger factory.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("Intros")]
-public class VisualizationController(ILogger<VisualizationController> logger, MediaSegmentUpdateManager mediaSegmentUpdateManager) : ControllerBase
+public class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentManager mediaSegmentManager, ILoggerFactory loggerFactory) : ControllerBase
 {
     private readonly ILogger<VisualizationController> _logger = logger;
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
+    private readonly ILoggerFactory _loggerFactory = loggerFactory;
 
     /// <summary>
     /// Returns all show names and seasons.
@@ -203,7 +206,8 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
 
             if (Plugin.Instance.Configuration.UpdateMediaSegments)
             {
-                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, cancellationToken).ConfigureAwait(false);
+                var mediaSegmentUpdateManager = new MediaSegmentUpdateManager(_mediaSegmentManager, _loggerFactory.CreateLogger<MediaSegmentUpdateManager>());
+                await mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, cancellationToken).ConfigureAwait(false);
             }
 
             return NoContent();

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -12,7 +12,6 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
-using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -26,17 +25,15 @@ namespace IntroSkipper.Controllers;
 /// Initializes a new instance of the <see cref="VisualizationController"/> class.
 /// </remarks>
 /// <param name="logger">Logger.</param>
-/// <param name="mediaSegmentManager">Media segment manager.</param>
-/// <param name="loggerFactory">Logger factory.</param>
+/// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("Intros")]
-public class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentManager mediaSegmentManager, ILoggerFactory loggerFactory) : ControllerBase
+public class VisualizationController(ILogger<VisualizationController> logger, MediaSegmentUpdateManager mediaSegmentUpdateManager) : ControllerBase
 {
     private readonly ILogger<VisualizationController> _logger = logger;
-    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
-    private readonly ILoggerFactory _loggerFactory = loggerFactory;
+    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
 
     /// <summary>
     /// Returns all show names and seasons.
@@ -206,8 +203,7 @@ public class VisualizationController(ILogger<VisualizationController> logger, IM
 
             if (Plugin.Instance.Configuration.UpdateMediaSegments)
             {
-                var mediaSegmentUpdateManager = new MediaSegmentUpdateManager(_mediaSegmentManager, _loggerFactory.CreateLogger<MediaSegmentUpdateManager>());
-                await mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, cancellationToken).ConfigureAwait(false);
+                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, cancellationToken).ConfigureAwait(false);
             }
 
             return NoContent();

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -287,21 +286,29 @@ public static partial class FFmpegWrapper
         var keyframes = new List<double>();
         var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, stderr: true));
 
-        // Parse the output to extract timestamps
-        foreach (var line in raw.Split('\n'))
+        foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
         {
-            // Look for frames that are both I-frames and keyframes
-            if (line.Contains("type:I", StringComparison.OrdinalIgnoreCase) &&
-                line.Contains("iskey:1", StringComparison.OrdinalIgnoreCase))
+            if (!line.Contains("type:I", StringComparison.OrdinalIgnoreCase) ||
+                !line.Contains("iskey:1", StringComparison.OrdinalIgnoreCase))
             {
-                var ptsTimeStart = line.IndexOf("pts_time:", StringComparison.OrdinalIgnoreCase) + 9;
-                var ptsTimeEnd = line.IndexOf(' ', ptsTimeStart);
-                var ptsTimeStr = line[ptsTimeStart..ptsTimeEnd];
+                continue;
+            }
 
-                if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out double timestamp))
-                {
-                    keyframes.Add(timestamp + range.Start);
-                }
+            var ptsIndex = line.IndexOf("pts_time:", StringComparison.OrdinalIgnoreCase);
+            if (ptsIndex == -1)
+            {
+                continue;
+            }
+
+            var ptsTimeStr = line[(ptsIndex + 9)..].Split(' ', 2)[0];
+
+            if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out double timestamp))
+            {
+                keyframes.Add(timestamp + range.Start);
+            }
+            else
+            {
+                Logger?.LogWarning("Failed to parse timestamp: {PtsTimeStr} from line: {Line}", ptsTimeStr, line);
             }
         }
 

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -191,7 +191,7 @@ public static partial class FFmpegWrapper
             }
         }
 
-        return silenceRanges.ToArray();
+        return [.. silenceRanges];
     }
 
     /// <summary>
@@ -259,7 +259,53 @@ public static partial class FFmpegWrapper
             }
         }
 
-        return blackFrames.ToArray();
+        return [.. blackFrames];
+    }
+
+    /// <summary>
+    /// Detects key frames in a media file within a time range.
+    /// </summary>
+    /// <param name="episode">Media file to analyze.</param>
+    /// <param name="range">Time range to search.</param>
+    /// <returns>Array of timestamps of key frames.</returns>
+    public static double[] DetectKeyFrames(QueuedEpisode episode, TimeRange range)
+    {
+        var args = string.Format(
+            CultureInfo.InvariantCulture,
+            "-ss {0} -i \"{1}\" -to {2} -an -dn -sn -vf \"select='eq(pict_type,I)',showinfo\" -f null -",
+            range.Start,
+            episode.Path,
+            range.End - range.Start);
+
+        var cacheKey = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}-keyframes-{1}-{2}-v1",
+            episode.EpisodeId.ToString("N"),
+            range.Start,
+            range.End);
+
+        var keyframes = new List<double>();
+        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, stderr: true));
+
+        // Parse the output to extract timestamps
+        foreach (var line in raw.Split('\n'))
+        {
+            // Look for frames that are both I-frames and keyframes
+            if (line.Contains("type:I", StringComparison.OrdinalIgnoreCase) &&
+                line.Contains("iskey:1", StringComparison.OrdinalIgnoreCase))
+            {
+                var ptsTimeStart = line.IndexOf("pts_time:", StringComparison.OrdinalIgnoreCase) + 9;
+                var ptsTimeEnd = line.IndexOf(' ', ptsTimeStart);
+                var ptsTimeStr = line[ptsTimeStart..ptsTimeEnd];
+
+                if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out double timestamp))
+                {
+                    keyframes.Add(timestamp + range.Start);
+                }
+            }
+        }
+
+        return [.. keyframes];
     }
 
     /// <summary>
@@ -349,7 +395,8 @@ public static partial class FFmpegWrapper
 
         // The silencedetect and blackframe filters output data at the info log level.
         var useInfoLevel = args.Contains("silencedetect", StringComparison.OrdinalIgnoreCase) ||
-            args.Contains("blackframe", StringComparison.OrdinalIgnoreCase);
+            args.Contains("blackframe", StringComparison.OrdinalIgnoreCase) ||
+            args.Contains("showinfo", StringComparison.OrdinalIgnoreCase);
 
         var logLevel = useInfoLevel ? "info" : "warning";
 
@@ -480,7 +527,7 @@ public static partial class FFmpegWrapper
         // Try to cache this fingerprint.
         CacheFingerprint(episode, mode, results);
 
-        return results.ToArray();
+        return [.. results];
     }
 
     /// <summary>
@@ -496,7 +543,7 @@ public static partial class FFmpegWrapper
         AnalysisMode mode,
         out uint[] fingerprint)
     {
-        fingerprint = Array.Empty<uint>();
+        fingerprint = [];
 
         // If fingerprint caching isn't enabled, don't try to load anything.
         if (!(Plugin.Instance?.Configuration.CacheFingerprints ?? false))
@@ -512,31 +559,42 @@ public static partial class FFmpegWrapper
             return false;
         }
 
-        var raw = File.ReadAllLines(path, Encoding.UTF8);
-        var result = new List<uint>();
-
-        // Read each stringified uint.
-        result.EnsureCapacity(raw.Length);
-
+        string[] raw;
         try
         {
-            foreach (var rawNumber in raw)
-            {
-                result.Add(Convert.ToUInt32(rawNumber, CultureInfo.InvariantCulture));
-            }
+            raw = File.ReadAllLines(path, Encoding.UTF8);
         }
-        catch (FormatException)
+        catch (IOException ex)
         {
-            // Occurs when the cached fingerprint is corrupt.
-            Logger?.LogDebug(
-                "Cached fingerprint for {Path} ({Id}) is corrupt, ignoring cache",
-                episode.Path,
-                episode.EpisodeId);
-
+            Logger?.LogError(ex, "I/O error while reading fingerprint cache from {Path}", path);
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Logger?.LogError(ex, "Access error while reading fingerprint cache from {Path}", path);
             return false;
         }
 
-        fingerprint = result.ToArray();
+        var result = new List<uint>(raw.Length);
+
+        foreach (var rawNumber in raw)
+        {
+            if (uint.TryParse(rawNumber, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint number))
+            {
+                result.Add(number);
+            }
+            else
+            {
+                Logger?.LogDebug(
+                    "Invalid fingerprint entry '{RawNumber}' found in cache for {Path} ({Id}), ignoring cache",
+                    rawNumber,
+                    episode.Path,
+                    episode.EpisodeId);
+                return false;
+            }
+        }
+
+        fingerprint = [.. result];
         return true;
     }
 

--- a/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
+++ b/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
@@ -23,7 +23,6 @@ namespace IntroSkipper.Manager
     /// <param name="logger">logger.</param>
     public class MediaSegmentUpdateManager(IMediaSegmentManager mediaSegmentManager, ILogger<MediaSegmentUpdateManager> logger)
     {
-        private const int DefaultMaxParallelism = 3;
         private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
         private readonly ILogger<MediaSegmentUpdateManager> _logger = logger;
         private readonly SegmentProvider _segmentProvider = new();
@@ -46,7 +45,7 @@ namespace IntroSkipper.Manager
                 new ParallelOptions
                 {
                     CancellationToken = cancellationToken,
-                    MaxDegreeOfParallelism = DefaultMaxParallelism
+                    MaxDegreeOfParallelism = Plugin.Instance!.Configuration.MaxParallelism
                 },
                 async (episode, ct) =>
                 {

--- a/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
+++ b/IntroSkipper/Manager/MediaSegmentUpdateManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
+using IntroSkipper.Providers;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller;
 using MediaBrowser.Model;
@@ -20,12 +21,12 @@ namespace IntroSkipper.Manager
     /// </summary>
     /// <param name="mediaSegmentManager">MediaSegmentManager.</param>
     /// <param name="logger">logger.</param>
-    /// <param name="segmentProvider">segmentProvider.</param>
-    public class MediaSegmentUpdateManager(IMediaSegmentManager mediaSegmentManager, ILogger<MediaSegmentUpdateManager> logger, IMediaSegmentProvider segmentProvider)
+    public class MediaSegmentUpdateManager(IMediaSegmentManager mediaSegmentManager, ILogger<MediaSegmentUpdateManager> logger)
     {
+        private const int DefaultMaxParallelism = 3;
         private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
         private readonly ILogger<MediaSegmentUpdateManager> _logger = logger;
-        private readonly IMediaSegmentProvider _segmentProvider = segmentProvider;
+        private readonly SegmentProvider _segmentProvider = new();
         private readonly string _id = Plugin.Instance!.Name.ToLowerInvariant()
                         .GetMD5()
                         .ToString("N", CultureInfo.InvariantCulture);
@@ -36,33 +37,66 @@ namespace IntroSkipper.Manager
         /// <param name="episodes">Queued media items.</param>
         /// <param name="cancellationToken">CancellationToken.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task UpdateMediaSegmentsAsync(IReadOnlyList<QueuedEpisode> episodes, CancellationToken cancellationToken)
+        public async Task UpdateMediaSegmentsAsync(
+            IReadOnlyList<QueuedEpisode> episodes,
+            CancellationToken cancellationToken)
         {
-            foreach (var episode in episodes)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                try
+            await Parallel.ForEachAsync(
+                episodes,
+                new ParallelOptions
                 {
-                    var existingSegments = await _mediaSegmentManager.GetSegmentsAsync(episode.EpisodeId, null, false).ConfigureAwait(false);
-                    await Task.WhenAll(existingSegments.Select(s => _mediaSegmentManager.DeleteSegmentAsync(s.Id))).ConfigureAwait(false);
-
-                    var newSegments = await _segmentProvider.GetMediaSegments(new MediaSegmentGenerationRequest { ItemId = episode.EpisodeId }, cancellationToken).ConfigureAwait(false);
-
-                    if (newSegments.Count == 0)
+                    CancellationToken = cancellationToken,
+                    MaxDegreeOfParallelism = DefaultMaxParallelism
+                },
+                async (episode, ct) =>
+                {
+                    try
                     {
-                        _logger.LogDebug("No segments found for episode {EpisodeId}", episode.EpisodeId);
-                        continue;
+                        // Retrieve the existing segments for the episode.
+                        var existingSegments = await _mediaSegmentManager
+                            .GetSegmentsAsync(episode.EpisodeId, null, false)
+                            .ConfigureAwait(false);
+
+                        // Start deletion of existing segments concurrently.
+                        var deleteTask = Task.WhenAll(
+                            existingSegments.Select(segment => _mediaSegmentManager.DeleteSegmentAsync(segment.Id)));
+
+                        // Start generating new segments concurrently.
+                        var newSegmentsTask = _segmentProvider
+                            .GetMediaSegments(new MediaSegmentGenerationRequest { ItemId = episode.EpisodeId }, ct);
+
+                        // Await both deletion and generation concurrently.
+                        await Task.WhenAll(deleteTask, newSegmentsTask).ConfigureAwait(false);
+
+                        // Check cancellation before proceeding.
+                        ct.ThrowIfCancellationRequested();
+
+                        // Retrieve the newly generated segments.
+                        var newSegments = await newSegmentsTask.ConfigureAwait(false);
+
+                        if (newSegments.Count == 0)
+                        {
+                            _logger.LogDebug("No segments found for episode {EpisodeId}", episode.EpisodeId);
+                            return;
+                        }
+
+                        // Insert the new segments concurrently.
+                        await Task.WhenAll(
+                            newSegments.Select(segment => _mediaSegmentManager.CreateSegmentAsync(segment, _id)))
+                            .ConfigureAwait(false);
+
+                        _logger.LogDebug("Updated {SegmentCount} segments for episode {EpisodeId}", newSegments.Count, episode.EpisodeId);
                     }
-
-                    await Task.WhenAll(newSegments.Select(s => _mediaSegmentManager.CreateSegmentAsync(s, _id))).ConfigureAwait(false);
-
-                    _logger.LogDebug("Updated {SegmentCount} segments for episode {EpisodeId}", newSegments.Count, episode.EpisodeId);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error processing episode {EpisodeId}", episode.EpisodeId);
-                }
-            }
+                    catch (OperationCanceledException)
+                    {
+                        _logger.LogDebug("Processing for episode {EpisodeId} was canceled.", episode.EpisodeId);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error processing episode {EpisodeId}", episode.EpisodeId);
+                    }
+                }).ConfigureAwait(false);
         }
     }
 }

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -1,7 +1,6 @@
 // Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
 // SPDX-License-Identifier: GPL-3.0-only.
 
-using IntroSkipper.Manager;
 using IntroSkipper.Providers;
 using IntroSkipper.Services;
 using MediaBrowser.Controller;
@@ -21,7 +20,6 @@ namespace IntroSkipper
             serviceCollection.AddHostedService<AutoSkip>();
             serviceCollection.AddHostedService<Entrypoint>();
             serviceCollection.AddSingleton<IMediaSegmentProvider, SegmentProvider>();
-            serviceCollection.AddSingleton<MediaSegmentUpdateManager>();
         }
     }
 }

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -1,6 +1,7 @@
 // Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
 // SPDX-License-Identifier: GPL-3.0-only.
 
+using IntroSkipper.Manager;
 using IntroSkipper.Providers;
 using IntroSkipper.Services;
 using MediaBrowser.Controller;
@@ -20,6 +21,7 @@ namespace IntroSkipper
             serviceCollection.AddHostedService<AutoSkip>();
             serviceCollection.AddHostedService<Entrypoint>();
             serviceCollection.AddSingleton<IMediaSegmentProvider, SegmentProvider>();
+            serviceCollection.AddTransient<MediaSegmentUpdateManager>();
         }
     }
 }

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -31,9 +31,7 @@ namespace IntroSkipper.Providers
             ArgumentNullException.ThrowIfNull(Plugin.Instance);
 
             var segments = new List<MediaSegmentDto>();
-            var remainingTicks = Plugin.Instance.Configuration.RemainingSecondsOfIntro * TimeSpan.TicksPerSecond;
             var itemSegments = Plugin.Instance.GetTimestamps(request.ItemId);
-            var runTimeTicks = Plugin.Instance.GetItem(request.ItemId)?.RunTimeTicks ?? 0;
 
             // Define mappings between AnalysisMode and MediaSegmentType
             var segmentMappings = new List<(AnalysisMode Mode, MediaSegmentType Type)>
@@ -49,7 +47,7 @@ namespace IntroSkipper.Providers
                 if (itemSegments.TryGetValue(mode, out var segment) && segment.Valid)
                 {
                     long startTicks = (long)(segment.Start * TimeSpan.TicksPerSecond);
-                    long endTicks = CalculateEndTicks(mode, segment, runTimeTicks, remainingTicks);
+                    long endTicks = (long)(segment.End * TimeSpan.TicksPerSecond);
 
                     segments.Add(new MediaSegmentDto
                     {
@@ -62,26 +60,6 @@ namespace IntroSkipper.Providers
             }
 
             return Task.FromResult<IReadOnlyList<MediaSegmentDto>>(segments);
-        }
-
-        /// <summary>
-        /// Calculates the end ticks based on the segment type and runtime.
-        /// </summary>
-        private static long CalculateEndTicks(AnalysisMode mode, Segment segment, long runTimeTicks, long remainingTicks)
-        {
-            long endTicks = (long)(segment.End * TimeSpan.TicksPerSecond);
-
-            if (mode is AnalysisMode.Preview or AnalysisMode.Credits)
-            {
-                if (runTimeTicks > 0 && runTimeTicks < endTicks + TimeSpan.TicksPerSecond)
-                {
-                    return Math.Max(runTimeTicks, endTicks);
-                }
-
-                return endTicks - remainingTicks;
-            }
-
-            return endTicks - remainingTicks;
         }
 
         /// <inheritdoc/>

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -10,7 +10,6 @@ using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Manager;
-using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
@@ -25,17 +24,17 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="logger">Task logger.</param>
 /// <param name="loggerFactory">Logger factory.</param>
 /// <param name="libraryManager">Library manager.</param>
-/// <param name="mediaSegmentManager">Media segment manager.</param>
+/// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
 public class BaseItemAnalyzerTask(
     ILogger logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
-    IMediaSegmentManager mediaSegmentManager)
+    MediaSegmentUpdateManager mediaSegmentUpdateManager)
 {
     private readonly ILogger _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private readonly ILibraryManager _libraryManager = libraryManager;
-    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
+    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly bool _ffmpegValid = FFmpegWrapper.CheckFFmpegVersion();
 
@@ -63,10 +62,6 @@ public class BaseItemAnalyzerTask(
             _libraryManager);
 
         var queue = queueManager.GetMediaItems();
-
-        var mediaSegmentUpdateManager = new MediaSegmentUpdateManager(
-            _mediaSegmentManager,
-            _loggerFactory.CreateLogger<MediaSegmentUpdateManager>());
 
         if (seasonsToAnalyze?.Count > 0)
         {
@@ -139,7 +134,7 @@ public class BaseItemAnalyzerTask(
 
             if (_config.RebuildMediaSegments || (updateMediaSegments && _config.UpdateMediaSegments))
             {
-                await mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, ct).ConfigureAwait(false);
+                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, ct).ConfigureAwait(false);
             }
         }).ConfigureAwait(false);
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -10,6 +10,7 @@ using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Manager;
+using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
 
@@ -24,17 +25,17 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="logger">Task logger.</param>
 /// <param name="loggerFactory">Logger factory.</param>
 /// <param name="libraryManager">Library manager.</param>
-/// <param name="mediaSegmentUpdateManager">MediaSegmentUpdateManager.</param>
+/// <param name="mediaSegmentManager">Media segment manager.</param>
 public class BaseItemAnalyzerTask(
     ILogger logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
-    MediaSegmentUpdateManager mediaSegmentUpdateManager)
+    IMediaSegmentManager mediaSegmentManager)
 {
     private readonly ILogger _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private readonly ILibraryManager _libraryManager = libraryManager;
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly bool _ffmpegValid = FFmpegWrapper.CheckFFmpegVersion();
 
@@ -62,6 +63,10 @@ public class BaseItemAnalyzerTask(
             _libraryManager);
 
         var queue = queueManager.GetMediaItems();
+
+        var mediaSegmentUpdateManager = new MediaSegmentUpdateManager(
+            _mediaSegmentManager,
+            _loggerFactory.CreateLogger<MediaSegmentUpdateManager>());
 
         if (seasonsToAnalyze?.Count > 0)
         {
@@ -134,7 +139,7 @@ public class BaseItemAnalyzerTask(
 
             if (_config.RebuildMediaSegments || (updateMediaSegments && _config.UpdateMediaSegments))
             {
-                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, ct).ConfigureAwait(false);
+                await mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, ct).ConfigureAwait(false);
             }
         }).ConfigureAwait(false);
 

--- a/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
+++ b/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using IntroSkipper.Manager;
 using IntroSkipper.Services;
+using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
@@ -22,12 +22,12 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="loggerFactory">Logger factory.</param>
 /// <param name="libraryManager">Library manager.</param>
 /// <param name="logger">Logger.</param>
-/// <param name="mediaSegmentUpdateManager">MediaSegment Update Manager.</param>
+/// <param name="mediaSegmentManager">Media segment manager.</param>
 public class DetectSegmentsTask(
     ILogger<DetectSegmentsTask> logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
-    MediaSegmentUpdateManager mediaSegmentUpdateManager) : IScheduledTask
+    IMediaSegmentManager mediaSegmentManager) : IScheduledTask
 {
     private readonly ILogger<DetectSegmentsTask> _logger = logger;
 
@@ -35,7 +35,7 @@ public class DetectSegmentsTask(
 
     private readonly ILibraryManager _libraryManager = libraryManager;
 
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
 
     /// <summary>
     /// Gets the task name.
@@ -85,7 +85,7 @@ public class DetectSegmentsTask(
                 _loggerFactory.CreateLogger<DetectSegmentsTask>(),
                 _loggerFactory,
                 _libraryManager,
-                _mediaSegmentUpdateManager);
+                _mediaSegmentManager);
 
             await baseIntroAnalyzer.AnalyzeItemsAsync(progress, cancellationToken).ConfigureAwait(false);
         }

--- a/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
+++ b/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using IntroSkipper.Manager;
 using IntroSkipper.Services;
-using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
@@ -22,12 +22,12 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="loggerFactory">Logger factory.</param>
 /// <param name="libraryManager">Library manager.</param>
 /// <param name="logger">Logger.</param>
-/// <param name="mediaSegmentManager">Media segment manager.</param>
+/// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
 public class DetectSegmentsTask(
     ILogger<DetectSegmentsTask> logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
-    IMediaSegmentManager mediaSegmentManager) : IScheduledTask
+    MediaSegmentUpdateManager mediaSegmentUpdateManager) : IScheduledTask
 {
     private readonly ILogger<DetectSegmentsTask> _logger = logger;
 
@@ -35,7 +35,7 @@ public class DetectSegmentsTask(
 
     private readonly ILibraryManager _libraryManager = libraryManager;
 
-    private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
+    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
 
     /// <summary>
     /// Gets the task name.
@@ -85,7 +85,7 @@ public class DetectSegmentsTask(
                 _loggerFactory.CreateLogger<DetectSegmentsTask>(),
                 _loggerFactory,
                 _libraryManager,
-                _mediaSegmentManager);
+                _mediaSegmentUpdateManager);
 
             await baseIntroAnalyzer.AnalyzeItemsAsync(progress, cancellationToken).ConfigureAwait(false);
         }

--- a/IntroSkipper/Services/AutoSkip.cs
+++ b/IntroSkipper/Services/AutoSkip.cs
@@ -147,7 +147,7 @@ public sealed class AutoSkip(
             intros.Remove(currentIntro);
 
             // Check if adjacent segment is within the maximum skip range.
-            var maxTimeSkip = _config.MaximumTimeSkip + _config.RemainingSecondsOfIntro;
+            var maxTimeSkip = _config.MaximumTimeSkip;
             var nextIntro = intros.FirstOrDefault(i => introEnd + maxTimeSkip >= i.IntroStart &&
                     introEnd < i.IntroEnd);
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
-using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -29,7 +28,7 @@ namespace IntroSkipper.Services
         private readonly ILibraryManager _libraryManager;
         private readonly ILogger<Entrypoint> _logger;
         private readonly ILoggerFactory _loggerFactory;
-        private readonly IMediaSegmentManager _mediaSegmentManager;
+        private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager;
         private readonly HashSet<Guid> _seasonsToAnalyze = [];
         private readonly Timer _queueTimer;
         private static readonly SemaphoreSlim _analysisSemaphore = new(1, 1);
@@ -44,19 +43,19 @@ namespace IntroSkipper.Services
         /// <param name="taskManager">Task manager.</param>
         /// <param name="logger">Logger.</param>
         /// <param name="loggerFactory">Logger factory.</param>
-        /// <param name="mediaSegmentManager">Media segment manager.</param>
+        /// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
         public Entrypoint(
             ILibraryManager libraryManager,
             ITaskManager taskManager,
             ILogger<Entrypoint> logger,
             ILoggerFactory loggerFactory,
-            IMediaSegmentManager mediaSegmentManager)
+            MediaSegmentUpdateManager mediaSegmentUpdateManager)
         {
             _libraryManager = libraryManager;
             _taskManager = taskManager;
             _logger = logger;
             _loggerFactory = loggerFactory;
-            _mediaSegmentManager = mediaSegmentManager;
+            _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
 
             _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
             _queueTimer = new Timer(
@@ -208,7 +207,7 @@ namespace IntroSkipper.Services
                     _seasonsToAnalyze.Clear();
                     _analyzeAgain = false;
 
-                    var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _mediaSegmentManager);
+                    var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _mediaSegmentUpdateManager);
                     await analyzer.AnalyzeItemsAsync(new Progress<double>(), _cancellationTokenSource.Token, seasonIds).ConfigureAwait(false);
 
                     if (_analyzeAgain && !_cancellationTokenSource.IsCancellationRequested)

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -28,7 +29,7 @@ namespace IntroSkipper.Services
         private readonly ILibraryManager _libraryManager;
         private readonly ILogger<Entrypoint> _logger;
         private readonly ILoggerFactory _loggerFactory;
-        private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager;
+        private readonly IMediaSegmentManager _mediaSegmentManager;
         private readonly HashSet<Guid> _seasonsToAnalyze = [];
         private readonly Timer _queueTimer;
         private static readonly SemaphoreSlim _analysisSemaphore = new(1, 1);
@@ -43,19 +44,19 @@ namespace IntroSkipper.Services
         /// <param name="taskManager">Task manager.</param>
         /// <param name="logger">Logger.</param>
         /// <param name="loggerFactory">Logger factory.</param>
-        /// <param name="mediaSegmentUpdateManager">MediaSegment Update Manager.</param>
+        /// <param name="mediaSegmentManager">Media segment manager.</param>
         public Entrypoint(
             ILibraryManager libraryManager,
             ITaskManager taskManager,
             ILogger<Entrypoint> logger,
             ILoggerFactory loggerFactory,
-            MediaSegmentUpdateManager mediaSegmentUpdateManager)
+            IMediaSegmentManager mediaSegmentManager)
         {
             _libraryManager = libraryManager;
             _taskManager = taskManager;
             _logger = logger;
             _loggerFactory = loggerFactory;
-            _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+            _mediaSegmentManager = mediaSegmentManager;
 
             _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
             _queueTimer = new Timer(
@@ -207,7 +208,7 @@ namespace IntroSkipper.Services
                     _seasonsToAnalyze.Clear();
                     _analyzeAgain = false;
 
-                    var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _mediaSegmentUpdateManager);
+                    var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _mediaSegmentManager);
                     await analyzer.AnalyzeItemsAsync(new Progress<double>(), _cancellationTokenSource.Token, seasonIds).ConfigureAwait(false);
 
                     if (_analyzeAgain && !_cancellationTokenSource.IsCancellationRequested)


### PR DESCRIPTION
To Do: Update How 'Segment Playback Duration' Works

## Summary by Sourcery

Add keyframe snapping for segments.

New Features:
- Introduce a feature to snap intro detection to the nearest keyframe.

Tests:
- Update tests to cover the new keyframe snapping functionality.