### PR TITLE
remove Enqueue all episodes at startup

### DIFF
--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -12,7 +12,6 @@ using IntroSkipper.Configuration;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
-using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -97,10 +96,6 @@ namespace IntroSkipper.Services
             {
                 InitializeWebInjector();
             }
-
-            // Enqueue all episodes at startup to ensure any FFmpeg errors appear as early as possible
-            _logger.LogInformation("Running startup enqueue");
-            new QueueManager(_loggerFactory.CreateLogger<QueueManager>(), _libraryManager).GetMediaItems();
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
for some user there is a problem

IntroSkipper.Services.Entrypoint: Error while executing the initial enqueue. System.NullReferenceException: Object reference not set to an instance of an object.
   at IntroSkipper.Manager.QueueManager.GetMediaItems()
   at IntroSkipper.Services.Entrypoint.StartAsync(CancellationToken cancellationToken)

## Summary by Sourcery

Remove the startup logic that enqueued all episodes and clean up an unused configuration import to avoid startup errors

Bug Fixes:
- Remove initial enqueue of all episodes at startup to prevent NullReferenceException in Entrypoint

Chores:
- Eliminate unused MediaBrowser.Common.Configuration import