### PR TITLE
feat: AutoSkip support for SyncPlay

### DIFF
--- a/IntroSkipper/Services/AutoSkip.cs
+++ b/IntroSkipper/Services/AutoSkip.cs
@@ -13,6 +13,7 @@ using IntroSkipper.Data;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
+using MediaBrowser.Controller.SyncPlay;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Session;
@@ -31,10 +32,12 @@ namespace IntroSkipper.Services;
 /// <param name="userDataManager">User data manager.</param>
 /// <param name="sessionManager">Session manager.</param>
 /// <param name="logger">Logger.</param>
+/// <param name="syncPlayManager">Sync play manager.</param>
 public sealed class AutoSkip(
     IUserDataManager userDataManager,
     ISessionManager sessionManager,
-    ILogger<AutoSkip> logger) : IHostedService, IDisposable
+    ILogger<AutoSkip> logger,
+    ISyncPlayManager syncPlayManager) : IHostedService, IDisposable
 {
     private const int PlaybackTimerInterval = 1000; // 1 second interval
     private const int NotificationTimeoutMs = 2000;
@@ -45,6 +48,7 @@ public sealed class AutoSkip(
     private readonly ConcurrentDictionary<string, Dictionary<AnalysisMode, Segment>> _sentSeekCommand = [];
     private readonly HashSet<string> _clientList = [];
     private readonly HashSet<AnalysisMode> _segmentTypes = [];
+    private readonly ISyncPlayManager _syncPlayManager = syncPlayManager;
     private PluginConfiguration _config = new();
     private bool _autoSkipEnabled;
 
@@ -179,6 +183,23 @@ public sealed class AutoSkip(
 
             _logger.LogDebug("Found segment for session {Session}, removing from list, {Intros} segments remaining", session.DeviceId, intros.Count);
             _logger.LogTrace("Playback position is {Position}", position);
+
+            // If SyncPlay is active for this user, skip auto-skipping.
+            if (_syncPlayManager.IsUserActive(session.UserId))
+            {
+                _logger.LogDebug("SyncPlay is active for user {UserId}, skipping auto-skip for Device {Session}", session.UserId, session.DeviceId);
+                _sessionManager.SendMessageCommand(
+                    session.Id,
+                    session.Id,
+                    new MessageCommand
+                    {
+                        Header = string.Empty,
+                        Text = "Server side Auto-skip doesn't work with SyncPlay",
+                        TimeoutMs = NotificationTimeoutMs,
+                    },
+                    CancellationToken.None);
+                continue;
+            }
 
             // Notify the user that an introduction is being skipped for them.
             var notificationText = FormatNotificationText(_config.AutoSkipNotificationText, currentSegmentType, currentIntro.Start, currentIntro.End);

--- a/IntroSkipper/Services/AutoSkip.cs
+++ b/IntroSkipper/Services/AutoSkip.cs
@@ -148,11 +148,12 @@ public sealed class AutoSkip(
 
     private void PlaybackTimer_Elapsed(object? sender, ElapsedEventArgs e)
     {
+        var handledSyncPlayGroups = new HashSet<Guid>();
+
         var eligibleSessions = _sessionManager.Sessions
             .Where(s => s.PlayState?.PositionTicks.HasValue == true) // Ensure PlayState and PositionTicks are valid
             .Where(s => _config.AutoSkip || _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase))
             .Where(s => _sentSeekCommand.ContainsKey(s.DeviceId))
-            .Where(s => _syncPlayManager.IsUserActive(s.UserId) == false)
             .ToList();
 
         foreach (var session in eligibleSessions)
@@ -186,6 +187,61 @@ public sealed class AutoSkip(
 
             _logger.LogDebug("Found segment for session {Session}, removing from list, {Intros} segments remaining", session.DeviceId, intros.Count);
             _logger.LogTrace("Playback position is {Position}", position);
+
+            IReadOnlyCollection<string>? syncPlayParticipants = null;
+            Guid? syncPlayGroupId = null;
+            var isSyncPlaySession = _syncPlayManager.IsUserActive(session.UserId);
+            if (isSyncPlaySession)
+            {
+                // Find the active SyncPlay group for this session.
+                // In Jellyfin 10.11, GroupInfoDto.Participants are usernames (not session ids).
+                var groups = _syncPlayManager.ListGroups(session, new ListGroupsRequest());
+                var group = string.IsNullOrWhiteSpace(session.UserName)
+                    ? null
+                    : groups?.FirstOrDefault(g => g.Participants.Contains(session.UserName, StringComparer.OrdinalIgnoreCase));
+
+                if (group is not null)
+                {
+                    syncPlayGroupId = group.GroupId;
+                    syncPlayParticipants = group.Participants;
+                }
+            }
+
+            // If this is a SyncPlay session, only one session in the group should handle the group request.
+            // We additionally synchronize the per-device segment state across all group participants so we
+            // don't repeatedly re-evaluate already-skipped segments on other sessions.
+            if (syncPlayGroupId.HasValue && syncPlayParticipants is not null)
+            {
+                if (!handledSyncPlayGroups.Add(syncPlayGroupId.Value))
+                {
+                    continue;
+                }
+
+                var participantSet = new HashSet<string>(syncPlayParticipants, StringComparer.OrdinalIgnoreCase);
+                var participantSessions = _sessionManager.Sessions
+                    .Where(s => !string.IsNullOrWhiteSpace(s.UserName) && participantSet.Contains(s.UserName))
+                    .ToList();
+
+                foreach (var participant in participantSessions)
+                {
+                    if (_sentSeekCommand.TryGetValue(participant.DeviceId, out var participantIntros))
+                    {
+                        participantIntros.Remove(currentSegmentType);
+                        if (nextSegment.Value is not null)
+                        {
+                            participantIntros.Remove(nextSegment.Key);
+                        }
+                    }
+                }
+
+                _syncPlayManager.HandleRequest(
+                    session,
+                    new SeekGroupRequest((long)introEnd * TimeSpan.TicksPerSecond),
+                    CancellationToken.None);
+
+                // For SyncPlay group playback, do not send individual seek commands.
+                continue;
+            }
 
             // Notify the user that an introduction is being skipped for them.
             var notificationText = FormatNotificationText(_config.AutoSkipNotificationText, currentSegmentType, currentIntro.Start, currentIntro.End);

--- a/IntroSkipper/Services/AutoSkip.cs
+++ b/IntroSkipper/Services/AutoSkip.cs
@@ -14,6 +14,8 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.SyncPlay;
+using MediaBrowser.Controller.SyncPlay.PlaybackRequests;
+using MediaBrowser.Controller.SyncPlay.Requests;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Session;
@@ -150,6 +152,7 @@ public sealed class AutoSkip(
             .Where(s => s.PlayState?.PositionTicks.HasValue == true) // Ensure PlayState and PositionTicks are valid
             .Where(s => _config.AutoSkip || _clientList.Contains(s.Client, StringComparer.OrdinalIgnoreCase))
             .Where(s => _sentSeekCommand.ContainsKey(s.DeviceId))
+            .Where(s => _syncPlayManager.IsUserActive(s.UserId) == false)
             .ToList();
 
         foreach (var session in eligibleSessions)
@@ -183,23 +186,6 @@ public sealed class AutoSkip(
 
             _logger.LogDebug("Found segment for session {Session}, removing from list, {Intros} segments remaining", session.DeviceId, intros.Count);
             _logger.LogTrace("Playback position is {Position}", position);
-
-            // If SyncPlay is active for this user, skip auto-skipping.
-            if (_syncPlayManager.IsUserActive(session.UserId))
-            {
-                _logger.LogDebug("SyncPlay is active for user {UserId}, skipping auto-skip for Device {Session}", session.UserId, session.DeviceId);
-                _sessionManager.SendMessageCommand(
-                    session.Id,
-                    session.Id,
-                    new MessageCommand
-                    {
-                        Header = string.Empty,
-                        Text = "Server side Auto-skip doesn't work with SyncPlay",
-                        TimeoutMs = NotificationTimeoutMs,
-                    },
-                    CancellationToken.None);
-                continue;
-            }
 
             // Notify the user that an introduction is being skipped for them.
             var notificationText = FormatNotificationText(_config.AutoSkipNotificationText, currentSegmentType, currentIntro.Start, currentIntro.End);

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Some web UI features (for example, adjusting the skip-button timeout) require th
     - Add as a plugin source repository to your Jellyfin server.
      ```
      https://www.iamparadox.dev/jellyfin/plugins/manifest.json
-     ``` 
+     ```
     - Find "File Transformation" in the Catalog and install it.
 </details>
 
@@ -58,10 +58,6 @@ Some web UI features (for example, adjusting the skip-button timeout) require th
 ## Policies
 - [Code of conduct](CODE_OF_CONDUCT.md)
 - [Privacy policy](PRIVACY.md)
-
-## Limitations
-
-* SyncPlay is not (yet) compatible with any method of skipping due to the nature of how the clients are synced.
 
 ## [Detection parameters](https://github.com/intro-skipper/intro-skipper/wiki#detection-parameters)
 


### PR DESCRIPTION
## Summary by Sourcery

Add AutoSkip support for SyncPlay group playback, ensuring synchronized skipping behavior across all participants in a group.

New Features:
- Enable AutoSkip to recognize and operate on SyncPlay sessions and groups.
- Coordinate skip actions across all members of a SyncPlay group using group-level seek requests.

Enhancements:
- Avoid duplicate skip handling within the same SyncPlay group by tracking processed groups per timer cycle.
- Synchronize per-device segment state across SyncPlay participants to prevent re-processing already skipped segments.