### PR TITLE
Refine intro time adjustment logic and add tests

### DIFF
--- a/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
+++ b/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
@@ -1,0 +1,77 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only.
+
+using System;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public class TestTimeAdjustmentHelper
+{
+    private static (TimeAdjustmentHelper helper, PluginConfiguration cfg) CreateHelper(PluginConfiguration? cfg = null)
+    {
+        cfg ??= new PluginConfiguration
+        {
+            EndSnapThreshold = 2.0,
+            AdjustIntroBasedOnChapters = false,
+            AdjustIntroBasedOnSilence = false,
+            SnapToKeyframe = false,
+            AdjustWindowInward = 2.0,
+            AdjustWindowOutward = 2.0,
+            IntroStartOffset = 0,
+            IntroEndOffset = 0,
+        };
+
+        return (new TimeAdjustmentHelper(new NullLoggerFactory().CreateLogger("Test"), cfg), cfg);
+    }
+
+    [Fact]
+    public void StartOffset_IsIgnored_When_SnappingToEpisodeStart()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2; // user-configured offset
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 1.2, End = 10 };
+
+        var adjusted = helper.AdjustIntroTimes(episode, original);
+
+        Assert.Equal(0, adjusted.Start);
+        Assert.Equal(10, adjusted.End);
+    }
+
+    [Fact]
+    public void StartOffset_IsApplied_When_NotSnapping()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2;
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 5, End = 12 };
+
+        var adjusted = helper.AdjustIntroTimes(episode, original);
+
+        Assert.Equal(7, adjusted.Start);
+        Assert.Equal(12, adjusted.End);
+    }
+
+    [Fact]
+    public void Start_And_End_Are_Clamped_To_Duration()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 0;
+        cfg.IntroEndOffset = 100; // will try to push end negative
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 30 };
+        var original = new Segment(episode.EpisodeId) { Start = -5, End = 200 };
+
+        var adjusted = helper.AdjustIntroTimes(episode, original);
+
+        Assert.Equal(0, adjusted.Start); // clamped from -5 to 0 and snapped
+        Assert.Equal(30, adjusted.End);  // clamped from 200 to duration before end logic kicks in
+    }
+}

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -50,16 +50,17 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
             originalIntro.Start,
             originalIntro.End);
 
-        // Clamp original bounds to the media duration to avoid downstream surprises
-        double adjustedStart = Math.Clamp(originalIntro.Start, 0, duration);
+        // Evaluate negativity and snap threshold against the raw start before any clamping
+        double rawStart = originalIntro.Start;
+        double adjustedStart = rawStart;
         bool snapToEpisodeStart = false;
 
-        if (adjustedStart < 0)
+        if (rawStart < 0)
         {
-            _logger.LogWarning("{EpisodeId} {Name}: Negative intro start {Start}, resetting to 0", episode.EpisodeId, episode.Name, adjustedStart);
+            _logger.LogWarning("{EpisodeId} {Name}: Negative intro start {Start}, resetting to 0", episode.EpisodeId, episode.Name, rawStart);
             snapToEpisodeStart = true;
         }
-        else if (adjustedStart <= _config.EndSnapThreshold + Epsilon)
+        else if (rawStart <= _config.EndSnapThreshold)
         {
             // If the detected start is within threshold of episode start, snap
             snapToEpisodeStart = true;
@@ -67,7 +68,7 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
         else if (useChapters && chapters.Count > 0)
         {
             // Only adjust to chapter boundaries if we're not snapping to start
-            var searchRange = GetSearchRange(originalIntro.Start, duration, _config.AdjustWindowOutward, _config.AdjustWindowInward);
+            var searchRange = GetSearchRange(rawStart, duration, _config.AdjustWindowOutward, _config.AdjustWindowInward);
             adjustedStart = GetChapterBoundary(chapters, adjustedStart, searchRange);
         }
 
@@ -84,19 +85,12 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
         else
         {
             // Apply configurable start offset only if we are not snapping to the episode start
-            adjustedStart += _config.IntroStartOffset;
-            if (adjustedStart < 0)
-            {
-                adjustedStart = 0;
-            }
-            else if (adjustedStart > duration)
-            {
-                adjustedStart = duration;
-            }
+            adjustedStart = Math.Clamp(adjustedStart + _config.IntroStartOffset, 0, duration);
         }
 
-        double adjustedEnd = Math.Clamp(originalIntro.End, 0, duration);
-        if (adjustedEnd >= duration - _config.EndSnapThreshold - Epsilon)
+        double rawEnd = originalIntro.End;
+        double adjustedEnd = rawEnd;
+        if (rawEnd >= duration - _config.EndSnapThreshold)
         {
             adjustedEnd = duration;
         }

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -60,7 +60,7 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
             _logger.LogWarning("{EpisodeId} {Name}: Negative intro start {Start}, resetting to 0", episode.EpisodeId, episode.Name, rawStart);
             snapToEpisodeStart = true;
         }
-        else if (rawStart <= _config.EndSnapThreshold)
+        else if (rawStart <= _config.EndSnapThreshold + Epsilon)
         {
             // If the detected start is within threshold of episode start, snap
             snapToEpisodeStart = true;
@@ -69,7 +69,8 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
         {
             // Only adjust to chapter boundaries if we're not snapping to start
             var searchRange = GetSearchRange(rawStart, duration, _config.AdjustWindowOutward, _config.AdjustWindowInward);
-            adjustedStart = GetChapterBoundary(chapters, adjustedStart, searchRange);
+            // Match the reference time to the range center to avoid mismatches
+            adjustedStart = GetChapterBoundary(chapters, rawStart, searchRange);
         }
 
         if (snapToEpisodeStart)
@@ -90,7 +91,7 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
 
         double rawEnd = originalIntro.End;
         double adjustedEnd = rawEnd;
-        if (rawEnd >= duration - _config.EndSnapThreshold)
+        if (rawEnd >= duration - _config.EndSnapThreshold - Epsilon)
         {
             adjustedEnd = duration;
         }
@@ -151,26 +152,25 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
     /// Finds the chapter boundary (start time in seconds) within the given search range.
     /// Returns currentEnd if no chapter is found.
     /// </summary>
-    private static double GetChapterBoundary(IReadOnlyList<ChapterInfo> chapters, double currentEnd, TimeRange searchRange)
+    private static double GetChapterBoundary(IReadOnlyList<ChapterInfo> chapters, double referenceTime, TimeRange searchRange)
     {
-        // Consider chapters within range inclusively with a small epsilon, and choose the closest to currentEnd
-        double? best = null;
-        double bestDist = double.MaxValue;
+        // Collect candidate chapter times within the inclusive range
+        var candidates = new List<double>();
         foreach (var chapter in chapters)
         {
             var chapterTime = TimeSpan.FromTicks(chapter.StartPositionTicks).TotalSeconds;
             if (chapterTime + Epsilon >= searchRange.Start && chapterTime - Epsilon <= searchRange.End)
             {
-                var dist = Math.Abs(chapterTime - currentEnd);
-                if (dist < bestDist)
-                {
-                    bestDist = dist;
-                    best = chapterTime;
-                }
+                candidates.Add(chapterTime);
             }
         }
 
-        return best ?? currentEnd;
+        if (candidates.Count == 0)
+        {
+            return referenceTime;
+        }
+
+        return SelectNearest(candidates, referenceTime);
     }
 
     /// <summary>
@@ -220,16 +220,24 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
     private static double SnapToNearestKeyframe(QueuedEpisode episode, double time, TimeRange searchRange)
     {
         var keyframes = FFmpegWrapper.DetectKeyFrames(episode, searchRange);
-        double nearest = time;
+        return SelectNearest(keyframes, time);
+    }
+
+    /// <summary>
+    /// Selects the value in candidates nearest to the reference; returns reference if no candidates.
+    /// </summary>
+    private static double SelectNearest(IEnumerable<double> candidates, double reference)
+    {
+        double nearest = reference;
         double best = double.MaxValue;
 
-        foreach (var kf in keyframes)
+        foreach (var v in candidates)
         {
-            double d = Math.Abs(kf - time);
+            double d = Math.Abs(v - reference);
             if (d < best)
             {
                 best = d;
-                nearest = kf;
+                nearest = v;
             }
         }
 

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using MediaBrowser.Model.Entities;
@@ -13,6 +12,7 @@ namespace IntroSkipper.Analyzers;
 /// </summary>
 public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
 {
+    private const double Epsilon = 1e-3; // 1 ms tolerance for floating point comparisons
     private readonly ILogger _logger = logger;
     private readonly PluginConfiguration _config = config;
 
@@ -50,27 +50,53 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
             originalIntro.Start,
             originalIntro.End);
 
-        double adjustedStart = originalIntro.Start;
+        // Clamp original bounds to the media duration to avoid downstream surprises
+        double adjustedStart = Math.Clamp(originalIntro.Start, 0, duration);
+        bool snapToEpisodeStart = false;
+
         if (adjustedStart < 0)
         {
             _logger.LogWarning("{EpisodeId} {Name}: Negative intro start {Start}, resetting to 0", episode.EpisodeId, episode.Name, adjustedStart);
-            adjustedStart = 0;
+            snapToEpisodeStart = true;
         }
-        else if (adjustedStart < _config.EndSnapThreshold)
+        else if (adjustedStart <= _config.EndSnapThreshold + Epsilon)
         {
-            adjustedStart = 0;
+            // If the detected start is within threshold of episode start, snap
+            snapToEpisodeStart = true;
         }
         else if (useChapters && chapters.Count > 0)
         {
+            // Only adjust to chapter boundaries if we're not snapping to start
             var searchRange = GetSearchRange(originalIntro.Start, duration, _config.AdjustWindowOutward, _config.AdjustWindowInward);
-            adjustedStart = GetChapterBoundary(chapters, originalIntro.Start, searchRange);
+            adjustedStart = GetChapterBoundary(chapters, adjustedStart, searchRange);
         }
 
-        // Apply configurable start offset after all other start logic
-        adjustedStart += _config.IntroStartOffset;
+        if (snapToEpisodeStart)
+        {
+            // When snapping to episode start, do NOT apply IntroStartOffset
+            _logger.LogTrace(
+                "{EpisodeId} {Name}: Snapping intro start to 0 (within threshold {Threshold}), skipping IntroStartOffset",
+                episode.EpisodeId,
+                episode.Name,
+                _config.EndSnapThreshold);
+            adjustedStart = 0;
+        }
+        else
+        {
+            // Apply configurable start offset only if we are not snapping to the episode start
+            adjustedStart += _config.IntroStartOffset;
+            if (adjustedStart < 0)
+            {
+                adjustedStart = 0;
+            }
+            else if (adjustedStart > duration)
+            {
+                adjustedStart = duration;
+            }
+        }
 
-        double adjustedEnd = originalIntro.End;
-        if (adjustedEnd > duration - _config.EndSnapThreshold)
+        double adjustedEnd = Math.Clamp(originalIntro.End, 0, duration);
+        if (adjustedEnd >= duration - _config.EndSnapThreshold - Epsilon)
         {
             adjustedEnd = duration;
         }
@@ -83,6 +109,8 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
             }
 
             adjustedEnd -= _config.IntroEndOffset;
+            // Keep end inside media duration after offset
+            adjustedEnd = Math.Clamp(adjustedEnd, 0, duration);
 
             var silenceRange = GetSearchRange(adjustedEnd, duration, _config.AdjustWindowInward, _config.AdjustWindowOutward);
             if (_config.AdjustIntroBasedOnSilence)
@@ -131,16 +159,24 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
     /// </summary>
     private static double GetChapterBoundary(IReadOnlyList<ChapterInfo> chapters, double currentEnd, TimeRange searchRange)
     {
+        // Consider chapters within range inclusively with a small epsilon, and choose the closest to currentEnd
+        double? best = null;
+        double bestDist = double.MaxValue;
         foreach (var chapter in chapters)
         {
             var chapterTime = TimeSpan.FromTicks(chapter.StartPositionTicks).TotalSeconds;
-            if (chapterTime > searchRange.Start && chapterTime < searchRange.End)
+            if (chapterTime + Epsilon >= searchRange.Start && chapterTime - Epsilon <= searchRange.End)
             {
-                return chapterTime;
+                var dist = Math.Abs(chapterTime - currentEnd);
+                if (dist < bestDist)
+                {
+                    bestDist = dist;
+                    best = chapterTime;
+                }
             }
         }
 
-        return currentEnd;
+        return best ?? currentEnd;
     }
 
     /// <summary>
@@ -190,10 +226,20 @@ public class TimeAdjustmentHelper(ILogger logger, PluginConfiguration config)
     private static double SnapToNearestKeyframe(QueuedEpisode episode, double time, TimeRange searchRange)
     {
         var keyframes = FFmpegWrapper.DetectKeyFrames(episode, searchRange);
-        return keyframes
-            .OrderBy(kf => Math.Abs(kf - time))
-            .DefaultIfEmpty(time)
-            .First();
+        double nearest = time;
+        double best = double.MaxValue;
+
+        foreach (var kf in keyframes)
+        {
+            double d = Math.Abs(kf - time);
+            if (d < best)
+            {
+                best = d;
+                nearest = kf;
+            }
+        }
+
+        return nearest;
     }
 
     /// <summary>


### PR DESCRIPTION
Improves TimeAdjustmentHelper to clamp intro segment bounds to media duration, correctly handle IntroStartOffset when snapping to episode start, and apply floating point tolerance for threshold comparisons. Adds unit tests to verify offset application, snapping behavior, and clamping logic.

Issues
Fixes #563

## Summary by Sourcery

Refine time adjustment logic to clamp segment bounds, correctly handle snapping behavior and floating-point thresholds, and add comprehensive unit tests.

Bug Fixes:
- Clamp intro start and end times within media duration boundaries
- Prevent applying IntroStartOffset when snapping intro start to episode start
- Fix threshold comparisons for floating-point times by introducing Epsilon tolerance

Enhancements:
- Evaluate raw start values and use a snapToEpisodeStart flag with trace logging for snapping logic
- Enhance GetChapterBoundary and SnapToNearestKeyframe to select nearest matching point and remove LINQ dependency

Tests:
- Add unit tests for IntroStartOffset behavior when snapping and when not snapping
- Add unit test to verify start and end clamping to media duration

Chores:
- Remove unused System.Linq import