### PR TITLE
Add check for plugin skip before excluding

### DIFF
--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -72,7 +72,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         foreach (var folder in virtualFolders)
         {
             // If libraries have been selected for analysis, ensure this library was selected.
-            if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true)
+            if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true && !plugin.PluginSkip)
             {
                 _logger.LogDebug("Not analyzing library \"{Name}\": Intro Skipper is disabled in library settings. To enable, check library configuration > Media Segment Providers", folder.Name);
                 continue;

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -72,7 +72,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         foreach (var folder in virtualFolders)
         {
             // If libraries have been selected for analysis, ensure this library was selected.
-            if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true && !plugin.PluginSkip)
+            if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true && !plugin.Configuration.PluginSkip)
             {
                 _logger.LogDebug("Not analyzing library \"{Name}\": Intro Skipper is disabled in library settings. To enable, check library configuration > Media Segment Providers", folder.Name);
                 continue;


### PR DESCRIPTION
Allows server-side skip to override the library selections (for editing and removing timestamps in the editor)

## Summary by Sourcery

Bug Fixes:
- Allow plugin-level skip configuration to override library-level disabled media segment provider settings when deciding to analyze a library.