### PR TITLE
Implement alternative blackframe analyzer

### DIFF
--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -22,7 +22,7 @@ public class TestBlackFrames
         expected.AddRange(CreateFrameSequence(5, 6));
         expected.AddRange(CreateFrameSequence(8, 9.96));
 
-        var actual = FFmpegWrapper.DetectBlackFrames(QueueFile("rainbow.mp4"), new(0, 10), 85);
+        var actual = FFmpegWrapper.DetectBlackFrames(QueueFile("rainbow.mp4"), new(0, 10), 85, 32);
 
         for (var i = 0; i < expected.Count; i++)
         {
@@ -43,7 +43,7 @@ public class TestBlackFrames
         var episode = QueueFile("credits.mp4");
         episode.Duration = (int)new TimeSpan(0, 5, 30).TotalSeconds;
 
-        var result = analyzer.AnalyzeMediaFile(episode, 240, 85);
+        var result = analyzer.AnalyzeMediaFile(episode, 240, 85, 32);
         Assert.NotNull(result);
         Assert.InRange(result.Start, 300 - range, 300 + range);
     }

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -64,7 +64,7 @@ public class TestBlackFrames
 
         for (var i = start; i < end; i += 0.04)
         {
-            frames.Add(new(100, i));
+            frames.Add(new(100, i, 0));
         }
 
         return [.. frames];

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -48,6 +48,8 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
         _logger.LogDebug("Analyzing {Count} episodes for credits using black frame detection", unanalyzedEpisodes.Count);
 
         var minimumPercentage = _config.BlackFrameMinimumPercentage;
+        var threshold = _config.BlackFrameThreshold;
+        var minimumDuration = _config.MinimumCreditsDuration;
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
 
         foreach (var episode in unanalyzedEpisodes)
@@ -56,7 +58,7 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
 
             try
             {
-                var credit = DetectCredits(episode);
+                var credit = DetectCredits(episode, minimumPercentage, threshold, minimumDuration);
 
                 if (credit is null || !credit.Valid)
                 {
@@ -87,24 +89,26 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
     /// Detects the start of blackframe credits from FFmpeg blackframe filter output.
     /// </summary>
     /// <param name="episode">Media file to analyze.</param>
+    /// <param name="minimumPercentage">Minimum percentage of the frame that must be black.</param>
+    /// <param name="threshold">Threshold for black frame detection.</param>
+    /// <param name="minimumDuration">Minimum duration of the credits.</param>
     /// <returns>Time range of the detected credits.</returns>
-    public Segment? DetectCredits(QueuedEpisode episode)
+    public Segment? DetectCredits(QueuedEpisode episode, int minimumPercentage, int threshold, int minimumDuration)
     {
-        var blackFrames = FFmpegWrapper.DetectBlackFrames(episode).ToList();
+        var blackFrames = FFmpegWrapper.DetectBlackFrames(episode, threshold).ToList();
 
         if (blackFrames.Count == 0)
         {
             return null;
         }
 
-        var scenes = DetectCreditScenes(blackFrames);
+        var scenes = DetectCreditScenes(blackFrames, minimumPercentage);
         if (scenes.Count == 0)
         {
             return null;
         }
 
         var lastFrameTime = blackFrames[^1].Time;
-        var minimumDuration = _config.MinimumCreditsDuration;
 
         // Start from the last scene and work backwards to find the first valid credits segment
         for (var i = scenes.Count - 1; i >= 0; i--)
@@ -129,7 +133,7 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
         return null;
     }
 
-    private List<CreditScene> DetectCreditScenes(List<BlackFrame> frames)
+    private static List<CreditScene> DetectCreditScenes(List<BlackFrame> frames, int minimumPercentage)
     {
         var scenes = new List<CreditScene>();
         BlackFrame? sceneStart = null;
@@ -137,8 +141,10 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
 
         // Normalize the threshold based on consistent dark elements, capping floor at 30%
         // Adapts the detection sensitivity to the video's natural black levels
-        var floor = Math.Min(frames.Min(f => f.Percentage), 30);
-        var minimum = (_config.BlackFrameMinimumPercentage * (100 - floor) / 100) + floor;
+        var orderedFrames = frames.OrderBy(f => f.Percentage).ToList();
+        var percentileIndex = (int)(frames.Count * 0.01); // 1st percentile
+        var floor = Math.Min(orderedFrames[percentileIndex].Percentage, 30);
+        var minimum = (minimumPercentage * (100 - floor) / 100) + floor;
         var sceneChange = (95 * (100 - floor) / 100) + floor;
 
         for (var i = 0; i < frames.Count; i++)

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -1,0 +1,178 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Analyzers;
+
+/// <summary>
+/// Media file analyzer used to detect end credits that consist of text overlaid on a black background.
+/// Uses an adaptive binary search algorithm to efficiently locate the start of credits.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="BlackFrameAltAnalyzer"/> class.
+/// </remarks>
+/// <param name="logger">Logger for the analyzer.</param>
+public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger) : IMediaFileAnalyzer
+{
+    private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+    private readonly ILogger<BlackFrameAltAnalyzer> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<QueuedEpisode>> AnalyzeMediaFiles(
+        IReadOnlyList<QueuedEpisode> analysisQueue,
+        AnalysisMode mode,
+        CancellationToken cancellationToken)
+    {
+        if (mode != AnalysisMode.Credits)
+        {
+            throw new NotImplementedException($"{nameof(BlackFrameAltAnalyzer)} only supports {nameof(AnalysisMode.Credits)} mode");
+        }
+
+        var unanalyzedEpisodes = analysisQueue
+            .Where(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed)
+            .ToList();
+
+        if (unanalyzedEpisodes.Count == 0)
+        {
+            return analysisQueue;
+        }
+
+        _logger.LogDebug("Analyzing {Count} episodes for credits using black frame detection", unanalyzedEpisodes.Count);
+
+        foreach (var episode in unanalyzedEpisodes)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            try
+            {
+                var credit = DetectCredits(
+                        episode,
+                        _config.BlackFrameMinimumPercentage);
+
+                if (credit is null || !credit.Valid)
+                {
+                    _logger.LogDebug("No valid credits found for {Episode}", episode.Name);
+                    continue;
+                }
+
+                _logger.LogDebug("Found credits for {Episode} at {Start:F2}s", episode.Name, credit.Start);
+
+                episode.SetAnalyzed(mode, EpisodeState.Analyzed);
+                await Plugin.Instance!.UpdateTimestampAsync(credit, mode).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error analyzing {Episode} for credits", episode.Name);
+            }
+        }
+
+        return analysisQueue;
+    }
+
+    /// <summary>
+    /// Detects the start of blackframe credits from FFmpeg blackframe filter output.
+    /// </summary>
+    /// <param name="episode">Media file to analyze.</param>
+    /// <param name="minimum">Minimum percentage of black pixels to consider a frame a black frame.</param>
+    /// <returns>Time range of the detected credits.</returns>
+    public Segment? DetectCredits(QueuedEpisode episode, int minimum)
+    {
+        var blackFrames = FFmpegWrapper.DetectBlackFrames(episode);
+        _logger.LogDebug("Detected {Count} black frames for {Episode}", blackFrames.Length, episode.Name);
+        if (blackFrames.Length == 0)
+        {
+            return null;
+        }
+
+        var scenes = DetectCreditScenes(blackFrames, minimum);
+        if (scenes.Length == 0)
+        {
+            return null;
+        }
+
+        var lastScene = scenes[^1];
+        var start = lastScene.StartTime + episode.CreditsFingerprintStart;
+        var end = lastScene.EndTime == blackFrames[^1].Time ? episode.Duration : lastScene.EndTime + episode.CreditsFingerprintStart;
+
+        return new Segment(episode.EpisodeId, new TimeRange(start, end));
+    }
+
+    private static CreditScene[] DetectCreditScenes(BlackFrame[] blackFrames, int minimum = 85)
+    {
+        var scenes = new List<CreditScene>();
+        BlackFrame? sceneStart = null;
+        BlackFrame? lastBlack = null;
+
+        foreach (var frame in blackFrames)
+        {
+            var isBlack = frame.Percentage >= minimum;
+
+            // Start new scene
+            if (isBlack && sceneStart is null)
+            {
+                sceneStart = frame;
+                lastBlack = frame;
+            }
+
+            // Continue scene
+            else if (isBlack)
+            {
+                lastBlack = frame;
+            }
+
+            // End scene if gap is too large
+            else if (sceneStart is not null && lastBlack is not null && frame.Frame - lastBlack.Frame > 5)
+            {
+                if (lastBlack.Frame - sceneStart.Frame >= 5)
+                {
+                    scenes.Add(new CreditScene(sceneStart.Frame, lastBlack.Frame, sceneStart.Time, lastBlack.Time));
+                }
+
+                sceneStart = null;
+            }
+        }
+
+        // Handle final scene
+        if (sceneStart is not null && lastBlack is not null && lastBlack.Frame - sceneStart.Frame >= 5)
+        {
+            scenes.Add(new CreditScene(sceneStart.Frame, lastBlack.Frame, sceneStart.Time, lastBlack.Time));
+        }
+
+        // Merge scenes that are close together
+        if (scenes.Count == 0)
+        {
+            return [];
+        }
+
+        var merged = new List<CreditScene>();
+        var current = scenes[0];
+
+        foreach (var scene in scenes.Skip(1))
+        {
+            if (scene.StartFrame - current.EndFrame <= 10)
+            {
+                current = new CreditScene(current.StartFrame, scene.EndFrame, current.StartTime, scene.EndTime);
+            }
+            else
+            {
+                merged.Add(current);
+                current = scene;
+            }
+        }
+
+        merged.Add(current);
+
+        return [.. merged];
+    }
+}

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -22,6 +22,8 @@ namespace IntroSkipper.Analyzers;
 /// <param name="logger">Logger for the analyzer.</param>
 public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger) : IMediaFileAnalyzer
 {
+    private const int MaximumTimeSkip = 15;
+    private const double EndTolerance = MaximumTimeSkip / 2;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly ILogger<BlackFrameAltAnalyzer> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -107,8 +109,6 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
         {
             return null;
         }
-
-        const double EndTolerance = 7.5; // 7.5 seconds from the end
 
         // Start from the last scene and work backwards to find the first valid credits segment
         for (var i = scenes.Count - 1; i >= 0; i--)
@@ -201,7 +201,7 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
         for (var i = 1; i < scenes.Count; i++)
         {
             var scene = scenes[i];
-            if (scene.StartFrame - current.EndFrame <= 10)
+            if (scene.StartTime - current.EndTime <= MaximumTimeSkip)
             {
                 current = new CreditScene(current.StartFrame, scene.EndFrame, current.StartTime, scene.EndTime);
             }

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -56,7 +56,7 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
 
             try
             {
-                var credit = DetectCredits(episode, minimumPercentage);
+                var credit = DetectCredits(episode);
 
                 if (credit is null || !credit.Valid)
                 {
@@ -87,18 +87,17 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
     /// Detects the start of blackframe credits from FFmpeg blackframe filter output.
     /// </summary>
     /// <param name="episode">Media file to analyze.</param>
-    /// <param name="minimum">Minimum percentage of black pixels to consider a frame a black frame.</param>
     /// <returns>Time range of the detected credits.</returns>
-    public Segment? DetectCredits(QueuedEpisode episode, int minimum)
+    public Segment? DetectCredits(QueuedEpisode episode)
     {
-        var blackFrames = FFmpegWrapper.DetectBlackFrames(episode);
+        var blackFrames = FFmpegWrapper.DetectBlackFrames(episode).ToList();
 
-        if (blackFrames.Length == 0)
+        if (blackFrames.Count == 0)
         {
             return null;
         }
 
-        var scenes = DetectCreditScenes(blackFrames, minimum);
+        var scenes = DetectCreditScenes(blackFrames);
         if (scenes.Count == 0)
         {
             return null;
@@ -130,15 +129,19 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
         return null;
     }
 
-    private static List<CreditScene> DetectCreditScenes(BlackFrame[] blackFrames, int minimum = 85)
+    private List<CreditScene> DetectCreditScenes(List<BlackFrame> frames)
     {
         var scenes = new List<CreditScene>();
         BlackFrame? sceneStart = null;
         BlackFrame? lastBlack = null;
 
-        Span<BlackFrame> frames = blackFrames;
+        // Normalize the threshold based on consistent dark elements, capping floor at 30%
+        // Adapts the detection sensitivity to the video's natural black levels
+        var floor = Math.Min(frames.Min(f => f.Percentage), 30);
+        var minimum = (_config.BlackFrameMinimumPercentage * (100 - floor) / 100) + floor;
+        var sceneChange = (95 * (100 - floor) / 100) + floor;
 
-        for (var i = 0; i < frames.Length; i++)
+        for (var i = 0; i < frames.Count; i++)
         {
             var frame = frames[i];
             var isBlack = frame.Percentage >= minimum;
@@ -158,7 +161,7 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
 
             // End scene if gap is too large or we're at the last frame
             else if (sceneStart is not null && lastBlack is not null &&
-                    (i == frames.Length - 1 || frame.Frame - lastBlack.Frame > 5))
+                    (i == frames.Count - 1 || frame.Frame - lastBlack.Frame > 5))
             {
                 if (lastBlack.Frame - sceneStart.Frame >= 5)
                 {
@@ -209,11 +212,11 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
             var startTime = scene.StartTime;
             var endTime = scene.EndTime;
 
-            // Look for a transition frame (95% black) in the first part of the scene
-            for (var i = 0; i < frames.Length; i++)
+            // Look for a scene change in the first part of the scene
+            for (var i = 0; i < frames.Count; i++)
             {
                 var frame = frames[i];
-                if (frame.Frame >= startFrame && frame.Frame <= endFrame && frame.Percentage >= 95)
+                if (frame.Frame >= startFrame && frame.Frame <= endFrame && frame.Percentage >= sceneChange)
                 {
                     startFrame = frame.Frame;
                     startTime = frame.Time;

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -47,18 +47,16 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
 
         _logger.LogDebug("Analyzing {Count} episodes for credits using black frame detection", unanalyzedEpisodes.Count);
 
+        var minimumPercentage = _config.BlackFrameMinimumPercentage;
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+
         foreach (var episode in unanalyzedEpisodes)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                var credit = DetectCredits(
-                        episode,
-                        _config.BlackFrameMinimumPercentage);
+                var credit = DetectCredits(episode, minimumPercentage);
 
                 if (credit is null || !credit.Valid)
                 {
@@ -69,7 +67,12 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
                 _logger.LogDebug("Found credits for {Episode} at {Start:F2}s", episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await Plugin.Instance!.UpdateTimestampAsync(credit, mode).ConfigureAwait(false);
+                await plugin.UpdateTimestampAsync(credit, mode).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("Analysis cancelled by user");
+                break;
             }
             catch (Exception ex)
             {
@@ -89,33 +92,55 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
     public Segment? DetectCredits(QueuedEpisode episode, int minimum)
     {
         var blackFrames = FFmpegWrapper.DetectBlackFrames(episode);
-        _logger.LogDebug("Detected {Count} black frames for {Episode}", blackFrames.Length, episode.Name);
+
         if (blackFrames.Length == 0)
         {
             return null;
         }
 
         var scenes = DetectCreditScenes(blackFrames, minimum);
-        if (scenes.Length == 0)
+        if (scenes.Count == 0)
         {
             return null;
         }
 
-        var lastScene = scenes[^1];
-        var start = lastScene.StartTime + episode.CreditsFingerprintStart;
-        var end = lastScene.EndTime == blackFrames[^1].Time ? episode.Duration : lastScene.EndTime + episode.CreditsFingerprintStart;
+        var lastFrameTime = blackFrames[^1].Time;
+        var minimumDuration = _config.MinimumCreditsDuration;
 
-        return new Segment(episode.EpisodeId, new TimeRange(start, end));
+        // Start from the last scene and work backwards to find the first valid credits segment
+        for (var i = scenes.Count - 1; i >= 0; i--)
+        {
+            var scene = scenes[i];
+            var start = scene.StartTime + episode.CreditsFingerprintStart;
+            var end = scene.EndTime == lastFrameTime ? episode.Duration : scene.EndTime + episode.CreditsFingerprintStart;
+            var duration = end - start;
+
+            if (duration >= minimumDuration)
+            {
+                _logger.LogTrace(
+                    "Found valid credits segment: start={Start:F2}s, end={End:F2}s, duration={Duration:F2}s",
+                    start,
+                    end,
+                    duration);
+
+                return new Segment(episode.EpisodeId, new TimeRange(start, end));
+            }
+        }
+
+        return null;
     }
 
-    private static CreditScene[] DetectCreditScenes(BlackFrame[] blackFrames, int minimum = 85)
+    private static List<CreditScene> DetectCreditScenes(BlackFrame[] blackFrames, int minimum = 85)
     {
         var scenes = new List<CreditScene>();
         BlackFrame? sceneStart = null;
         BlackFrame? lastBlack = null;
 
-        foreach (var frame in blackFrames)
+        Span<BlackFrame> frames = blackFrames;
+
+        for (var i = 0; i < frames.Length; i++)
         {
+            var frame = frames[i];
             var isBlack = frame.Percentage >= minimum;
 
             // Start new scene
@@ -131,8 +156,9 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
                 lastBlack = frame;
             }
 
-            // End scene if gap is too large
-            else if (sceneStart is not null && lastBlack is not null && frame.Frame - lastBlack.Frame > 5)
+            // End scene if gap is too large or we're at the last frame
+            else if (sceneStart is not null && lastBlack is not null &&
+                    (i == frames.Length - 1 || frame.Frame - lastBlack.Frame > 5))
             {
                 if (lastBlack.Frame - sceneStart.Frame >= 5)
                 {
@@ -150,16 +176,17 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
         }
 
         // Merge scenes that are close together
-        if (scenes.Count == 0)
+        if (scenes.Count <= 1)
         {
-            return [];
+            return scenes;
         }
 
-        var merged = new List<CreditScene>();
+        var merged = new List<CreditScene>(scenes.Count);
         var current = scenes[0];
 
-        foreach (var scene in scenes.Skip(1))
+        for (var i = 1; i < scenes.Count; i++)
         {
+            var scene = scenes[i];
             if (scene.StartFrame - current.EndFrame <= 10)
             {
                 current = new CreditScene(current.StartFrame, scene.EndFrame, current.StartTime, scene.EndTime);
@@ -173,6 +200,30 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
 
         merged.Add(current);
 
-        return [.. merged];
+        // Find the transition frame for each merged scene
+        var finalScenes = new List<CreditScene>(merged.Count);
+        foreach (var scene in merged)
+        {
+            var startFrame = scene.StartFrame;
+            var endFrame = scene.EndFrame;
+            var startTime = scene.StartTime;
+            var endTime = scene.EndTime;
+
+            // Look for a transition frame (95% black) in the first part of the scene
+            for (var i = 0; i < frames.Length; i++)
+            {
+                var frame = frames[i];
+                if (frame.Frame >= startFrame && frame.Frame <= endFrame && frame.Percentage >= 95)
+                {
+                    startFrame = frame.Frame;
+                    startTime = frame.Time;
+                    break;
+                }
+            }
+
+            finalScenes.Add(new CreditScene(startFrame, endFrame, startTime, endTime));
+        }
+
+        return finalScenes;
     }
 }

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -108,14 +108,19 @@ public sealed class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer> logger)
             return null;
         }
 
-        var lastFrameTime = blackFrames[^1].Time;
+        const double EndTolerance = 7.5; // 7.5 seconds from the end
 
         // Start from the last scene and work backwards to find the first valid credits segment
         for (var i = scenes.Count - 1; i >= 0; i--)
         {
             var scene = scenes[i];
             var start = scene.StartTime + episode.CreditsFingerprintStart;
-            var end = scene.EndTime == lastFrameTime ? episode.Duration : scene.EndTime + episode.CreditsFingerprintStart;
+
+            // Check if scene end is close to episode end
+            var end = episode.Duration - scene.EndTime < EndTolerance
+                ? episode.Duration
+                : scene.EndTime + episode.CreditsFingerprintStart;
+
             var duration = end - start;
 
             if (duration >= minimumDuration)

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -50,6 +50,9 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
 
         double searchStart = 0.0;
 
+        var percentage = _config.BlackFrameMinimumPercentage;
+        var threshold = _config.BlackFrameThreshold;
+
         foreach (var episode in unanalyzedEpisodes)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -60,18 +63,19 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
             try
             {
                 // First try to use chapter markers if available
-                if (!_config.UseChapterMarkersBlackFrame || !TryAnalyzeChapters(episode, out var credit))
+                if (!_config.UseChapterMarkersBlackFrame || !TryAnalyzeChapters(episode, percentage, threshold, out var credit))
                 {
                     // If no suitable chapters found, use black frame detection
                     if (searchStart < _config.MinimumCreditsDuration)
                     {
-                        searchStart = FindSearchStart(episode);
+                        searchStart = FindSearchStart(episode, percentage, threshold);
                     }
 
                     credit = AnalyzeMediaFile(
                         episode,
                         searchStart,
-                        _config.BlackFrameMinimumPercentage);
+                        percentage,
+                        threshold);
                 }
 
                 if (credit is null || !credit.Valid)
@@ -103,8 +107,9 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
     /// <param name="episode">Media file to analyze.</param>
     /// <param name="initialStart">Initial search position from the end of the file.</param>
     /// <param name="minimumBlackPercentage">Minimum percentage of the frame that must be black.</param>
+    /// <param name="threshold">Threshold for black frame detection.</param>
     /// <returns>Credits segment if found; otherwise null.</returns>
-    public Segment? AnalyzeMediaFile(QueuedEpisode episode, double initialStart, int minimumBlackPercentage)
+    public Segment? AnalyzeMediaFile(QueuedEpisode episode, double initialStart, int minimumBlackPercentage, int threshold)
     {
         ArgumentNullException.ThrowIfNull(episode);
 
@@ -130,7 +135,7 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
                 var timeRange = new TimeRange(scanTime, scanTime + 2);
 
                 // Detect black frames in the current time range
-                var blackFrames = FFmpegWrapper.DetectBlackFrames(episode, timeRange, minimumBlackPercentage);
+                var blackFrames = FFmpegWrapper.DetectBlackFrames(episode, timeRange, minimumBlackPercentage, threshold);
 
                 _logger.LogTrace(
                     "{Episode} at {Start:F2}s has {Count} black frames",
@@ -192,9 +197,11 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
     /// Attempts to find credits by analyzing chapter markers.
     /// </summary>
     /// <param name="episode">Episode to analyze.</param>
+    /// <param name="percentage">Minimum percentage of the frame that must be black.</param>
+    /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="segment">Output segment if credits are found.</param>
     /// <returns>True if credits were found using chapters; otherwise false.</returns>
-    private bool TryAnalyzeChapters(QueuedEpisode episode, out Segment? segment)
+    private bool TryAnalyzeChapters(QueuedEpisode episode, int percentage, int threshold, out Segment? segment)
     {
         ArgumentNullException.ThrowIfNull(episode);
 
@@ -221,7 +228,8 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
             var hasBlackFramesAtStart = FFmpegWrapper.DetectBlackFrames(
                 episode,
                 startRange,
-                _config.BlackFrameMinimumPercentage).Length > 0;
+                percentage,
+                threshold).Length > 0;
 
             if (!hasBlackFramesAtStart)
             {
@@ -234,7 +242,8 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
             var hasBlackFramesBefore = FFmpegWrapper.DetectBlackFrames(
                 episode,
                 beforeRange,
-                _config.BlackFrameMinimumPercentage).Length > 0;
+                percentage,
+                threshold).Length > 0;
 
             if (!hasBlackFramesBefore)
             {
@@ -252,8 +261,10 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
     /// Finds an optimal starting point for the credits search to avoid false positives.
     /// </summary>
     /// <param name="episode">Episode to analyze.</param>
+    /// <param name="percentage">Minimum percentage of the frame that must be black.</param>
+    /// <param name="threshold">Threshold for black frame detection.</param>
     /// <returns>Search start position in seconds from the end of the file.</returns>
-    private double FindSearchStart(QueuedEpisode episode)
+    private double FindSearchStart(QueuedEpisode episode, int percentage, int threshold)
     {
         ArgumentNullException.ThrowIfNull(episode);
 
@@ -269,7 +280,7 @@ public sealed class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger) : IMe
 
             var timeRange = new TimeRange(scanTime - 1.0, scanTime);
 
-            var blackFrames = FFmpegWrapper.DetectBlackFrames(episode, timeRange, _config.BlackFrameMinimumPercentage);
+            var blackFrames = FFmpegWrapper.DetectBlackFrames(episode, timeRange, percentage, threshold);
 
             _logger.LogTrace(
                 "Search: scanning at {Position:F2}s ({DistanceFromEnd:F2}s from end), found {Count} black frames",

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -50,6 +50,11 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public bool CacheFingerprints { get; set; } = true;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to use the alternative black frame analyzer.
+    /// </summary>
+    public bool UseAlternativeBlackFrameAnalyzer { get; set; }
+
     // ===== Media Segment handling =====
 
     /// <summary>

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -157,6 +157,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public int BlackFrameMinimumPercentage { get; set; } = 85;
 
     /// <summary>
+    /// Gets or sets the threshold for black frame detection.
+    /// </summary>
+    public int BlackFrameThreshold { get; set; } = 32;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to use chapter markers for credits detection.
     /// </summary>
     public bool UseChapterMarkersBlackFrame { get; set; } = true;

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -318,7 +318,13 @@
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="BlackFrameMinimumPercentage"> Minimum percentage of black pixels </label>
                                     <input id="BlackFrameMinimumPercentage" type="number" is="emby-input" min="0" max="100" />
-                                    <div class="fieldDescription">Minimum percentage of black pixels in a frame before it is considered a black frame.</div>
+                                    <div class="fieldDescription">Minimum percentage of black pixels in a frame before it is considered a black frame. Defaults to 85.</div>
+                                </div>
+
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="BlackFrameThreshold"> Black frame threshold </label>
+                                    <input id="BlackFrameThreshold" type="number" is="emby-input" min="16" max="255" />
+                                    <div class="fieldDescription">The threshold below which a pixel value is considered black. Defaults to 32.</div>
                                 </div>
                             </details>
 
@@ -858,6 +864,7 @@
                     "SilenceDetectionMaximumNoise",
                     "SilenceDetectionMinimumDuration",
                     "BlackFrameMinimumPercentage",
+                    "BlackFrameThreshold",
                     "ChapterAnalyzerIntroductionPattern",
                     "ChapterAnalyzerEndCreditsPattern",
                     "ChapterAnalyzerPreviewPattern",

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -294,6 +294,17 @@
                                 <br />
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
+                                        <input id="UseAlternativeBlackFrameAnalyzer" type="checkbox" is="emby-checkbox" />
+                                        <span>Use alternative black frame analyzer</span>
+                                    </label>
+
+                                    <div class="fieldDescription">
+                                        If enabled, the alternative black frame analyzer will be used.
+                                    </div>
+                                </div>
+
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label class="emby-checkbox-label">
                                         <input id="UseChapterMarkersBlackFrame" type="checkbox" is="emby-checkbox" />
                                         <span>Use chapter markers for credits detection</span>
                                     </label>
@@ -855,7 +866,7 @@
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments","UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe"];
 
                 // visualizer elements
                 const analyzeMovies = document.getElementById("AnalyzeMovies");

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -295,23 +295,24 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
                                         <input id="UseAlternativeBlackFrameAnalyzer" type="checkbox" is="emby-checkbox" />
-                                        <span>Use alternative black frame analyzer</span>
+                                        <span>Use alternative black frame analyzer (experimental)</span>
                                     </label>
 
                                     <div class="fieldDescription">
-                                        If enabled, the alternative black frame analyzer will be used.
+                                        If enabled, the alternative black frame analyzer will be used. This analyzer is experimental and may not work as expected.
                                     </div>
                                 </div>
 
-                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                <div class="checkboxContainer checkboxContainer-withDescription" id="ChapterMarkersBlackFrameSetting">
                                     <label class="emby-checkbox-label">
                                         <input id="UseChapterMarkersBlackFrame" type="checkbox" is="emby-checkbox" />
                                         <span>Use chapter markers for credits detection</span>
                                     </label>
 
                                     <div class="fieldDescription">
-                                        If enabled, chapter markers will be used to identify credits segments.
+                                        If enabled, chapter markers will be used to identify credits segments. Tries to detect credits by looking for a black frames close to chapter markers.
                                     </div>
+                                    <br />
                                 </div>
 
                                 <div class="inputContainer">
@@ -906,6 +907,8 @@
                 const librariesContainer = document.querySelector("div.folderAccessListContainer");
                 const autoSkipClientList = document.querySelector("div.AutoSkipClientListContainer");
                 const fullLengthChapters = document.getElementById("FullLengthChapters");
+                const useAlternativeBlackFrameAnalyzer = document.getElementById("UseAlternativeBlackFrameAnalyzer");
+                const chapterMarkersBlackFrameSetting = document.getElementById("ChapterMarkersBlackFrameSetting");
                 const snapToKeyframe = document.getElementById("SnapToKeyframe");
                 const globalTimestamps = document.getElementById("GlobalTimestamps");
                 const btnEraseGlobalTimestamps = document.getElementById("btnEraseGlobalTimestamps");
@@ -999,6 +1002,16 @@
                         serverSkipSettings.style.display = "none";
                     }
                 }
+
+                async function alternativeBlackFrameAnalyzerSettingsVisible() {
+                    if (useAlternativeBlackFrameAnalyzer.checked) {
+                        chapterMarkersBlackFrameSetting.style.display = "none";
+                    } else {
+                        chapterMarkersBlackFrameSetting.style.display = "unset";
+                    }
+                }
+
+                useAlternativeBlackFrameAnalyzer.addEventListener("change", alternativeBlackFrameAnalyzerSettingsVisible);
 
                 async function snapSettingsVisible() {
                     if (snapToKeyframe.checked) {
@@ -1527,6 +1540,7 @@
                         generateAutoSkipTypeList();
                         generateAutoSkipClientList();
                         pluginSkipSettingVisible();
+                        alternativeBlackFrameAnalyzerSettingsVisible();
                         snapSettingsVisible();
                         globalTimestampChanged();
 

--- a/IntroSkipper/Data/BlackFrame.cs
+++ b/IntroSkipper/Data/BlackFrame.cs
@@ -9,17 +9,7 @@ namespace IntroSkipper.Data;
 /// <remarks>
 /// Initializes a new instance of the <see cref="BlackFrame"/> class.
 /// </remarks>
-/// <param name="percent">Percentage of the frame that is black.</param>
-/// <param name="time">Time this frame appears at.</param>
-public class BlackFrame(int percent, double time)
-{
-    /// <summary>
-    /// Gets or sets the percentage of the frame that is black.
-    /// </summary>
-    public int Percentage { get; set; } = percent;
-
-    /// <summary>
-    /// Gets or sets the time (in seconds) this frame appeared at.
-    /// </summary>
-    public double Time { get; set; } = time;
-}
+/// <param name="Percentage">Percentage of the frame that is black.</param>
+/// <param name="Time">Time this frame appears at.</param>
+/// <param name="Frame">Frame number.</param>
+public record BlackFrame(int Percentage, double Time, int Frame);

--- a/IntroSkipper/Data/CreditScene.cs
+++ b/IntroSkipper/Data/CreditScene.cs
@@ -1,0 +1,13 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only.
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// A scene of black frames.
+/// </summary>
+/// <param name="StartFrame">The frame number of the first black frame.</param>
+/// <param name="EndFrame">The frame number of the last black frame.</param>
+/// <param name="StartTime">The time of the first black frame.</param>
+/// <param name="EndTime">The time of the last black frame.</param>
+public record CreditScene(int StartFrame, int EndFrame, double StartTime, double EndTime);

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -221,40 +221,65 @@ public static partial class FFmpegWrapper
             range.Start,
             range.End);
 
-        var blackFrames = new List<BlackFrame>();
+        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, true));
 
+        return ParseBlackFrame(raw, minimum);
+    }
+
+    /// <summary>
+    /// Finds the location of all black frames in a media file starting at a given time.
+    /// </summary>
+    /// <param name="episode">Media file to analyze.</param>
+    /// <returns>Array of frames that are mostly black.</returns>
+    public static BlackFrame[] DetectBlackFrames(QueuedEpisode episode)
+    {
+        ArgumentNullException.ThrowIfNull(episode);
+
+        // Seek to the start of the time range and find frames that are at least 50% black.
+        var args = string.Format(
+            CultureInfo.InvariantCulture,
+            "-skip_frame nokey -ss {0} -i \"{1}\" -an -dn -sn -vf \"blackframe=amount=0\" -f null -",
+            episode.CreditsFingerprintStart,
+            episode.Path);
+
+        // Cache the results to GUID-blackframes-START-END-v1.
+        var cacheKey = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}-blackframes-{1}-alt",
+            episode.EpisodeId.ToString("N"),
+            episode.CreditsFingerprintStart);
+
+        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, true));
+
+        return ParseBlackFrame(raw);
+    }
+
+    private static BlackFrame[] ParseBlackFrame(string raw, int minimum = 0)
+    {
+        var blackFrames = new List<BlackFrame>();
         /* Run the blackframe filter.
          *
          * Sample output:
          * [Parsed_blackframe_0 @ 0x0000000] frame:1 pblack:99 pts:43 t:0.043000 type:B last_keyframe:0
          * [Parsed_blackframe_0 @ 0x0000000] frame:2 pblack:99 pts:85 t:0.085000 type:B last_keyframe:0
          */
-        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, true));
         foreach (var line in raw.Split('\n'))
         {
-            // There is no FFmpeg flag to hide metadata such as description
-            // In our case, the metadata contained something that matched the regex.
-            if (line.StartsWith("[Parsed_blackframe_", StringComparison.OrdinalIgnoreCase))
+            var match = _blackFrameRegex.Match(line);
+            if (!match.Success)
             {
-                var matches = _blackFrameRegex.Matches(line);
-                if (matches.Count != 2)
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                var (strPercent, strTime) = (
-                    matches[0].Value.Split(':')[1],
-                    matches[1].Value.Split(':')[1]
-                );
+            var frame = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+            var percentage = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+            var time = double.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture);
 
-                var bf = new BlackFrame(
-                    Convert.ToInt32(strPercent, CultureInfo.InvariantCulture),
-                    Convert.ToDouble(strTime, CultureInfo.InvariantCulture));
+            var bf = new BlackFrame(percentage, time, frame);
 
-                if (bf.Percentage > minimum)
-                {
-                    blackFrames.Add(bf);
-                }
+            if (bf.Percentage >= minimum)
+            {
+                blackFrames.Add(bf);
             }
         }
 
@@ -725,6 +750,6 @@ public static partial class FFmpegWrapper
     [GeneratedRegex("silence_(?<type>start|end): (?<time>[0-9\\.]+)")]
     private static partial Regex SilenceRegex();
 
-    [GeneratedRegex("(pblack|t):[0-9.]+")]
+    [GeneratedRegex(@"\[Parsed_blackframe_0 @ [^\]]+\] frame:(\d+) pblack:(\d+) .*? t:([\d.]+)")]
     private static partial Regex BlackFrameRegex();
 }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -199,19 +199,22 @@ public static partial class FFmpegWrapper
     /// <param name="episode">Media file to analyze.</param>
     /// <param name="range">Time range to search.</param>
     /// <param name="minimum">Percentage of the frame that must be black.</param>
+    /// <param name="threshold">Threshold for black frame detection.</param>
     /// <returns>Array of frames that are mostly black.</returns>
     public static BlackFrame[] DetectBlackFrames(
         QueuedEpisode episode,
         TimeRange range,
-        int minimum)
+        int minimum,
+        int threshold)
     {
         // Seek to the start of the time range and find frames that are at least 50% black.
         var args = string.Format(
             CultureInfo.InvariantCulture,
-            "-ss {0} -i \"{1}\" -to {2} -an -dn -sn -vf \"blackframe=amount=50\" -f null -",
+            "-ss {0} -i \"{1}\" -to {2} -an -dn -sn -vf \"blackframe=amount=50:threshold={3}\" -f null -",
             range.Start,
             episode.Path,
-            range.End - range.Start);
+            range.End - range.Start,
+            threshold);
 
         // Cache the results to GUID-blackframes-START-END-v1.
         var cacheKey = string.Format(
@@ -230,17 +233,19 @@ public static partial class FFmpegWrapper
     /// Finds the location of all black frames in a media file starting at a given time.
     /// </summary>
     /// <param name="episode">Media file to analyze.</param>
+    /// <param name="threshold">Threshold for black frame detection.</param>
     /// <returns>Array of frames that are mostly black.</returns>
-    public static BlackFrame[] DetectBlackFrames(QueuedEpisode episode)
+    public static BlackFrame[] DetectBlackFrames(QueuedEpisode episode, int threshold)
     {
         ArgumentNullException.ThrowIfNull(episode);
 
-        // Seek to the start of the time range and find frames that are at least 50% black.
+        // Seek to the start of the time range and get the black level of each frame.
         var args = string.Format(
             CultureInfo.InvariantCulture,
-            "-skip_frame nokey -ss {0} -i \"{1}\" -an -dn -sn -vf \"blackframe=amount=0\" -f null -",
+            "-skip_frame nokey -ss {0} -i \"{1}\" -an -dn -sn -vf \"blackframe=amount=0:threshold={2}\" -f null -",
             episode.CreditsFingerprintStart,
-            episode.Path);
+            episode.Path,
+            threshold);
 
         // Cache the results to GUID-blackframes-START-END-v1.
         var cacheKey = string.Format(

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -187,6 +187,10 @@ public class BaseItemAnalyzerTask(
         // Create analyzers list
         var analyzers = new List<IMediaFileAnalyzer>();
 
+        IMediaFileAnalyzer blackFrameAnalyzer = _config.UseAlternativeBlackFrameAnalyzer
+            ? new BlackFrameAltAnalyzer(_loggerFactory.CreateLogger<BlackFrameAltAnalyzer>())
+            : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>());
+
         // Add analyzers based on conditions
         if (!chromaprintOnly && action is AnalyzerAction.Chapter or AnalyzerAction.Default)
         {
@@ -200,7 +204,7 @@ public class BaseItemAnalyzerTask(
 
         if (!chromaprintOnly && mode is AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.BlackFrame)
         {
-            analyzers.Add(new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()));
+            analyzers.Add(blackFrameAnalyzer);
         }
 
         if (!first.IsAnime && !first.IsMovie && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)


### PR DESCRIPTION
Alternative BlackFrame analyzer with the following improvements:

- Analyzes black frame percentage for all key frames at the end of episodes/movies
- Detects contiguous sequences of black key frames
- Capable of identifying post-credit scenes with higher accuracy
- Optional feature that must be enabled in settings
- May have slightly higher performance impact than the original method

Needs testing.

## Summary by Sourcery

Implements an alternative black frame analyzer for more accurate detection of post-credit scenes. The new analyzer analyzes black frame percentage for all key frames, detects contiguous sequences of black key frames, and can be enabled in the plugin settings.

New Features:
- Adds an alternative black frame analyzer that analyzes black frame percentage for all key frames at the end of episodes/movies.
- The alternative analyzer detects contiguous sequences of black key frames.
- The alternative analyzer is capable of identifying post-credit scenes with higher accuracy.
- Adds an option to enable the alternative black frame analyzer in the plugin settings.