### PR TITLE
Make analysis parameters just parameters

### DIFF
--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -55,20 +55,25 @@
                                 </div>
                             </div>
 
-                            <div class="checkboxContainer">
-                                <label class="emby-checkbox-label">
-                                    <input id="AnalyzeMovies" type="checkbox" is="emby-checkbox" />
-                                    <span>Analyze Movies</span>
-                                </label>
-                            </div>
-
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
-                                    <input id="AnalyzeSeasonZero" type="checkbox" is="emby-checkbox" />
-                                    <span>Analyze Season 0 (Specials / Extras)</span>
+                                    <input id="SelectAllLibraries" type="checkbox" is="emby-checkbox" />
+                                    <span>Enable analysis for all libraries (uncheck to limit analysis to specific libraries)</span>
                                 </label>
+                                <div class="folderAccessListContainer" style="margin-bottom: -1em">
+                                    <div class="folderAccess">
+                                        <h3 class="checkboxListLabel">Limit analysis to the following libraries</h3>
+                                        <div class="checkboxList paperList" style="padding: 0.5em 1em" id="libraryCheckboxes"></div>
+                                    </div>
+                                    <label class="inputLabel" for="SelectedLibraries"></label>
+                                    <input id="SelectedLibraries" type="hidden" is="emby-input" />
+                                </div>
+                            </div>
 
-                                <div class="fieldDescription">Note: Shows containing both a specials and extra folder will identify extras as season 0 and ignore specials, regardless of this setting.</div>
+                            <div class="inputContainer" id="excludedSeries">
+                                <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
+                                <input id="ExcludeSeries" type="text" is="emby-input" />
+                                <div class="fieldDescription">Exclude series from analysis. Enter a comma-separated list of series names to exclude.</div>
                             </div>
 
                             <div class="checkboxContainer">
@@ -99,33 +104,28 @@
                                 </label>
                             </div>
 
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="AnalyzeMovies" type="checkbox" is="emby-checkbox" />
+                                    <span>Analyze Movies</span>
+                                </label>
+                            </div>
+
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input id="AnalyzeSeasonZero" type="checkbox" is="emby-checkbox" />
+                                    <span>Analyze Season 0 (Specials / Extras)</span>
+                                </label>
+
+                                <div class="fieldDescription">Note: Shows containing both a specials and extra folder will identify extras as season 0 and ignore specials, regardless of this setting.</div>
+                            </div>
+
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
                                     <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
                                     <span>Prefer Chromaprint Analysis</span>
                                 </label>
                                 <div class="fieldDescription">Setting an analysis mode in the advanced options will override this setting.</div>
-                            </div>
-
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label class="emby-checkbox-label">
-                                    <input id="SelectAllLibraries" type="checkbox" is="emby-checkbox" />
-                                    <span>Enable analysis for all libraries (uncheck to limit analysis to specific libraries)</span>
-                                </label>
-                                <div class="folderAccessListContainer" style="margin-bottom: -1em">
-                                    <div class="folderAccess">
-                                        <h3 class="checkboxListLabel">Limit analysis to the following libraries</h3>
-                                        <div class="checkboxList paperList" style="padding: 0.5em 1em" id="libraryCheckboxes"></div>
-                                    </div>
-                                    <label class="inputLabel" for="SelectedLibraries"></label>
-                                    <input id="SelectedLibraries" type="hidden" is="emby-input" />
-                                </div>
-                            </div>
-
-                            <div class="inputContainer" id="excludedSeries">
-                                <label class="inputLabel inputLabelUnfocused" for="ExcludeSeries"> Exclude series </label>
-                                <input id="ExcludeSeries" type="text" is="emby-input" />
-                                <div class="fieldDescription">Exclude series from analysis. Enter a comma-separated list of series names to exclude.</div>
                             </div>
 
                             <details id="intro_reqs">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -131,6 +131,14 @@
                             <details id="intro_reqs">
                                 <summary>Modify Analysis Parameters</summary>
 
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label class="emby-checkbox-label">
+                                        <input id="FullLengthChapters" type="checkbox" is="emby-checkbox" />
+                                        <span>Ignore duration limits for chapters</span>
+                                    </label>
+                                    <div class="fieldDescription">Allow segments to extend to the end of a chapter when the marker exceeds other user settings, such as percentage or duration.</div>
+                                </div>
+
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="AnalysisPercent"> Percent of media to analyze </label>
                                     <input id="AnalysisPercent" type="number" is="emby-input" min="1" max="90" />
@@ -147,13 +155,6 @@
                                 <p>If the percentage or maximum runtime settings are modified, the cached fingerprints and timestamps for each series, season, or movie you want to analyze with the modified settings <b>will have to be recreated</b>.</p>
                                 <p>Increasing either of the above settings will cause episode analysis to take much longer.</p>
                                 <br />
-
-                                <div class="checkboxContainer checkboxContainer-withDescription">
-                                    <label class="emby-checkbox-label">
-                                        <input id="FullLengthChapters" type="checkbox" is="emby-checkbox" />
-                                        <span>Ignore duration limits for chapters</span>
-                                    </label>
-                                </div>
 
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="MinimumIntroDuration"> Minimum introduction duration (in seconds) </label>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -71,6 +71,42 @@
                                 <div class="fieldDescription">Note: Shows containing both a specials and extra folder will identify extras as season 0 and ignore specials, regardless of this setting.</div>
                             </div>
 
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="ScanIntroduction" type="checkbox" is="emby-checkbox" />
+                                    <span>Identify Introductions</span>
+                                </label>
+                            </div>
+
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="ScanCredits" type="checkbox" is="emby-checkbox" />
+                                    <span>Identify Credits</span>
+                                </label>
+                            </div>
+
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="ScanRecap" type="checkbox" is="emby-checkbox" />
+                                    <span>Identify Recaps</span>
+                                </label>
+                            </div>
+
+                            <div class="checkboxContainer">
+                                <label class="emby-checkbox-label">
+                                    <input id="ScanPreview" type="checkbox" is="emby-checkbox" />
+                                    <span>Identify Previews</span>
+                                </label>
+                            </div>
+
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
+                                    <span>Prefer Chromaprint Analysis</span>
+                                </label>
+                                <div class="fieldDescription">Setting an analysis mode in the advanced options will override this setting.</div>
+                            </div>
+
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
                                     <input id="SelectAllLibraries" type="checkbox" is="emby-checkbox" />
@@ -95,40 +131,6 @@
                             <details id="intro_reqs">
                                 <summary>Modify Analysis Parameters</summary>
 
-                                <p>
-                                    <b style="color: orange">Changing segment parameters requires regenerating media segments before changes take effect.</b>
-                                    <br />
-                                    Per the jellyfin MediaSegments API, records must be updated individually and may be slow to regenerate.
-                                </p>
-
-                                <div class="checkboxContainer">
-                                    <label class="emby-checkbox-label">
-                                        <input id="ScanIntroduction" type="checkbox" is="emby-checkbox" />
-                                        <span>Identify Introductions</span>
-                                    </label>
-                                </div>
-
-                                <div class="checkboxContainer">
-                                    <label class="emby-checkbox-label">
-                                        <input id="ScanCredits" type="checkbox" is="emby-checkbox" />
-                                        <span>Identify Credits</span>
-                                    </label>
-                                </div>
-
-                                <div class="checkboxContainer">
-                                    <label class="emby-checkbox-label">
-                                        <input id="ScanRecap" type="checkbox" is="emby-checkbox" />
-                                        <span>Identify Recaps</span>
-                                    </label>
-                                </div>
-
-                                <div class="checkboxContainer">
-                                    <label class="emby-checkbox-label">
-                                        <input id="ScanPreview" type="checkbox" is="emby-checkbox" />
-                                        <span>Identify Previews</span>
-                                    </label>
-                                </div>
-
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="AnalysisPercent"> Percent of media to analyze </label>
                                     <input id="AnalysisPercent" type="number" is="emby-input" min="1" max="90" />
@@ -145,14 +147,6 @@
                                 <p>If the percentage or maximum runtime settings are modified, the cached fingerprints and timestamps for each series, season, or movie you want to analyze with the modified settings <b>will have to be recreated</b>.</p>
                                 <p>Increasing either of the above settings will cause episode analysis to take much longer.</p>
                                 <br />
-
-                                <div class="checkboxContainer checkboxContainer-withDescription">
-                                    <label class="emby-checkbox-label">
-                                        <input id="PreferChromaprint" type="checkbox" is="emby-checkbox" />
-                                        <span>Prefer Chromaprint Analysis</span>
-                                    </label>
-                                    <div class="fieldDescription">Setting an analysis mode in the advanced options will override this setting.</div>
-                                </div>
 
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
@@ -216,6 +210,7 @@
                                         <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
                                     </div>
                                 </div>
+                                <br />
                             </details>
 
                             <details id="adjustment">
@@ -418,7 +413,12 @@
                                 </div>
                             </details>
 
-                            <br />
+                            <p>
+                                <b style="color: orange">Changing analysis or detection requires regenerating media segments before changes take effect.</b>
+                                <br />
+                                Per the jellyfin MediaSegments API, records must be updated individually and may be slow to regenerate.
+                            </p>
+
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label class="emby-checkbox-label">
                                     <input id="RebuildMediaSegments" type="checkbox" is="emby-checkbox" />


### PR DESCRIPTION
## Summary by Sourcery

Reorganize the configuration page for analysis parameters, moving key settings to the main configuration area and simplifying the layout

Enhancements:
- Restructured the configuration page to make analysis settings more accessible
- Consolidated analysis-related checkboxes into the main configuration section

Chores:
- Moved warning message about segment regeneration to a more prominent location