### PR TITLE
Make analyzer order configurable

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -41,11 +41,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AnalyzeSeasonZero { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to only use chromaprint.
-    /// </summary>
-    public bool PreferChromaprint { get; set; }
-
-    /// <summary>
     /// Gets or sets a value indicating whether the episode's fingerprint should be cached to the filesystem.
     /// </summary>
     public bool CacheFingerprints { get; set; } = true;
@@ -67,14 +62,19 @@ public class PluginConfiguration : BasePluginConfiguration
     // ===== Custom analysis settings =====
 
     /// <summary>
-    /// Gets or sets a value indicating whether Introductions should be analyzed.
+    /// Gets or sets the list of analyzers to use for introductions.
     /// </summary>
-    public bool ScanIntroduction { get; set; } = true;
+    public string IntroAnalyzerOrderList { get; set; } = "Chapter:true, Chromaprint:true";
 
     /// <summary>
-    /// Gets or sets a value indicating whether Credits should be analyzed.
+    /// Gets or sets the list of analyzers to use for credits.
     /// </summary>
-    public bool ScanCredits { get; set; } = true;
+    public string CreditsAnalyzerOrderList { get; set; } = "Chapter:true, BlackFrame:true, Chromaprint:true";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to always prefer Chromaprint for anime.
+    /// </summary>
+    public bool AnimeChromaprint { get; set; } = true;
 
     /// <summary>
     /// Gets or sets a value indicating whether Recaps should be analyzed.

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -87,14 +87,6 @@
                                 </div>
                             </div>
 
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label class="emby-checkbox-label">
-                                    <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
-                                    <span>Prefer Chromaprint Analysis</span>
-                                </label>
-                                <div class="fieldDescription">Setting an analysis mode in the advanced options will override this setting.</div>
-                            </div>
-
                             <div class="inputContainer" id="excludedSeries">
                                 <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
                                 <input id="ExcludeSeries" type="text" is="emby-input" />
@@ -110,18 +102,16 @@
                                     Per the jellyfin MediaSegments API, records must be updated individually and may be slow to regenerate.
                                 </p>
 
-                                <div class="checkboxContainer">
-                                    <label class="emby-checkbox-label">
-                                        <input id="ScanIntroduction" type="checkbox" is="emby-checkbox" />
-                                        <span>Identify Introductions</span>
-                                    </label>
+                                <div id="introAnalyzerOrderContainer" style="margin-bottom: -1.5em;">
+                                    <h3 class="checkboxListLabel"><b>Identify Introductions</b> <br />Drag to reorder analyzers (highest priority first):</h3>
+                                    <div class="checkboxList paperList sortableList" style="padding: 0.5em 1em" id="introAnalyzerOrderList"></div>
+                                    <input id="IntroAnalyzerOrderList" type="hidden" is="emby-input" />
                                 </div>
 
-                                <div class="checkboxContainer">
-                                    <label class="emby-checkbox-label">
-                                        <input id="ScanCredits" type="checkbox" is="emby-checkbox" />
-                                        <span>Identify Credits</span>
-                                    </label>
+                                <div id="creditsAnalyzerOrderContainer" style="margin-bottom: -0.5em;">
+                                    <h3 class="checkboxListLabel"><b>Identify Credits</b> <br />Drag to reorder analyzers (highest priority first):</h3>
+                                    <div class="checkboxList paperList sortableList" style="padding: 0.5em 1em" id="creditsAnalyzerOrderList"></div>
+                                    <input id="CreditsAnalyzerOrderList" type="hidden" is="emby-input" />
                                 </div>
 
                                 <div class="checkboxContainer">
@@ -851,11 +841,13 @@
                     "ChapterAnalyzerPreviewPattern",
                     "ChapterAnalyzerRecapPattern",
                     "TypeList",
+                    "IntroAnalyzerOrderList",
+                    "CreditsAnalyzerOrderList",
                     // UI customization
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeMovies", "AnalyzeSeasonZero", "SelectAllLibraries", "UpdateMediaSegments", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanRecap", "ScanPreview", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe"];
 
                 // visualizer elements
                 const analyzeMovies = document.getElementById("AnalyzeMovies");
@@ -936,6 +928,183 @@
                     textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
                         .map((checkbox) => checkbox.nextElementSibling.textContent)
                         .join(", ");
+                }
+
+                function generateSortableCheckboxList(items, containerId, textFieldId) {
+                    const container = document.getElementById(containerId);
+                    const savedOrderText = document.getElementById(textFieldId).value;
+
+                    // Parse the saved format like "Chapter:true, BlackFrame:false, Chromaprint:true"
+                    const savedItems = new Map();
+                    if (savedOrderText) {
+                        savedOrderText.split(", ").forEach(item => {
+                            if (item.includes(":")) {
+                                const [name, enabledStr] = item.split(":");
+                                savedItems.set(name, enabledStr.toLowerCase() === "true");
+                            } else {
+                                // Legacy format support
+                                savedItems.set(item, true);
+                            }
+                        });
+                    }
+
+                    // Create ordered array - first use saved order, then add any remaining items
+                    let orderedItems = [...savedItems.keys()];
+                    items.forEach(item => {
+                        if (!orderedItems.includes(item)) {
+                            orderedItems.push(item);
+                            savedItems.set(item, false); // Default to disabled for items not in saved list
+                        }
+                    });
+
+                    const fragment = document.createDocumentFragment();
+                    for (const item of orderedItems) {
+                        const div = document.createElement("div");
+                        div.className = "sortable-item";
+                        div.draggable = true;
+                        div.style.cursor = "move";
+                        div.style.padding = "5px";
+                        div.style.marginBottom = "5px";
+                        div.style.background = "rgba(0, 0, 0, 0.1)";
+                        div.style.borderRadius = "4px";
+                        div.style.display = "flex";
+                        div.style.alignItems = "center";
+
+                        // Add drag handle
+                        const handle = document.createElement("span");
+                        handle.innerHTML = "&#8801;"; // Unicode hamburger icon
+                        handle.style.marginRight = "10px";
+                        handle.style.cursor = "move";
+                        handle.style.fontSize = "1.2em";
+                        div.appendChild(handle);
+
+                        const label = document.createElement("label");
+                        label.className = "emby-checkbox-label";
+                        label.style.margin = "0";
+                        label.style.flex = "1";
+                        label.innerHTML = '<input type="checkbox" is="emby-checkbox"' +
+                                         (savedItems.get(item) ? " checked" : "") + '>' +
+                                         '<span class="checkboxLabel">' + item + "</span>";
+                        div.appendChild(label);
+
+                        // Add drag and drop event listeners
+                        div.addEventListener("dragstart", handleDragStart);
+                        div.addEventListener("dragover", handleDragOver);
+                        div.addEventListener("dragenter", handleDragEnter);
+                        div.addEventListener("dragleave", handleDragLeave);
+                        div.addEventListener("drop", handleDrop);
+                        div.addEventListener("dragend", handleDragEnd);
+
+                        fragment.appendChild(div);
+                    }
+
+                    container.innerHTML = "";
+                    container.appendChild(fragment);
+
+                    container.addEventListener("change", (e) => {
+                        if (e.target.type === "checkbox") {
+                            updateSortableList(document.getElementById(textFieldId), container);
+                        }
+                    }, { passive: true });
+
+                    // Initialize the list
+                    updateSortableList(document.getElementById(textFieldId), container);
+                }
+
+                function updateSortableList(textField, container) {
+                    const items = Array.from(container.querySelectorAll('.sortable-item'));
+                    const result = items.map(item => {
+                        const checkbox = item.querySelector('input[type="checkbox"]');
+                        const label = item.querySelector('.checkboxLabel');
+                        return label.textContent + ":" + (checkbox.checked ? "true" : "false");
+                    }).join(", ");
+
+                    textField.value = result;
+                }
+
+                // Drag and drop handlers
+                let dragSrcEl = null;
+
+                function handleDragStart(e) {
+                    dragSrcEl = this;
+                    e.dataTransfer.effectAllowed = 'move';
+                    e.dataTransfer.setData('text/html', this.innerHTML);
+                    this.style.opacity = '0.4';
+                }
+
+                function handleDragOver(e) {
+                    if (e.preventDefault) {
+                        e.preventDefault();
+                    }
+                    e.dataTransfer.dropEffect = 'move';
+                    return false;
+                }
+
+                function handleDragEnter(e) {
+                    this.classList.add('over');
+                    this.style.borderTop = '2px solid #38c';
+                }
+
+                function handleDragLeave(e) {
+                    this.classList.remove('over');
+                    this.style.borderTop = '';
+                }
+
+                function handleDrop(e) {
+                    if (e.stopPropagation) {
+                        e.stopPropagation();
+                    }
+
+                    if (dragSrcEl !== this) {
+                        const list = this.parentNode;
+                        const items = Array.from(list.children);
+                        const fromIndex = items.indexOf(dragSrcEl);
+                        const toIndex = items.indexOf(this);
+
+                        if (fromIndex < toIndex) {
+                            list.insertBefore(dragSrcEl, this.nextSibling);
+                        } else {
+                            list.insertBefore(dragSrcEl, this);
+                        }
+
+                        // Update the hidden field with the new order
+                        const containerId = list.id;
+                        let textFieldId = '';
+
+                        // Map container IDs to their corresponding hidden fields
+                        switch (containerId) {
+                            case 'introAnalyzerOrderList':
+                                textFieldId = 'IntroAnalyzerOrderList';
+                                break;
+                            case 'creditsAnalyzerOrderList':
+                                textFieldId = 'CreditsAnalyzerOrderList';
+                                break;
+                        }
+
+                        if (textFieldId) {
+                            updateSortableList(document.getElementById(textFieldId), list);
+                        }
+                    }
+
+                    return false;
+                }
+
+                function handleDragEnd(e) {
+                    this.style.opacity = '1';
+                    this.style.borderTop = '';
+
+                    const items = document.querySelectorAll('.sortable-item');
+                    items.forEach(item => {
+                        item.classList.remove('over');
+                        item.style.borderTop = '';
+                    });
+                }
+
+                function generateAnalyzerOrderLists() {
+                    const introAnalyzers = ["Chapter", "Chromaprint"];
+                    const creditsAnalyzers = ["Chapter", "BlackFrame", "Chromaprint"];
+                    generateSortableCheckboxList(introAnalyzers, "introAnalyzerOrderList", "IntroAnalyzerOrderList");
+                    generateSortableCheckboxList(creditsAnalyzers, "creditsAnalyzerOrderList", "CreditsAnalyzerOrderList");
                 }
 
                 function generateCheckboxList(items, containerId, textFieldId) {
@@ -1515,6 +1684,7 @@
                         autoSkipChanged();
                         generateAutoSkipTypeList();
                         generateAutoSkipClientList();
+                        generateAnalyzerOrderLists();
                         pluginSkipSettingVisible();
                         snapSettingsVisible();
                         globalTimestampChanged();

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,26 +19,36 @@ namespace IntroSkipper.ScheduledTasks;
 /// <summary>
 /// Common code shared by all media item analyzer tasks.
 /// </summary>
-/// <remarks>
-/// Initializes a new instance of the <see cref="BaseItemAnalyzerTask"/> class.
-/// </remarks>
-/// <param name="logger">Task logger.</param>
-/// <param name="loggerFactory">Logger factory.</param>
-/// <param name="libraryManager">Library manager.</param>
-/// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
-public class BaseItemAnalyzerTask(
-    ILogger logger,
-    ILoggerFactory loggerFactory,
-    ILibraryManager libraryManager,
-    MediaSegmentUpdateManager mediaSegmentUpdateManager)
+public class BaseItemAnalyzerTask
 {
-    private readonly ILogger _logger = logger;
-    private readonly ILoggerFactory _loggerFactory = loggerFactory;
-    private readonly ILibraryManager _libraryManager = libraryManager;
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly ILogger _logger;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILibraryManager _libraryManager;
+    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly bool _ffmpegValid = FFmpegWrapper.CheckFFmpegVersion();
-    private Dictionary<AnalysisMode, List<IMediaFileAnalyzer>> _analyzers = [];
+    private readonly MediaAnalyzerFactory _analyzerFactory;
+    private Dictionary<AnalysisMode, Collection<IMediaFileAnalyzer>> _analyzers = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseItemAnalyzerTask"/> class.
+    /// </summary>
+    /// <param name="logger">Task logger.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    /// <param name="libraryManager">Library manager.</param>
+    /// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
+    public BaseItemAnalyzerTask(
+        ILogger logger,
+        ILoggerFactory loggerFactory,
+        ILibraryManager libraryManager,
+        MediaSegmentUpdateManager mediaSegmentUpdateManager)
+    {
+        _logger = logger;
+        _loggerFactory = loggerFactory;
+        _libraryManager = libraryManager;
+        _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+        _analyzerFactory = new MediaAnalyzerFactory(loggerFactory, _config, _ffmpegValid);
+    }
 
     /// <summary>
     /// Analyze all media items on the server.
@@ -71,7 +82,7 @@ public class BaseItemAnalyzerTask(
                 "If Jellyfin is running in a container, upgrade to version 10.10.0 or newer.");
         }
 
-        _analyzers = GetAnalyzers();
+        _analyzers = (Dictionary<AnalysisMode, Collection<IMediaFileAnalyzer>>)_analyzerFactory.GetAnalyzers();
 
         var modes = _analyzers.Keys;
 
@@ -178,7 +189,7 @@ public class BaseItemAnalyzerTask(
             first.SeriesName,
             first.SeasonNumber);
 
-        var analyzers = GetFilteredAnalyzers(first, mode, _analyzers[mode]);
+        var analyzers = _analyzerFactory.GetFilteredAnalyzers(first, mode, _analyzers[mode]);
 
         // Use each analyzer to find skippable ranges in all media files, removing successfully
         // analyzed items from the queue.
@@ -192,101 +203,5 @@ public class BaseItemAnalyzerTask(
         await Plugin.Instance!.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId)).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
-    }
-
-    private Dictionary<AnalysisMode, List<IMediaFileAnalyzer>> GetAnalyzers()
-    {
-        var analyzers = new Dictionary<AnalysisMode, List<IMediaFileAnalyzer>>();
-
-        // Create analyzer lists
-        var introAnalyzers = ParseAnalyzers(_config.IntroAnalyzerOrderList);
-        var creditsAnalyzers = ParseAnalyzers(_config.CreditsAnalyzerOrderList, includeBlackFrame: true);
-        var chapterAnalyzer = new List<IMediaFileAnalyzer> { new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()) };
-
-        // Populate the dictionary
-        if (introAnalyzers.Count > 0)
-        {
-            analyzers.Add(AnalysisMode.Introduction, introAnalyzers);
-        }
-
-        if (creditsAnalyzers.Count > 0)
-        {
-            analyzers.Add(AnalysisMode.Credits, creditsAnalyzers);
-        }
-
-        if (_config.ScanRecap)
-        {
-            analyzers.Add(AnalysisMode.Recap, chapterAnalyzer);
-        }
-
-        if (_config.ScanPreview)
-        {
-            analyzers.Add(AnalysisMode.Preview, chapterAnalyzer);
-        }
-
-        return analyzers;
-    }
-
-    private List<IMediaFileAnalyzer> ParseAnalyzers(string? configString, bool includeBlackFrame = false)
-    {
-        var result = new List<IMediaFileAnalyzer>();
-        if (string.IsNullOrEmpty(configString))
-        {
-            return result;
-        }
-
-        var analyzerItems = configString.Split(',')
-            .Select(item =>
-            {
-                var parts = item.Split(':', 2);
-                return (Name: parts[0].Trim(), Enabled: bool.Parse(parts[1]));
-            })
-            .Where(analyzer => analyzer.Enabled)
-            .ToList();
-
-        foreach (var (name, _) in analyzerItems)
-        {
-            IMediaFileAnalyzer? instance = name switch
-            {
-                "Chapter" => new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()),
-                "Chromaprint" when _ffmpegValid => new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()),
-                "BlackFrame" when includeBlackFrame => new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()),
-                _ => null
-            };
-
-            if (instance is not null)
-            {
-                result.Add(instance);
-            }
-        }
-
-        return result;
-    }
-
-    private List<IMediaFileAnalyzer> GetFilteredAnalyzers(QueuedEpisode first, AnalysisMode mode, List<IMediaFileAnalyzer> analyzers)
-    {
-        List<IMediaFileAnalyzer> result = Plugin.Instance!.GetAnalyzerAction(first.SeasonId, mode) switch
-        {
-            AnalyzerAction.Chapter => [.. analyzers.OfType<ChapterAnalyzer>()],
-            AnalyzerAction.Chromaprint => [.. analyzers.OfType<ChromaprintAnalyzer>()],
-            AnalyzerAction.BlackFrame => [.. analyzers.OfType<BlackFrameAnalyzer>()],
-            AnalyzerAction.None => [],
-            _ when first.IsMovie => [.. analyzers.Where(a => a is not ChromaprintAnalyzer)],
-            _ => [.. analyzers]
-        };
-
-        if (result.Count > 1 && first.IsAnime && _config.AnimeChromaprint && mode == AnalysisMode.Credits)
-        {
-            int chromaprintIndex = result.FindIndex(a => a is ChromaprintAnalyzer);
-            int blackFrameIndex = result.FindIndex(a => a is BlackFrameAnalyzer);
-
-            // Swap the analyzers if needed
-            if (chromaprintIndex != -1 && blackFrameIndex != -1 && chromaprintIndex > blackFrameIndex)
-            {
-                (result[blackFrameIndex], result[chromaprintIndex]) = (result[chromaprintIndex], result[blackFrameIndex]);
-            }
-        }
-
-        return result;
     }
 }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -37,6 +37,7 @@ public class BaseItemAnalyzerTask(
     private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly bool _ffmpegValid = FFmpegWrapper.CheckFFmpegVersion();
+    private Dictionary<AnalysisMode, List<IMediaFileAnalyzer>> _analyzers = [];
 
     /// <summary>
     /// Analyze all media items on the server.
@@ -50,13 +51,6 @@ public class BaseItemAnalyzerTask(
         CancellationToken cancellationToken,
         IReadOnlyCollection<Guid>? seasonsToAnalyze = null)
     {
-        HashSet<AnalysisMode> modes = [
-            .. _config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>()
-        ];
-
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager);
@@ -69,19 +63,23 @@ public class BaseItemAnalyzerTask(
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        int totalQueued = queue.Sum(kvp => kvp.Value.Count) * modes.Count;
-        if (totalQueued == 0)
-        {
-            _logger.LogInformation("No libraries selected for analysis. To enable, check library configuration > Media Segment Providers.");
-            return;
-        }
-
         if (!_ffmpegValid)
         {
             _logger.LogInformation(
                 "Skipping Chromaprint analysis! Chromaprint is not enabled in the current ffmpeg. " +
                 "If Jellyfin is running natively, install jellyfin-ffmpeg7. " +
                 "If Jellyfin is running in a container, upgrade to version 10.10.0 or newer.");
+        }
+
+        _analyzers = GetAnalyzers();
+
+        var modes = _analyzers.Keys;
+
+        int totalQueued = queue.Sum(kvp => kvp.Value.Count) * modes.Count;
+        if (totalQueued == 0)
+        {
+            _logger.LogInformation("No libraries selected for analysis. To enable, check library configuration > Media Segment Providers.");
+            return;
         }
 
         int totalProcessed = 0;
@@ -172,10 +170,6 @@ public class BaseItemAnalyzerTask(
         }
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
-        var action = plugin.GetAnalyzerAction(first.SeasonId, mode);
-
-        var chromaprintOnly = _ffmpegValid && _config.PreferChromaprint && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint;
 
         _logger.LogInformation(
             "[Mode: {Mode}] Analyzing {Count} files from {Name} season {Season}",
@@ -184,29 +178,7 @@ public class BaseItemAnalyzerTask(
             first.SeriesName,
             first.SeasonNumber);
 
-        // Create analyzers list
-        var analyzers = new List<IMediaFileAnalyzer>();
-
-        // Add analyzers based on conditions
-        if (!chromaprintOnly && action is AnalyzerAction.Chapter or AnalyzerAction.Default)
-        {
-            analyzers.Add(new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()));
-        }
-
-        if (first.IsAnime && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
-        {
-            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
-        }
-
-        if (!chromaprintOnly && mode is AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.BlackFrame)
-        {
-            analyzers.Add(new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()));
-        }
-
-        if (!first.IsAnime && !first.IsMovie && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
-        {
-            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
-        }
+        var analyzers = GetFilteredAnalyzers(first, mode, _analyzers[mode]);
 
         // Use each analyzer to find skippable ranges in all media files, removing successfully
         // analyzed items from the queue.
@@ -220,5 +192,101 @@ public class BaseItemAnalyzerTask(
         await Plugin.Instance!.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId)).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
+    }
+
+    private Dictionary<AnalysisMode, List<IMediaFileAnalyzer>> GetAnalyzers()
+    {
+        var analyzers = new Dictionary<AnalysisMode, List<IMediaFileAnalyzer>>();
+
+        // Create analyzer lists
+        var introAnalyzers = ParseAnalyzers(_config.IntroAnalyzerOrderList);
+        var creditsAnalyzers = ParseAnalyzers(_config.CreditsAnalyzerOrderList, includeBlackFrame: true);
+        var chapterAnalyzer = new List<IMediaFileAnalyzer> { new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()) };
+
+        // Populate the dictionary
+        if (introAnalyzers.Count > 0)
+        {
+            analyzers.Add(AnalysisMode.Introduction, introAnalyzers);
+        }
+
+        if (creditsAnalyzers.Count > 0)
+        {
+            analyzers.Add(AnalysisMode.Credits, creditsAnalyzers);
+        }
+
+        if (_config.ScanRecap)
+        {
+            analyzers.Add(AnalysisMode.Recap, chapterAnalyzer);
+        }
+
+        if (_config.ScanPreview)
+        {
+            analyzers.Add(AnalysisMode.Preview, chapterAnalyzer);
+        }
+
+        return analyzers;
+    }
+
+    private List<IMediaFileAnalyzer> ParseAnalyzers(string? configString, bool includeBlackFrame = false)
+    {
+        var result = new List<IMediaFileAnalyzer>();
+        if (string.IsNullOrEmpty(configString))
+        {
+            return result;
+        }
+
+        var analyzerItems = configString.Split(',')
+            .Select(item =>
+            {
+                var parts = item.Split(':', 2);
+                return (Name: parts[0].Trim(), Enabled: bool.Parse(parts[1]));
+            })
+            .Where(analyzer => analyzer.Enabled)
+            .ToList();
+
+        foreach (var (name, _) in analyzerItems)
+        {
+            IMediaFileAnalyzer? instance = name switch
+            {
+                "Chapter" => new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()),
+                "Chromaprint" when _ffmpegValid => new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()),
+                "BlackFrame" when includeBlackFrame => new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()),
+                _ => null
+            };
+
+            if (instance is not null)
+            {
+                result.Add(instance);
+            }
+        }
+
+        return result;
+    }
+
+    private List<IMediaFileAnalyzer> GetFilteredAnalyzers(QueuedEpisode first, AnalysisMode mode, List<IMediaFileAnalyzer> analyzers)
+    {
+        List<IMediaFileAnalyzer> result = Plugin.Instance!.GetAnalyzerAction(first.SeasonId, mode) switch
+        {
+            AnalyzerAction.Chapter => [.. analyzers.OfType<ChapterAnalyzer>()],
+            AnalyzerAction.Chromaprint => [.. analyzers.OfType<ChromaprintAnalyzer>()],
+            AnalyzerAction.BlackFrame => [.. analyzers.OfType<BlackFrameAnalyzer>()],
+            AnalyzerAction.None => [],
+            _ when first.IsMovie => [.. analyzers.Where(a => a is not ChromaprintAnalyzer)],
+            _ => [.. analyzers]
+        };
+
+        if (result.Count > 1 && first.IsAnime && _config.AnimeChromaprint && mode == AnalysisMode.Credits)
+        {
+            int chromaprintIndex = result.FindIndex(a => a is ChromaprintAnalyzer);
+            int blackFrameIndex = result.FindIndex(a => a is BlackFrameAnalyzer);
+
+            // Swap the analyzers if needed
+            if (chromaprintIndex != -1 && blackFrameIndex != -1 && chromaprintIndex > blackFrameIndex)
+            {
+                (result[blackFrameIndex], result[chromaprintIndex]) = (result[chromaprintIndex], result[blackFrameIndex]);
+            }
+        }
+
+        return result;
     }
 }

--- a/IntroSkipper/ScheduledTasks/MediaAnalyzerFactory.cs
+++ b/IntroSkipper/ScheduledTasks/MediaAnalyzerFactory.cs
@@ -1,0 +1,152 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.ScheduledTasks;
+
+/// <summary>
+/// Manages the creation and configuration of media analyzers based on plugin settings.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MediaAnalyzerFactory"/> class.
+/// </remarks>
+/// <param name="loggerFactory">Logger factory for creating analyzer-specific loggers.</param>
+/// <param name="config">Plugin configuration.</param>
+/// <param name="ffmpegValid">Whether FFmpeg with Chromaprint is available.</param>
+public class MediaAnalyzerFactory(
+    ILoggerFactory loggerFactory,
+    PluginConfiguration config,
+    bool ffmpegValid)
+{
+    private readonly ILoggerFactory _loggerFactory = loggerFactory;
+    private readonly PluginConfiguration _config = config;
+    private readonly bool _ffmpegValid = ffmpegValid;
+
+    /// <summary>
+    /// Gets analyzers for all configured analysis modes.
+    /// </summary>
+    /// <returns>Dictionary mapping analysis modes to their associated analyzers.</returns>
+    public IReadOnlyDictionary<AnalysisMode, Collection<IMediaFileAnalyzer>> GetAnalyzers()
+    {
+        var analyzers = new Dictionary<AnalysisMode, Collection<IMediaFileAnalyzer>>();
+
+        // Create analyzer lists
+        var introAnalyzers = ParseAnalyzers(_config.IntroAnalyzerOrderList);
+        var creditsAnalyzers = ParseAnalyzers(_config.CreditsAnalyzerOrderList, includeBlackFrame: true);
+        var chapterAnalyzer = new Collection<IMediaFileAnalyzer> { new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()) };
+
+        // Populate the dictionary
+        if (introAnalyzers.Count > 0)
+        {
+            analyzers.Add(AnalysisMode.Introduction, introAnalyzers);
+        }
+
+        if (creditsAnalyzers.Count > 0)
+        {
+            analyzers.Add(AnalysisMode.Credits, creditsAnalyzers);
+        }
+
+        if (_config.ScanRecap)
+        {
+            analyzers.Add(AnalysisMode.Recap, chapterAnalyzer);
+        }
+
+        if (_config.ScanPreview)
+        {
+            analyzers.Add(AnalysisMode.Preview, chapterAnalyzer);
+        }
+
+        return analyzers;
+    }
+
+    /// <summary>
+    /// Parses a comma-separated configuration string into a list of analyzers.
+    /// </summary>
+    /// <param name="configString">Configuration string from settings.</param>
+    /// <param name="includeBlackFrame">Whether to include BlackFrame analyzer.</param>
+    /// <returns>Collection of configured analyzers.</returns>
+    private Collection<IMediaFileAnalyzer> ParseAnalyzers(string? configString, bool includeBlackFrame = false)
+    {
+        var result = new Collection<IMediaFileAnalyzer>();
+        if (string.IsNullOrEmpty(configString))
+        {
+            return result;
+        }
+
+        var analyzerItems = configString.Split(',')
+            .Select(item =>
+            {
+                var parts = item.Split(':', 2);
+                if (parts.Length < 2 || !bool.TryParse(parts[1].Trim(), out var enabled))
+                {
+                    return (Name: parts[0].Trim(), Enabled: false);
+                }
+
+                return (Name: parts[0].Trim(), Enabled: enabled);
+            })
+            .Where(analyzer => analyzer.Enabled)
+            .ToList();
+
+        foreach (var (name, _) in analyzerItems)
+        {
+            IMediaFileAnalyzer? instance = name switch
+            {
+                "Chapter" => new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()),
+                "Chromaprint" when _ffmpegValid => new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()),
+                "BlackFrame" when includeBlackFrame => new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()),
+                _ => null
+            };
+
+            if (instance is not null)
+            {
+                result.Add(instance);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets filtered analyzers based on specific episode and mode.
+    /// </summary>
+    /// <param name="first">First episode to analyze.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="analyzers">Available analyzers for this mode.</param>
+    /// <returns>Collection of filtered analyzers.</returns>
+    public IReadOnlyCollection<IMediaFileAnalyzer> GetFilteredAnalyzers(
+        QueuedEpisode first,
+        AnalysisMode mode,
+        IReadOnlyCollection<IMediaFileAnalyzer> analyzers)
+    {
+        List<IMediaFileAnalyzer> result = Plugin.Instance!.GetAnalyzerAction(first.SeasonId, mode) switch
+        {
+            AnalyzerAction.Chapter => [.. analyzers.OfType<ChapterAnalyzer>()],
+            AnalyzerAction.Chromaprint => [.. analyzers.OfType<ChromaprintAnalyzer>()],
+            AnalyzerAction.BlackFrame => [.. analyzers.OfType<BlackFrameAnalyzer>()],
+            AnalyzerAction.None => [],
+            _ when first.IsMovie => [.. analyzers.Where(a => a is not ChromaprintAnalyzer)],
+            _ => [.. analyzers]
+        };
+
+        if (result.Count > 1 && first.IsAnime && _config.AnimeChromaprint && mode == AnalysisMode.Credits)
+        {
+            int chromaprintIndex = result.FindIndex(a => a is ChromaprintAnalyzer);
+            int blackFrameIndex = result.FindIndex(a => a is BlackFrameAnalyzer);
+
+            // Swap the analyzers if needed
+            if (chromaprintIndex != -1 && blackFrameIndex != -1 && chromaprintIndex > blackFrameIndex)
+            {
+                (result[blackFrameIndex], result[chromaprintIndex]) = (result[chromaprintIndex], result[blackFrameIndex]);
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Allows users to configure the order and selection of analyzers for identifying intros and credits. This change introduces a drag-and-drop interface in the plugin configuration to prioritize analyzers like Chapter, Chromaprint, and BlackFrame. It also removes the 'PreferChromaprint' option and adds a setting to prefer Chromaprint for anime credits.

New Features:
- Introduces configurable analyzer order for intro and credit detection.
- Adds AnimeChromaprint setting to prefer Chromaprint analyzer for anime credits

Enhancements:
- Implements a drag-and-drop interface for configuring analyzer order.
- Adds a setting to prefer Chromaprint for anime credits.
- Refactors the analyzer selection logic to use the configured order.
- Improves the flexibility of the analysis process by allowing users to customize the analyzer pipeline to their needs.
- Adds UI to configure the order of the analyzers

Tests:
- Adds drag and drop functionality to reorder analyzers