### PR TITLE
Add support for commercial segments

### DIFF
--- a/IntroSkipper.Tests/AutoSkipTests.cs
+++ b/IntroSkipper.Tests/AutoSkipTests.cs
@@ -14,6 +14,7 @@ public class TestAutoSkip
     [InlineData("%segmenttype from %start to %end", AnalysisMode.Credits, 65.7, 125.2, "Credits from 66 to 125")]
     [InlineData("%segmenttype detected (%duration seconds)", AnalysisMode.Recap, 30.4, 90.2, "Recap detected (60 seconds)")]
     [InlineData("", AnalysisMode.Preview, 10, 20, "")]
+    [InlineData("Now skipping %segmenttype", AnalysisMode.Commercial, 5.1, 35.9, "Now skipping Commercial")]
     [InlineData(null, AnalysisMode.Introduction, 10, 20, "")]
     public void FormatNotificationText_ReplacesPlaceholdersCorrectly(string? template, AnalysisMode segmentType, double start, double end, string expected)
     {

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -39,6 +39,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
             AnalysisMode.Credits => _config.ChapterAnalyzerEndCreditsPattern,
             AnalysisMode.Recap => _config.ChapterAnalyzerRecapPattern,
             AnalysisMode.Preview => _config.ChapterAnalyzerPreviewPattern,
+            AnalysisMode.Commercial => _config.ChapterAnalyzerCommercialPattern,
             _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Unexpected analysis mode: {mode}")
         };
 
@@ -189,6 +190,7 @@ public class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFileAnalyz
                 episode.Category == QueuedMediaCategory.Movie ? _config.MaximumMovieCreditsDuration : _config.MaximumCreditsDuration),
             AnalysisMode.Recap => (_config.MinimumRecapDuration, _config.MaximumRecapDuration),
             AnalysisMode.Preview => (_config.MinimumPreviewDuration, _config.MaximumPreviewDuration),
+            AnalysisMode.Commercial => (_config.MinimumCommercialDuration, _config.MaximumCommercialDuration),
             _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Unsupported analysis mode: {mode}")
         };
     }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -92,6 +92,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool ScanPreview { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether Commercials should be analyzed.
+    /// </summary>
+    public bool ScanCommercial { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the percentage of each episode's audio track to analyze.
     /// </summary>
     public int AnalysisPercent { get; set; } = 25;
@@ -150,6 +155,16 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the maximum length of similar audio that will be considered a preview.
     /// </summary>
     public int MaximumPreviewDuration { get; set; } = 120;
+
+    /// <summary>
+    /// Gets or sets the minimum length of similar audio that will be considered a commercial.
+    /// </summary>
+    public int MinimumCommercialDuration { get; set; } = 15;
+
+    /// <summary>
+    /// Gets or sets the maximum length of similar audio that will be considered a commercial.
+    /// </summary>
+    public int MaximumCommercialDuration { get; set; } = 120;
 
     /// <summary>
     /// Gets or sets the minimum percentage of a frame that must consist of black pixels before it is considered a black frame.
@@ -225,6 +240,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public string ChapterAnalyzerRecapPattern { get; set; } =
         @"(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?!\sEnd)(\s|:|$)";
 
+    /// <summary>
+    /// Gets or sets the regular expression used to detect Commercial chapters.
+    /// </summary>
+    public string ChapterAnalyzerCommercialPattern { get; set; }
+
     // ===== Playback settings =====
 
     /// <summary>
@@ -256,6 +276,11 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether preview should be automatically skipped.
     /// </summary>
     public bool AutoSkipPreview { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether commercial should be automatically skipped.
+    /// </summary>
+    public bool AutoSkipCommercial { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the introduction in the first episode of a season should be ignored.

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -243,7 +243,8 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets the regular expression used to detect Commercial chapters.
     /// </summary>
-    public string ChapterAnalyzerCommercialPattern { get; set; }
+    public string ChapterAnalyzerCommercialPattern { get; set; } =
+        @"(^|\s)(Ad(vert(isement)?)?|Commercial)(?!\sEnd)(\s|$)";
 
     // ===== Playback settings =====
 

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -75,7 +75,7 @@
                             </div>
 
                             <div class="checkboxContainer" style="display: flex; flex-direction: row; flex-wrap: nowrap; align-items: center;">
-                                <span style="font-weight: 600; margin-right: 1em; white-space: nowrap;">Analyze:</span>
+                                <span style="font-weight: 600; margin-right: 1em; white-space: nowrap;">Analyze for:</span>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanIntroduction" type="checkbox" is="emby-checkbox" />
                                     <span>Intros</span>
@@ -550,7 +550,7 @@
                                     <br />
                                     <h3 style="margin: 0">Analyzer actions</h3>
                                     <p style="margin: 0">
-                                        Choose how segments should be analyzed for this season.<br />
+                                        Choose how each segment type should be analyzed for this season.<br />
                                         <i>
                                             Default uses all available detection methods (Chromaprint, Chapter, and BlackFrame for credits).<br />
                                             Select specific methods to limit analysis, or None to skip detection entirely.

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -384,8 +384,8 @@
 
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="ChapterAnalyzerCommercialPattern"> Commercials </label>
-                                    <input id="ChapterAnalyzerCommercialPattern" type="text" placeholder="" is="emby-input" />
-                                    <div class="fieldDescription">Enter a regular expression to detect commercial chapters. <br />Default: <code></code></div>
+                                    <input id="ChapterAnalyzerCommercialPattern" type="text" placeholder="(^|\s)(Ad(vert(isement)?)?|Commercial)(?!\sEnd)(\s|$)" is="emby-input" />
+                                    <div class="fieldDescription">Enter a regular expression to detect commercial chapters. <br />Default: <code>(^|\s)(Ad(vert(isement)?)?|Commercial)(?!\sEnd)(\s|$)</code></div>
                                 </div>
                             </details>
 

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -78,7 +78,7 @@
                                 <span style="font-weight: 600; margin-right: 1em; white-space: nowrap;">Analyze for:</span>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanIntroduction" type="checkbox" is="emby-checkbox" />
-                                    <span>Intros</span>
+                                    <span>Introduction</span>
                                 </label>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanCredits" type="checkbox" is="emby-checkbox" />
@@ -86,11 +86,11 @@
                                 </label>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanRecap" type="checkbox" is="emby-checkbox" />
-                                    <span>Recaps</span>
+                                    <span>Recap</span>
                                 </label>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanPreview" type="checkbox" is="emby-checkbox" />
-                                    <span>Previews</span>
+                                    <span>Preview</span>
                                 </label>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanCommercial" type="checkbox" is="emby-checkbox" />
@@ -113,6 +113,7 @@
                                     <span>Use File Transformation Plugin to patch the web interface</span>
                                 </label>
                                 <div id="divSkipbuttonHideDelayContent">
+                                    <br />
                                     <label class="inputLabel inputLabelUnfocused" for="SkipbuttonHideDelay"> Skip button hide delay (in seconds) </label>
                                     <input id="SkipbuttonHideDelay" type="number" is="emby-input" min="0" max="1000"/>
                                     <div class="fieldDescription">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -75,10 +75,10 @@
                             </div>
 
                             <div class="checkboxContainer" style="display: flex; flex-direction: row; flex-wrap: nowrap; align-items: center;">
-                                <span style="font-weight: 600; margin-right: 1em; white-space: nowrap;">Analyze for:</span>
+                                <span style="font-weight: 600; margin-right: 1em; white-space: nowrap;">Analyze:</span>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanIntroduction" type="checkbox" is="emby-checkbox" />
-                                    <span>Introductions</span>
+                                    <span>Intros</span>
                                 </label>
                                 <label class="emby-checkbox-label">
                                     <input id="ScanCredits" type="checkbox" is="emby-checkbox" />
@@ -559,16 +559,16 @@
                                     <br />
 
                                     <div id="analyzerActionsContainer" style="display: flex; align-items: center; gap: 1.5em">
-                                        <label for="actionRecap" style="width: 23%">
-                                            <span>Recap analysis</span>
+                                        <label for="actionRecap" style="width: 20%">
+                                            <span>Recap</span>
                                             <select is="emby-select" id="actionRecap" class="emby-select-withcolor emby-select">
                                                 <option value="Default">Default</option>
                                                 <option value="Chapter">Chapter</option>
                                                 <option value="None">None</option>
                                             </select>
                                         </label>
-                                        <label for="actionIntro" style="width: 23%">
-                                            <span>Introduction analysis</span>
+                                        <label for="actionIntro" style="width: 20%">
+                                            <span>Introduction</span>
                                             <select is="emby-select" id="actionIntro" class="emby-select-withcolor emby-select">
                                                 <option value="Default">Default</option>
                                                 <option value="Chapter">Chapter</option>
@@ -576,8 +576,8 @@
                                                 <option value="None">None</option>
                                             </select>
                                         </label>
-                                        <label for="actionCredits" style="width: 23%">
-                                            <span>Credits (Outro) analysis</span>
+                                        <label for="actionCredits" style="width: 20%">
+                                            <span>Credits (Outro)</span>
                                             <select is="emby-select" id="actionCredits" class="emby-select-withcolor emby-select">
                                                 <option value="Default">Default</option>
                                                 <option value="Chapter">Chapter</option>
@@ -586,16 +586,16 @@
                                                 <option value="None">None</option>
                                             </select>
                                         </label>
-                                        <label for="actionPreview" style="width: 23%">
-                                            <span>Preview analysis</span>
+                                        <label for="actionPreview" style="width: 20%">
+                                            <span>Preview</span>
                                             <select is="emby-select" id="actionPreview" class="emby-select-withcolor emby-select">
                                                 <option value="Default">Default</option>
                                                 <option value="Chapter">Chapter</option>
                                                 <option value="None">None</option>
                                             </select>
                                         </label>
-                                        <label for="actionCommercial" style="width: 23%">
-                                            <span>Commercial analysis</span>
+                                        <label for="actionCommercial" style="width: 20%">
+                                            <span>Commercial</span>
                                             <select is="emby-select" id="actionCommercial" class="emby-select-withcolor emby-select">
                                                 <option value="Default">Default</option>
                                                 <option value="Chapter">Chapter</option>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -92,6 +92,10 @@
                                     <input id="ScanPreview" type="checkbox" is="emby-checkbox" />
                                     <span>Previews</span>
                                 </label>
+                                <label class="emby-checkbox-label">
+                                    <input id="ScanCommercial" type="checkbox" is="emby-checkbox" />
+                                    <span>Commercials</span>
+                                </label>
                             </div>
 
                             <div class="checkboxContainer checkboxContainer-withDescription">
@@ -216,6 +220,18 @@
                                         <label class="inputLabel inputLabelUnfocused" for="MaximumPreviewDuration"> Maximum preview duration (in seconds) </label>
                                         <input id="MaximumPreviewDuration" type="number" is="emby-input" min="1" />
                                         <div class="fieldDescription">Segments which are longer than this duration will not be considered a preview.</div>
+                                    </div>
+
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="MinimumCommercialDuration"> Minimum commercial duration (in seconds) </label>
+                                        <input id="MinimumCommercialDuration" type="number" is="emby-input" min="1" />
+                                        <div class="fieldDescription">Segments which are shorter than this duration will not be considered a commercial.</div>
+                                    </div>
+
+                                    <div class="inputContainer">
+                                        <label class="inputLabel inputLabelUnfocused" for="MaximumCommercialDuration"> Maximum commercial duration (in seconds) </label>
+                                        <input id="MaximumCommercialDuration" type="number" is="emby-input" min="1" />
+                                        <div class="fieldDescription">Segments which are longer than this duration will not be considered a commercial.</div>
                                     </div>
                                 </div>
                                 <br />
@@ -364,6 +380,12 @@
                                     <label class="inputLabel inputLabelUnfocused" for="ChapterAnalyzerRecapPattern"> Recaps </label>
                                     <input id="ChapterAnalyzerRecapPattern" type="text" placeholder="(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?!\sEnd)(\s|:|$)" is="emby-input" />
                                     <div class="fieldDescription">Enter a regular expression to detect recap chapters. <br />Default: <code>(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?!\sEnd)(\s|:|$)</code></div>
+                                </div>
+
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="ChapterAnalyzerCommercialPattern"> Commercials </label>
+                                    <input id="ChapterAnalyzerCommercialPattern" type="text" placeholder="" is="emby-input" />
+                                    <div class="fieldDescription">Enter a regular expression to detect commercial chapters. <br />Default: <code></code></div>
                                 </div>
                             </details>
 
@@ -567,6 +589,14 @@
                                         <label for="actionPreview" style="width: 23%">
                                             <span>Preview analysis</span>
                                             <select is="emby-select" id="actionPreview" class="emby-select-withcolor emby-select">
+                                                <option value="Default">Default</option>
+                                                <option value="Chapter">Chapter</option>
+                                                <option value="None">None</option>
+                                            </select>
+                                        </label>
+                                        <label for="actionCommercial" style="width: 23%">
+                                            <span>Commercial analysis</span>
+                                            <select is="emby-select" id="actionCommercial" class="emby-select-withcolor emby-select">
                                                 <option value="Default">Default</option>
                                                 <option value="Chapter">Chapter</option>
                                                 <option value="None">None</option>
@@ -793,6 +823,8 @@
                                         <option value="credits">Global Credits Timestamps</option>
 
                                         <option value="preview">Global Preview Timestamps</option>
+
+                                        <option value="commercial">Global Commercial Timestamps</option>
                                     </select>
                                     <div class="checkboxContainer checkboxContainer" style="margin: 0">
                                         <label class="emby-checkbox-label">
@@ -878,6 +910,8 @@
                     "MaximumRecapDuration",
                     "MinimumPreviewDuration",
                     "MaximumPreviewDuration",
+                    "MinimumCommercialDuration",
+                    "MaximumCommercialDuration",
                     "ProcessPriority",
                     "ProcessThreads",
                     // playback
@@ -894,12 +928,13 @@
                     "ChapterAnalyzerEndCreditsPattern",
                     "ChapterAnalyzerPreviewPattern",
                     "ChapterAnalyzerRecapPattern",
+                    "ChapterAnalyzerCommercialPattern",
                     "TypeList",
                     // UI customization
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments","UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments","UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "ScanCommercial", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
 
                 // visualizer elements
                 const analyzerActionsSection = document.querySelector("div#analyzerActionsSection");
@@ -907,6 +942,7 @@
                 const actionCredits = analyzerActionsSection.querySelector("select#actionCredits");
                 const actionRecap = analyzerActionsSection.querySelector("select#actionRecap");
                 const actionPreview = analyzerActionsSection.querySelector("select#actionPreview");
+                const actionCommercial = analyzerActionsSection.querySelector("select#actionCommercial");
                 const actionFileTransformation = document.getElementById("UseFileTransformationPlugin");
                 const divSkipbuttonHideDelayContent = document.getElementById("divSkipbuttonHideDelayContent");
                 const saveAnalyzerActionsButton = analyzerActionsSection.querySelector("button#saveAnalyzerActions");
@@ -1015,7 +1051,7 @@
                 }
 
                 async function generateAutoSkipTypeList() {
-                    const types = ["Introduction", "Credits", "Recap", "Preview"];
+                    const types = ["Introduction", "Credits", "Recap", "Preview", "Commercial"];
                     generateCheckboxList(types, "autoSkipTypeCheckboxes", "TypeList");
                 }
 
@@ -1201,6 +1237,7 @@
                     actionCredits.value = analyzerActions.Credits || "Default";
                     actionRecap.value = analyzerActions.Recap || "Default";
                     actionPreview.value = analyzerActions.Preview || "Default";
+                    actionCommercial.value = analyzerActions.Commercial || "Default";
                     analyzerActionsSection.style.display = "unset";
 
                     // show the erase season button
@@ -1635,6 +1672,7 @@
                             Credits: actionCredits.value,
                             Recap: actionRecap.value,
                             Preview: actionPreview.value,
+                            Commercial: actionCommercial.value,
                         },
                     };
 
@@ -1780,6 +1818,9 @@
                             break;
                         case "preview":
                             eraseTimestamps("Preview");
+                            break;
+                        case "commercial":
+                            eraseTimestamps("Commercial");
                             break;
                         default:
                             return;

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -100,6 +100,7 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
             "recap" => AnalysisMode.Recap,
             "preview" => AnalysisMode.Preview,
             "outro" or "credits" => AnalysisMode.Credits,
+            "commercial" => AnalysisMode.Commercial,
             _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown segment type '{type}'")
         };
 

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -59,7 +59,8 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
             (AnalysisMode.Introduction, timestamps.Introduction),
             (AnalysisMode.Credits, timestamps.Credits),
             (AnalysisMode.Recap, timestamps.Recap),
-            (AnalysisMode.Preview, timestamps.Preview)
+            (AnalysisMode.Preview, timestamps.Preview),
+            (AnalysisMode.Commercial, timestamps.Commercial)
         };
 
         foreach (var (mode, segment) in segmentTypes)
@@ -126,6 +127,11 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
             times.Preview = previewSegment;
         }
 
+        if (segments.TryGetValue(AnalysisMode.Commercial, out var commercialSegment))
+        {
+            times.Commercial = commercialSegment;
+        }
+
         return times;
     }
 
@@ -149,6 +155,21 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
         if (segments.TryGetValue(AnalysisMode.Credits, out var creditSegment))
         {
             result[AnalysisMode.Credits] = creditSegment;
+        }
+
+        if (segments.TryGetValue(AnalysisMode.Recap, out var recapSegment))
+        {
+            result[AnalysisMode.Recap] = recapSegment;
+        }
+
+        if (segments.TryGetValue(AnalysisMode.Preview, out var previewSegment))
+        {
+            result[AnalysisMode.Preview] = previewSegment;
+        }
+
+        if (segments.TryGetValue(AnalysisMode.Commercial, out var commercialSegment))
+        {
+            result[AnalysisMode.Commercial] = commercialSegment;
         }
 
         return result;

--- a/IntroSkipper/Data/AnalysisMode.cs
+++ b/IntroSkipper/Data/AnalysisMode.cs
@@ -27,4 +27,9 @@ public enum AnalysisMode
     /// Detect recaps.
     /// </summary>
     Recap,
+
+    /// <summary>
+    /// Detect commercials. Only for Segment editor.
+    /// </summary>
+    Commercial
 }

--- a/IntroSkipper/Data/TimeStamps.cs
+++ b/IntroSkipper/Data/TimeStamps.cs
@@ -28,5 +28,10 @@ namespace IntroSkipper.Data
         /// Gets or sets Preview.
         /// </summary>
         public Segment Preview { get; set; } = new Segment();
+
+        /// <summary>
+        /// Gets or sets Commercial.
+        /// </summary>
+        public Segment Commercial { get; set; } = new Segment();
     }
 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -300,6 +300,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             MediaSegmentType.Recap => AnalysisMode.Recap,
             MediaSegmentType.Preview => AnalysisMode.Preview,
             MediaSegmentType.Outro => AnalysisMode.Credits,
+            MediaSegmentType.Commercial => AnalysisMode.Commercial,
             _ => throw new NotImplementedException(),
         };
     }

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -29,7 +29,8 @@ namespace IntroSkipper.Providers
             [AnalysisMode.Introduction] = MediaSegmentType.Intro,
             [AnalysisMode.Recap] = MediaSegmentType.Recap,
             [AnalysisMode.Preview] = MediaSegmentType.Preview,
-            [AnalysisMode.Credits] = MediaSegmentType.Outro
+            [AnalysisMode.Credits] = MediaSegmentType.Outro,
+            [AnalysisMode.Commercial] = MediaSegmentType.Commercial
         };
 
         /// <inheritdoc/>

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -54,7 +54,8 @@ public class BaseItemAnalyzerTask(
             .. _config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
             .. _config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
             .. _config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>()
+            .. _config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>(),
+            .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
         var queueManager = new QueueManager(


### PR DESCRIPTION
Introduces a new AnalysisMode.Commercial enum value and maps MediaSegmentType.Commercial to it in Plugin.cs. This enables commercial segments for use in the Segment editor.

## Summary by Sourcery

Add full support for commercial segments by extending the analysis mode, configuration, UI, controllers, providers, and tests to detect, display, and skip commercials in the plugin.

New Features:
- Introduce commercial segment support by adding AnalysisMode.Commercial and mapping MediaSegmentType.Commercial
- Extend plugin configuration with ScanCommercial, minimum/maximum commercial durations, regex pattern, and auto-skip option
- Add commercial segment controls to the UI in the configuration page, analyzer actions, and fingerprint visualizer
- Update controllers, providers, and timestamp models to handle commercial segments throughout the segment editor

Tests:
- Add unit test to verify notification formatting for commercial segments