### PR TITLE
Propagate cancellation and async DB operations

### DIFF
--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -73,7 +73,7 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
                 LogFoundCredits(episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await plugin.UpdateTimestampAsync(credit, mode).ConfigureAwait(false);
+                await plugin.UpdateTimestampAsync(credit, mode, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -92,6 +92,10 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
                 // Update search start for next episode based on this result
                 searchStart = episode.Duration - credit.Start + _config.MinimumCreditsDuration;
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 LogErrorAnalyzingCredits(_logger, ex, episode.Name);

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -87,7 +87,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
                 LogFoundCredits(_logger, episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await Plugin.Instance!.UpdateTimestampAsync(credit, mode).ConfigureAwait(false);
+                await Plugin.Instance!.UpdateTimestampAsync(credit, mode, cancellationToken).ConfigureAwait(false);
 
                 // Update search start for next episode based on this result
                 searchStart = episode.Duration - credit.Start + _config.MinimumCreditsDuration;

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -73,7 +73,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger) : IMediaFi
             skipRange = timeAdjustmentHelper.AdjustIntroTimes(episode, skipRange, false);
 
             episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-            await Plugin.Instance!.UpdateTimestampAsync(skipRange, mode).ConfigureAwait(false);
+            await Plugin.Instance!.UpdateTimestampAsync(skipRange, mode, cancellationToken).ConfigureAwait(false);
         }
 
         return analysisQueue;

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -168,7 +168,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
             {
                 var adjustedIntro = timeAdjustmentHelper.AdjustIntroTimes(currentEpisode, intro);
                 currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await Plugin.Instance!.UpdateTimestampAsync(adjustedIntro, mode).ConfigureAwait(false);
+                await Plugin.Instance!.UpdateTimestampAsync(adjustedIntro, mode, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -401,8 +401,8 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
         return BitOperations.PopCount(number);
     }
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Caught fingerprint error: {Ex}")]
-    private partial void LogCaughtFingerprintError(object ex);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Caught fingerprint error")]
+    private partial void LogCaughtFingerprintError(Exception exception);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Index search successful")]
     private partial void LogIndexSearchSuccessful();

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using MediaBrowser.Model.Entities;
@@ -149,15 +150,10 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
     private static double GetChapterBoundary(IReadOnlyList<ChapterInfo> chapters, double referenceTime, TimeRange searchRange)
     {
         // Collect candidate chapter times within the inclusive range
-        var candidates = new List<double>();
-        foreach (var chapter in chapters)
-        {
-            var chapterTime = TimeSpan.FromTicks(chapter.StartPositionTicks).TotalSeconds;
-            if (chapterTime + Epsilon >= searchRange.Start && chapterTime - Epsilon <= searchRange.End)
-            {
-                candidates.Add(chapterTime);
-            }
-        }
+        var candidates = chapters
+            .Select(c => TimeSpan.FromTicks(c.StartPositionTicks).TotalSeconds)
+            .Where(t => t + Epsilon >= searchRange.Start && t - Epsilon <= searchRange.End)
+            .ToList();
 
         if (candidates.Count == 0)
         {

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -53,6 +53,7 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
     /// <param name="itemId">The ItemId.</param>
     /// <param name="providerId">Provider of the Segment.</param>
     /// <param name="segment">MediaSegment data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The created segment.</returns>
     [HttpPost("{itemId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -60,7 +61,8 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
     public async Task<ActionResult<QueryResult<MediaSegmentDto>>> CreateSegmentAsync(
         [FromRoute, Required] Guid itemId,
         [FromQuery, Required] string providerId,
-        [FromBody, Required] MediaSegmentDto segment)
+        [FromBody, Required] MediaSegmentDto segment,
+        CancellationToken cancellationToken = default)
     {
         var item = Plugin.Instance!.GetItem(itemId);
         if (item is null)
@@ -71,11 +73,11 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
         var seg = new Segment(itemId, new TimeRange(TimeSpan.FromTicks(segment.StartTicks).TotalSeconds, TimeSpan.FromTicks(segment.EndTicks).TotalSeconds));
         var mode = Plugin.MapSegmentTypeToMode(segment.Type);
 
-        await Plugin.Instance!.UpdateTimestampAsync(seg, mode).ConfigureAwait(false);
+        await Plugin.Instance!.UpdateTimestampAsync(seg, mode, cancellationToken).ConfigureAwait(false);
 
         var queuedItem = new QueuedEpisode { EpisodeId = item.Id };
 
-        await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync([queuedItem], CancellationToken.None).ConfigureAwait(false);
+        await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync([queuedItem], cancellationToken).ConfigureAwait(false);
 
         return Ok();
     }
@@ -86,13 +88,15 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
     /// <param name="segmentId">The Id of the media segment to delete.</param>
     /// <param name="itemId">The item id the segment belongs to (used to remove plugin DB entry).</param>
     /// <param name="type">The media segment type name (Intro/Recap/Preview/Outro).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>HTTP 200 on success, 404 when item not found.</returns>
     [HttpDelete("{segmentId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult> DeleteSegmentAsync(
         [FromRoute, Required] Guid segmentId,
         [FromQuery, Required] Guid itemId,
-        [FromQuery, Required] string type)
+        [FromQuery, Required] string type,
+        CancellationToken cancellationToken = default)
     {
         // Delete the segment from Jellyfin's media segment manager
         await _mediaSegmentUpdateManager.DeleteSegmentAsync(segmentId).ConfigureAwait(false);
@@ -107,7 +111,7 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
             _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown segment type '{type}'")
         };
 
-        await Plugin.Instance!.DeleteTimestampAsync(itemId, mode).ConfigureAwait(false);
+        await Plugin.Instance!.DeleteTimestampAsync(itemId, mode, cancellationToken).ConfigureAwait(false);
 
         return Ok();
     }

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -111,7 +111,10 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
             _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown segment type '{type}'")
         };
 
-        await Plugin.Instance!.DeleteTimestampAsync(itemId, mode, cancellationToken).ConfigureAwait(false);
+        // The Jellyfin segment is already deleted above, so the plugin DB delete must
+        // run to completion — aborting here would leave a stale record that gets
+        // recreated on the next media segment sync.
+        await Plugin.Instance!.DeleteTimestampAsync(itemId, mode, CancellationToken.None).ConfigureAwait(false);
 
         return Ok();
     }

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -189,13 +189,10 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false, CancellationToken cancellationToken = default)
     {
         using var db = Plugin.CreateDbContext();
-        var segments = await db.DbSegment
+        await db.DbSegment
             .Where(s => s.Type == mode)
-            .ToListAsync(cancellationToken)
+            .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);
-
-        db.DbSegment.RemoveRange(segments);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {
@@ -214,8 +211,9 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     [HttpPost("Intros/RebuildDatabase")]
     public async Task<ActionResult> RebuildDatabase()
     {
+        // Database rebuild is destructive and must run to completion — do not bind to HttpContext.RequestAborted.
         using var db = Plugin.CreateDbContext();
-        await db.RebuildDatabaseAsync(Plugin.CreateDbContext, cancellationToken: HttpContext.RequestAborted).ConfigureAwait(false);
+        await db.RebuildDatabaseAsync(Plugin.CreateDbContext).ConfigureAwait(false);
         return NoContent();
     }
 }

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -196,7 +196,9 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {
-            await Task.Run(() => FFmpegWrapper.DeleteCacheFiles(mode), cancellationToken).ConfigureAwait(false);
+            // Cache deletion must run to completion — the DB rows are already gone,
+            // so aborting here would leave orphaned files with no way to clean them up.
+            await Task.Run(() => FFmpegWrapper.DeleteCacheFiles(mode), CancellationToken.None).ConfigureAwait(false);
         }
 
         return NoContent();

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -8,7 +8,6 @@ using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
-using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities.Movies;
@@ -68,7 +67,7 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
             if (segment.Valid)
             {
                 segment.EpisodeId = id;
-                await Plugin.Instance!.UpdateTimestampAsync(segment, mode).ConfigureAwait(false);
+                await Plugin.Instance!.UpdateTimestampAsync(segment, mode, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -90,12 +89,13 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     /// Gets the timestamps for the provided episode.
     /// </summary>
     /// <param name="id">Episode ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <response code="200">Sucess.</response>
     /// <response code="404">Given ID is not an Episode.</response>
     /// <returns>Episode Timestamps.</returns>
     [HttpGet("Episode/{Id}/Timestamps")]
     [ActionName("UpdateTimestamps")]
-    public ActionResult<TimeStamps> GetTimestamps([FromRoute] Guid id)
+    public async Task<ActionResult<TimeStamps>> GetTimestamps([FromRoute] Guid id, CancellationToken cancellationToken = default)
     {
         // only get return content for episodes
         var rawItem = Plugin.Instance!.GetItem(id);
@@ -105,7 +105,7 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
         }
 
         var times = new TimeStamps();
-        var segments = Plugin.Instance!.GetTimestamps(id);
+        var segments = await Plugin.Instance!.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (segments.TryGetValue(AnalysisMode.Introduction, out var introSegment))
         {
@@ -139,12 +139,13 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     /// Gets a dictionary of all skippable segments.
     /// </summary>
     /// <param name="id">Media ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <response code="200">Skippable segments dictionary.</response>
     /// <returns>Dictionary of skippable segments.</returns>
     [HttpGet("Episode/{id}/IntroSkipperSegments")]
-    public ActionResult<Dictionary<AnalysisMode, Segment>> GetSkippableSegments([FromRoute] Guid id)
+    public async Task<ActionResult<Dictionary<AnalysisMode, Segment>>> GetSkippableSegments([FromRoute] Guid id, CancellationToken cancellationToken = default)
     {
-        var segments = Plugin.Instance!.GetTimestamps(id);
+        var segments = await Plugin.Instance!.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
         var result = new Dictionary<AnalysisMode, Segment>();
 
         if (segments.TryGetValue(AnalysisMode.Introduction, out var introSegment))
@@ -180,24 +181,25 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     /// </summary>
     /// <param name="mode">Mode.</param>
     /// <param name="eraseCache">Erase cache.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <response code="204">Operation successful.</response>
     /// <returns>No content.</returns>
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPost("Intros/EraseTimestamps")]
-    public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false)
+    public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(Plugin.Instance!.DbPath);
+        using var db = Plugin.CreateDbContext();
         var segments = await db.DbSegment
             .Where(s => s.Type == mode)
-            .ToListAsync()
+            .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
         db.DbSegment.RemoveRange(segments);
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {
-            await Task.Run(() => FFmpegWrapper.DeleteCacheFiles(mode)).ConfigureAwait(false);
+            await Task.Run(() => FFmpegWrapper.DeleteCacheFiles(mode), cancellationToken).ConfigureAwait(false);
         }
 
         return NoContent();
@@ -210,10 +212,10 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
     /// <returns>No content.</returns>
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPost("Intros/RebuildDatabase")]
-    public ActionResult RebuildDatabase()
+    public async Task<ActionResult> RebuildDatabase()
     {
-        using var db = new IntroSkipperDbContext(Plugin.Instance!.DbPath);
-        db.RebuildDatabase();
+        using var db = Plugin.CreateDbContext();
+        await db.RebuildDatabaseAsync(Plugin.CreateDbContext, cancellationToken: HttpContext.RequestAborted).ConfigureAwait(false);
         return NoContent();
     }
 }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -9,7 +9,6 @@ using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
-using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
 using MediaBrowser.Common.Api;
@@ -19,6 +18,7 @@ using MediaBrowser.Model.IO;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Controllers;
@@ -113,20 +113,17 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     /// Returns the analyzer actions for the provided season.
     /// </summary>
     /// <param name="seasonId">Season ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of episode titles.</returns>
     [HttpGet("AnalyzerActions/{SeasonId}")]
-    public ActionResult<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAnalyzerAction([FromRoute] Guid seasonId)
+    public async Task<ActionResult<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>>> GetAnalyzerAction([FromRoute] Guid seasonId, CancellationToken cancellationToken = default)
     {
         if (!Plugin.Instance!.QueuedMediaItems.ContainsKey(seasonId))
         {
             return NotFound();
         }
 
-        var analyzerActions = new Dictionary<AnalysisMode, AnalyzerAction>();
-        foreach (var mode in Enum.GetValues<AnalysisMode>())
-        {
-            analyzerActions[mode] = Plugin.Instance!.GetAnalyzerAction(seasonId, mode);
-        }
+        var analyzerActions = await Plugin.Instance!.GetAllAnalyzerActionsAsync(seasonId, cancellationToken).ConfigureAwait(false);
 
         return Ok(analyzerActions);
     }
@@ -182,25 +179,33 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
         try
         {
-            using var db = new IntroSkipperDbContext(Plugin.Instance!.DbPath);
+            using var db = Plugin.CreateDbContext();
 
-            foreach (var episode in episodes)
+            // Batch-load all segments for this season's episodes in a single query
+            var episodeIds = episodes.Select(e => e.EpisodeId).ToArray();
+            var existingSegments = await db.DbSegment
+                .Where(s => episodeIds.Contains(s.ItemId))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            db.DbSegment.RemoveRange(existingSegments);
+
+            if (eraseCache)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var existingSegments = db.DbSegment.Where(s => s.ItemId == episode.EpisodeId);
-
-                db.DbSegment.RemoveRange(existingSegments);
-
-                if (eraseCache)
+                foreach (var episode in episodes)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     await Task.Run(() => FFmpegWrapper.DeleteFingerprintCache(episode.EpisodeId), cancellationToken).ConfigureAwait(false);
                 }
             }
 
-            var seasonInfo = db.DbSeasonInfo.Where(s => s.SeasonId == seasonId);
+            // Batch-load season info and clear episode IDs
+            var seasonInfos = await db.DbSeasonInfo
+                .Where(s => s.SeasonId == seasonId)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-            foreach (var info in seasonInfo)
+            foreach (var info in seasonInfos)
             {
                 db.Entry(info).Property(s => s.EpisodeIds).CurrentValue = [];
             }
@@ -225,11 +230,12 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     /// Updates the analyzer actions for the provided season.
     /// </summary>
     /// <param name="request">Update analyzer actions request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>No content.</returns>
     [HttpPost("AnalyzerActions/UpdateSeason")]
-    public async Task<ActionResult> UpdateAnalyzerActions([FromBody] UpdateAnalyzerActionsRequest request)
+    public async Task<ActionResult> UpdateAnalyzerActions([FromBody] UpdateAnalyzerActionsRequest request, CancellationToken cancellationToken = default)
     {
-        await Plugin.Instance!.SetAnalyzerActionAsync(request.Id, request.AnalyzerActions).ConfigureAwait(false);
+        await Plugin.Instance!.SetAnalyzerActionAsync(request.Id, request.AnalyzerActions, cancellationToken).ConfigureAwait(false);
 
         return NoContent();
     }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -181,14 +181,13 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
         {
             using var db = Plugin.CreateDbContext();
 
-            // Batch-load all segments for this season's episodes in a single query
-            var episodeIds = episodes.Select(e => e.EpisodeId).ToArray();
-            var existingSegments = await db.DbSegment
+            // ExecuteDeleteAsync runs a single server-side DELETE and bypasses the change tracker.
+            // This is safe here because the tracked operations below target DbSeasonInfo, not DbSegment.
+            var episodeIds = episodes.Select(e => e.EpisodeId).ToHashSet();
+            await db.DbSegment
                 .Where(s => episodeIds.Contains(s.ItemId))
-                .ToListAsync(cancellationToken)
+                .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
-
-            db.DbSegment.RemoveRange(existingSegments);
 
             if (eraseCache)
             {
@@ -218,6 +217,10 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
             }
 
             return NoContent();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -191,10 +191,11 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
             if (eraseCache)
             {
+                // Cache deletion must run to completion — the DB rows are already gone,
+                // so aborting here would leave orphaned files with no way to clean them up.
                 foreach (var episode in episodes)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await Task.Run(() => FFmpegWrapper.DeleteFingerprintCache(episode.EpisodeId), cancellationToken).ConfigureAwait(false);
+                    await Task.Run(() => FFmpegWrapper.DeleteFingerprintCache(episode.EpisodeId), CancellationToken.None).ConfigureAwait(false);
                 }
             }
 

--- a/IntroSkipper/Data/SeasonQueueSnapshot.cs
+++ b/IntroSkipper/Data/SeasonQueueSnapshot.cs
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Immutable season-scoped snapshot used during queue verification to avoid per-episode database lookups.
+/// </summary>
+/// <param name="EpisodeIdsByMode">Episode identifiers grouped by analysis mode.</param>
+/// <param name="SegmentsByEpisodeId">Existing segments grouped by episode and analysis mode.</param>
+internal sealed record SeasonQueueSnapshot(
+    IReadOnlyDictionary<AnalysisMode, HashSet<Guid>> EpisodeIdsByMode,
+    IReadOnlyDictionary<Guid, IReadOnlyDictionary<AnalysisMode, Segment>> SegmentsByEpisodeId);

--- a/IntroSkipper/Data/SeasonQueueSnapshot.cs
+++ b/IntroSkipper/Data/SeasonQueueSnapshot.cs
@@ -12,5 +12,5 @@ namespace IntroSkipper.Data;
 /// <param name="EpisodeIdsByMode">Episode identifiers grouped by analysis mode.</param>
 /// <param name="SegmentsByEpisodeId">Existing segments grouped by episode and analysis mode.</param>
 internal sealed record SeasonQueueSnapshot(
-    IReadOnlyDictionary<AnalysisMode, HashSet<Guid>> EpisodeIdsByMode,
+    IReadOnlyDictionary<AnalysisMode, IReadOnlySet<Guid>> EpisodeIdsByMode,
     IReadOnlyDictionary<Guid, IReadOnlyDictionary<AnalysisMode, Segment>> SegmentsByEpisodeId);

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -3,9 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using IntroSkipper.Data;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
@@ -19,7 +23,7 @@ namespace IntroSkipper.Db;
 /// </remarks>
 public class IntroSkipperDbContext : DbContext
 {
-    private readonly string _dbPath;
+    private readonly string? _dbPath;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IntroSkipperDbContext"/> class.
@@ -38,9 +42,7 @@ public class IntroSkipperDbContext : DbContext
     /// <param name="options">The options.</param>
     public IntroSkipperDbContext(DbContextOptions<IntroSkipperDbContext> options) : base(options)
     {
-        var folder = Environment.SpecialFolder.LocalApplicationData;
-        var path = Environment.GetFolderPath(folder);
-        _dbPath = System.IO.Path.Join(path, "introskipper.db");
+        _dbPath = null;
         DbSegment = Set<DbSegment>();
         DbSeasonInfo = Set<DbSeasonInfo>();
     }
@@ -58,7 +60,11 @@ public class IntroSkipperDbContext : DbContext
     /// <inheritdoc/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder.UseSqlite($"Data Source={_dbPath}");
+        if (!optionsBuilder.IsConfigured)
+        {
+            optionsBuilder
+                .UseSqlite($"Data Source={_dbPath}");
+        }
     }
 
     /// <inheritdoc/>
@@ -106,59 +112,77 @@ public class IntroSkipperDbContext : DbContext
 
     /// <summary>
     /// Applies any pending migrations to the database.
+    /// Uses synchronous EF Core APIs to avoid sync-over-async deadlock risks.
     /// </summary>
     public void ApplyMigrations()
     {
-        // If database doesn't exist or can't connect, create it with migrations
-        if (!Database.CanConnect())
-        {
-            Database.Migrate();
-            return;
-        }
-
-        // If migrations table exists, apply pending migrations normally
-        if (Database.GetAppliedMigrations().Any())
-        {
-            Database.Migrate();
-            return;
-        }
-
-        // For databases without migration history
-        RebuildDatabase();
+        Database.Migrate();
     }
 
     /// <summary>
-    /// Rebuilds the database while preserving valid segments and season information.
+    /// Asynchronously applies any pending migrations to the database.
     /// </summary>
-    public void RebuildDatabase()
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task ApplyMigrationsAsync(CancellationToken cancellationToken = default)
     {
-        // Backup existing data
-        List<DbSegment> segments = [];
-        List<DbSeasonInfo> seasonInfos = [];
+        await Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+    }
 
+    /// <summary>
+    /// Asynchronously rebuilds the database while attempting to preserve valid segments and season information.
+    /// </summary>
+    /// <param name="contextFactory">Factory delegate to create sibling <see cref="IntroSkipperDbContext"/> instances.</param>
+    /// <param name="forceCleanOnBackupFailure">
+    /// When <c>true</c>, rebuild proceeds with an empty database if the backup read fails.
+    /// When <c>false</c>, the rebuild aborts to avoid data loss.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task RebuildDatabaseAsync(Func<IntroSkipperDbContext> contextFactory, bool forceCleanOnBackupFailure = false, CancellationToken cancellationToken = default)
+    {
+        var segments = new List<DbSegment>();
+        var seasonInfos = new List<DbSeasonInfo>();
+        var backupFailed = false;
+
+        // Best-effort backup — a corrupted DB will fail here, and that's fine.
         try
         {
-            using var db = new IntroSkipperDbContext(_dbPath);
-            segments = [.. db.DbSegment.AsEnumerable().Where(s => s.ToSegment().Valid)];
-            seasonInfos = [.. db.DbSeasonInfo];
+            using var db = contextFactory();
+            segments = await db.DbSegment.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+            segments = [.. segments.Where(s => s.ToSegment().Valid)];
+            seasonInfos = await db.DbSeasonInfo.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // Don't swallow cancellation
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException("Failed to read database data", ex);
+            if (!forceCleanOnBackupFailure)
+            {
+                throw new InvalidOperationException("Failed to back up the existing database before rebuild. Aborting rebuild to avoid data loss.", ex);
+            }
+
+            // Explicit clean-rebuild fallback requested by the caller.
+            backupFailed = true;
         }
-        finally
+
+        if (backupFailed)
         {
-            // Delete old database
-            Database.EnsureDeleted();
-
-            // Create new database with proper migration history
-            Database.Migrate();
+            DeleteDatabaseFiles();
+        }
+        else
+        {
+            await Database.EnsureDeletedAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        // Restore the data
+        await Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+
+        // Restore whatever data was salvaged
         if (segments.Count > 0 || seasonInfos.Count > 0)
         {
-            using var db = new IntroSkipperDbContext(_dbPath);
+            using var db = contextFactory();
             if (segments.Count > 0)
             {
                 db.DbSegment.AddRange(segments);
@@ -169,7 +193,43 @@ public class IntroSkipperDbContext : DbContext
                 db.DbSeasonInfo.AddRange(seasonInfos);
             }
 
-            db.SaveChanges();
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private void DeleteDatabaseFiles()
+    {
+        var dbPath = GetDatabaseFilePath();
+        if (string.IsNullOrEmpty(dbPath))
+        {
+            throw new InvalidOperationException("Cannot delete a database file when the context was created without a configured database path.");
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private string? GetDatabaseFilePath()
+    {
+        if (!string.IsNullOrEmpty(_dbPath))
+        {
+            return _dbPath;
+        }
+
+        var connectionString = Database.GetConnectionString();
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return null;
+        }
+
+        var builder = new SqliteConnectionStringBuilder(connectionString);
+        return builder.DataSource is not (null or "" or ":memory:") ? builder.DataSource : null;
     }
 }

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -157,7 +157,7 @@ public class IntroSkipperDbContext : DbContext
         {
             throw; // Don't swallow cancellation
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is SqliteException or DbUpdateException or JsonException)
         {
             if (!forceCleanOnBackupFailure)
             {
@@ -205,14 +205,30 @@ public class IntroSkipperDbContext : DbContext
             throw new InvalidOperationException("Cannot delete a database file when the context was created without a configured database path.");
         }
 
+        // Close this context's own connection before clearing pools, so nothing holds a lock.
+        Database.CloseConnection();
         SqliteConnection.ClearAllPools();
 
-        foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+        // Attempt to delete all files, collecting failures so one locked file doesn't prevent the rest.
+        List<(string Path, Exception Exception)>? failures = null;
+        foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" }.Where(File.Exists))
         {
-            if (File.Exists(path))
+            try
             {
                 File.Delete(path);
             }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                failures ??= [];
+                failures.Add((path, ex));
+            }
+        }
+
+        if (failures is { Count: > 0 })
+        {
+            throw new AggregateException(
+                $"Failed to delete {failures.Count} database file(s): {string.Join(", ", failures.Select(f => f.Path))}",
+                failures.Select(f => f.Exception));
         }
     }
 

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using IntroSkipper.Data;
@@ -368,13 +369,8 @@ public static partial class FFmpegWrapper
         }
 
         // Print all remaining logs
-        foreach (var kvp in ChromaprintLogs)
+        foreach (var kvp in ChromaprintLogs.Where(kvp => kvp.Key is not "error" and not "version"))
         {
-            if (kvp.Key == "error" || kvp.Key == "version")
-            {
-                continue;
-            }
-
             logs += FormatFFmpegLog(kvp.Key);
         }
 
@@ -739,18 +735,14 @@ public static partial class FFmpegWrapper
     /// <param name="mode">Analysis mode.</param>
     public static void DeleteCacheFiles(AnalysisMode mode)
     {
-        foreach (var filePath in Directory.EnumerateFiles(Plugin.Instance!.FingerprintCachePath))
+        foreach (var filePath in Directory.EnumerateFiles(Plugin.Instance!.FingerprintCachePath)
+            .Where(f => mode == AnalysisMode.Introduction
+                ? !f.Contains("credit", StringComparison.OrdinalIgnoreCase)
+                    && !f.Contains("blackframes", StringComparison.OrdinalIgnoreCase)
+                : f.Contains("credit", StringComparison.OrdinalIgnoreCase)
+                    || f.Contains("blackframes", StringComparison.OrdinalIgnoreCase)))
         {
-            var shouldDelete = (mode == AnalysisMode.Introduction)
-                    ? !filePath.Contains("credit", StringComparison.OrdinalIgnoreCase)
-                    && !filePath.Contains("blackframes", StringComparison.OrdinalIgnoreCase)
-                    : filePath.Contains("credit", StringComparison.OrdinalIgnoreCase)
-                    || filePath.Contains("blackframes", StringComparison.OrdinalIgnoreCase);
-
-            if (shouldDelete)
-            {
-                File.Delete(filePath);
-            }
+            File.Delete(filePath);
         }
     }
 

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -210,10 +210,9 @@ public sealed partial class MediaSegmentsFirstEpisodeFilter(
 
     private static MediaSegmentDto[] FilterSegments(IEnumerable<MediaSegmentDto>? segments)
     {
-        return segments?
-            .Where(segment => segment.Type != MediaSegmentType.Intro)
-            .ToArray()
-            ?? [];
+        return segments is null
+            ? []
+            : [.. segments.Where(segment => segment.Type != MediaSegmentType.Intro)];
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "MediaSegments request missing item id. Route: {RouteValues}")]

--- a/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
+++ b/IntroSkipper/Filters/MediaSegmentsFirstEpisodeFilter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using IntroSkipper.Helper;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
@@ -136,8 +137,7 @@ public sealed partial class MediaSegmentsFirstEpisodeFilter(
 
         // When anime restriction is enabled, only filter anime series
         return episode.Series is Series series &&
-            (series.Tags.Contains("anime", StringComparison.OrdinalIgnoreCase) ||
-            series.Genres.Contains("anime", StringComparison.OrdinalIgnoreCase));
+            SeriesHelper.IsAnime(series);
     }
 
     private static bool IsMediaSegmentsRequest(ResultExecutingContext context)

--- a/IntroSkipper/Helper/SeriesHelper.cs
+++ b/IntroSkipper/Helper/SeriesHelper.cs
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using Jellyfin.Extensions;
+using MediaBrowser.Controller.Entities.TV;
+
+namespace IntroSkipper.Helper;
+
+/// <summary>
+/// Shared helpers for <see cref="Series"/> metadata queries.
+/// </summary>
+internal static class SeriesHelper
+{
+    /// <summary>
+    /// Determines whether a series is tagged or categorised as anime.
+    /// </summary>
+    /// <param name="series">The series to inspect.</param>
+    /// <returns><c>true</c> when the series has an "anime" tag or genre; otherwise <c>false</c>.</returns>
+    internal static bool IsAnime(Series series) =>
+        series.Tags.Contains("anime", StringComparison.OrdinalIgnoreCase) ||
+        series.Genres.Contains("anime", StringComparison.OrdinalIgnoreCase);
+}

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
+using IntroSkipper.Helper;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
@@ -285,8 +286,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
 
         if (pluginInstance.GetItem(episode.SeriesId) is Series series &&
-            (series.Tags.Contains("anime", StringComparison.OrdinalIgnoreCase) ||
-             series.Genres.Contains("anime", StringComparison.OrdinalIgnoreCase)))
+            SeriesHelper.IsAnime(series))
         {
             return QueuedMediaCategory.AnimeEpisode;
         }
@@ -380,8 +380,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// </summary>
     /// <param name="candidates">Queued media items.</param>
     /// <param name="modes">Analysis modes.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Media items that have been verified to exist in Jellyfin and in storage.</returns>
-    internal IReadOnlyList<QueuedEpisode> VerifyQueue(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes)
+    internal async Task<IReadOnlyList<QueuedEpisode>> VerifyQueueAsync(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes, CancellationToken cancellationToken = default)
     {
         if (candidates == null || candidates.Count == 0)
         {
@@ -390,12 +391,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         var verified = new List<QueuedEpisode>(candidates.Count);
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
-        var episodeIds = plugin.GetEpisodeIds(candidates[0].SeasonId);
+        var snapshot = await plugin.GetSeasonQueueSnapshotAsync(candidates[0].SeasonId, [.. candidates.Select(c => c.EpisodeId)], cancellationToken).ConfigureAwait(false);
 
         foreach (var candidate in candidates)
         {
             try
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var path = plugin.GetItemPath(candidate.EpisodeId);
 
                 if (string.IsNullOrEmpty(path) || !File.Exists(path))
@@ -406,19 +408,24 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
                 verified.Add(candidate);
 
-                var hasSegments = plugin.GetTimestamps(candidate.EpisodeId);
-
                 foreach (var mode in modes)
                 {
-                    if (hasSegments.TryGetValue(mode, out var seg))
+                    if (snapshot.SegmentsByEpisodeId.TryGetValue(candidate.EpisodeId, out var hasSegments) &&
+                        hasSegments.TryGetValue(mode, out _))
                     {
                         candidate.SetAnalyzed(mode, EpisodeState.Analyzed);
                     }
-                    else if (!plugin.AnalyzeAgain && episodeIds.TryGetValue(mode, out var ids) && ids.Contains(candidate.EpisodeId))
+                    else if (!plugin.AnalyzeAgain &&
+                             snapshot.EpisodeIdsByMode.TryGetValue(mode, out var ids) &&
+                             ids.Contains(candidate.EpisodeId))
                     {
                         candidate.SetAnalyzed(mode, EpisodeState.NoSegments);
                     }
                 }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -444,8 +451,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     [LoggerMessage(Level = LogLevel.Information, Message = "Running enqueue of items in library {Name}")]
     private static partial void LogRunningEnqueueLibrary(ILogger logger, string name);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to enqueue items from library {Name}: {Exception}")]
-    private static partial void LogFailedEnqueueLibrary(ILogger logger, string name, object exception);
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to enqueue items from library {Name}")]
+    private static partial void LogFailedEnqueueLibrary(ILogger logger, string name, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Refreshed metadata for {Count} episodes with invalid SeasonIds")]
     private static partial void LogRefreshedMetadata(ILogger logger, int count);
@@ -492,6 +499,6 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping {Name} ({Id}): file not found")]
     private static partial void LogSkippingFileNotFound(ILogger logger, string name, Guid id);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping analysis of {Name} ({Id}): {Exception}")]
-    private static partial void LogSkippingAnalysisException(ILogger logger, string name, Guid id, object exception);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping analysis of {Name} ({Id})")]
+    private static partial void LogSkippingAnalysisException(ILogger logger, string name, Guid id, Exception exception);
 }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -91,6 +91,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             {
                 await QueueLibraryContents(folderId, cancellationToken).ConfigureAwait(false);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 LogFailedEnqueueLibrary(_logger, folder.Name, ex);
@@ -182,6 +186,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 {
                     LogItemNotEpisodeOrMovie(_logger, item.Name);
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -148,8 +148,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// Creates a new <see cref="IntroSkipperDbContext"/> instance configured for the plugin database.
     /// </summary>
     /// <returns>A new <see cref="IntroSkipperDbContext"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
     public static IntroSkipperDbContext CreateDbContext()
-        => new(Instance!.DbPath);
+    {
+        ArgumentNullException.ThrowIfNull(Instance);
+        return new IntroSkipperDbContext(Instance.DbPath);
+    }
 
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
@@ -213,9 +217,10 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     internal async Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        db.DbSegment.RemoveRange(db.DbSegment
-            .Where(s => !episodeIds.Contains(s.ItemId)));
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await db.DbSegment
+            .Where(s => !episodeIds.Contains(s.ItemId))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     internal async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
@@ -272,7 +277,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     internal async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var episodeIdArray = episodeIds.Distinct().ToArray();
+        var episodeIdArray = (Guid[])[.. episodeIds.Distinct()];
 
         var seasonInfos = await db.DbSeasonInfo
             .AsNoTracking()
@@ -289,7 +294,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 .ConfigureAwait(false);
 
         return new SeasonQueueSnapshot(
-            seasonInfos.ToDictionary(s => s.Type, s => s.EpisodeIds.ToHashSet()),
+            seasonInfos.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
             segments
                 .GroupBy(s => s.ItemId)
                 .ToDictionary(
@@ -327,11 +332,10 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     internal async Task CleanSeasonInfoAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var obsoleteSeasons = await db.DbSeasonInfo
+        await db.DbSeasonInfo
             .Where(s => !ids.Contains(s.SeasonId))
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-        db.DbSeasonInfo.RemoveRange(obsoleteSeasons);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -6,11 +6,11 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
-using IntroSkipper.Helper;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -85,7 +85,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // Initialize database, restore timestamps if available.
         try
         {
-            using var db = new IntroSkipperDbContext(_dbPath);
+            using var db = CreateDbContext();
             db.ApplyMigrations();
         }
         catch (Exception ex)
@@ -144,6 +144,13 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public static Plugin? Instance { get; private set; }
 
+    /// <summary>
+    /// Creates a new <see cref="IntroSkipperDbContext"/> instance configured for the plugin database.
+    /// </summary>
+    /// <returns>A new <see cref="IntroSkipperDbContext"/>.</returns>
+    public static IntroSkipperDbContext CreateDbContext()
+        => new(Instance!.DbPath);
+
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {
@@ -166,14 +173,14 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id);
 
-    internal async Task UpdateTimestampAsync(Segment segment, AnalysisMode mode)
+    internal async Task UpdateTimestampAsync(Segment segment, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
+        using var db = CreateDbContext();
 
         try
         {
             var existing = await db.DbSegment
-                .FirstOrDefaultAsync(s => s.ItemId == segment.EpisodeId && s.Type == mode)
+                .FirstOrDefaultAsync(s => s.ItemId == segment.EpisodeId && s.Type == mode, cancellationToken)
                 .ConfigureAwait(false);
 
             var dbSegment = new DbSegment(segment, mode);
@@ -186,7 +193,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 db.DbSegment.Add(dbSegment);
             }
 
-            await db.SaveChangesAsync().ConfigureAwait(false);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -195,27 +202,28 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         }
     }
 
-    internal IReadOnlyDictionary<AnalysisMode, Segment> GetTimestamps(Guid id)
+    internal async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
-        return db.DbSegment.Where(s => s.ItemId == id)
-            .ToDictionary(s => s.Type, s => s.ToSegment());
+        using var db = CreateDbContext();
+        return await db.DbSegment.Where(s => s.ItemId == id)
+            .ToDictionaryAsync(s => s.Type, s => s.ToSegment(), cancellationToken)
+            .ConfigureAwait(false);
     }
 
-    internal async Task CleanTimestamps(IEnumerable<Guid> episodeIds)
+    internal async Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
+        using var db = CreateDbContext();
         db.DbSegment.RemoveRange(db.DbSegment
             .Where(s => !episodeIds.Contains(s.ItemId)));
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    internal async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions)
+    internal async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
+        using var db = CreateDbContext();
         var existingEntries = await db.DbSeasonInfo
             .Where(s => s.SeasonId == id)
-            .ToDictionaryAsync(s => s.Type)
+            .ToDictionaryAsync(s => s.Type, cancellationToken)
             .ConfigureAwait(false);
 
         foreach (var (mode, action) in analyzerActions)
@@ -230,13 +238,15 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             }
         }
 
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    internal async Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds)
+    internal async Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
-        var seasonInfo = db.DbSeasonInfo.FirstOrDefault(s => s.SeasonId == id && s.Type == mode);
+        using var db = CreateDbContext();
+        var seasonInfo = await db.DbSeasonInfo
+            .FirstOrDefaultAsync(s => s.SeasonId == id && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
 
         if (seasonInfo is null)
         {
@@ -248,30 +258,80 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             db.Entry(seasonInfo).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
         }
 
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    internal IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>> GetEpisodeIds(Guid id)
+    internal async Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
-        return db.DbSeasonInfo.Where(s => s.SeasonId == id)
-            .ToDictionary(s => s.Type, s => s.EpisodeIds);
+        using var db = CreateDbContext();
+        return await db.DbSeasonInfo.Where(s => s.SeasonId == id)
+            .ToDictionaryAsync(s => s.Type, s => s.EpisodeIds, cancellationToken)
+            .ConfigureAwait(false);
     }
 
-    internal AnalyzerAction GetAnalyzerAction(Guid id, AnalysisMode mode)
+    internal async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
-        return db.DbSeasonInfo.FirstOrDefault(s => s.SeasonId == id && s.Type == mode)?.Action ?? AnalyzerAction.Default;
+        using var db = CreateDbContext();
+        var episodeIdArray = episodeIds.Distinct().ToArray();
+
+        var seasonInfos = await db.DbSeasonInfo
+            .AsNoTracking()
+            .Where(s => s.SeasonId == seasonId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var segments = episodeIdArray.Length == 0
+            ? []
+            : await db.DbSegment
+                .AsNoTracking()
+                .Where(s => episodeIdArray.Contains(s.ItemId))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        return new SeasonQueueSnapshot(
+            seasonInfos.ToDictionary(s => s.Type, s => s.EpisodeIds.ToHashSet()),
+            segments
+                .GroupBy(s => s.ItemId)
+                .ToDictionary(
+                    group => group.Key,
+                    group => (IReadOnlyDictionary<AnalysisMode, Segment>)group.ToDictionary(segment => segment.Type, segment => segment.ToSegment())));
     }
 
-    internal async Task CleanSeasonInfoAsync(IEnumerable<Guid> ids)
+    internal async Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
+        using var db = CreateDbContext();
+        var infos = await db.DbSeasonInfo
+            .Where(s => s.SeasonId == seasonId)
+            .ToDictionaryAsync(s => s.Type, s => s.Action, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Fill in defaults for any missing modes
+        var result = new Dictionary<AnalysisMode, AnalyzerAction>();
+        foreach (var mode in Enum.GetValues<AnalysisMode>())
+        {
+            result[mode] = infos.TryGetValue(mode, out var action) ? action : AnalyzerAction.Default;
+        }
+
+        return result;
+    }
+
+    internal async Task<AnalyzerAction> GetAnalyzerActionAsync(Guid id, AnalysisMode mode, CancellationToken cancellationToken = default)
+    {
+        using var db = CreateDbContext();
+        var info = await db.DbSeasonInfo
+            .FirstOrDefaultAsync(s => s.SeasonId == id && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
+        return info?.Action ?? AnalyzerAction.Default;
+    }
+
+    internal async Task CleanSeasonInfoAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
+    {
+        using var db = CreateDbContext();
         var obsoleteSeasons = await db.DbSeasonInfo
             .Where(s => !ids.Contains(s.SeasonId))
-            .ToListAsync().ConfigureAwait(false);
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
         db.DbSeasonInfo.RemoveRange(obsoleteSeasons);
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
@@ -292,20 +352,21 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     /// <param name="itemId">The item id whose timestamp should be removed.</param>
     /// <param name="mode">The analysis mode representing the segment type.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    internal async Task DeleteTimestampAsync(Guid itemId, AnalysisMode mode)
+    internal async Task DeleteTimestampAsync(Guid itemId, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
-        using var db = new IntroSkipperDbContext(_dbPath);
-        var entry = await db.DbSegment.FirstOrDefaultAsync(s => s.ItemId == itemId && s.Type == mode).ConfigureAwait(false);
+        using var db = CreateDbContext();
+        var entry = await db.DbSegment.FirstOrDefaultAsync(s => s.ItemId == itemId && s.Type == mode, cancellationToken).ConfigureAwait(false);
         if (entry is not null)
         {
             db.DbSegment.Remove(entry);
-            await db.SaveChangesAsync().ConfigureAwait(false);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database: {Exception}")]
-    private static partial void LogDatabaseInitializationError(ILogger logger, object exception);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
+    private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update timestamp for episode {EpisodeId}")]
     private static partial void LogFailedToUpdateTimestamp(ILogger logger, Exception ex, Guid episodeId);

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -37,13 +37,13 @@ namespace IntroSkipper.Providers
         public string Name => Plugin.Instance!.Name;
 
         /// <inheritdoc/>
-        public Task<IReadOnlyList<MediaSegmentDto>> GetMediaSegments(MediaSegmentGenerationRequest request, CancellationToken cancellationToken)
+        public async Task<IReadOnlyList<MediaSegmentDto>> GetMediaSegments(MediaSegmentGenerationRequest request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
             ArgumentNullException.ThrowIfNull(Plugin.Instance);
 
             var segments = new List<MediaSegmentDto>();
-            var itemSegments = Plugin.Instance.GetTimestamps(request.ItemId);
+            var itemSegments = await Plugin.Instance.GetTimestampsAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
 
             foreach (var (mode, type) in _segmentMappings)
             {
@@ -62,7 +62,7 @@ namespace IntroSkipper.Providers
                 }
             }
 
-            return Task.FromResult<IReadOnlyList<MediaSegmentDto>>(segments);
+            return segments;
         }
 
         /// <inheritdoc/>

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -103,7 +103,7 @@ public partial class BaseItemAnalyzerTask(
         {
             var updateMediaSegments = false;
 
-            var episodes = queueManager.VerifyQueue(season.Value, modes);
+            var episodes = await queueManager.VerifyQueueAsync(season.Value, modes, ct).ConfigureAwait(false);
             if (episodes.Count == 0)
             {
                 return;
@@ -192,7 +192,7 @@ public partial class BaseItemAnalyzerTask(
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
-        var action = plugin.GetAnalyzerAction(first.SeasonId, mode);
+        var action = await plugin.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
 
         var chromaprintOnly = _ffmpegValid && _config.PreferChromaprint && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint;
 
@@ -235,7 +235,7 @@ public partial class BaseItemAnalyzerTask(
         }
 
         // Set the episode IDs for the analyzed items
-        await Plugin.Instance!.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId)).ConfigureAwait(false);
+        await Plugin.Instance!.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), cancellationToken).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
     }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -100,7 +100,7 @@ public partial class CleanCacheTask : IScheduledTask
             .SelectMany(episodes => episodes.Select(e => e.EpisodeId))
             .ToHashSet();
 
-        await plugin.CleanTimestamps(enabledLibraryEpisodeIds).ConfigureAwait(false);
+        await plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
 
         // Identify episode IDs with cached files that are no longer in enabled libraries
         var invalidEpisodeIds = Directory.EnumerateFiles(plugin.FingerprintCachePath)
@@ -117,7 +117,7 @@ public partial class CleanCacheTask : IScheduledTask
         }
 
         // Clean up Season information by removing items that are no longer exist.
-        await plugin.CleanSeasonInfoAsync(queue.Keys).ConfigureAwait(false);
+        await plugin.CleanSeasonInfoAsync(queue.Keys, cancellationToken).ConfigureAwait(false);
 
         plugin.AnalyzeAgain = true;
 


### PR DESCRIPTION
Introduce async/cancellation support and refactor DB access: add CreateDbContext helper, convert many Plugin DB methods to async with CancellationToken, replace direct IntroSkipperDbContext construction, and propagate cancellationToken through analyzers, controllers, providers, and scheduled tasks. Add SeasonQueueSnapshot record for batch queue verification and SeriesHelper.IsAnime to centralize anime detection. Rewrite database rebuild/migration logic to use async APIs, best-effort backup/restore, and safe file deletion fallback. Misc: rename/return types for VerifyQueueAsync and other methods to use snapshots and async data access to reduce per-episode DB lookups.

## Summary by Sourcery

Introduce centralized plugin DbContext creation, add async/cancellable database operations throughout the plugin, and optimize queue verification with season-level snapshots to reduce per-episode DB access.

New Features:
- Add SeasonQueueSnapshot data structure to capture season-level episode IDs and segments for queue verification.
- Add SeriesHelper utility to centralize anime detection for series metadata.
- Expose async APIs on the plugin for retrieving timestamps, episode IDs, analyzer actions, and applying database migrations.

Enhancements:
- Refactor direct IntroSkipperDbContext construction to use a shared CreateDbContext helper and safer connection configuration.
- Rewrite database rebuild and migration logic to use async EF Core APIs, best-effort backup/restore, and robust file deletion handling.
- Batch database access in queue verification and season erase flows to minimize repeated per-episode queries.
- Propagate CancellationToken through controllers, analyzers, providers, and tasks to allow cancellation of long-running operations.
- Improve logging signatures for database and enqueue errors by using strongly typed Exception parameters.