### PR TITLE
Add configurable skip button hide delay feature

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -349,4 +349,14 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether movies should be analyzed.
     /// </summary>
     public bool AnalyzeMovies { get; set; }
+
+    /// <summary>
+    /// Gets or sets the amount of seconds to wait before hiding the skip button.
+    /// </summary>
+    public int SkipbuttonHideDelay { get; set; } = 8;
+
+    /// <summary>
+    /// Gets a value indicating whether the File Transformation plugin is enabled.
+    /// </summary>
+    public bool FileTransformationPluginEnabled => Plugin.Instance?.FileTransformationPluginEnabled ?? false;
 }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -351,6 +351,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AnalyzeMovies { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to use the File Transformation plugin if available.
+    /// </summary>
+    public bool UseFileTransformationPlugin { get; set; }
+
+    /// <summary>
     /// Gets or sets the amount of seconds to wait before hiding the skip button.
     /// </summary>
     public int SkipbuttonHideDelay { get; set; } = 8;

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -104,19 +104,25 @@
                             </div>
 
                             <div id="divSkipbuttonHideDelay" class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="SkipbuttonHideDelay"> Skip button hide delay (in seconds) </label>
-                                <input id="SkipbuttonHideDelay" type="number" is="emby-input" min="0" max="1000"/>
-                                <div class="fieldDescription">
-                                    <span id="skipButtonDescription">Time in seconds before the skip button automatically hides. Set to 0 for persistent skip button (never hides).</span>
-                                    <br />
-                                    <span style="font-size: 0.85em; color: #ffa500; display: inline-block; margin-top: 4px;">Note: This setting only affects clients using the web client player (web browsers, Android when using the web player, LG webOS, etc). If changes don't appear, refresh the page or clear the browser cache.</span>
-                                    <div id="fileTransformationWarning" style="display: none; color: orange; margin-top: 8px;">
-                                        <strong>⚠️ File Transformation Plugin Required</strong><br />
-                                        This feature requires the File Transformation plugin to work.
-                                        <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" style="color: #2196f3;">
-                                            Install it here
-                                        </a>
+                                <label class="emby-checkbox-label">
+                                    <input id="UseFileTransformationPlugin" type="checkbox" is="emby-checkbox" />
+                                    <span>Use File Transformation Plugin to patch the web interface</span>
+                                </label>
+                                <div id="divSkipbuttonHideDelayContent">
+                                    <label class="inputLabel inputLabelUnfocused" for="SkipbuttonHideDelay"> Skip button hide delay (in seconds) </label>
+                                    <input id="SkipbuttonHideDelay" type="number" is="emby-input" min="0" max="1000"/>
+                                    <div class="fieldDescription">
+                                        <span id="skipButtonDescription">Time in seconds before the skip button automatically hides. Set to 0 for persistent skip button (never hides).</span>
                                     </div>
+                                </div>
+                                <br />
+                                <span style="font-size: 0.85em; color: #ffa500; display: inline-block; margin-top: 4px;">Note: This setting only affects clients using the web client player (web browsers, Android when using the web player, LG webOS, etc). If changes don't appear, refresh the page or clear the browser cache.</span>
+                                <div id="fileTransformationWarning" style="display: none; color: orange; margin-top: 8px;">
+                                    <strong>File Transformation Plugin Required</strong><br />
+                                    This feature requires the File Transformation plugin to work.
+                                    <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" style="color: #2196f3;">
+                                        Install it here
+                                    </a>
                                 </div>
                             </div>
 
@@ -893,7 +899,7 @@
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments","UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments","UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
 
                 // visualizer elements
                 const analyzerActionsSection = document.querySelector("div#analyzerActionsSection");
@@ -901,6 +907,8 @@
                 const actionCredits = analyzerActionsSection.querySelector("select#actionCredits");
                 const actionRecap = analyzerActionsSection.querySelector("select#actionRecap");
                 const actionPreview = analyzerActionsSection.querySelector("select#actionPreview");
+                const actionFileTransformation = document.getElementById("UseFileTransformationPlugin");
+                const divSkipbuttonHideDelayContent = document.getElementById("divSkipbuttonHideDelayContent");
                 const saveAnalyzerActionsButton = analyzerActionsSection.querySelector("button#saveAnalyzerActions");
                 const scanSeasonButton = document.querySelector("button#scanSeason");
                 const canvas = document.querySelector("canvas#troubleshooter");
@@ -958,6 +966,16 @@
                         recapPreviewDurations.style.display = "none";
                     } else {
                         recapPreviewDurations.style.display = "unset";
+                    }
+                }
+
+                actionFileTransformation.addEventListener("change", fileTransformationChanged);
+
+                function fileTransformationChanged() {
+                    if (actionFileTransformation.checked) {
+                        divSkipbuttonHideDelayContent.style.display = "unset";
+                    } else {
+                        divSkipbuttonHideDelayContent.style.display = "none";
                     }
                 }
 
@@ -1507,6 +1525,8 @@
                     } else {
                         // Plugin is not available - disable the field and show warning
                         skipButtonField.disabled = true;
+                        actionFileTransformation.disabled = true;
+                        actionFileTransformation.checked = false;
                         skipButtonContainer.classList.add("disabled-block");
                         warning.style.display = "block";
                     }
@@ -1548,6 +1568,7 @@
                             generateAutoSkipTypeList();
                             generateAutoSkipClientList();
                             pluginSkipSettingVisible();
+                            fileTransformationChanged();
                             alternativeBlackFrameAnalyzerSettingsVisible();
                             adjustSettingsVisible();
                             globalTimestampChanged();

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -22,6 +22,19 @@
                         font-size: 1em;
                         margin-bottom: 4px;
                     }
+                    /* Disabled state styling */
+                    .disabled-block {
+                        opacity: .6;
+                    }
+                    .disabled-block input,
+                    .disabled-block select,
+                    .disabled-block button {
+                        pointer-events: none;
+                    }
+                    .disabled-block .inputLabel,
+                    .disabled-block label.emby-checkbox-label span {
+                        font-style: italic;
+                    }
                 </style>
                 <div class="content-primary">
                     <form id="FingerprintConfigForm">
@@ -95,7 +108,9 @@
                                 <input id="SkipbuttonHideDelay" type="number" is="emby-input" min="0" max="1000"/>
                                 <div class="fieldDescription">
                                     <span id="skipButtonDescription">Time in seconds before the skip button automatically hides. Set to 0 for persistent skip button (never hides).</span>
-                                    <div id="fileTransformationWarning" style="display: none; color: #f44336; margin-top: 8px;">
+                                    <br />
+                                    <span style="font-size: 0.85em; color: #ffa500; display: inline-block; margin-top: 4px;">Note: This setting only affects clients using the web client player (web browsers, Android when using the web player, LG webOS, etc). If changes don't appear, refresh the page or clear the browser cache.</span>
+                                    <div id="fileTransformationWarning" style="display: none; color: orange; margin-top: 8px;">
                                         <strong>⚠️ File Transformation Plugin Required</strong><br />
                                         This feature requires the File Transformation plugin to work.
                                         <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" style="color: #2196f3;">
@@ -1487,12 +1502,12 @@
                     if (config.FileTransformationPluginEnabled) {
                         // Plugin is available - enable the field
                         skipButtonField.disabled = false;
-                        skipButtonContainer.style.opacity = "1";
+                        skipButtonContainer.classList.remove("disabled-block");
                         warning.style.display = "none";
                     } else {
                         // Plugin is not available - disable the field and show warning
                         skipButtonField.disabled = true;
-                        skipButtonContainer.style.opacity = "0.5";
+                        skipButtonContainer.classList.add("disabled-block");
                         warning.style.display = "block";
                     }
                 }

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -90,6 +90,21 @@
                                 <div class="fieldDescription">Note: Shows containing both a specials and extra folder will identify extras as season 0 and ignore specials, regardless of this setting.</div>
                             </div>
 
+                            <div id="divSkipbuttonHideDelay" class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="SkipbuttonHideDelay"> Skip button hide delay (in seconds) </label>
+                                <input id="SkipbuttonHideDelay" type="number" is="emby-input" min="0" max="1000"/>
+                                <div class="fieldDescription">
+                                    <span id="skipButtonDescription">Time in seconds before the skip button automatically hides. Set to 0 for persistent skip button (never hides).</span>
+                                    <div id="fileTransformationWarning" style="display: none; color: #f44336; margin-top: 8px;">
+                                        <strong>⚠️ File Transformation Plugin Required</strong><br />
+                                        This feature requires the File Transformation plugin to work.
+                                        <a href="https://github.com/IAmParadox27/jellyfin-plugin-file-transformation" target="_blank" style="color: #2196f3;">
+                                            Install it here
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+
                             <details id="intro_reqs">
                                 <summary>Modify Analysis Parameters</summary>
 
@@ -848,6 +863,7 @@
                     "IntroEndOffset",
                     "IntroStartOffset",
                     "AutoSkipDelay",
+                    "SkipbuttonHideDelay",
                     // internals
                     "SilenceDetectionMaximumNoise",
                     "SilenceDetectionMinimumDuration",
@@ -1462,6 +1478,25 @@
                     return new Date(seconds * 1000).toISOString().slice(14, 19);
                 }
 
+                // Check if File Transformation plugin is available and enable/disable skip button settings
+                function checkFileTransformationPlugin(config) {
+                    const skipButtonField = document.querySelector("#SkipbuttonHideDelay");
+                    const skipButtonContainer = document.querySelector("#divSkipbuttonHideDelay");
+                    const warning = document.querySelector("#fileTransformationWarning");
+
+                    if (config.FileTransformationPluginEnabled) {
+                        // Plugin is available - enable the field
+                        skipButtonField.disabled = false;
+                        skipButtonContainer.style.opacity = "1";
+                        warning.style.display = "none";
+                    } else {
+                        // Plugin is not available - disable the field and show warning
+                        skipButtonField.disabled = true;
+                        skipButtonContainer.style.opacity = "0.5";
+                        warning.style.display = "block";
+                    }
+                }
+
                 // erase all intro/credits timestamps
                 function eraseTimestamps(mode) {
                     const lower = mode.toLocaleLowerCase();
@@ -1501,6 +1536,7 @@
                             alternativeBlackFrameAnalyzerSettingsVisible();
                             adjustSettingsVisible();
                             globalTimestampChanged();
+                            checkFileTransformationPlugin(config);
 
                             Dashboard.hideLoadingMsg();
                         })

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -18,6 +18,12 @@ namespace IntroSkipper.Helper
         private const string TimeoutAssignmentPattern = @"\(t\.hideTimeout=setTimeout\(t\.hideSkipButton\.bind\(t\)\,8e3\)\)";
 
         /// <summary>
+        /// Regex to match the focusability check.
+        /// </summary>
+        private const string FocusabilityAssignmentPattern =
+            @"(?:(?:var)\s+)?r\s*=\s*document\.activeElement\s*&&\s*pe\.A\.isCurrentlyFocusable\(document\.activeElement\)";
+
+        /// <summary>
         /// Number of milliseconds per second.
         /// </summary>
         private const int MillisecondsPerSecond = 1000;
@@ -29,6 +35,9 @@ namespace IntroSkipper.Helper
 
         [GeneratedRegex(TimeoutAssignmentPattern)]
         private static partial Regex TimeoutAssignmentRegex();
+
+        [GeneratedRegex(FocusabilityAssignmentPattern, RegexOptions.CultureInvariant)]
+        private static partial Regex FocusabilityAssignmentRegex();
 
         /// <summary>
         /// Transforms the file contents by modifying JavaScript timeout values.
@@ -56,7 +65,12 @@ namespace IntroSkipper.Helper
             bool persist = !TryGetValidTimeoutMs(config.SkipbuttonHideDelay, out var hideDelayMs);
 
             // Replace the hardcoded 8e3 (8000 ms) timeout with our configurable value
-            return ReplaceTimeoutAssignment(contents, persist ? "true" : "false", hideDelayMs.ToString(CultureInfo.InvariantCulture));
+            var updated = ReplaceTimeoutAssignment(contents, persist ? "true" : "false", hideDelayMs.ToString(CultureInfo.InvariantCulture));
+
+            // Add playback time condition to focusability check to gate skip button behavior
+            updated = ReplaceFocusabilityCheck(updated);
+
+            return updated;
         }
 
         /// <summary>
@@ -67,6 +81,13 @@ namespace IntroSkipper.Helper
         /// <param name="hideDelayMs">The delay in milliseconds before hiding the skip button.</param>
         /// <returns>The modified content with persistent skip button behavior.</returns>
         private static string ReplaceTimeoutAssignment(string contents, string persist, string hideDelayMs) => TimeoutAssignmentRegex().Replace(contents, $"{persist}||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),{hideDelayMs}))");
+
+        /// <summary>
+        /// Adds a current time check to the focusability condition.
+        /// </summary>
+        /// <param name="contents">The JavaScript content to modify.</param>
+        /// <returns>The modified content.</returns>
+        private static string ReplaceFocusabilityCheck(string contents) => FocusabilityAssignmentRegex().Replace(contents, m => m.Value + "&&t.playbackManager.currentTime()>3000");
 
         /// <summary>
         /// Attempts to convert seconds to milliseconds with validation and overflow protection.

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -1,0 +1,84 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace IntroSkipper.Helper
+{
+    /// <summary>
+    /// A class responsible for injecting a script into the jellyfin web.
+    /// </summary>
+    public static partial class Injector
+    {
+        /// <summary>
+        /// Pattern to match the timeout assignment in the showSkipButton method.
+        /// </summary>
+        private const string TimeoutAssignmentPattern = @"\(t\.hideTimeout=setTimeout\(t\.hideSkipButton\.bind\(t\)\,8e3\)\)";
+
+        /// <summary>
+        /// Number of milliseconds per second.
+        /// </summary>
+        private const int MillisecondsPerSecond = 1000;
+
+        /// <summary>
+        /// Maximum safe number of seconds that can be converted to milliseconds without overflow.
+        /// </summary>
+        private const int MaxSafeSeconds = int.MaxValue / MillisecondsPerSecond;
+
+        [GeneratedRegex(TimeoutAssignmentPattern)]
+        private static partial Regex TimeoutAssignmentRegex();
+
+        /// <summary>
+        /// Transforms the file contents by modifying JavaScript timeout values.
+        /// </summary>
+        /// <param name="payload">The payload containing the file contents to transform.</param>
+        /// <returns>The transformed file contents with modified timeout values.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when payload is null.</exception>
+        public static string FileTransformer(PayloadRequest payload)
+        {
+            ArgumentNullException.ThrowIfNull(payload);
+
+            var contents = payload.Contents ?? string.Empty;
+            if (string.IsNullOrEmpty(contents))
+            {
+                return contents;
+            }
+
+            var config = Plugin.Instance?.Configuration;
+            if (config is null)
+            {
+                return contents;
+            }
+
+            // Validate and get the timeout value
+            bool persist = !TryGetValidTimeoutMs(config.SkipbuttonHideDelay, out var hideDelayMs);
+
+            // Replace the hardcoded 8e3 (8000 ms) timeout with our configurable value
+            return ReplaceTimeoutAssignment(contents, persist ? "true" : "false", hideDelayMs.ToString(CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Makes the skip button persistent by removing the setTimeout call that auto-hides it.
+        /// </summary>
+        /// <param name="contents">The JavaScript content to modify.</param>
+        /// <param name="persist">true if the skip button should be persistent; otherwise, false.</param>
+        /// <param name="hideDelayMs">The delay in milliseconds before hiding the skip button.</param>
+        /// <returns>The modified content with persistent skip button behavior.</returns>
+        private static string ReplaceTimeoutAssignment(string contents, string persist, string hideDelayMs) => TimeoutAssignmentRegex().Replace(contents, $"{persist}||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),{hideDelayMs}))");
+
+        /// <summary>
+        /// Attempts to convert seconds to milliseconds with validation and overflow protection.
+        /// </summary>
+        /// <param name="seconds">The number of seconds to convert.</param>
+        /// <param name="milliseconds">When this method returns, contains the equivalent milliseconds if the conversion succeeded, or 0 if it failed.</param>
+        /// <returns>true if the conversion succeeded; otherwise, false.</returns>
+        private static bool TryGetValidTimeoutMs(int seconds, out int milliseconds)
+        {
+            var valid = seconds > 0 && seconds <= MaxSafeSeconds;
+            milliseconds = valid ? seconds * MillisecondsPerSecond : 0;
+            return valid;
+        }
+    }
+}

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -18,10 +18,20 @@ namespace IntroSkipper.Helper
         private const string TimeoutAssignmentPattern = @"\(t\.hideTimeout=setTimeout\(t\.hideSkipButton\.bind\(t\)\,8e3\)\)";
 
         /// <summary>
+        /// Pattern to match the timeout check in the hideSkipButton method.
+        /// </summary>
+        private const string TimeoutOsdChangePattern = @"\:this\.hideTimeout\|\|this\.hideSkipButton\(\)";
+
+        /// <summary>
         /// Regex to match the focusability check.
         /// </summary>
         private const string FocusabilityAssignmentPattern =
             @"(?:(?:var)\s+)?r\s*=\s*document\.activeElement\s*&&\s*pe\.A\.isCurrentlyFocusable\(document\.activeElement\)";
+
+        /// <summary>
+        /// Pattern to identify the playback stop handler to avoid modifying it.
+        /// </summary>
+        private const string PlaybackStopPattern = @"t\.prototype\.onPlaybackStop=function\(\){this\.currentSegment=null\,this\.hideSkipButton\(\),";
 
         /// <summary>
         /// Number of milliseconds per second.
@@ -36,8 +46,14 @@ namespace IntroSkipper.Helper
         [GeneratedRegex(TimeoutAssignmentPattern)]
         private static partial Regex TimeoutAssignmentRegex();
 
+        [GeneratedRegex(TimeoutOsdChangePattern)]
+        private static partial Regex TimeoutOsdChangeRegex();
+
         [GeneratedRegex(FocusabilityAssignmentPattern, RegexOptions.CultureInvariant)]
         private static partial Regex FocusabilityAssignmentRegex();
+
+        [GeneratedRegex(PlaybackStopPattern)]
+        private static partial Regex PlaybackStopRegex();
 
         /// <summary>
         /// Transforms the file contents by modifying JavaScript timeout values.
@@ -63,12 +79,19 @@ namespace IntroSkipper.Helper
 
             // Validate and get the timeout value
             bool persist = !TryGetValidTimeoutMs(config.SkipbuttonHideDelay, out var hideDelayMs);
+            string persistStr = persist ? "true" : "false";
 
             // Replace the hardcoded 8e3 (8000 ms) timeout with our configurable value
-            var updated = ReplaceTimeoutAssignment(contents, persist ? "true" : "false", hideDelayMs.ToString(CultureInfo.InvariantCulture));
+            var updated = ReplaceTimeoutAssignment(contents, persistStr, hideDelayMs.ToString(CultureInfo.InvariantCulture));
+
+            // Replace the timeout check in hideSkipButton to respect the persist setting
+            updated = ReplaceTimeoutOsdChange(updated, persistStr);
 
             // Add playback time condition to focusability check to gate skip button behavior
             updated = ReplaceFocusabilityCheck(updated);
+
+            // Ensure we did not modify the playback stop handler
+            updated = ReplacePlaybackStopHandler(updated);
 
             return updated;
         }
@@ -83,11 +106,24 @@ namespace IntroSkipper.Helper
         private static string ReplaceTimeoutAssignment(string contents, string persist, string hideDelayMs) => TimeoutAssignmentRegex().Replace(contents, $"{persist}||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),{hideDelayMs}))");
 
         /// <summary>
+        /// Makes the skip button persistent by removing the setTimeout call that auto-hides it.
+        /// </summary>
+        /// <param name="contents">The JavaScript content to modify.</param>
+        /// <param name="persist">true if the skip button should be persistent; otherwise, false.</param>
+        /// <returns>The modified content.</returns>
+        private static string ReplaceTimeoutOsdChange(string contents, string persist) => TimeoutOsdChangeRegex().Replace(contents, $":{persist}||this.hideTimeout||this.hideSkipButton()");
+
+        /// <summary>
         /// Adds a current time check to the focusability condition.
         /// </summary>
         /// <param name="contents">The JavaScript content to modify.</param>
         /// <returns>The modified content.</returns>
-        private static string ReplaceFocusabilityCheck(string contents) => FocusabilityAssignmentRegex().Replace(contents, m => m.Value + "&&t.playbackManager.currentTime()>3000");
+        private static string ReplaceFocusabilityCheck(string contents) => FocusabilityAssignmentRegex().Replace(contents, m => m.Value + $"&&t.playbackManager.currentTime()>{MillisecondsPerSecond}");
+
+        /// <summary>
+        /// Ensures that the playback stop handler is valid.
+        /// </summary>
+        private static string ReplacePlaybackStopHandler(string contents) => PlaybackStopRegex().Replace(contents, "t.prototype.onPlaybackStop=function(e,t){this.currentSegment=null,this.hideSkipButton(),t.nextItem||");
 
         /// <summary>
         /// Attempts to convert seconds to milliseconds with validation and overflow protection.

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -56,7 +56,7 @@ namespace IntroSkipper.Helper
             }
 
             var config = Plugin.Instance?.Configuration;
-            if (config is null)
+            if (config is null || !config.UseFileTransformationPlugin)
             {
                 return contents;
             }

--- a/IntroSkipper/Helper/PayloadRequest.cs
+++ b/IntroSkipper/Helper/PayloadRequest.cs
@@ -1,0 +1,18 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Text.Json.Serialization;
+
+namespace IntroSkipper.Helper;
+
+/// <summary>
+/// Represents the payload for a patch request.
+/// </summary>
+public class PayloadRequest
+{
+    /// <summary>
+    /// Gets or sets represents the contents of the patch request.
+    /// </summary>
+    [JsonPropertyName("contents")]
+    public string? Contents { get; set; }
+}

--- a/IntroSkipper/IntroSkipper.csproj
+++ b/IntroSkipper/IntroSkipper.csproj
@@ -11,8 +11,8 @@
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.0-rc5" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.0-rc5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />

--- a/IntroSkipper/IntroSkipper.csproj
+++ b/IntroSkipper/IntroSkipper.csproj
@@ -13,11 +13,12 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.11.*-*" />
     <PackageReference Include="Jellyfin.Model" Version="10.11.*-*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4-beta1" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Configuration\configPage.html" />

--- a/IntroSkipper/IntroSkipper.csproj
+++ b/IntroSkipper/IntroSkipper.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4-beta1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Configuration\configPage.html" />

--- a/IntroSkipper/IntroSkipper.csproj
+++ b/IntroSkipper/IntroSkipper.csproj
@@ -11,10 +11,10 @@
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0-rc5" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0-rc5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.*-*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" PrivateAssets="All" />

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -103,7 +103,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         FileTransformationPluginEnabled = _pluginManager
             .Plugins
-            .Any(p => p.Name.Equals("File Transformation", StringComparison.OrdinalIgnoreCase));
+            .Any(p => p.Id == Guid.Parse("5e87cc92-571a-4d8d-8d98-d2d4147f9f90")); // File Transformation plugin ID
     }
 
     /// <summary>

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -32,6 +32,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
+    private readonly IPluginManager _pluginManager;
     private readonly ILogger<Plugin> _logger;
     private readonly string _dbPath;
 
@@ -43,6 +44,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="serverConfiguration">Server configuration manager.</param>
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="chapterRepository">Chapter repository.</param>
+    /// <param name="pluginManager">Plugin manager.</param>
     /// <param name="logger">Logger.</param>
     public Plugin(
         IApplicationPaths applicationPaths,
@@ -50,6 +52,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         IServerConfigurationManager serverConfiguration,
         ILibraryManager libraryManager,
         IChapterManager chapterRepository,
+        IPluginManager pluginManager,
         ILogger<Plugin> logger)
         : base(applicationPaths, xmlSerializer)
     {
@@ -57,6 +60,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         _libraryManager = libraryManager;
         _chapterRepository = chapterRepository;
+        _pluginManager = pluginManager;
         _logger = logger;
 
         FFmpegPath = serverConfiguration.GetEncodingOptions().EncoderAppPathDisplay;
@@ -96,6 +100,10 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         {
             logger.LogWarning("Error initializing database: {Exception}", ex);
         }
+
+        FileTransformationPluginEnabled = _pluginManager
+            .Plugins
+            .Any(p => p.Name.Equals("File Transformation", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -132,6 +140,11 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// Gets the full path to FFmpeg.
     /// </summary>
     public string FFmpegPath { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the File Transformation plugin is enabled.
+    /// </summary>
+    public bool FileTransformationPluginEnabled { get; private set; }
 
     /// <inheritdoc />
     public override string Name => "Intro Skipper";

--- a/IntroSkipper/Services/AutoSkip.cs
+++ b/IntroSkipper/Services/AutoSkip.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using IntroSkipper.Configuration;
-using IntroSkipper.Controllers;
 using IntroSkipper.Data;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -93,7 +93,10 @@ namespace IntroSkipper.Services
             FFmpegWrapper.CheckFFmpegVersion();
 
             // Initialize web injector for skip button timeout modification
-            InitializeWebInjector();
+            if (Plugin.Instance?.FileTransformationPluginEnabled == true)
+            {
+                InitializeWebInjector();
+            }
 
             // Enqueue all episodes at startup to ensure any FFmpeg errors appear as early as possible
             _logger.LogInformation("Running startup enqueue");

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -191,7 +191,6 @@ namespace IntroSkipper.Services
         {
             _config = (PluginConfiguration)e;
             Plugin.Instance!.AnalyzeAgain = true;
-            InitializeWebInjector();
         }
 
         /// <summary>

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
+using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -16,6 +21,7 @@ using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace IntroSkipper.Services
 {
@@ -86,6 +92,9 @@ namespace IntroSkipper.Services
             FFmpegWrapper.Logger = _logger;
             FFmpegWrapper.CheckFFmpegVersion();
 
+            // Initialize web injector for skip button timeout modification
+            InitializeWebInjector();
+
             // Enqueue all episodes at startup to ensure any FFmpeg errors appear as early as possible
             _logger.LogInformation("Running startup enqueue");
             new QueueManager(_loggerFactory.CreateLogger<QueueManager>(), _libraryManager).GetMediaItems();
@@ -103,6 +112,32 @@ namespace IntroSkipper.Services
 
             _queueTimer.Change(Timeout.Infinite, 0);
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Initializes the web injector for skip button timeout modification.
+        /// </summary>
+        private void InitializeWebInjector()
+        {
+            JObject payload = new JObject
+            {
+                { "id", "c83d86bb-a1e0-4c35-a113-e2101cf4ee6b" },
+                { "fileNamePattern", "main.jellyfin.bundle.js" },
+                { "callbackAssembly", GetType().Assembly.FullName },
+                { "callbackClass", typeof(Injector).FullName },
+                { "callbackMethod", nameof(Injector.FileTransformer) }
+            };
+
+            Assembly? fileTransformationAssembly =
+                AssemblyLoadContext.All.SelectMany(x => x.Assemblies).FirstOrDefault(x =>
+                    x.FullName?.Contains(".FileTransformation", StringComparison.Ordinal) ?? false);
+
+            if (fileTransformationAssembly is not null)
+            {
+                Type? pluginInterfaceType = fileTransformationAssembly.GetType("Jellyfin.Plugin.FileTransformation.PluginInterface");
+
+                pluginInterfaceType?.GetMethod("RegisterTransformation")?.Invoke(null, [payload]);
+            }
         }
 
         /// <summary>
@@ -156,6 +191,7 @@ namespace IntroSkipper.Services
         {
             _config = (PluginConfiguration)e;
             Plugin.Instance!.AnalyzeAgain = true;
+            InitializeWebInjector();
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ It will NOT return a manifest when viewed in a browser, as no Jellyfin version i
 https://intro-skipper.org/manifest.json
 ```
 
+## Optional: File Transformation plugin
+
+Some web UI features (for example, adjusting the skip-button timeout) require the File Transformation plugin. If it’s not installed, Intro Skipper will still work, but those enhancements won’t be applied.
+
+- Plugin repo: https://github.com/IAmParadox27/jellyfin-plugin-file-transformation
+- Easiest way to install:
+  1. Add `https://www.iamparadox.dev/jellyfin/plugins/manifest.json` as a plugin source repository to your Jellyfin server.
+  2. Find "File Transformation" in the Catalog and install it.
+
 ## System requirements
 
 * Jellyfin 10.11.0-rc2 (or newer)


### PR DESCRIPTION
Introduces a new setting to configure the skip button hide delay, requiring the File Transformation plugin. Adds helper classes for script injection and payload handling, updates the configuration page UI and logic, and integrates with the File Transformation plugin to modify the skip button timeout in the web client.

## Summary by Sourcery

Add a new configurable skip button hide delay feature by integrating with the File Transformation plugin and injecting custom script into the Jellyfin web client.

New Features:
- Expose a SkipbuttonHideDelay setting (default 8 seconds) in plugin configuration
- Add a UI input for skip button delay with a warning when the File Transformation plugin is missing
- Register a file transformer callback that modifies the Jellyfin web bundle JavaScript to apply the configured delay

Enhancements:
- Automatically enable or disable the skip delay UI based on the presence of the File Transformation plugin
- Safely convert and validate the configured delay from seconds to milliseconds with overflow protection