### PR TITLE
Run ScanSeason as background task

### DIFF
--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -175,7 +175,10 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
     [HttpDelete("Show/{SeriesId}/{SeasonId}")]
     public async Task<ActionResult> EraseSeasonAsync([FromRoute] Guid seriesId, [FromRoute] Guid seasonId, [FromQuery] bool eraseCache = false, CancellationToken cancellationToken = default)
     {
-        var episodes = Plugin.Instance!.QueuedMediaItems[seasonId];
+        if (!Plugin.Instance!.QueuedMediaItems.TryGetValue(seasonId, out var episodes))
+        {
+            return NotFound();
+        }
 
         if (episodes.Count == 0)
         {
@@ -245,30 +248,49 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
     /// <param name="cancellationToken">cancellationToken.</param>
     /// <returns>No content.</returns>
     [HttpPost("ScanSeason/{SeriesId}/{SeasonId}")]
-    public async Task<ActionResult> ScanSeason([FromRoute] Guid seriesId, [FromRoute] Guid seasonId, CancellationToken cancellationToken = default)
+    public ActionResult ScanSeason([FromRoute] Guid seriesId, [FromRoute] Guid seasonId, CancellationToken cancellationToken = default)
     {
         if (_libraryManager is null)
         {
             throw new InvalidOperationException("Library manager was null");
         }
 
-        // Erase season timestamps
-        await EraseSeasonAsync(seriesId, seasonId, true, cancellationToken).ConfigureAwait(false);
+        // Run erase + analyze in background so it doesn't get canceled when the HTTP request ends/timeouts
+        _ = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    // Do not bind to the HTTP request cancellation; long-running job should complete even if client disconnects
+                    using (await ScheduledTaskSemaphore.AcquireAsync(CancellationToken.None).ConfigureAwait(false))
+                    {
+                        _logger.LogInformation("Start (Re-) scan of season/movie {Season}", seasonId);
 
-        using (await ScheduledTaskSemaphore.AcquireAsync(cancellationToken).ConfigureAwait(false))
-        {
-            _logger.LogInformation("Start (Re-) scan of season/movie {Season}", seasonId);
+                        // Erase season timestamps and cache first
+                        await EraseSeasonAsync(seriesId, seasonId, true, CancellationToken.None).ConfigureAwait(false);
 
-            var baseIntroAnalyzer = new BaseItemAnalyzerTask(
-                _loggerFactory.CreateLogger<DetectSegmentsTask>(),
-                _loggerFactory,
-                _libraryManager,
-                _mediaSegmentUpdateManager);
+                        var baseIntroAnalyzer = new BaseItemAnalyzerTask(
+                            _loggerFactory.CreateLogger<DetectSegmentsTask>(),
+                            _loggerFactory,
+                            _libraryManager,
+                            _mediaSegmentUpdateManager);
 
-            await baseIntroAnalyzer.AnalyzeItemsAsync(new Progress<double>(), cancellationToken, [seasonId]).ConfigureAwait(false);
-        }
+                        await baseIntroAnalyzer.AnalyzeItemsAsync(new Progress<double>(), CancellationToken.None, [seasonId]).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogInformation("Manual season rescan for {SeasonId} was canceled.", seasonId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error during manual season rescan for {SeasonId}", seasonId);
+                }
+            },
+            CancellationToken.None);
 
-        return NoContent();
+        // Immediately return to the client; background task continues
+        return Accepted();
     }
 
     private static string GetProductionYear(Guid seriesId)


### PR DESCRIPTION
The ScanSeason endpoint now starts the erase and analyze operations in a background task, allowing the HTTP request to return immediately with an Accepted response. This prevents long-running jobs from being canceled if the client disconnects or the request times out.

#553

## Summary by Sourcery

Dispatch ScanSeason operations as non-blocking background tasks to prevent cancellation on client disconnect and immediately return 202 Accepted, while adding proper error handling and a missing-queue 404 response.

New Features:
- Run ScanSeason endpoint operations in a background Task and return 202 Accepted immediately without waiting for completion.

Bug Fixes:
- Return 404 NotFound in EraseSeasonAsync when the specified season ID is not queued instead of unhandled exception.

Enhancements:
- Wrap background rescan logic in try/catch to log cancellations and errors.
- Use CancellationToken.None and a semaphore to ensure long-running jobs complete independently of HTTP request lifetime.