### PR TITLE
Option to favor chromaprint scan

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -41,6 +41,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AnalyzeSeasonZero { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to only use chromaprint.
+    /// </summary>
+    public bool PreferChromaprint { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the episode's fingerprint should be cached to the filesystem.
     /// </summary>
     public bool CacheFingerprints { get; set; } = true;

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -130,6 +130,14 @@
                                     </label>
                                 </div>
 
+                                <div class="checkboxContainer">
+                                    <label class="emby-checkbox-label">
+                                        <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
+                                        <span>Prefer Chromaprint</span>
+                                        <div class="fieldDescription">Setting an analysis mode in the advanced options will override this setting.</div>
+                                    </label>
+                                </div>
+
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="AnalysisPercent"> Percent of media to analyze </label>
                                     <input id="AnalysisPercent" type="number" is="emby-input" min="1" max="90" />
@@ -824,7 +832,7 @@
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe"];
 
                 // visualizer elements
                 const analyzeMovies = document.getElementById("AnalyzeMovies");

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -87,7 +87,7 @@
                                 </div>
                             </div>
 
-                            <div class="checkboxContainer" "checkboxContainer-withDescription">
+                            <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
                                     <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
                                     <span>Prefer Chromaprint</span>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -87,6 +87,14 @@
                                 </div>
                             </div>
 
+                            <div class="checkboxContainer" checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
+                                    <span>Prefer Chromaprint</span>
+                                </label>
+                                <div class="fieldDescription">Setting an analysis mode in the advanced options will override this setting.</div>
+                            </div>
+
                             <div class="inputContainer" id="excludedSeries">
                                 <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
                                 <input id="ExcludeSeries" type="text" is="emby-input" />
@@ -127,14 +135,6 @@
                                     <label class="emby-checkbox-label">
                                         <input id="ScanPreview" type="checkbox" is="emby-checkbox" />
                                         <span>Identify Previews</span>
-                                    </label>
-                                </div>
-
-                                <div class="checkboxContainer">
-                                    <label class="emby-checkbox-label">
-                                        <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
-                                        <span>Prefer Chromaprint</span>
-                                        <div class="fieldDescription">Setting an analysis mode in the advanced options will override this setting.</div>
                                     </label>
                                 </div>
 

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -87,7 +87,7 @@
                                 </div>
                             </div>
 
-                            <div class="checkboxContainer" checkboxContainer-withDescription">
+                            <div class="checkboxContainer" "checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
                                     <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
                                     <span>Prefer Chromaprint</span>

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -175,6 +175,8 @@ public class BaseItemAnalyzerTask(
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var action = plugin.GetAnalyzerAction(first.SeasonId, mode);
 
+        var chromaprintOnly = _ffmpegValid && plugin.Configuration.PreferChromaprint && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint;
+
         _logger.LogInformation(
             "[Mode: {Mode}] Analyzing {Count} files from {Name} season {Season}",
             mode,
@@ -186,7 +188,7 @@ public class BaseItemAnalyzerTask(
         var analyzers = new List<IMediaFileAnalyzer>();
 
         // Add analyzers based on conditions
-        if (action is AnalyzerAction.Chapter or AnalyzerAction.Default)
+        if (!chromaprintOnly && action is AnalyzerAction.Chapter or AnalyzerAction.Default)
         {
             analyzers.Add(new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()));
         }
@@ -196,7 +198,7 @@ public class BaseItemAnalyzerTask(
             analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }
 
-        if (mode is AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.BlackFrame)
+        if (!chromaprintOnly && mode is AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.BlackFrame)
         {
             analyzers.Add(new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()));
         }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -175,7 +175,7 @@ public class BaseItemAnalyzerTask(
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var action = plugin.GetAnalyzerAction(first.SeasonId, mode);
 
-        var chromaprintOnly = _ffmpegValid && plugin.Configuration.PreferChromaprint && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint;
+        var chromaprintOnly = _ffmpegValid && _config.PreferChromaprint && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint;
 
         _logger.LogInformation(
             "[Mode: {Mode}] Analyzing {Count} files from {Name} season {Season}",


### PR DESCRIPTION
Only applies when setting default or chromaprint as the analysis type to allow overriding

## Summary by Sourcery

This pull request introduces a new feature that allows users to prioritize Chromaprint analysis by adding a 'Prefer Chromaprint' option in the plugin configuration. When enabled, the system will favor Chromaprint analysis over other methods when the analysis type is set to default or Chromaprint.

New Features:
- Adds an option to prefer Chromaprint analysis when the analysis type is set to default or Chromaprint, allowing users to prioritize Chromaprint analysis over other methods.

Enhancements:
- The system now checks if Chromaprint-only analysis is preferred before adding other analyzers like ChapterAnalyzer or BlackFrameAnalyzer, ensuring Chromaprint is prioritized when specified.