### PR TITLE
Support analyze .strm files

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -41,6 +41,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool AnalyzeSeasonZero { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to process IsShortcut videos.
+    /// </summary>
+    public bool ProcessShortcutVideos { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to only use chromaprint.
     /// </summary>
     public bool PreferChromaprint { get; set; }

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -116,6 +116,15 @@
                                 <div class="fieldDescription">Note: Shows containing both a specials and extra folder will identify extras as season 0 and ignore specials, regardless of this setting.</div>
                             </div>
 
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input id="ProcessShortcutVideos" type="checkbox" is="emby-checkbox" />
+                                    <span>Process Shortcut Videos (.strm files)</span>
+                                </label>
+
+                                <div class="fieldDescription">If enabled, shortcut videos (e.g., .strm files) will be processed during analysis. Disable this if you want to skip analyzing shortcut videos.</div>
+                            </div>
+
                             <div id="divSkipbuttonHideDelay" class="inputContainer">
                                 <label class="emby-checkbox-label">
                                     <input id="UseFileTransformationPlugin" type="checkbox" is="emby-checkbox" />
@@ -912,7 +921,7 @@
                     "AutoSkipNotificationText",
                 ];
 
-                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments","UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
+                const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "ProcessShortcutVideos", "UpdateMediaSegments","UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "PreferChromaprint", "CacheFingerprints", "PluginSkip", "AutoSkip", "SkipFirstEpisode", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
 
                 // visualizer elements
                 const analyzerActionsSection = document.querySelector("div#analyzerActionsSection");

--- a/IntroSkipper/Data/QueuedEpisode.cs
+++ b/IntroSkipper/Data/QueuedEpisode.cs
@@ -54,6 +54,11 @@ public class QueuedEpisode
     public string Path { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the shortcut path to episode.
+    /// </summary>
+    public string ShortcutPath { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the name of the episode.
     /// </summary>
     public string Name { get; set; } = string.Empty;
@@ -67,6 +72,11 @@ public class QueuedEpisode
     /// Gets or sets a value indicating whether this media item should be excluded from analysis.
     /// </summary>
     public bool IsExcluded { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this media item is a shortcut.
+    /// </summary>
+    public bool IsShortcut { get; set; }
 
     /// <summary>
     /// Gets or sets the timestamp (in seconds) to stop searching for an introduction at.

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -152,7 +152,7 @@ public static partial class FFmpegWrapper
             "-vn -sn -dn " +
                 "-ss {0} -i \"{1}\" -to {2} -vn -dn -sn -af \"silencedetect=noise={3}dB:duration=0.1\" -f null -",
             range.Start,
-            episode.Path,
+            episode.IsShortcut ? episode.ShortcutPath : episode.Path,
             range.End - range.Start,
             Plugin.Instance?.Configuration.SilenceDetectionMaximumNoise ?? -50);
 
@@ -212,7 +212,7 @@ public static partial class FFmpegWrapper
             CultureInfo.InvariantCulture,
             "-ss {0} -i \"{1}\" -to {2} -an -dn -sn -vf \"blackframe=amount=50:threshold={3}\" -f null -",
             range.Start,
-            episode.Path,
+            episode.IsShortcut ? episode.ShortcutPath : episode.Path,
             range.End - range.Start,
             threshold);
 
@@ -244,7 +244,7 @@ public static partial class FFmpegWrapper
             CultureInfo.InvariantCulture,
             "-skip_frame nokey -ss {0} -i \"{1}\" -an -dn -sn -vf \"blackframe=amount=0:threshold={2}\" -f null -",
             episode.CreditsFingerprintStart,
-            episode.Path,
+            episode.IsShortcut ? episode.ShortcutPath : episode.Path,
             threshold);
 
         // Cache the results to GUID-blackframes-START-END-v1.
@@ -303,7 +303,7 @@ public static partial class FFmpegWrapper
             CultureInfo.InvariantCulture,
             "-skip_frame nokey -ss {0} -i \"{1}\" -to {2} -an -dn -sn -vf \"showinfo\" -f null -",
             range.Start,
-            episode.Path,
+            episode.IsShortcut ? episode.ShortcutPath : episode.Path,
             range.End - range.Start);
 
         var cacheKey = string.Format(
@@ -509,6 +509,91 @@ public static partial class FFmpegWrapper
     }
 
     /// <summary>
+    /// Get media duration as runtime ticks via ffprobe.
+    /// Does not use cache.
+    /// Returns 0 when duration cannot be parsed from output.
+    /// </summary>
+    /// <param name="path">Full path of the media to probe.</param>
+    /// <returns>Duration (seconds).</returns>
+    public static double ProbeDuration(string path)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
+        Logger?.LogTrace("Probing duration for \"{File}\"", path);
+
+        // Use ffprobe to get duration in seconds
+        var args = string.Format(
+            CultureInfo.InvariantCulture,
+            "-v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 \"{0}\"",
+            path);
+
+        var raw = Encoding.UTF8.GetString(GetProbeOutput(args, timeout: 15_000));
+
+        // Try to parse the duration as a double (seconds)
+        if (!double.TryParse(raw.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var durationSeconds))
+        {
+            Logger?.LogDebug("Duration not found or N/A for \"{File}\"", path);
+            return 0L;
+        }
+
+        return durationSeconds;
+    }
+
+    /// <summary>
+    /// Runs ffprobe and returns standard output.
+    /// </summary>
+    /// <param name="args">Arguments to pass to ffprobe.</param>
+    /// <param name="timeout">Timeout (in milliseconds) to wait for ffprobe to exit.</param>
+    private static ReadOnlySpan<byte> GetProbeOutput(
+        string args,
+        int timeout = 60 * 1000)
+    {
+        var ffprobePath = Plugin.Instance?.FFmpegPath != null
+            ? Regex.Replace(Plugin.Instance.FFmpegPath, @"ffmpeg$", "ffprobe", RegexOptions.IgnoreCase)
+            : "ffprobe";
+
+        var info = new ProcessStartInfo(ffprobePath, args)
+        {
+            WindowStyle = ProcessWindowStyle.Hidden,
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            ErrorDialog = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = false
+        };
+
+        using var ffprobe = new Process { StartInfo = info };
+        Logger?.LogDebug("Starting ffprobe with the following arguments: {Arguments}", ffprobe.StartInfo.Arguments);
+
+        ffprobe.Start();
+
+        try
+        {
+            ffprobe.PriorityClass = Plugin.Instance?.Configuration.ProcessPriority ?? ProcessPriorityClass.BelowNormal;
+        }
+        catch (Exception e)
+        {
+            Logger?.LogDebug("ffprobe priority could not be modified. {Message}", e.Message);
+        }
+
+        using var ms = new MemoryStream();
+        var buf = new byte[4096];
+
+        using (var streamReader = ffprobe.StandardOutput)
+        {
+            int bytesRead;
+            while ((bytesRead = streamReader.BaseStream.Read(buf, 0, buf.Length)) > 0)
+            {
+                ms.Write(buf, 0, bytesRead);
+            }
+        }
+
+        ffprobe.WaitForExit(timeout);
+
+        return ms.ToArray();
+    }
+
+    /// <summary>
     /// Fingerprint a queued episode.
     /// </summary>
     /// <param name="episode">Queued episode to fingerprint.</param>
@@ -536,7 +621,7 @@ public static partial class FFmpegWrapper
             CultureInfo.InvariantCulture,
             "-ss {0} -i \"{1}\" -to {2} -ac 2 -f chromaprint -fp_format raw -",
             start,
-            episode.Path,
+            episode.IsShortcut ? episode.ShortcutPath : episode.Path,
             end - start);
 
         // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -590,6 +590,21 @@ public static partial class FFmpegWrapper
 
         ffprobe.WaitForExit(timeout);
 
+        if (!ffprobe.HasExited)
+        {
+            // Handle timeout: kill process and log error
+            try
+            {
+                ffprobe.Kill();
+            }
+            catch { /* ignore if already exited */ }
+        }
+
+        if (ffprobe.ExitCode != 0)
+        {
+            Logger?.LogWarning("ffprobe exited with code {ExitCode} for arguments: {Arguments}", ffprobe.ExitCode, ffprobe.StartInfo.Arguments);
+        }
+
         return ms.ToArray();
     }
 

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -264,6 +264,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             Duration = duration,
             IntroFingerprintEnd = fingerprintDuration,
             CreditsFingerprintStart = Math.Max(0, duration - maxCreditsDuration),
+            IsShortcut = episode.IsShortcut,
+            ShortcutPath = episode.ShortcutPath,
         });
 
         pluginInstance.TotalQueued++;
@@ -316,6 +318,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             CreditsFingerprintStart = Math.Max(0, duration - pluginInstance.Configuration.MaximumMovieCreditsDuration),
             Category = QueuedMediaCategory.Movie,
             IsExcluded = IsSeriesExcluded(movie.Name),
+            IsShortcut = movie.IsShortcut,
+            ShortcutPath = movie.ShortcutPath,
         });
 
         pluginInstance.TotalQueued++;
@@ -367,6 +371,39 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 {
                     _logger.LogDebug("Skipping {Name} ({Id}): file not found", candidate.Name, candidate.EpisodeId);
                     continue;
+                }
+
+                // Skip shortcut videos if ProcessShortcutVideos is disabled
+                if (candidate.IsShortcut && !plugin.Configuration.ProcessShortcutVideos)
+                {
+                    _logger.LogDebug("Skipping {Name} ({Id}): shortcut video processing is disabled", candidate.Name, candidate.EpisodeId);
+                    continue;
+                }
+
+                // Jellyfin does not automatically probe .strm duration
+                if (candidate.IsShortcut && candidate.Duration == 0)
+                {
+                    var duration = FFmpegWrapper.ProbeDuration(candidate.ShortcutPath);
+                    candidate.Duration = duration;
+
+                    // Recalculate fingerprint ranges based on actual duration
+                    if (candidate.Category == QueuedMediaCategory.Movie)
+                    {
+                        candidate.CreditsFingerprintStart = Math.Max(0, duration - plugin.Configuration.MaximumMovieCreditsDuration);
+                    }
+                    else
+                    {
+                        var fingerprintDuration = Math.Min(
+                            duration >= 5 * 60 ? duration * _analysisPercent : duration,
+                            60 * plugin.Configuration.AnalysisLengthLimit);
+
+                        var maxCreditsDuration = Math.Min(
+                            duration >= 5 * 60 ? duration * _analysisPercent : duration,
+                            60 * plugin.Configuration.MaximumCreditsDuration);
+
+                        candidate.IntroFingerprintEnd = fingerprintDuration;
+                        candidate.CreditsFingerprintStart = Math.Max(0, duration - maxCreditsDuration);
+                    }
                 }
 
                 verified.Add(candidate);


### PR DESCRIPTION
Add support for analyzing .strm files and include an option to disable this feature. Since analyzing .strm files may trigger rate limits, it is turned off by default.

#594

## Summary by Sourcery

Enable support for analyzing .strm shortcut videos by tracking and routing analysis to their real paths, probing durations with ffprobe to adjust fingerprinting, and controlling the feature via a new ProcessShortcutVideos configuration option.

New Features:
- Add ProcessShortcutVideos option to enable or disable analyzing .strm shortcut files

Enhancements:
- Introduce IsShortcut and ShortcutPath on queued media and route FFmpeg analysis to shortcut paths where applicable
- Integrate ffprobe-based duration probing to determine real runtime for shortcut files and adjust fingerprint analysis ranges
- Update QueueManager to skip or process shortcut videos based on the new setting and recalculate intro/credits segments after probing duration

Documentation:
- Add ProcessShortcutVideos checkbox to the plugin configuration UI