### PR TITLE
feat: add option to skip first episode intro

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -108,6 +108,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool FullLengthChapters { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether the introduction in the first episode of a season should be ignored.
+    /// </summary>
+    public bool SkipFirstEpisode { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets the minimum length of similar audio that will be considered an introduction.
     /// </summary>
     public int MinimumIntroDuration { get; set; } = 15;

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -176,6 +176,14 @@
                                     <div class="fieldDescription">Allow segments to extend to the end of a chapter when the marker exceeds other user settings, such as percentage or duration.</div>
                                 </div>
 
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label class="emby-checkbox-label">
+                                        <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
+                                        <span>Play Segments for First Episode of a Season</span>
+                                    </label>
+                                    <div class="fieldDescription">If checked, segments for the first episode in a season will not be recorded.</div>
+                                </div>
+
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="AnalysisPercent"> Percent of media to analyze </label>
                                     <input id="AnalysisPercent" type="number" is="emby-input" min="1" max="90" />
@@ -823,7 +831,7 @@
                         "ChapterAnalyzerCommercialPattern",
                     ];
 
-                    const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments", "UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "ScanCommercial", "PreferChromaprint", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
+                    const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments", "UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "SkipFirstEpisode", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "ScanCommercial", "PreferChromaprint", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
 
                     // timestamp / maintenance elements
                     const analyzerActionsSection = document.querySelector("div#analyzerActionsSection");

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -179,9 +179,9 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
                                         <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
-                                        <span>Play Segments for First Episode of a Season</span>
+                                        <span>Skip Segments for First Episode of a Season</span>
                                     </label>
-                                    <div class="fieldDescription">If checked, segments for the first episode in a season will not be recorded.</div>
+                                    <div class="fieldDescription">If checked, segments for the first episode in a season will be ignored.</div>
                                 </div>
 
                                 <div class="inputContainer">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -329,7 +329,7 @@
                                         <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
                                         <span>Ignore intros for first episode of a season</span>
                                     </label>
-                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be recorded.</div>
+                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be skipped.</div>
                                 </div>
 
                                 <fieldset>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -179,9 +179,9 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
                                         <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
-                                        <span>Skip Segments for First Episode of a Season</span>
+                                        <span>Ignore Intro Segments for First Episode of a Season</span>
                                     </label>
-                                    <div class="fieldDescription">If checked, segments for the first episode in a season will be ignored.</div>
+                                    <div class="fieldDescription">If checked, Intro segments for the first episode in a season will be ignored.</div>
                                 </div>
 
                                 <div class="inputContainer">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -176,14 +176,6 @@
                                     <div class="fieldDescription">Allow segments to extend to the end of a chapter when the marker exceeds other user settings, such as percentage or duration.</div>
                                 </div>
 
-                                <div class="checkboxContainer checkboxContainer-withDescription">
-                                    <label class="emby-checkbox-label">
-                                        <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
-                                        <span>Ignore intros for first episode of a season</span>
-                                    </label>
-                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be recorded.</div>
-                                </div>
-
                                 <div class="inputContainer">
                                     <label class="inputLabel inputLabelUnfocused" for="AnalysisPercent"> Percent of media to analyze </label>
                                     <input id="AnalysisPercent" type="number" is="emby-input" min="1" max="90" />
@@ -330,6 +322,14 @@
                                     <label class="inputLabel inputLabelUnfocused" for="EndSnapThreshold"> Snap to episode start/end threshold </label>
                                     <input id="EndSnapThreshold" type="number" is="emby-input" min="0" />
                                     <div class="fieldDescription">If a segment's start or end is within this many seconds of the episode's start or end, it will be automatically adjusted (snapped) to match the episode boundary. Set to 0 to disable snapping.</div>
+                                </div>
+
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label class="emby-checkbox-label">
+                                        <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
+                                        <span>Ignore intros for first episode of a season</span>
+                                    </label>
+                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be recorded.</div>
                                 </div>
 
                                 <fieldset>

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -179,9 +179,9 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label class="emby-checkbox-label">
                                         <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
-                                        <span>Ignore Intro Segments for First Episode of a Season</span>
+                                        <span>Ignore intros for first episode of a season</span>
                                     </label>
-                                    <div class="fieldDescription">If checked, Intro segments for the first episode in a season will be ignored.</div>
+                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be recorded.</div>
                                 </div>
 
                                 <div class="inputContainer">

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -30,17 +30,15 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
     ILibraryManager libraryManager,
     ILogger<MediaSegmentsFirstEpisodeFilter> logger) : IAsyncResultFilter
 {
+    private static readonly string[] _routeItemKeys = ["itemId", "id", "ItemId"];
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly ILogger<MediaSegmentsFirstEpisodeFilter> _logger = logger;
 
     /// <inheritdoc />
     public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
     {
-        _logger.LogDebug("MediaSegments filter invoked. Path: {Path}", context.HttpContext.Request.Path.Value);
-
         if (!IsMediaSegmentsRequest(context))
         {
-            _logger.LogDebug("Request is not MediaSegments. Skipping filter.");
             await next().ConfigureAwait(false);
             return;
         }
@@ -52,18 +50,14 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
             return;
         }
 
-        _logger.LogDebug("MediaSegments request item id: {ItemId}", itemId);
-
         if (_libraryManager.GetItemById(itemId) is not Episode episode)
         {
-            _logger.LogDebug("Item {ItemId} is not an episode. Skipping filter.", itemId);
             await next().ConfigureAwait(false);
             return;
         }
 
         if (!IsFirstEpisode(episode))
         {
-            _logger.LogDebug("Episode {EpisodeId} is not the first episode. Skipping filter.", episode.Id);
             await next().ConfigureAwait(false);
             return;
         }
@@ -72,12 +66,10 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
 
         if (context.Result is ObjectResult objectResult)
         {
-            _logger.LogDebug("Filtering ObjectResult media segments for {EpisodeId}.", episode.Id);
             objectResult.Value = FilterIntroSegments(objectResult.Value);
         }
         else if (context.Result is JsonResult jsonResult)
         {
-            _logger.LogDebug("Filtering JsonResult media segments for {EpisodeId}.", episode.Id);
             jsonResult.Value = FilterIntroSegments(jsonResult.Value);
         }
         else
@@ -94,7 +86,6 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
 
         if (Plugin.Instance?.Configuration?.SkipFirstEpisode != true)
         {
-            _logger.LogDebug("SkipFirstEpisode disabled in config. Not filtering.");
             return false;
         }
 
@@ -130,54 +121,40 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
 
     private static bool IsMediaSegmentsRequest(ResultExecutingContext context)
     {
+        static bool ContainsMediaSegments(string? value)
+            => value?.Contains("MediaSegments", StringComparison.OrdinalIgnoreCase) == true;
+
         if (context.RouteData.Values.TryGetValue("controller", out var controller)
-            && controller is not null
-            && controller.ToString()!.Contains("MediaSegments", StringComparison.OrdinalIgnoreCase))
+            && ContainsMediaSegments(controller?.ToString()))
         {
             return true;
         }
 
-        if (context.ActionDescriptor.DisplayName?.Contains("MediaSegments", StringComparison.OrdinalIgnoreCase) == true)
+        if (ContainsMediaSegments(context.ActionDescriptor.DisplayName))
         {
             return true;
         }
 
         var path = context.HttpContext.Request.Path.Value;
-        return path?.Contains("/MediaSegments", StringComparison.OrdinalIgnoreCase) == true;
+        return ContainsMediaSegments(path);
     }
 
     private static bool TryGetItemId(ResultExecutingContext context, out Guid itemId)
     {
-        if (TryParseRouteValue(context, "itemId", out itemId)
-            || TryParseRouteValue(context, "id", out itemId)
-            || TryParseRouteValue(context, "ItemId", out itemId))
+        foreach (var key in _routeItemKeys)
         {
-            return true;
+            if (TryParseGuid(context.RouteData.Values.TryGetValue(key, out var value) ? value : null, out itemId))
+            {
+                return true;
+            }
         }
 
-        var query = context.HttpContext.Request.Query;
-        if (query.TryGetValue("itemId", out var itemIdValues)
-            && Guid.TryParse(itemIdValues.FirstOrDefault(), out itemId))
-        {
-            return true;
-        }
-
-        itemId = Guid.Empty;
-        return false;
+        var queryValue = context.HttpContext.Request.Query["itemId"].FirstOrDefault();
+        return Guid.TryParse(queryValue, out itemId);
     }
 
-    private static bool TryParseRouteValue(ResultExecutingContext context, string key, out Guid itemId)
-    {
-        if (context.RouteData.Values.TryGetValue(key, out var value)
-            && value is not null
-            && Guid.TryParse(value.ToString(), out itemId))
-        {
-            return true;
-        }
-
-        itemId = Guid.Empty;
-        return false;
-    }
+    private static bool TryParseGuid(object? value, out Guid guid)
+        => Guid.TryParse(value?.ToString(), out guid);
 
     private object? FilterIntroSegments(object? value)
     {
@@ -188,16 +165,15 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
 
         if (value is QueryResult<MediaSegmentDto> queryResult)
         {
-            _logger.LogDebug("Filtering QueryResult media segments. Count: {Count}", queryResult.Items?.Count ?? 0);
-            var items = queryResult.Items
-                ?.Where(segment => segment.Type != MediaSegmentType.Intro)
-                .ToArray();
-
-            _logger.LogDebug("Filtered QueryResult media segments. Count: {Count}", items?.Length ?? 0);
+            var items = FilterSegments(queryResult.Items);
+            _logger.LogDebug(
+                "Filtering QueryResult media segments. Before: {Before}, After: {After}",
+                queryResult.Items?.Count ?? 0,
+                items.Length);
 
             return new QueryResult<MediaSegmentDto>
             {
-                Items = items ?? Array.Empty<MediaSegmentDto>(),
+                Items = items,
                 StartIndex = queryResult.StartIndex,
                 TotalRecordCount = items?.Length ?? 0
             };
@@ -205,14 +181,20 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
 
         if (value is IEnumerable<MediaSegmentDto> segments)
         {
-            var segmentList = segments.ToList();
-            _logger.LogDebug("Filtering list media segments. Count: {Count}", segmentList.Count);
-            return segmentList
-                .Where(segment => segment.Type != MediaSegmentType.Intro)
-                .ToList();
+            var filtered = FilterSegments(segments);
+            _logger.LogDebug("Filtering list media segments. After: {Count}", filtered.Length);
+            return filtered.ToList();
         }
 
         _logger.LogDebug("Media segments response was not a list of media segments. Type: {Type}", value.GetType().FullName);
         return value;
+    }
+
+    private static MediaSegmentDto[] FilterSegments(IEnumerable<MediaSegmentDto>? segments)
+    {
+        return segments?
+            .Where(segment => segment.Type != MediaSegmentType.Intro)
+            .ToArray()
+            ?? [];
     }
 }

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -68,7 +68,7 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
             return;
         }
 
-        _logger.LogInformation("Filtering intro segments for first episode {EpisodeId} (SeasonId: {SeasonId}, Index: {Index})", episode.Id, episode.SeasonId, episode.IndexNumber);
+        _logger.LogDebug("Filtering intro segments for first episode {EpisodeId} (SeasonId: {SeasonId}, Index: {Index})", episode.Id, episode.SeasonId, episode.IndexNumber);
 
         if (context.Result is ObjectResult objectResult)
         {
@@ -94,7 +94,7 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
 
         if (Plugin.Instance?.Configuration?.SkipFirstEpisode != true)
         {
-            _logger.LogInformation("SkipFirstEpisode disabled in config. Not filtering.");
+            _logger.LogDebug("SkipFirstEpisode disabled in config. Not filtering.");
             return false;
         }
 
@@ -190,7 +190,7 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
         {
             _logger.LogDebug("Filtering QueryResult media segments. Count: {Count}", queryResult.Items?.Count ?? 0);
             var items = queryResult.Items
-                ?.Where(segment => !string.Equals(segment.Type.ToString(), "Intro", StringComparison.OrdinalIgnoreCase))
+                ?.Where(segment => segment.Type != MediaSegmentType.Intro)
                 .ToArray();
 
             _logger.LogDebug("Filtered QueryResult media segments. Count: {Count}", items?.Length ?? 0);
@@ -199,7 +199,7 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
             {
                 Items = items ?? Array.Empty<MediaSegmentDto>(),
                 StartIndex = queryResult.StartIndex,
-                TotalRecordCount = items?.Length ?? 0
+                TotalRecordCount = queryResult.TotalRecordCount
             };
         }
 
@@ -207,8 +207,8 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
         {
             var segmentList = segments.ToList();
             _logger.LogDebug("Filtering list media segments. Count: {Count}", segmentList.Count);
-            return segments
-                .Where(segment => !string.Equals(segment.Type.ToString(), "Intro", StringComparison.OrdinalIgnoreCase))
+            return segmentList
+                .Where(segment => segment.Type != MediaSegmentType.Intro)
                 .ToList();
         }
 

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -21,23 +21,17 @@ namespace IntroSkipper.Filters;
 /// <summary>
 /// Filters media segment responses to remove intro segments for season premieres.
 /// </summary>
-public sealed class MediaSegmentsFirstEpisodeFilter : IAsyncResultFilter
+/// <remarks>
+/// Initializes a new instance of the <see cref="MediaSegmentsFirstEpisodeFilter"/> class.
+/// </remarks>
+/// <param name="libraryManager">Library manager.</param>
+/// <param name="logger">Logger.</param>
+public sealed class MediaSegmentsFirstEpisodeFilter(
+    ILibraryManager libraryManager,
+    ILogger<MediaSegmentsFirstEpisodeFilter> logger) : IAsyncResultFilter
 {
-    private readonly ILibraryManager _libraryManager;
-    private readonly ILogger<MediaSegmentsFirstEpisodeFilter> _logger;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="MediaSegmentsFirstEpisodeFilter"/> class.
-    /// </summary>
-    /// <param name="libraryManager">Library manager.</param>
-    /// <param name="logger">Logger.</param>
-    public MediaSegmentsFirstEpisodeFilter(
-        ILibraryManager libraryManager,
-        ILogger<MediaSegmentsFirstEpisodeFilter> logger)
-    {
-        _libraryManager = libraryManager;
-        _logger = logger;
-    }
+    private readonly ILibraryManager _libraryManager = libraryManager;
+    private readonly ILogger<MediaSegmentsFirstEpisodeFilter> _logger = logger;
 
     /// <inheritdoc />
     public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -1,0 +1,162 @@
+// Copyright (C) 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.MediaSegments;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Filters;
+
+/// <summary>
+/// Filters media segment responses to remove intro segments for season premieres.
+/// </summary>
+public sealed class MediaSegmentsFirstEpisodeFilter : IAsyncResultFilter
+{
+    private readonly ILibraryManager _libraryManager;
+    private readonly ILogger<MediaSegmentsFirstEpisodeFilter> _logger;
+    private readonly PluginConfiguration _config;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MediaSegmentsFirstEpisodeFilter"/> class.
+    /// </summary>
+    /// <param name="libraryManager">Library manager.</param>
+    /// <param name="logger">Logger.</param>
+    public MediaSegmentsFirstEpisodeFilter(
+        ILibraryManager libraryManager,
+        ILogger<MediaSegmentsFirstEpisodeFilter> logger)
+    {
+        _libraryManager = libraryManager;
+        _logger = logger;
+        _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+    }
+
+    /// <inheritdoc />
+    public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+    {
+        if (!IsMediaSegmentsRequest(context) || !TryGetItemId(context, out var itemId))
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        if (_libraryManager.GetItemById(itemId) is not Episode episode)
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        if (!IsFirstEpisode(episode))
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        if (context.Result is ObjectResult objectResult)
+        {
+            objectResult.Value = FilterIntroSegments(objectResult.Value);
+        }
+        else if (context.Result is JsonResult jsonResult)
+        {
+            jsonResult.Value = FilterIntroSegments(jsonResult.Value);
+        }
+
+        await next().ConfigureAwait(false);
+    }
+
+    private bool IsFirstEpisode(Episode episode)
+        => _config.SkipFirstEpisode
+            && episode.IndexNumber.HasValue
+            && episode.IndexNumber.Value == 1;
+
+    private static bool IsMediaSegmentsRequest(ResultExecutingContext context)
+    {
+        if (context.RouteData.Values.TryGetValue("controller", out var controller)
+            && controller is not null
+            && controller.ToString()!.Contains("MediaSegments", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (context.ActionDescriptor.DisplayName?.Contains("MediaSegments", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return true;
+        }
+
+        var path = context.HttpContext.Request.Path.Value;
+        return path?.Contains("/MediaSegments", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private static bool TryGetItemId(ResultExecutingContext context, out Guid itemId)
+    {
+        if (TryParseRouteValue(context, "itemId", out itemId)
+            || TryParseRouteValue(context, "id", out itemId)
+            || TryParseRouteValue(context, "ItemId", out itemId))
+        {
+            return true;
+        }
+
+        var query = context.HttpContext.Request.Query;
+        if (query.TryGetValue("itemId", out var itemIdValues)
+            && Guid.TryParse(itemIdValues.FirstOrDefault(), out itemId))
+        {
+            return true;
+        }
+
+        itemId = Guid.Empty;
+        return false;
+    }
+
+    private static bool TryParseRouteValue(ResultExecutingContext context, string key, out Guid itemId)
+    {
+        if (context.RouteData.Values.TryGetValue(key, out var value)
+            && value is not null
+            && Guid.TryParse(value.ToString(), out itemId))
+        {
+            return true;
+        }
+
+        itemId = Guid.Empty;
+        return false;
+    }
+
+    private object? FilterIntroSegments(object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (value is QueryResult<MediaSegmentDto> queryResult)
+        {
+            var items = queryResult.Items
+                ?.Where(segment => !string.Equals(segment.Type.ToString(), "Intro", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            return new QueryResult<MediaSegmentDto>
+            {
+                Items = items ?? Array.Empty<MediaSegmentDto>(),
+                StartIndex = queryResult.StartIndex,
+                TotalRecordCount = items?.Length ?? 0
+            };
+        }
+
+        if (value is IEnumerable<MediaSegmentDto> segments)
+        {
+            return segments
+                .Where(segment => !string.Equals(segment.Type.ToString(), "Intro", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        _logger.LogDebug("Media segments response was not a list of media segments. Type: {Type}", value.GetType().FullName);
+        return value;
+    }
+}

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -199,7 +199,7 @@ public sealed class MediaSegmentsFirstEpisodeFilter(
             {
                 Items = items ?? Array.Empty<MediaSegmentDto>(),
                 StartIndex = queryResult.StartIndex,
-                TotalRecordCount = queryResult.TotalRecordCount
+                TotalRecordCount = items?.Length ?? 0
             };
         }
 

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using IntroSkipper.Configuration;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.MediaSegments;
@@ -23,7 +25,6 @@ public sealed class MediaSegmentsFirstEpisodeFilter : IAsyncResultFilter
 {
     private readonly ILibraryManager _libraryManager;
     private readonly ILogger<MediaSegmentsFirstEpisodeFilter> _logger;
-    private readonly PluginConfiguration _config;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MediaSegmentsFirstEpisodeFilter"/> class.
@@ -36,46 +37,102 @@ public sealed class MediaSegmentsFirstEpisodeFilter : IAsyncResultFilter
     {
         _libraryManager = libraryManager;
         _logger = logger;
-        _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     }
 
     /// <inheritdoc />
     public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
     {
-        if (!IsMediaSegmentsRequest(context) || !TryGetItemId(context, out var itemId))
+        _logger.LogDebug("MediaSegments filter invoked. Path: {Path}", context.HttpContext.Request.Path.Value);
+
+        if (!IsMediaSegmentsRequest(context))
         {
+            _logger.LogDebug("Request is not MediaSegments. Skipping filter.");
             await next().ConfigureAwait(false);
             return;
         }
 
+        if (!TryGetItemId(context, out var itemId))
+        {
+            _logger.LogWarning("MediaSegments request missing item id. Route: {RouteValues}", context.RouteData.Values);
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        _logger.LogDebug("MediaSegments request item id: {ItemId}", itemId);
+
         if (_libraryManager.GetItemById(itemId) is not Episode episode)
         {
+            _logger.LogDebug("Item {ItemId} is not an episode. Skipping filter.", itemId);
             await next().ConfigureAwait(false);
             return;
         }
 
         if (!IsFirstEpisode(episode))
         {
+            _logger.LogDebug("Episode {EpisodeId} is not the first episode. Skipping filter.", episode.Id);
             await next().ConfigureAwait(false);
             return;
         }
 
+        _logger.LogInformation("Filtering intro segments for first episode {EpisodeId} (SeasonId: {SeasonId}, Index: {Index})", episode.Id, episode.SeasonId, episode.IndexNumber);
+
         if (context.Result is ObjectResult objectResult)
         {
+            _logger.LogDebug("Filtering ObjectResult media segments for {EpisodeId}.", episode.Id);
             objectResult.Value = FilterIntroSegments(objectResult.Value);
         }
         else if (context.Result is JsonResult jsonResult)
         {
+            _logger.LogDebug("Filtering JsonResult media segments for {EpisodeId}.", episode.Id);
             jsonResult.Value = FilterIntroSegments(jsonResult.Value);
+        }
+        else
+        {
+            _logger.LogDebug("MediaSegments result type not recognized: {ResultType}", context.Result?.GetType().FullName);
         }
 
         await next().ConfigureAwait(false);
     }
 
     private bool IsFirstEpisode(Episode episode)
-        => _config.SkipFirstEpisode
-            && episode.IndexNumber.HasValue
-            && episode.IndexNumber.Value == 1;
+    {
+        _logger.LogDebug("Evaluating first-episode status for {EpisodeId} (SeasonId: {SeasonId}, Index: {Index})", episode.Id, episode.SeasonId, episode.IndexNumber);
+
+        if (Plugin.Instance?.Configuration?.SkipFirstEpisode != true)
+        {
+            _logger.LogInformation("SkipFirstEpisode disabled in config. Not filtering.");
+            return false;
+        }
+
+        if (episode.SeasonId == Guid.Empty)
+        {
+            _logger.LogDebug("Episode {EpisodeId} has no SeasonId. Not filtering.", episode.Id);
+            return false;
+        }
+
+        var query = new InternalItemsQuery
+        {
+            ParentId = episode.SeasonId,
+            IncludeItemTypes = [BaseItemKind.Episode],
+            Recursive = false,
+            IsVirtualItem = false,
+            OrderBy = [(ItemSortBy.IndexNumber, SortOrder.Ascending)]
+        };
+
+        var firstEpisode = _libraryManager.GetItemList(query, false)
+            .OfType<Episode>()
+            .FirstOrDefault();
+
+        if (firstEpisode is null)
+        {
+            _logger.LogDebug("No first episode found for SeasonId {SeasonId}. Not filtering.", episode.SeasonId);
+            return false;
+        }
+
+        _logger.LogDebug("Season {SeasonId} first episode is {FirstEpisodeId}. Current episode is {EpisodeId}.", episode.SeasonId, firstEpisode.Id, episode.Id);
+
+        return firstEpisode.Id == episode.Id;
+    }
 
     private static bool IsMediaSegmentsRequest(ResultExecutingContext context)
     {
@@ -137,9 +194,12 @@ public sealed class MediaSegmentsFirstEpisodeFilter : IAsyncResultFilter
 
         if (value is QueryResult<MediaSegmentDto> queryResult)
         {
+            _logger.LogDebug("Filtering QueryResult media segments. Count: {Count}", queryResult.Items?.Count ?? 0);
             var items = queryResult.Items
                 ?.Where(segment => !string.Equals(segment.Type.ToString(), "Intro", StringComparison.OrdinalIgnoreCase))
                 .ToArray();
+
+            _logger.LogDebug("Filtered QueryResult media segments. Count: {Count}", items?.Length ?? 0);
 
             return new QueryResult<MediaSegmentDto>
             {
@@ -151,6 +211,8 @@ public sealed class MediaSegmentsFirstEpisodeFilter : IAsyncResultFilter
 
         if (value is IEnumerable<MediaSegmentDto> segments)
         {
+            var segmentList = segments.ToList();
+            _logger.LogDebug("Filtering list media segments. Count: {Count}", segmentList.Count);
             return segments
                 .Where(segment => !string.Equals(segment.Type.ToString(), "Intro", StringComparison.OrdinalIgnoreCase))
                 .ToList();

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (C) 2026 Intro-Skipper contributors <intro-skipper.org>
 // SPDX-License-Identifier: GPL-3.0-only
 
+using IntroSkipper.Filters;
 using IntroSkipper.Manager;
 using IntroSkipper.Providers;
 using IntroSkipper.Services;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Controller.Plugins;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace IntroSkipper
@@ -22,6 +24,11 @@ namespace IntroSkipper
             serviceCollection.AddHostedService<Entrypoint>();
             serviceCollection.AddSingleton<IMediaSegmentProvider, SegmentProvider>();
             serviceCollection.AddTransient<MediaSegmentUpdateManager>();
+            serviceCollection.AddSingleton<MediaSegmentsFirstEpisodeFilter>();
+            serviceCollection.Configure<MvcOptions>(options =>
+            {
+                options.Filters.AddService<MediaSegmentsFirstEpisodeFilter>();
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable option to ignore intro segments for the first episode of each season and apply it via a global media segments response filter.

New Features:
- Introduce a SkipFirstEpisode configuration flag to control whether intros are skipped for season premieres.
- Expose a new UI checkbox to allow users to enable or disable ignoring intros for the first episode of a season.
- Add an ASP.NET Core result filter that removes intro media segments from responses for first episodes when the setting is enabled.

Enhancements:
- Register the new media segments first-episode filter in the plugin's service configuration so it is applied to relevant media segment requests.