### PR TITLE
docs: correct namespace override for serilog

### DIFF
--- a/docs/debug_logs.md
+++ b/docs/debug_logs.md
@@ -29,7 +29,7 @@
             "Override": {
                 "Microsoft": "Warning",
                 "System": "Warning",                // be sure to add the trailing comma after "Warning",
-                "ConfusedPolarBear": "Debug"        // newly added line
+                "IntroSkipper": "Debug"             // newly added line
             }
         },
         // rest of file ommited for brevity


### PR DESCRIPTION
Found this while doing some testing with my own issue, so fixed it.

## Summary by Sourcery

Documentation:
- Corrects the namespace override in the debug logs documentation, changing 'ConfusedPolarBear' to 'IntroSkipper'.