### PR TITLE
Update description for SkipFirstEpisode checkbox

### DIFF
--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -337,7 +337,7 @@
                                         <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
                                         <span>Ignore intros for first episode of a season</span>
                                     </label>
-                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will be skipped.</div>
+                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be skipped during playback.</div>
                                 </div>
 
                                 <div id="SkipFirstEpisodeAnimeContainer" class="checkboxContainer checkboxContainer-withDescription" style="display: none;">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -337,7 +337,6 @@
                                         <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
                                         <span>Ignore intros for first episode of a season</span>
                                     </label>
-                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be skipped during playback.</div>
                                 </div>
 
                                 <div id="SkipFirstEpisodeAnimeContainer" class="checkboxContainer checkboxContainer-withDescription" style="display: none;">

--- a/IntroSkipper/Configuration/configPage.html
+++ b/IntroSkipper/Configuration/configPage.html
@@ -337,7 +337,7 @@
                                         <input id="SkipFirstEpisode" type="checkbox" is="emby-checkbox" />
                                         <span>Ignore intros for first episode of a season</span>
                                     </label>
-                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will not be skipped.</div>
+                                    <div class="fieldDescription">If checked, intro segments for the first episode in a season will be skipped.</div>
                                 </div>
 
                                 <div id="SkipFirstEpisodeAnimeContainer" class="checkboxContainer checkboxContainer-withDescription" style="display: none;">


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the SkipFirstEpisode checkbox help text to state that it skips intros for the first episode in a season.