### PR TITLE
Refresh episode metadata if SeasonId is invalid

### DIFF
--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -50,14 +50,15 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
     /// <summary>
     /// Returns all show names and seasons.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Dictionary of show names to a list of season names.</returns>
     [HttpGet("Shows")]
-    public ActionResult<Dictionary<Guid, ShowInfos>> GetShowSeasons()
+    public async Task<ActionResult<Dictionary<Guid, ShowInfos>>> GetShowSeasons(CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Returning season IDs by series name");
 
         // Ensure the queue is up to date
-        new QueueManager(_loggerFactory.CreateLogger<QueueManager>(), _libraryManager, _providerManager, _fileSystem).GetMediaItems();
+        await new QueueManager(_loggerFactory.CreateLogger<QueueManager>(), _libraryManager, _providerManager, _fileSystem).GetMediaItems(cancellationToken).ConfigureAwait(false);
 
         var showSeasons = new Dictionary<Guid, ShowInfos>();
 

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -14,6 +14,8 @@ using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -29,16 +31,20 @@ namespace IntroSkipper.Controllers;
 /// <param name="logger">Logger.</param>
 /// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
 /// <param name="libraryManager">libraryManager.</param>
+/// <param name="providerManager">providerManager.</param>
+/// <param name="fileSystem">fileSystem.</param>
 /// <param name="loggerFactory">loggerFactory.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("Intros")]
-public class VisualizationController(ILogger<VisualizationController> logger, MediaSegmentUpdateManager mediaSegmentUpdateManager, ILibraryManager libraryManager, ILoggerFactory loggerFactory) : ControllerBase
+public class VisualizationController(ILogger<VisualizationController> logger, MediaSegmentUpdateManager mediaSegmentUpdateManager, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem, ILoggerFactory loggerFactory) : ControllerBase
 {
     private readonly ILogger<VisualizationController> _logger = logger;
     private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
     private readonly ILibraryManager _libraryManager = libraryManager;
+    private readonly IProviderManager _providerManager = providerManager;
+    private readonly IFileSystem _fileSystem = fileSystem;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
 
     /// <summary>
@@ -51,7 +57,7 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
         _logger.LogDebug("Returning season IDs by series name");
 
         // Ensure the queue is up to date
-        new QueueManager(_loggerFactory.CreateLogger<QueueManager>(), _libraryManager).GetMediaItems();
+        new QueueManager(_loggerFactory.CreateLogger<QueueManager>(), _libraryManager, _providerManager, _fileSystem).GetMediaItems();
 
         var showSeasons = new Dictionary<Guid, ShowInfos>();
 
@@ -281,6 +287,8 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
                             _loggerFactory.CreateLogger<DetectSegmentsTask>(),
                             _loggerFactory,
                             _libraryManager,
+                            _providerManager,
+                            _fileSystem,
                             _mediaSegmentUpdateManager);
 
                         await baseIntroAnalyzer.AnalyzeItemsAsync(new Progress<double>(), CancellationToken.None, [seasonId]).ConfigureAwait(false);

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using IntroSkipper.Data;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
@@ -38,14 +39,16 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private readonly IProviderManager _providerManager = providerManager;
     private readonly ILogger<QueueManager> _logger = logger;
     private readonly Dictionary<Guid, List<QueuedEpisode>> _queuedEpisodes = [];
+    private readonly HashSet<Guid> _refreshedEpisodes = [];
     private double _analysisPercent;
     private List<string> _excludeSeries = [];
 
     /// <summary>
     /// Gets all media items on the server.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
-    public IReadOnlyDictionary<Guid, List<QueuedEpisode>> GetMediaItems()
+    public async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
     {
         var plugin = Plugin.Instance;
         if (plugin is null)
@@ -85,12 +88,17 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
             try
             {
-                QueueLibraryContents(folderId);
+                await QueueLibraryContents(folderId, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger.LogError("Failed to enqueue items from library {Name}: {Exception}", folder.Name, ex);
             }
+        }
+
+        if (_refreshedEpisodes.Count > 0)
+        {
+            _logger.LogInformation("Refreshed metadata for {Count} episodes with invalid SeasonIds", _refreshedEpisodes.Count);
         }
 
         plugin.TotalSeasons = _queuedEpisodes.Count;
@@ -127,7 +135,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
     }
 
-    private void QueueLibraryContents(Guid id)
+    private async Task QueueLibraryContents(Guid id, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Constructing anonymous internal query");
 
@@ -162,7 +170,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 {
                     if (!IsSeriesExcluded(episode.SeriesName))
                     {
-                        QueueEpisode(episode);
+                        await QueueEpisode(episode, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -224,7 +232,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return _excludeSeries.Contains(normalizedName);
     }
 
-    private void QueueEpisode(Episode episode)
+    private async Task QueueEpisode(Episode episode, CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
@@ -239,7 +247,17 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
 
         // Allocate a new list for each new season
-        var seasonId = GetSeasonId(episode);
+        var seasonId = await GetSeasonId(episode, cancellationToken).ConfigureAwait(false);
+        if (seasonId == Guid.Empty)
+        {
+            _logger.LogWarning(
+                "Not queuing episode \"{Name}\" from series \"{Series}\" ({Id}) as SeasonId could not be resolved",
+                episode.Name,
+                episode.SeriesName,
+                episode.Id);
+            return;
+        }
+
         if (!_queuedEpisodes.TryGetValue(seasonId, out var seasonEpisodes))
         {
             seasonEpisodes = [];
@@ -328,7 +346,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         pluginInstance.TotalQueued++;
     }
 
-    private Guid GetSeasonId(Episode episode)
+    private async Task<Guid> GetSeasonId(Episode episode, CancellationToken cancellationToken)
     {
         if (episode.ParentIndexNumber == 0 && episode.AiredSeasonNumber != 0) // In-season special
         {
@@ -343,9 +361,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
         }
 
-        if (episode.SeasonId == Guid.Empty && episode.IndexNumber != 0)
+        if (episode.SeasonId == Guid.Empty && episode.ParentIndexNumber is not null && !_refreshedEpisodes.Contains(episode.Id))
         {
             _logger.LogInformation("Episode {Name} ({Id}) has an invalid SeasonId", episode.Name, episode.Id);
+            _refreshedEpisodes.Add(episode.Id);
 
             var refreshOptions = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
             {
@@ -359,9 +378,16 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 RegenerateTrickplay = false
             };
 
-            _providerManager.RefreshSingleItem(episode, refreshOptions, CancellationToken.None);
+            await _providerManager.RefreshSingleItem(episode, refreshOptions, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogInformation("Updated metadata for episode {Name} ({Id}) to refresh SeasonId {SeasonId}", episode.Name, episode.Id, episode.SeasonId);
+            if (episode.SeasonId == Guid.Empty)
+            {
+                _logger.LogWarning("Failed to resolve SeasonId for episode {Name} ({Id}) after metadata refresh", episode.Name, episode.Id);
+            }
+            else
+            {
+                _logger.LogDebug("Successfully resolved SeasonId {SeasonId} for episode {Name} ({Id})", episode.SeasonId, episode.Name, episode.Id);
+            }
         }
 
         return episode.SeasonId;

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using IntroSkipper.Data;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
@@ -14,6 +15,8 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Manager;
@@ -26,9 +29,13 @@ namespace IntroSkipper.Manager;
 /// </remarks>
 /// <param name="logger">Logger.</param>
 /// <param name="libraryManager">Library manager.</param>
-public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager libraryManager)
+/// <param name="providerManager">Provider manager.</param>
+/// <param name="fileSystem">File system.</param>
+public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem)
 {
     private readonly ILibraryManager _libraryManager = libraryManager;
+    private readonly IFileSystem _fileSystem = fileSystem;
+    private readonly IProviderManager _providerManager = providerManager;
     private readonly ILogger<QueueManager> _logger = logger;
     private readonly Dictionary<Guid, List<QueuedEpisode>> _queuedEpisodes = [];
     private double _analysisPercent;
@@ -334,6 +341,27 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                     return kvp.Key;
                 }
             }
+        }
+
+        if (episode.SeasonId == Guid.Empty && episode.IndexNumber != 0)
+        {
+            _logger.LogInformation("Episode {Name} ({Id}) has an invalid SeasonId", episode.Name, episode.Id);
+
+            var refreshOptions = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+            {
+                MetadataRefreshMode = MetadataRefreshMode.Default,
+                ImageRefreshMode = MetadataRefreshMode.None,
+                ReplaceAllImages = false,
+                ReplaceAllMetadata = false,
+                ForceSave = false,
+                IsAutomated = false,
+                RemoveOldMetadata = false,
+                RegenerateTrickplay = false
+            };
+
+            _providerManager.RefreshSingleItem(episode, refreshOptions, CancellationToken.None);
+
+            _logger.LogInformation("Updated metadata for episode {Name} ({Id}) to refresh SeasonId {SeasonId}", episode.Name, episode.Id, episode.SeasonId);
         }
 
         return episode.SeasonId;

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -72,7 +72,7 @@ public class BaseItemAnalyzerTask(
             _providerManager,
             _fileSystem);
 
-        var queue = queueManager.GetMediaItems();
+        var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
 
         if (seasonsToAnalyze?.Count > 0)
         {

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -11,6 +11,8 @@ using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Manager;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.ScheduledTasks;
@@ -24,16 +26,22 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="logger">Task logger.</param>
 /// <param name="loggerFactory">Logger factory.</param>
 /// <param name="libraryManager">Library manager.</param>
+/// <param name="providerManager">Provider manager.</param>
+/// <param name="fileSystem">File system.</param>
 /// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
 public class BaseItemAnalyzerTask(
     ILogger logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
+    IProviderManager providerManager,
+    IFileSystem fileSystem,
     MediaSegmentUpdateManager mediaSegmentUpdateManager)
 {
     private readonly ILogger _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private readonly ILibraryManager _libraryManager = libraryManager;
+    private readonly IProviderManager _providerManager = providerManager;
+    private readonly IFileSystem _fileSystem = fileSystem;
     private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly bool _ffmpegValid = FFmpegWrapper.CheckFFmpegVersion();
@@ -60,7 +68,9 @@ public class BaseItemAnalyzerTask(
 
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
-            _libraryManager);
+            _libraryManager,
+            _providerManager,
+            _fileSystem);
 
         var queue = queueManager.GetMediaItems();
 

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Manager;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -20,10 +22,10 @@ namespace IntroSkipper.ScheduledTasks;
 public class CleanCacheTask : IScheduledTask
 {
     private readonly ILogger<CleanCacheTask> _logger;
-
     private readonly ILoggerFactory _loggerFactory;
-
     private readonly ILibraryManager _libraryManager;
+    private readonly IProviderManager _providerManager;
+    private readonly IFileSystem _fileSystem;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CleanCacheTask"/> class.
@@ -31,14 +33,20 @@ public class CleanCacheTask : IScheduledTask
     /// <param name="loggerFactory">Logger factory.</param>
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="logger">Logger.</param>
+    /// <param name="providerManager">Provider manager.</param>
+    /// <param name="fileSystem">File system.</param>
     public CleanCacheTask(
         ILogger<CleanCacheTask> logger,
         ILoggerFactory loggerFactory,
-        ILibraryManager libraryManager)
+        ILibraryManager libraryManager,
+        IProviderManager providerManager,
+        IFileSystem fileSystem)
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
         _libraryManager = libraryManager;
+        _providerManager = providerManager;
+        _fileSystem = fileSystem;
     }
 
     /// <summary>
@@ -78,7 +86,9 @@ public class CleanCacheTask : IScheduledTask
 
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
-            _libraryManager);
+            _libraryManager,
+            _providerManager,
+            _fileSystem);
 
         // Retrieve media items and get valid episode IDs
         var queue = queueManager.GetMediaItems();

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -91,7 +91,7 @@ public class CleanCacheTask : IScheduledTask
             _fileSystem);
 
         // Retrieve media items and get valid episode IDs
-        var queue = queueManager.GetMediaItems();
+        var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
         var validEpisodeIds = queue.Values
             .SelectMany(episodes => episodes.Select(e => e.EpisodeId))
             .ToHashSet();

--- a/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
+++ b/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using IntroSkipper.Manager;
 using IntroSkipper.Services;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -21,20 +23,23 @@ namespace IntroSkipper.ScheduledTasks;
 /// </remarks>
 /// <param name="loggerFactory">Logger factory.</param>
 /// <param name="libraryManager">Library manager.</param>
+/// <param name="providerManager">Provider manager.</param>
+/// <param name="fileSystem">File system.</param>
 /// <param name="logger">Logger.</param>
 /// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
 public class DetectSegmentsTask(
     ILogger<DetectSegmentsTask> logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
+    IProviderManager providerManager,
+    IFileSystem fileSystem,
     MediaSegmentUpdateManager mediaSegmentUpdateManager) : IScheduledTask
 {
     private readonly ILogger<DetectSegmentsTask> _logger = logger;
-
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
-
     private readonly ILibraryManager _libraryManager = libraryManager;
-
+    private readonly IProviderManager _providerManager = providerManager;
+    private readonly IFileSystem _fileSystem = fileSystem;
     private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
 
     /// <summary>
@@ -85,6 +90,8 @@ public class DetectSegmentsTask(
                 _loggerFactory.CreateLogger<DetectSegmentsTask>(),
                 _loggerFactory,
                 _libraryManager,
+                _providerManager,
+                _fileSystem,
                 _mediaSegmentUpdateManager);
 
             await baseIntroAnalyzer.AnalyzeItemsAsync(progress, cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -15,7 +15,9 @@ using IntroSkipper.ScheduledTasks;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -31,6 +33,8 @@ namespace IntroSkipper.Services
     {
         private readonly ITaskManager _taskManager;
         private readonly ILibraryManager _libraryManager;
+        private readonly IProviderManager _providerManager;
+        private readonly IFileSystem _fileSystem;
         private readonly ILogger<Entrypoint> _logger;
         private readonly ILoggerFactory _loggerFactory;
         private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager;
@@ -45,18 +49,24 @@ namespace IntroSkipper.Services
         /// Initializes a new instance of the <see cref="Entrypoint"/> class.
         /// </summary>
         /// <param name="libraryManager">Library manager.</param>
+        /// <param name="providerManager">Provider manager.</param>
+        /// <param name="fileSystem">File system.</param>
         /// <param name="taskManager">Task manager.</param>
         /// <param name="logger">Logger.</param>
         /// <param name="loggerFactory">Logger factory.</param>
         /// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
         public Entrypoint(
             ILibraryManager libraryManager,
+            IProviderManager providerManager,
+            IFileSystem fileSystem,
             ITaskManager taskManager,
             ILogger<Entrypoint> logger,
             ILoggerFactory loggerFactory,
             MediaSegmentUpdateManager mediaSegmentUpdateManager)
         {
             _libraryManager = libraryManager;
+            _providerManager = providerManager;
+            _fileSystem = fileSystem;
             _taskManager = taskManager;
             _logger = logger;
             _loggerFactory = loggerFactory;
@@ -241,7 +251,7 @@ namespace IntroSkipper.Services
                     _seasonsToAnalyze.Clear();
                     _analyzeAgain = false;
 
-                    var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _mediaSegmentUpdateManager);
+                    var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentUpdateManager);
                     await analyzer.AnalyzeItemsAsync(new Progress<double>(), _cancellationTokenSource.Token, seasonIds).ConfigureAwait(false);
 
                     if (_analyzeAgain && !_cancellationTokenSource.IsCancellationRequested)


### PR DESCRIPTION
## Summary by Sourcery

Refresh episode metadata when an episode has an invalid SeasonId and wire required provider and filesystem dependencies through the plugin entrypoint, tasks, and controller to support this behavior.

Bug Fixes:
- Trigger a metadata refresh for episodes whose SeasonId is empty while they have a valid index number, ensuring a correct SeasonId is populated.

Enhancements:
- Inject IProviderManager and IFileSystem into QueueManager and propagate these dependencies through scheduled tasks, the visualization controller, and the plugin entrypoint to enable metadata-based corrections.