### PR TITLE
feat: add handling for item removal in library manager

### DIFF
--- a/IntroSkipper.Tests/AssemblyInfo.cs
+++ b/IntroSkipper.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using Xunit;
+
+// The test suite uses process-wide static state (e.g., `Plugin.Instance`).
+// Run tests sequentially to avoid cross-test interference.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -1,0 +1,475 @@
+// Copyright (C) 2024 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using IntroSkipper.Configuration;
+using IntroSkipper.Services;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestEntrypointEvents
+{
+    [Fact]
+    public void OnItemChanged_IgnoresImageUpdates()
+    {
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+
+        var movie = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", Guid.NewGuid());
+        EntrypointTestHelpers.EnsureNonVirtual(movie);
+
+        var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: ItemUpdateType.ImageUpdate);
+        EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemChanged", args);
+
+        var seasonsToAnalyze = EntrypointTestHelpers.GetSeasonsToAnalyze(entrypoint);
+        Assert.Empty(seasonsToAnalyze);
+    }
+
+    [Fact]
+    public void OnItemChanged_QueuesMovieId_WhenAutoDetectEnabled()
+    {
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+
+        var movieId = Guid.NewGuid();
+        var movie = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", movieId);
+        EntrypointTestHelpers.EnsureNonVirtual(movie);
+
+        var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
+        EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemChanged", args);
+
+        var seasonsToAnalyze = EntrypointTestHelpers.GetSeasonsToAnalyze(entrypoint);
+        Assert.Contains(movieId, seasonsToAnalyze);
+    }
+
+    [Fact]
+    public void OnItemChanged_DoesNothing_WhenAutoDetectDisabled()
+    {
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
+
+        var movie = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", Guid.NewGuid());
+        EntrypointTestHelpers.EnsureNonVirtual(movie);
+
+        var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
+        EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemChanged", args);
+
+        var seasonsToAnalyze = EntrypointTestHelpers.GetSeasonsToAnalyze(entrypoint);
+        Assert.Empty(seasonsToAnalyze);
+    }
+
+    [Fact]
+    public void OnItemRemoved_DeletesCache_ForEpisode()
+    {
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var episodeId = Guid.NewGuid();
+
+        var file1 = Path.Combine(cacheDir, episodeId.ToString("N"));
+        var file2 = Path.Combine(cacheDir, episodeId.ToString("N") + "-credits");
+        File.WriteAllText(file1, "x");
+        File.WriteAllText(file2, "x");
+
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+
+        var episode = EntrypointTestHelpers.CreateUninitialized<Episode>();
+        EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+        EntrypointTestHelpers.EnsureNonVirtual(episode);
+
+        var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: episode, updateReason: 0);
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        {
+            EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
+        }
+
+        Assert.False(File.Exists(file1));
+        Assert.False(File.Exists(file2));
+    }
+
+    [Fact]
+    public void OnSettingsChanged_UpdatesConfig_AndSetsAnalyzeAgain()
+    {
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
+
+        var newConfig = new PluginConfiguration { AutoDetectIntros = true };
+
+        using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+        {
+            // Ensure AnalyzeAgain starts false.
+            var plugin = Plugin.Instance!;
+            plugin.AnalyzeAgain = false;
+
+            EntrypointTestHelpers.InvokePrivate(entrypoint, "OnSettingsChanged", (BasePluginConfiguration)newConfig);
+
+            Assert.True(plugin.AnalyzeAgain);
+        }
+
+        var storedConfig = (PluginConfiguration)EntrypointTestHelpers.GetPrivateField(entrypoint, "_config");
+        Assert.Same(newConfig, storedConfig);
+    }
+
+    [Fact]
+    public void OnLibraryRefresh_DoesNotSetAnalyzeAgain_WhenAutomaticTaskRunning()
+    {
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        EntrypointTestHelpers.SetPrivateField(entrypoint, "_analyzeAgain", false);
+
+        var cts = new System.Threading.CancellationTokenSource();
+        EntrypointTestHelpers.SetPrivateStaticField(typeof(Entrypoint), "_cancellationTokenSource", cts);
+
+        try
+        {
+            var taskResult = EntrypointTestHelpers.CreateTaskResult("RefreshLibrary", TaskCompletionStatus.Completed);
+            var args = EntrypointTestHelpers.CreateTaskCompletionEventArgs(taskResult);
+
+            EntrypointTestHelpers.InvokePrivate(entrypoint, "OnLibraryRefresh", args);
+
+            Assert.False((bool)EntrypointTestHelpers.GetPrivateField(entrypoint, "_analyzeAgain"));
+        }
+        finally
+        {
+            cts.Dispose();
+            EntrypointTestHelpers.SetPrivateStaticField(typeof(Entrypoint), "_cancellationTokenSource", null);
+        }
+    }
+}
+
+public sealed class TestFingerprintCacheDeletionOnRemove
+{
+    [Fact]
+    public void DeletesFingerprintCache_OnMovieRemoval_WhenAutoDetectEnabled()
+    {
+        var removedId = Guid.NewGuid();
+        var otherId = Guid.NewGuid();
+
+        var removedBaseName = removedId.ToString("N");
+        var otherBaseName = otherId.ToString("N");
+
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var file1 = Path.Combine(cacheDir, removedBaseName);
+        var file2 = Path.Combine(cacheDir, removedBaseName + "-credits");
+        var file3 = Path.Combine(cacheDir, removedBaseName + "-blackframes-0-10-v1");
+        var otherFile = Path.Combine(cacheDir, otherBaseName);
+
+        File.WriteAllText(file1, "x");
+        File.WriteAllText(file2, "x");
+        File.WriteAllText(file3, "x");
+        File.WriteAllText(otherFile, "x");
+
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+
+        var movie = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Path", "C:\\IntroSkipper.Tests\\removed.mkv");
+        EntrypointTestHelpers.EnsureNonVirtual(movie);
+        Assert.Equal(removedId, movie.Id);
+
+        var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        {
+            EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
+        }
+
+        Assert.False(File.Exists(file1));
+        Assert.False(File.Exists(file2));
+        Assert.False(File.Exists(file3));
+        Assert.True(File.Exists(otherFile));
+    }
+
+    [Fact]
+    public void DoesNotDeleteFingerprintCache_OnMovieRemoval_WhenAutoDetectDisabled()
+    {
+        var removedId = Guid.NewGuid();
+        var removedBaseName = removedId.ToString("N");
+
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var file1 = Path.Combine(cacheDir, removedBaseName);
+        var file2 = Path.Combine(cacheDir, removedBaseName + "-credits");
+
+        File.WriteAllText(file1, "x");
+        File.WriteAllText(file2, "x");
+
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
+
+        var movie = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Path", "C:\\IntroSkipper.Tests\\removed.mkv");
+        EntrypointTestHelpers.EnsureNonVirtual(movie);
+        Assert.Equal(removedId, movie.Id);
+
+        var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        {
+            EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
+        }
+
+        Assert.True(File.Exists(file1));
+        Assert.True(File.Exists(file2));
+    }
+
+    [Fact]
+    public void DoesNotDeleteFingerprintCache_WhenIdIsEmpty()
+    {
+        var removedId = Guid.Empty;
+        var removedBaseName = removedId.ToString("N");
+
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var file1 = Path.Combine(cacheDir, removedBaseName);
+        File.WriteAllText(file1, "x");
+
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+
+        var movie = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Path", "C:\\IntroSkipper.Tests\\removed.mkv");
+        EntrypointTestHelpers.EnsureNonVirtual(movie);
+        Assert.Equal(removedId, movie.Id);
+
+        var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        {
+            EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
+        }
+
+        Assert.True(File.Exists(file1));
+    }
+}
+
+internal static class EntrypointTestHelpers
+{
+    internal static Entrypoint CreateEntrypoint(bool autoDetectIntros)
+    {
+        // Entrypoint's ctor reads Plugin.Instance?.Configuration. Ensure Plugin.Instance is null during construction.
+        using var _ = new PluginInstanceNullScope();
+
+        var loggerFactory = LoggerFactory.Create(builder => { });
+        var logger = loggerFactory.CreateLogger<Entrypoint>();
+
+#pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.
+        var mediaSegmentUpdateManager = (IntroSkipper.Manager.MediaSegmentUpdateManager)FormatterServices.GetUninitializedObject(typeof(IntroSkipper.Manager.MediaSegmentUpdateManager));
+#pragma warning restore SYSLIB0050
+
+        var entrypoint = new Entrypoint(
+            libraryManager: null!,
+            providerManager: null!,
+            fileSystem: null!,
+            taskManager: null!,
+            logger: logger,
+            loggerFactory: loggerFactory,
+            mediaSegmentUpdateManager: mediaSegmentUpdateManager);
+
+        SetPrivateField(entrypoint, "_config", new PluginConfiguration { AutoDetectIntros = autoDetectIntros });
+        return entrypoint;
+    }
+
+    internal static HashSet<Guid> GetSeasonsToAnalyze(Entrypoint entrypoint)
+        => (HashSet<Guid>)GetPrivateField(entrypoint, "_seasonsToAnalyze");
+
+    internal static ItemChangeEventArgs CreateItemChangeEventArgs(object item, ItemUpdateType updateReason)
+    {
+#pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.
+        var args = (ItemChangeEventArgs)FormatterServices.GetUninitializedObject(typeof(ItemChangeEventArgs));
+#pragma warning restore SYSLIB0050
+
+        SetPropertyOrField(args, "Item", item);
+        SetPropertyOrField(args, "UpdateReason", updateReason);
+        return args;
+    }
+
+    internal static TaskResult CreateTaskResult(string key, TaskCompletionStatus status)
+    {
+#pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.
+        var result = (TaskResult)FormatterServices.GetUninitializedObject(typeof(TaskResult));
+#pragma warning restore SYSLIB0050
+        SetPropertyOrField(result, "Key", key);
+        SetPropertyOrField(result, "Status", status);
+        return result;
+    }
+
+    internal static TaskCompletionEventArgs CreateTaskCompletionEventArgs(TaskResult result)
+    {
+#pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.
+        var args = (TaskCompletionEventArgs)FormatterServices.GetUninitializedObject(typeof(TaskCompletionEventArgs));
+#pragma warning restore SYSLIB0050
+        SetPropertyOrField(args, "Result", result);
+        return args;
+    }
+
+    internal static void InvokePrivate(Entrypoint entrypoint, string methodName, object arg)
+    {
+        var method = typeof(Entrypoint).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(entrypoint, [null, arg]);
+    }
+
+    internal static object GetPrivateField(object instance, string fieldName)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return field!.GetValue(instance)!;
+    }
+
+    internal static void SetPrivateField(object instance, string fieldName, object value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(instance, value);
+    }
+
+    internal static void SetPrivateStaticField(Type type, string fieldName, object? value)
+    {
+        var field = type.GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(null, value);
+    }
+
+    internal static void SetPropertyOrField(object instance, string name, object value)
+    {
+        for (var type = instance.GetType(); type is not null; type = type.BaseType)
+        {
+            var prop = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (prop is not null)
+            {
+                var setter = prop.SetMethod ?? prop.GetSetMethod(nonPublic: true);
+                if (setter is not null)
+                {
+                    setter.Invoke(instance, [value]);
+                    return;
+                }
+            }
+
+            var field = type.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (field is not null)
+            {
+                field.SetValue(instance, value);
+                return;
+            }
+
+            var backing = type.GetField($"<{name}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            if (backing is not null)
+            {
+                backing.SetValue(instance, value);
+                return;
+            }
+        }
+
+        throw new InvalidOperationException($"Could not set property or field '{name}' on type '{instance.GetType().FullName}'.");
+    }
+
+    internal static void EnsureNonVirtual(object item)
+    {
+        TrySetFirstFieldOfType(item, typeof(LocationType), LocationType.FileSystem);
+        TrySetFirstFieldOfType(item, typeof(LocationType?), (LocationType?)LocationType.FileSystem);
+    }
+
+    internal static void TrySetFirstFieldOfType(object instance, Type fieldType, object value)
+    {
+        for (var type = instance.GetType(); type is not null; type = type.BaseType)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly))
+            {
+                if (field.FieldType == fieldType)
+                {
+                    field.SetValue(instance, value);
+                    return;
+                }
+            }
+        }
+
+        for (var type = instance.GetType(); type is not null; type = type.BaseType)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                if (field.Name.Contains("LocationType", StringComparison.OrdinalIgnoreCase) && field.FieldType == fieldType)
+                {
+                    field.SetValue(instance, value);
+                    return;
+                }
+            }
+        }
+    }
+
+    internal static T CreateUninitialized<T>() where T : class
+    {
+#pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.
+        return (T)FormatterServices.GetUninitializedObject(typeof(T));
+#pragma warning restore SYSLIB0050
+    }
+
+    internal static string CreateTempCacheDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", "chromaprints", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    internal sealed class PluginInstanceScope : IDisposable
+    {
+        private readonly Plugin? _original;
+
+        public PluginInstanceScope(string cacheDir)
+        {
+            CacheDir = cacheDir;
+
+            var instanceProp = typeof(Plugin).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(instanceProp);
+
+            _original = (Plugin?)instanceProp!.GetValue(null);
+
+#pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.
+            var plugin = (Plugin)FormatterServices.GetUninitializedObject(typeof(Plugin));
+#pragma warning restore SYSLIB0050
+
+            SetPropertyOrField(plugin, "FingerprintCachePath", CacheDir);
+
+            // Plugin.Instance has a private setter; invoke it via reflection.
+            var setter = instanceProp.SetMethod ?? instanceProp.GetSetMethod(nonPublic: true);
+            Assert.NotNull(setter);
+            setter!.Invoke(null, [plugin]);
+        }
+
+        public string CacheDir { get; }
+
+        public void Dispose()
+        {
+            var instanceProp = typeof(Plugin).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+            var setter = instanceProp!.SetMethod ?? instanceProp.GetSetMethod(nonPublic: true);
+            setter!.Invoke(null, [_original]);
+        }
+    }
+
+    private sealed class PluginInstanceNullScope : IDisposable
+    {
+        private readonly Plugin? _original;
+
+        public PluginInstanceNullScope()
+        {
+            var instanceProp = typeof(Plugin).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(instanceProp);
+
+            _original = (Plugin?)instanceProp!.GetValue(null);
+
+            var setter = instanceProp.SetMethod ?? instanceProp.GetSetMethod(nonPublic: true);
+            Assert.NotNull(setter);
+            setter!.Invoke(null, [null]);
+        }
+
+        public void Dispose()
+        {
+            var instanceProp = typeof(Plugin).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+            var setter = instanceProp!.SetMethod ?? instanceProp.GetSetMethod(nonPublic: true);
+            setter!.Invoke(null, [_original]);
+        }
+    }
+}

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -194,7 +194,7 @@ public class VisualizationController(ILogger<VisualizationController> logger, Me
 
                 if (eraseCache)
                 {
-                    await Task.Run(() => FFmpegWrapper.DeleteEpisodeCache(episode.EpisodeId), cancellationToken).ConfigureAwait(false);
+                    await Task.Run(() => FFmpegWrapper.DeleteFingerprintCache(episode.EpisodeId), cancellationToken).ConfigureAwait(false);
                 }
             }
 

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -663,7 +663,7 @@ public static partial class FFmpegWrapper
     /// <summary>
     /// Remove a cached episode fingerprint from disk.
     /// </summary>
-    /// <param name="id">Episode to remove from cache.</param>
+    /// <param name="id">Media item ID to remove from cache.</param>
     public static void DeleteFingerprintCache(Guid id)
     {
         var cachePath = Path.Join(

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -664,7 +664,7 @@ public static partial class FFmpegWrapper
     /// Remove a cached episode fingerprint from disk.
     /// </summary>
     /// <param name="id">Episode to remove from cache.</param>
-    public static void DeleteEpisodeCache(Guid id)
+    public static void DeleteFingerprintCache(Guid id)
     {
         var cachePath = Path.Join(
             Plugin.Instance!.FingerprintCachePath,

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -113,7 +113,7 @@ public class CleanCacheTask : IScheduledTask
         foreach (var episodeId in invalidEpisodeIds)
         {
             _logger.LogDebug("Deleting cache files for episode ID: {EpisodeId}", episodeId);
-            FFmpegWrapper.DeleteEpisodeCache(episodeId);
+            FFmpegWrapper.DeleteFingerprintCache(episodeId);
         }
 
         // Clean up Season information by removing items that are no longer exist.

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -12,6 +13,7 @@ using IntroSkipper.Configuration;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -162,29 +164,9 @@ namespace IntroSkipper.Services
                 return;
             }
 
-            if (!_config.AutoDetectIntros)
+            if (!TryGetValidItemForAutoProcessing(itemChangeEventArgs, out var item))
             {
                 return;
-            }
-
-            var item = itemChangeEventArgs.Item;
-            if (item is null)
-            {
-                return;
-            }
-
-            // Needed for unit tests: avoid analyzing for virtual items, but don't fail if the item
-            // is partially initialized.
-            try
-            {
-                if (item.LocationType == LocationType.Virtual)
-                {
-                    return;
-                }
-            }
-            catch
-            {
-                // Ignore LocationType evaluation issues.
             }
 
             Guid? id = item switch
@@ -212,29 +194,9 @@ namespace IntroSkipper.Services
         {
             try
             {
-                if (!_config.AutoDetectIntros)
+                if (!TryGetValidItemForAutoProcessing(itemChangeEventArgs, out var item))
                 {
                     return;
-                }
-
-                var item = itemChangeEventArgs.Item;
-                if (item is null)
-                {
-                    return;
-                }
-
-                // Needed for unit tests: avoid analyzing for virtual items, but don't fail if the item
-                // is partially initialized.
-                try
-                {
-                    if (item.LocationType == LocationType.Virtual)
-                    {
-                        return;
-                    }
-                }
-                catch
-                {
-                    // Ignore LocationType evaluation issues.
                 }
 
                 Guid? id = item switch
@@ -256,6 +218,42 @@ namespace IntroSkipper.Services
             {
                 _logger.LogWarning(ex, "Error deleting fingerprint cache on item removal");
             }
+        }
+
+        private bool TryGetValidItemForAutoProcessing(
+            ItemChangeEventArgs itemChangeEventArgs,
+            [NotNullWhen(true)] out BaseItem? item)
+        {
+            if (!_config.AutoDetectIntros)
+            {
+                item = null;
+                return false;
+            }
+
+            var candidate = itemChangeEventArgs.Item;
+            if (candidate is null)
+            {
+                item = null;
+                return false;
+            }
+
+            // Needed for unit tests: avoid analyzing for virtual items, but don't fail if the item
+            // is partially initialized.
+            try
+            {
+                if (candidate.LocationType == LocationType.Virtual)
+                {
+                    item = null;
+                    return false;
+                }
+            }
+            catch
+            {
+                // Ignore LocationType evaluation issues.
+            }
+
+            item = candidate;
+            return true;
         }
 
         /// <summary>

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -174,7 +174,7 @@ namespace IntroSkipper.Services
 
                 if (id.HasValue)
                 {
-                    var delay = 60;
+                    var delay = itemChangeEventArgs.UpdateReason == 0 ? 120 : 60;
 
                     _seasonsToAnalyze.Add(id.Value);
                     StartTimer(delay);

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -209,7 +209,7 @@ namespace IntroSkipper.Services
                 }
 
                 _logger.LogDebug("Media item removed, deleting fingerprint cache for {Id}", id);
-                FFmpegWrapper.DeleteEpisodeCache(id.Value);
+                FFmpegWrapper.DeleteFingerprintCache(id.Value);
             }
             catch (Exception ex)
             {

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -95,6 +95,7 @@ namespace IntroSkipper.Services
         {
             _libraryManager.ItemAdded += OnItemChanged;
             _libraryManager.ItemUpdated += OnItemChanged;
+            _libraryManager.ItemRemoved += OnItemRemoved;
             _taskManager.TaskCompleted += OnLibraryRefresh;
             Plugin.Instance!.ConfigurationChanged += OnSettingsChanged;
 
@@ -115,6 +116,7 @@ namespace IntroSkipper.Services
         {
             _libraryManager.ItemAdded -= OnItemChanged;
             _libraryManager.ItemUpdated -= OnItemChanged;
+            _libraryManager.ItemRemoved -= OnItemRemoved;
             _taskManager.TaskCompleted -= OnLibraryRefresh;
             Plugin.Instance!.ConfigurationChanged -= OnSettingsChanged;
 
@@ -172,11 +174,46 @@ namespace IntroSkipper.Services
 
                 if (id.HasValue)
                 {
-                    var delay = itemChangeEventArgs.UpdateReason == 0 ? 120 : 60;
+                    var delay = 60;
 
                     _seasonsToAnalyze.Add(id.Value);
                     StartTimer(delay);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Library item was removed.
+        /// </summary>
+        /// <param name="sender">The sending entity.</param>
+        /// <param name="itemChangeEventArgs">The <see cref="ItemChangeEventArgs"/>.</param>
+        private void OnItemRemoved(object? sender, ItemChangeEventArgs itemChangeEventArgs)
+        {
+            try
+            {
+                if (itemChangeEventArgs.Item is null)
+                {
+                    return;
+                }
+
+                Guid? id = itemChangeEventArgs.Item switch
+                {
+                    Episode episode => episode.Id,
+                    Movie movie => movie.Id,
+                    _ => null
+                };
+
+                if (!id.HasValue || id.Value == Guid.Empty)
+                {
+                    return;
+                }
+
+                _logger.LogDebug("Media item removed, deleting fingerprint cache for {Id}", id);
+                FFmpegWrapper.DeleteEpisodeCache(id.Value);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error deleting fingerprint cache on item removal");
             }
         }
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -162,23 +162,44 @@ namespace IntroSkipper.Services
                 return;
             }
 
-            if (_config.AutoDetectIntros &&
-                itemChangeEventArgs.Item is { LocationType: not LocationType.Virtual } item)
+            if (!_config.AutoDetectIntros)
             {
-                Guid? id = item switch
-                {
-                    Episode episode => episode.SeasonId,
-                    Movie movie => movie.Id,
-                    _ => null
-                };
+                return;
+            }
 
-                if (id.HasValue)
-                {
-                    var delay = itemChangeEventArgs.UpdateReason == 0 ? 120 : 60;
+            var item = itemChangeEventArgs.Item;
+            if (item is null)
+            {
+                return;
+            }
 
-                    _seasonsToAnalyze.Add(id.Value);
-                    StartTimer(delay);
+            // Needed for unit tests: avoid analyzing for virtual items, but don't fail if the item
+            // is partially initialized.
+            try
+            {
+                if (item.LocationType == LocationType.Virtual)
+                {
+                    return;
                 }
+            }
+            catch
+            {
+                // Ignore LocationType evaluation issues.
+            }
+
+            Guid? id = item switch
+            {
+                Episode episode => episode.SeasonId,
+                Movie movie => movie.Id,
+                _ => null
+            };
+
+            if (id.HasValue)
+            {
+                var delay = itemChangeEventArgs.UpdateReason == 0 ? 120 : 60;
+
+                _seasonsToAnalyze.Add(id.Value);
+                StartTimer(delay);
             }
         }
 
@@ -191,24 +212,45 @@ namespace IntroSkipper.Services
         {
             try
             {
-                if (_config.AutoDetectIntros &&
-                    itemChangeEventArgs.Item is { LocationType: not LocationType.Virtual } item)
+                if (!_config.AutoDetectIntros)
                 {
-                    Guid? id = itemChangeEventArgs.Item switch
-                    {
-                        Episode episode => episode.Id,
-                        Movie movie => movie.Id,
-                        _ => null
-                    };
+                    return;
+                }
 
-                    if (!id.HasValue || id.Value == Guid.Empty)
+                var item = itemChangeEventArgs.Item;
+                if (item is null)
+                {
+                    return;
+                }
+
+                // Needed for unit tests: avoid analyzing for virtual items, but don't fail if the item
+                // is partially initialized.
+                try
+                {
+                    if (item.LocationType == LocationType.Virtual)
                     {
                         return;
                     }
-
-                    _logger.LogDebug("Media item removed, deleting fingerprint cache for {Id}", id);
-                    FFmpegWrapper.DeleteFingerprintCache(id.Value);
                 }
+                catch
+                {
+                    // Ignore LocationType evaluation issues.
+                }
+
+                Guid? id = item switch
+                {
+                    Episode episode => episode.Id,
+                    Movie movie => movie.Id,
+                    _ => null
+                };
+
+                if (!id.HasValue || id.Value == Guid.Empty)
+                {
+                    return;
+                }
+
+                _logger.LogDebug("Media item removed, deleting fingerprint cache for {Id}", id);
+                FFmpegWrapper.DeleteFingerprintCache(id.Value);
             }
             catch (Exception ex)
             {

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -191,25 +191,24 @@ namespace IntroSkipper.Services
         {
             try
             {
-                if (itemChangeEventArgs.Item is null)
+                if (_config.AutoDetectIntros &&
+                    itemChangeEventArgs.Item is { LocationType: not LocationType.Virtual } item)
                 {
-                    return;
+                    Guid? id = itemChangeEventArgs.Item switch
+                    {
+                        Episode episode => episode.Id,
+                        Movie movie => movie.Id,
+                        _ => null
+                    };
+
+                    if (!id.HasValue || id.Value == Guid.Empty)
+                    {
+                        return;
+                    }
+
+                    _logger.LogDebug("Media item removed, deleting fingerprint cache for {Id}", id);
+                    FFmpegWrapper.DeleteFingerprintCache(id.Value);
                 }
-
-                Guid? id = itemChangeEventArgs.Item switch
-                {
-                    Episode episode => episode.Id,
-                    Movie movie => movie.Id,
-                    _ => null
-                };
-
-                if (!id.HasValue || id.Value == Guid.Empty)
-                {
-                    return;
-                }
-
-                _logger.LogDebug("Media item removed, deleting fingerprint cache for {Id}", id);
-                FFmpegWrapper.DeleteFingerprintCache(id.Value);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary by Sourcery

Handle removal of library items by cleaning up associated fingerprint cache and simplify timing behavior for item change processing.

Bug Fixes:
- Clear fingerprint cache when episodes or movies are removed from the library to avoid stale data.

Enhancements:
- Subscribe to library item removal events during service lifetime to trigger cleanup on deletions.
- Standardize the item change processing delay to a fixed value regardless of update reason.