### PR TITLE
Add option to show plugin in main menu

### DIFF
--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -316,6 +316,11 @@ public class PluginConfiguration : BasePluginConfiguration
     public int SkipbuttonHideDelay { get; set; } = 8;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to enable the main menu entry for the plugin.
+    /// </summary>
+    public bool EnableMainMenu { get; set; } = true;
+
+    /// <summary>
     /// Gets a value indicating whether the File Transformation plugin is enabled.
     /// </summary>
     [SuppressMessage(

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -156,6 +156,14 @@
                                 <div id="skipButtonCssStatus" style="margin-top: 8px; display: none"></div>
                             </div>
 
+                            <div class="checkboxContainer checkboxContainer-withDescription">
+                                <label class="emby-checkbox-label">
+                                    <input id="EnableMainMenu" type="checkbox" is="emby-checkbox" />
+                                    <span>Show Intro Skipper in Main Menu</span>
+                                </label>
+                                <div class="fieldDescription">Toggle the Intro Skipper entry in the server's main navigation. Save and refresh the client (or clear cache) to apply. Some clients may require a dashboard or server restart for the change to appear.</div>
+                            </div>
+
                             <details id="intro_reqs">
                                 <summary>Modify Analysis Parameters</summary>
 
@@ -831,7 +839,7 @@
                         "ChapterAnalyzerCommercialPattern",
                     ];
 
-                    const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments", "UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "SkipFirstEpisode", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "ScanCommercial", "PreferChromaprint", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
+                    const booleanConfigurationFields = ["AutoDetectIntros", "AnalyzeSeasonZero", "UpdateMediaSegments", "UseAlternativeBlackFrameAnalyzer", "UseChapterMarkersBlackFrame", "FullLengthChapters", "SkipFirstEpisode", "RebuildMediaSegments", "ScanIntroduction", "ScanCredits", "ScanRecap", "ScanPreview", "ScanCommercial", "EnableMainMenu", "PreferChromaprint", "SnapToKeyframe", "AdjustIntroBasedOnSilence", "AdjustIntroBasedOnChapters", "UseFileTransformationPlugin"];
 
                     // timestamp / maintenance elements
                     const analyzerActionsSection = document.querySelector("div#analyzerActionsSection");

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -157,7 +157,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             new PluginPageInfo
             {
                 Name = Name,
-                EnableInMainMenu = true,
+                EnableInMainMenu = Instance?.Configuration.EnableMainMenu ?? true,
                 EmbeddedResourcePath = GetType().Namespace + ".Configuration.configPage.html"
             }
         ];


### PR DESCRIPTION
Introduces a new configuration property 'EnableMainMenu' to control whether the Intro Skipper plugin appears in the server's main navigation. Updates the config page UI and plugin logic to respect this setting.

## Summary by Sourcery

Add a configurable option to control whether the Intro Skipper plugin is shown in the server's main menu.

New Features:
- Introduce an EnableMainMenu configuration option to toggle the Intro Skipper entry in the server's main navigation.

Enhancements:
- Update the configuration UI to expose the new main menu visibility toggle and persist it with other boolean settings.