### PR TITLE
Update manifest URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <br />
 It will NOT return a manifest when viewed in a browser, as no Jellyfin version is provided.**
 ```
-https://intro-skipper.org/manifest.json
+https://manifest.intro-skipper.org/manifest.json
 ```
 
 ### As of Jellyfin 10.10, Intro Skipper does **NOT** modify the UI.


### PR DESCRIPTION
I couldn't find the plugin until I changed the repo to this

## Summary by Sourcery

Documentation:
- Change the plugin manifest URL from intro-skipper.org to manifest.intro-skipper.org in README