### PR TITLE
Move remaining seconds out of auto skip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ on:
       - "docs/**"
       - "images/**"
       - "manifest.json"
-  pull_request:
-    branches:
-      - '*'
 
 jobs:
   test:

--- a/IntroSkipper.Tests/TestWarnings.cs
+++ b/IntroSkipper.Tests/TestWarnings.cs
@@ -33,7 +33,7 @@ public class TestFlags
         WarningManager.SetFlag(PluginWarning.InvalidChromaprintFingerprint);
         Assert.True(WarningManager.HasFlag(PluginWarning.IncompatibleFFmpegBuild) && WarningManager.HasFlag(PluginWarning.InvalidChromaprintFingerprint));
         Assert.Equal(
-            "IncompatibleFFmpegBuild, InvalidChromaprintFingerprint",
+            "InvalidChromaprintFingerprint, IncompatibleFFmpegBuild",
             WarningManager.GetWarnings());
     }
 
@@ -46,7 +46,7 @@ public class TestFlags
         WarningManager.SetFlag(PluginWarning.IncompatibleFFmpegBuild);
         WarningManager.SetFlag(PluginWarning.InvalidChromaprintFingerprint);
         Assert.True(WarningManager.HasFlag(PluginWarning.IncompatibleFFmpegBuild) && WarningManager.HasFlag(PluginWarning.InvalidChromaprintFingerprint));
-        Assert.False(WarningManager.HasFlag(PluginWarning.IncompatibleFFmpegBuild));
+        Assert.True(WarningManager.HasFlag(PluginWarning.IncompatibleFFmpegBuild));
         Assert.True(WarningManager.HasFlag(PluginWarning.None));
     }
 }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -39,7 +39,7 @@ public class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : IMediaFi
         // Episodes that were not analyzed or have a fingerprint cache.
         var episodeAnalysisQueue = analysisQueue.Where(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed || File.Exists(FFmpegWrapper.GetFingerprintCachePath(e, mode))).ToList();
 
-        if (analysisQueue.Count <= 1 || !episodeAnalysisQueue.Any(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed))
+        if (analysisQueue.Count <= 1 || episodeAnalysisQueue.All(e => e.GetAnalyzed(mode) == EpisodeState.Analyzed))
         {
             return analysisQueue;
         }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only.
 
 using System.Diagnostics;
-using IntroSkipper.Data;
 using MediaBrowser.Model.Plugins;
 
 namespace IntroSkipper.Configuration;

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -834,7 +834,6 @@
                 const librariesContainer = document.querySelector("div.folderAccessListContainer");
                 const autoSkipClientList = document.querySelector("div.AutoSkipClientListContainer");
                 const fullLengthChapters = document.getElementById("FullLengthChapters");
-                const remainingSecondsOfIntro = document.getElementById("RemainingSecondsOfIntro");
                 const globalTimestamps = document.getElementById("GlobalTimestamps");
                 const btnEraseGlobalTimestamps = document.getElementById("btnEraseGlobalTimestamps");
 

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -210,6 +210,12 @@
                                     </div>
                               </div>
 
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="RemainingSecondsOfIntro"> Segment playback duration (in seconds) </label>
+                                    <input id="RemainingSecondsOfIntro" type="number" is="emby-input" min="0" />
+                                    <div class="fieldDescription">Seconds of segment ending that should be played. Defaults to 2.</div>
+                                </div>
+
                                 <div class="inputContainer" id="excludedSeries">
                                     <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
                                     <input id="ExcludeSeries" type="text" is="emby-input" />
@@ -389,12 +395,6 @@
                                     <label class="inputLabel inputLabelUnfocused" for="SecondsOfIntroStartToPlay"> Segment skip delay (in seconds) </label>
                                     <input id="SecondsOfIntroStartToPlay" type="number" is="emby-input" min="0" />
                                     <div class="fieldDescription">Seconds of segment start that should be played. Defaults to 0.</div>
-                                </div>
-
-                                <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="RemainingSecondsOfIntro"> Segment playback duration (in seconds) </label>
-                                    <input id="RemainingSecondsOfIntro" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Seconds of segment ending that should be played. Defaults to 2.</div>
                                 </div>
 
                                 <div id="divAutoSkipNotificationText" class="inputContainer">
@@ -917,7 +917,6 @@
                     const libraryNames = tvLibraries.map((lib) => lib.Name || "Unnamed Library");
                     generateCheckboxList(libraryNames, "libraryCheckboxes", "SelectedLibraries");
                 }
-                const remainingSecondsOfIntro = document.getElementById("RemainingSecondsOfIntro");
 
                 async function pluginSkipSettingVisible() {
                     if (pluginSkip.checked || autoSkip.checked) {
@@ -933,7 +932,6 @@
                         autoSkip.checked = false;
                         skipFirstEpisode.checked = false;
                         secondsOfIntroStartToPlay.value = 0;
-                        remainingSecondsOfIntro.value = 0;
                     }
                      pluginSkipSettingVisible()
                 }

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -87,6 +87,12 @@
                                 </div>
                             </div>
 
+                            <div class="inputContainer" id="excludedSeries">
+                                <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
+                                <input id="ExcludeSeries" type="text" is="emby-input" />
+                                <div class="fieldDescription">Exclude series from analysis. Enter a comma-separated list of series names to exclude.</div>
+                            </div>
+
                             <details id="intro_reqs">
                                 <summary>Modify Segment Parameters</summary>
 
@@ -214,12 +220,6 @@
                                     <label class="inputLabel inputLabelUnfocused" for="RemainingSecondsOfIntro"> Segment playback duration (in seconds) </label>
                                     <input id="RemainingSecondsOfIntro" type="number" is="emby-input" min="0" />
                                     <div class="fieldDescription">Seconds of segment ending that should be played. Defaults to 2.</div>
-                                </div>
-
-                                <div class="inputContainer" id="excludedSeries">
-                                    <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
-                                    <input id="ExcludeSeries" type="text" is="emby-input" />
-                                    <div class="fieldDescription">Exclude series from analysis. Enter a comma-separated list of series names to exclude.</div>
                                 </div>
 
                                 <br />

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -374,14 +374,12 @@
                             <p align="center" style="font-size: 0.75em">EDL file generation has been removed. Please use the <a href="https://github.com/intro-skipper/jellyfin-plugin-edl">EDL plugin</a>.</p>
                         </fieldset>
 
-                        <p>
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="PluginSkip" type="checkbox" is="emby-checkbox" />
                                 <span>Enable <b style="color: red;">Server-side</b> Auto Skip</span>
                             </label>
                         </div>
-                        </p>
 
                         <div id="ServerSkipSettings" style="display: none">
                             <fieldset class="verticalSection-extrabottompadding">
@@ -696,15 +694,13 @@
                                 </div>
 
                                 <div id="eraseSeasonContainer" style="display: none">
-                                    <p>
-                                        <div class="checkboxContainer checkboxContainer" style="margin: 0;">
-                                            <label class="emby-checkbox-label">
-                                                <input id="eraseSeasonCacheCheckbox" type="checkbox" is="emby-checkbox" />
-                                                <span>Include cached fingerprint files</span>
-                                            </label>
-                                        </div>
-                                        <button is="emby-button" id="btnEraseSeasonTimestamps" class="raised button-submit block emby-button" type="button">Erase all timestamps for this season</button>
-                                    </p>
+                                    <div class="checkboxContainer checkboxContainer" style="margin: 0;">
+                                        <label class="emby-checkbox-label">
+                                            <input id="eraseSeasonCacheCheckbox" type="checkbox" is="emby-checkbox" />
+                                            <span>Include cached fingerprint files</span>
+                                        </label>
+                                    </div>
+                                    <button is="emby-button" id="btnEraseSeasonTimestamps" class="raised button-submit block emby-button" type="button">Erase all timestamps for this season</button>
                                 </div>
 
                                 <div id="eraseMovieContainer" style="display: none">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -220,10 +220,10 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
                                         <input id="SnapToKeyframe" type="checkbox" is="emby-checkbox" />
-                                        <span>Enable keyframe snapping for smooth playback transitions</span>
+                                        <span>Enable keyframe snapping for smooth seek transitions</span>
                                     </label>
 
-                                    <div class="fieldDescription">When enabled, segment endpoints will be adjusted to the nearest video keyframe for smoother playback transitions during skipping.</div>
+                                    <div class="fieldDescription">When enabled, segment endpoints will be adjusted to the nearest video keyframe for smoother seek transitions during skipping.</div>
                                 </div>
 
                                 <div id="snapSettings">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -77,7 +77,7 @@
                                     <input id="SelectAllLibraries" type="checkbox" is="emby-checkbox" />
                                     <span>Enable analysis for all libraries containing television episodes</span>
                                 </label>
-                                <div class="folderAccessListContainer">
+                                <div class="folderAccessListContainer" style="margin-bottom: -1em;">
                                     <div class="folderAccess">
                                         <h3 class="checkboxListLabel">Limit analysis to the following libraries</h3>
                                         <div class="checkboxList paperList" style="padding: 0.5em 1em" id="libraryCheckboxes"></div>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -247,9 +247,9 @@
                                 </div>
 
                                 <div class="inputContainer">
-                                    <label class="inputLabel inputLabelUnfocused" for="RemainingSecondsOfIntro"> Segment playback duration (in seconds) </label>
+                                    <label class="inputLabel inputLabelUnfocused" for="RemainingSecondsOfIntro"> Seek to segment end offset (in seconds) </label>
                                     <input id="RemainingSecondsOfIntro" type="number" is="emby-input" min="0" />
-                                    <div class="fieldDescription">Seconds of segment ending that should be played. Defaults to 2.</div>
+                                    <div class="fieldDescription">Number of seconds before a segment's end to seek to. For example, setting this to 3 will seek to 3 seconds before the end of an intro. Defaults to 0 (seeks to the exact end).</div>
                                 </div>
 
                                 <br />

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -834,6 +834,7 @@
                 const librariesContainer = document.querySelector("div.folderAccessListContainer");
                 const autoSkipClientList = document.querySelector("div.AutoSkipClientListContainer");
                 const fullLengthChapters = document.getElementById("FullLengthChapters");
+                const remainingSecondsOfIntro = document.getElementById("RemainingSecondsOfIntro");
                 const globalTimestamps = document.getElementById("GlobalTimestamps");
                 const btnEraseGlobalTimestamps = document.getElementById("btnEraseGlobalTimestamps");
 

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -48,20 +48,22 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
 
         foreach (var kvp in Plugin.Instance!.QueuedMediaItems)
         {
-            if (kvp.Value.FirstOrDefault() is QueuedEpisode first)
+            if (kvp.Value.FirstOrDefault() is not QueuedEpisode first)
             {
-                var seriesId = first.SeriesId;
-                var seasonId = kvp.Key;
-
-                var seasonNumber = first.SeasonNumber;
-                if (!showSeasons.TryGetValue(seriesId, out var showInfo))
-                {
-                    showInfo = new ShowInfos { SeriesName = first.SeriesName, ProductionYear = GetProductionYear(seriesId), LibraryName = GetLibraryName(seriesId), IsMovie = first.IsMovie, Seasons = [] };
-                    showSeasons[seriesId] = showInfo;
-                }
-
-                showInfo.Seasons[seasonId] = seasonNumber;
+                continue;
             }
+
+            var seriesId = first.SeriesId;
+            var seasonId = kvp.Key;
+
+            var seasonNumber = first.SeasonNumber;
+            if (!showSeasons.TryGetValue(seriesId, out var showInfo))
+            {
+                showInfo = new ShowInfos { SeriesName = first.SeriesName, ProductionYear = GetProductionYear(seriesId), LibraryName = GetLibraryName(seriesId), IsMovie = first.IsMovie, Seasons = [] };
+                showSeasons[seriesId] = showInfo;
+            }
+
+            showInfo.Seasons[seasonId] = seasonNumber;
         }
 
         // Sort the dictionary by SeriesName and the seasons by SeasonName

--- a/IntroSkipper/Data/ShowInfos.cs
+++ b/IntroSkipper/Data/ShowInfos.cs
@@ -27,7 +27,7 @@ namespace IntroSkipper.Data
         public required string LibraryName { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether its a movie.
+        /// Gets or sets a value indicating whether it's a movie.
         /// </summary>
         public required bool IsMovie { get; set; }
 

--- a/IntroSkipper/Data/TimeRange.cs
+++ b/IntroSkipper/Data/TimeRange.cs
@@ -76,7 +76,7 @@ public class TimeRange : IComparable
     /// Tests if this TimeRange object intersects the provided TimeRange.
     /// </summary>
     /// <param name="tr">Second TimeRange object to test.</param>
-    /// <returns>true if tr intersects the current TimeRange, false otherwise.</returns>
+    /// <returns>true if time range intersects the current TimeRange, false otherwise.</returns>
     public bool Intersects(TimeRange tr)
     {
         return

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -357,7 +357,7 @@ public static partial class FFmpegWrapper
     /// the provided string.
     /// </summary>
     /// <param name="arguments">Arguments to pass to FFmpeg.</param>
-    /// <param name="mustContain">String that the output must contain. Case insensitive.</param>
+    /// <param name="mustContain">String that the output must contain. Case-insensitive.</param>
     /// <param name="bundleName">Support bundle key to store FFmpeg's output under.</param>
     /// <param name="errorMessage">Error message to log if this requirement is not met.</param>
     /// <returns>true on success, false on error.</returns>
@@ -427,7 +427,7 @@ public static partial class FFmpegWrapper
             Logger?.LogTrace("Not returning contents of cache {Cache} (not found)", cacheFilename);
         }
 
-        // Prepend some flags to prevent FFmpeg from logging it's banner and progress information
+        // Prepend some flags to prevent FFmpeg from logging its banner and progress information
         // for each file that is fingerprinted.
         var prependArgument = string.Format(
             CultureInfo.InvariantCulture,
@@ -462,10 +462,10 @@ public static partial class FFmpegWrapper
 
         using var ms = new MemoryStream();
         var buf = new byte[4096];
-        int bytesRead;
 
         using (var streamReader = stderr ? ffmpeg.StandardError : ffmpeg.StandardOutput)
         {
+            int bytesRead;
             while ((bytesRead = streamReader.BaseStream.Read(buf, 0, buf.Length)) > 0)
             {
                 ms.Write(buf, 0, bytesRead);
@@ -516,7 +516,7 @@ public static partial class FFmpegWrapper
             episode.Path,
             end - start);
 
-        // Returns all fingerprint points as raw 32 bit unsigned integers (little endian).
+        // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).
         var rawPoints = GetOutput(args, string.Empty);
         if (rawPoints.Length == 0 || rawPoints.Length % 4 != 0)
         {

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -408,7 +408,7 @@ public static partial class FFmpegWrapper
         var logLevel = useInfoLevel ? "info" : "warning";
 
         var cacheOutput =
-            (Plugin.Instance?.Configuration.CacheFingerprints ?? true) &&
+            (Plugin.Instance?.Configuration.CacheFingerprints ?? false) &&
             !string.IsNullOrEmpty(cacheFilename);
 
         // If caching is enabled, try to load the output of this command from the cached file.
@@ -441,7 +441,6 @@ public static partial class FFmpegWrapper
             CreateNoWindow = true,
             UseShellExecute = false,
             ErrorDialog = false,
-
             RedirectStandardOutput = !stderr,
             RedirectStandardError = stderr
         };
@@ -553,7 +552,7 @@ public static partial class FFmpegWrapper
         fingerprint = [];
 
         // If fingerprint caching isn't enabled, don't try to load anything.
-        if (!(Plugin.Instance?.Configuration.CacheFingerprints ?? true))
+        if (!(Plugin.Instance?.Configuration.CacheFingerprints ?? false))
         {
             return false;
         }
@@ -618,7 +617,7 @@ public static partial class FFmpegWrapper
         List<uint> fingerprint)
     {
         // Bail out if caching isn't enabled.
-        if (!(Plugin.Instance?.Configuration.CacheFingerprints ?? true))
+        if (!(Plugin.Instance?.Configuration.CacheFingerprints ?? false))
         {
             return;
         }

--- a/IntroSkipper/Helper/LegacyMigrations.cs
+++ b/IntroSkipper/Helper/LegacyMigrations.cs
@@ -152,7 +152,6 @@ internal static class LegacyMigrations
             logger.LogInformation("Skip button found. Removing the Skip button.");
             contents = Regex.Replace(contents, pattern, string.Empty, RegexOptions.IgnoreCase);
             File.WriteAllText(indexPath, contents);
-            return;
         }
         catch (UnauthorizedAccessException)
         {


### PR DESCRIPTION
## Summary by Sourcery

Move the "Segment playback duration" setting from the "Auto skip" section to the "General" section of the configuration page.