### PR TITLE
Refactor media categorization and exclusion logic

### DIFF
--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -186,7 +186,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
         {
             AnalysisMode.Introduction => (_config.MinimumIntroDuration, _config.MaximumIntroDuration),
             AnalysisMode.Credits => (_config.MinimumCreditsDuration,
-                episode.IsMovie ? _config.MaximumMovieCreditsDuration : _config.MaximumCreditsDuration),
+                episode.Category == QueuedMediaCategory.Movie ? _config.MaximumMovieCreditsDuration : _config.MaximumCreditsDuration),
             AnalysisMode.Recap => (_config.MinimumRecapDuration, _config.MaximumRecapDuration),
             AnalysisMode.Preview => (_config.MinimumPreviewDuration, _config.MaximumPreviewDuration),
             _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Unsupported analysis mode: {mode}")

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -12,10 +12,8 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
-using IntroSkipper.Services;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -51,6 +49,9 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
     public ActionResult<Dictionary<Guid, ShowInfos>> GetShowSeasons()
     {
         _logger.LogDebug("Returning season IDs by series name");
+
+        // Ensure the queue is up to date
+        new QueueManager(_loggerFactory.CreateLogger<QueueManager>(), _libraryManager).GetMediaItems();
 
         var showSeasons = new Dictionary<Guid, ShowInfos>();
 

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -320,5 +320,5 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
             : "Unknown";
     }
 
-    private static bool IsMovie(QueuedEpisode episode) => episode.SeriesId == episode.SeasonId;
+    private static bool IsMovie(QueuedEpisode episode) => episode.Category == QueuedMediaCategory.Movie;
 }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -67,7 +67,14 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
             var seasonNumber = first.SeasonNumber;
             if (!showSeasons.TryGetValue(seriesId, out var showInfo))
             {
-                showInfo = new ShowInfos { SeriesName = first.SeriesName, ProductionYear = GetProductionYear(seriesId), LibraryName = GetLibraryName(seriesId), IsMovie = first.IsMovie, Seasons = [] };
+                showInfo = new ShowInfos
+                {
+                    SeriesName = first.SeriesName,
+                    ProductionYear = GetProductionYear(seriesId),
+                    LibraryName = GetLibraryName(seriesId),
+                    IsMovie = IsMovie(first),
+                    Seasons = []
+                };
                 showSeasons[seriesId] = showInfo;
             }
 
@@ -312,4 +319,6 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
             ? string.Join(", ", collectionFolders.Select(folder => folder.Name))
             : "Unknown";
     }
+
+    private static bool IsMovie(QueuedEpisode episode) => episode.SeriesId == episode.SeasonId;
 }

--- a/IntroSkipper/Data/QueuedEpisode.cs
+++ b/IntroSkipper/Data/QueuedEpisode.cs
@@ -59,14 +59,14 @@ public class QueuedEpisode
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a value indicating whether an episode is Anime.
+    /// Gets or sets the category for this media item.
     /// </summary>
-    public bool IsAnime { get; set; }
+    public QueuedMediaCategory Category { get; set; } = QueuedMediaCategory.Episode;
 
     /// <summary>
-    /// Gets or sets a value indicating whether an item is a movie.
+    /// Gets or sets a value indicating whether this media item should be excluded from analysis.
     /// </summary>
-    public bool IsMovie { get; set; }
+    public bool IsExcluded { get; set; }
 
     /// <summary>
     /// Gets or sets the timestamp (in seconds) to stop searching for an introduction at.

--- a/IntroSkipper/Data/QueuedMediaCategory.cs
+++ b/IntroSkipper/Data/QueuedMediaCategory.cs
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only.
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Describes how a media item in the processing queue should be treated.
+/// </summary>
+public enum QueuedMediaCategory
+{
+    /// <summary>
+    /// A standard episode that should be analyzed.
+    /// </summary>
+    Episode,
+
+    /// <summary>
+    /// An episode that should be treated with anime-specific rules.
+    /// </summary>
+    AnimeEpisode,
+
+    /// <summary>
+    /// A movie item.
+    /// </summary>
+    Movie
+}

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -372,11 +372,6 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         foreach (var candidate in candidates)
         {
-            if (candidate.IsExcluded)
-            {
-                continue;
-            }
-
             try
             {
                 var path = plugin.GetItemPath(candidate.EpisodeId);

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -357,7 +357,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// <returns>Media items that have been verified to exist in Jellyfin and in storage.</returns>
     internal IReadOnlyList<QueuedEpisode> VerifyQueue(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes)
     {
-        if (candidates == null || candidates.Count == 0 || candidates[0].IsExcluded)
+        if (candidates == null || candidates.Count == 0)
         {
             return [];
         }
@@ -368,6 +368,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         foreach (var candidate in candidates)
         {
+            if (candidate.IsExcluded)
+            {
+                continue;
+            }
+
             try
             {
                 var path = plugin.GetItemPath(candidate.EpisodeId);

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -278,6 +278,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             IntroFingerprintEnd = fingerprintDuration,
             CreditsFingerprintStart = Math.Max(0, duration - maxCreditsDuration),
         });
+
+        pluginInstance.TotalQueued++;
     }
 
     private static QueuedMediaCategory ResolveEpisodeCategory(Episode episode, IReadOnlyList<QueuedEpisode> seasonEpisodes, Plugin pluginInstance)
@@ -328,6 +330,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             Category = QueuedMediaCategory.Movie,
             IsExcluded = IsSeriesExcluded(movie.Name),
         });
+
+        pluginInstance.TotalQueued++;
     }
 
     private Guid GetSeasonId(Episode episode)

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -156,24 +156,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             {
                 if (item is Episode episode)
                 {
-                    if (!IsSeriesExcluded(episode.SeriesName))
-                    {
-                        QueueEpisode(episode);
-                    }
-                    else
-                    {
-                        _logger.LogDebug("Skipping excluded series: {Series}", episode.SeriesName);
-                    }
+                    QueueEpisode(episode);
                 }
                 else if (item is Movie movie)
                 {
                     if (!_analyzeMovies)
                     {
                         _logger.LogDebug("Skipping movie {Name}: movie analysis is disabled", movie.Name);
-                    }
-                    else if (IsSeriesExcluded(movie.Name))
-                    {
-                        _logger.LogDebug("Skipping excluded movie: {Name}", movie.Name);
                     }
                     else
                     {
@@ -263,13 +252,6 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return;
         }
 
-        var isAnime = seasonEpisodes.FirstOrDefault()?.IsAnime ??
-            (pluginInstance.GetItem(episode.SeriesId) is Series series &&
-                (series.Tags.Contains("anime", StringComparison.OrdinalIgnoreCase) ||
-                series.Genres.Contains("anime", StringComparison.OrdinalIgnoreCase)));
-
-        // Limit analysis to the first X% of the episode and at most Y minutes.
-        // X and Y default to 25% and 10 minutes.
         var duration = TimeSpan.FromTicks(episode.RunTimeTicks ?? 0).TotalSeconds;
         var fingerprintDuration = Math.Min(
             duration >= 5 * 60 ? duration * _analysisPercent : duration,
@@ -289,14 +271,30 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             EpisodeNumber = episode.IndexNumber ?? 0,
             EpisodeId = episode.Id,
             Name = episode.Name,
-            IsAnime = isAnime,
+            Category = ResolveEpisodeCategory(episode, seasonEpisodes, pluginInstance),
+            IsExcluded = IsSeriesExcluded(episode.SeriesName),
             Path = episode.Path,
             Duration = duration,
             IntroFingerprintEnd = fingerprintDuration,
-            CreditsFingerprintStart = duration - maxCreditsDuration,
+            CreditsFingerprintStart = Math.Max(0, duration - maxCreditsDuration),
         });
+    }
 
-        pluginInstance.TotalQueued++;
+    private static QueuedMediaCategory ResolveEpisodeCategory(Episode episode, IReadOnlyList<QueuedEpisode> seasonEpisodes, Plugin pluginInstance)
+    {
+        if (seasonEpisodes.FirstOrDefault()?.Category is QueuedMediaCategory cat && (cat == QueuedMediaCategory.AnimeEpisode || cat == QueuedMediaCategory.Episode))
+        {
+            return cat;
+        }
+
+        if (pluginInstance.GetItem(episode.SeriesId) is Series series &&
+            (series.Tags.Contains("anime", StringComparison.OrdinalIgnoreCase) ||
+             series.Genres.Contains("anime", StringComparison.OrdinalIgnoreCase)))
+        {
+            return QueuedMediaCategory.AnimeEpisode;
+        }
+
+        return QueuedMediaCategory.Episode;
     }
 
     private void QueueMovie(Movie movie)
@@ -326,11 +324,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             Name = movie.Name,
             Path = movie.Path,
             Duration = duration,
-            CreditsFingerprintStart = duration - pluginInstance.Configuration.MaximumMovieCreditsDuration,
-            IsMovie = true
+            CreditsFingerprintStart = Math.Max(0, duration - pluginInstance.Configuration.MaximumMovieCreditsDuration),
+            Category = QueuedMediaCategory.Movie,
+            IsExcluded = IsSeriesExcluded(movie.Name),
         });
-
-        pluginInstance.TotalQueued++;
     }
 
     private Guid GetSeasonId(Episode episode)
@@ -360,7 +357,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// <returns>Media items that have been verified to exist in Jellyfin and in storage.</returns>
     internal IReadOnlyList<QueuedEpisode> VerifyQueue(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes)
     {
-        if (candidates == null || candidates.Count == 0)
+        if (candidates == null || candidates.Count == 0 || candidates[0].IsExcluded)
         {
             return [];
         }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -100,11 +100,13 @@ public class BaseItemAnalyzerTask(
             {
                 return;
             }
-            else if (episodes[0].IsExcluded)
+
+            var first = episodes[0];
+            if (first.IsExcluded)
             {
                 Interlocked.Add(ref totalProcessed, episodes.Count * modes.Count);
                 progress.Report((double)totalProcessed / totalQueued * 100);
-                _logger.LogInformation("Skipping excluded season {Season} of {Series}", episodes[0].SeasonNumber, episodes[0].SeriesName);
+                _logger.LogInformation("Skipping excluded season {Season} of {Series}", first.SeasonNumber, first.SeriesName);
                 return;
             }
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -166,7 +166,11 @@ public class BaseItemAnalyzerTask(
         }
 
         var first = items[0];
-        if (!first.IsMovie && first.SeasonNumber == 0 && !_config.AnalyzeSeasonZero)
+        var category = first.Category;
+        var isMovie = category == QueuedMediaCategory.Movie;
+        var isAnime = category == QueuedMediaCategory.AnimeEpisode;
+
+        if (!isMovie && first.SeasonNumber == 0 && !_config.AnalyzeSeasonZero)
         {
             return 0;
         }
@@ -197,7 +201,7 @@ public class BaseItemAnalyzerTask(
             analyzers.Add(new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()));
         }
 
-        if (first.IsAnime && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
+        if (isAnime && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
         {
             analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }
@@ -207,7 +211,7 @@ public class BaseItemAnalyzerTask(
             analyzers.Add(blackFrameAnalyzer);
         }
 
-        if (!first.IsAnime && !first.IsMovie && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
+        if (!isAnime && !isMovie && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
         {
             analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -100,11 +100,16 @@ public class BaseItemAnalyzerTask(
             {
                 return;
             }
+            else if (episodes[0].IsExcluded)
+            {
+                Interlocked.Add(ref totalProcessed, episodes.Count * modes.Count);
+                progress.Report((double)totalProcessed / totalQueued * 100);
+                _logger.LogInformation("Skipping excluded season {Season} of {Series}", episodes[0].SeasonNumber, episodes[0].SeriesName);
+                return;
+            }
 
             try
             {
-                var firstEpisode = episodes[0];
-
                 foreach (var mode in modes)
                 {
                     ct.ThrowIfCancellationRequested();


### PR DESCRIPTION
Introduces QueuedMediaCategory enum to replace IsMovie and IsAnime flags, refactors episode and movie queuing to use category and exclusion properties, and updates analyzers and controllers to use the new categorization. 

Fix #579

## Summary by Sourcery

Replace boolean media flags with a unified categorization enum and exclusion property, update queueing and analysis logic to use the new classification, and clamp credit fingerprint start times to avoid negative values.

New Features:
- Add QueuedMediaCategory enum and IsExcluded property to categorize and skip media items

Bug Fixes:
- Clamp CreditsFingerprintStart to zero to prevent negative values

Enhancements:
- Replace IsMovie and IsAnime flags with Category and IsExcluded properties across queue manager, analyzers, and controllers
- Refactor queue manager to use Category for classification and skip excluded items via a centralized ResolveEpisodeCategory helper
- Update VisualizationController and BaseItemAnalyzerTask to switch on Category instead of boolean flags