### PR TITLE
add sliding window matcher fallback for cold open detection

### DIFF
--- a/IntroSkipper.Tests/TestSlidingWindowMatcher.cs
+++ b/IntroSkipper.Tests/TestSlidingWindowMatcher.cs
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public class TestSlidingWindowMatcher
+{
+    /// <summary>
+    /// Two identical fingerprints must produce a valid match with duration ≥ MinimumIntroDuration.
+    /// </summary>
+    [Fact]
+    public void TestIdenticalFingerprintsMatch()
+    {
+        var fp = GenerateFingerprint(seed: 42, length: 300);
+        var matcher = CreateMatcher();
+
+        var (lhs, rhs) = matcher.FindBestMatch(fp, fp);
+
+        Assert.NotNull(lhs);
+        Assert.NotNull(rhs);
+        Assert.True(lhs.Duration >= 15.0, $"Expected duration ≥ 15s, got {lhs.Duration}");
+    }
+
+    /// <summary>
+    /// Two completely independent random fingerprints have on average ~50% bit difference per XOR,
+    /// which is far above MaximumFingerprintPointDifferences (6 out of 32 bits).
+    /// FindBestMatch must return (null, null).
+    /// </summary>
+    [Fact]
+    public void TestRandomFingerprintsNoMatch()
+    {
+        var lhs = GenerateRandomFingerprint(seed: 1, length: 500);
+        var rhs = GenerateRandomFingerprint(seed: 2, length: 500);
+        var matcher = CreateMatcher();
+
+        var (lhsRange, rhsRange) = matcher.FindBestMatch(lhs, rhs);
+
+        Assert.Null(lhsRange);
+        Assert.Null(rhsRange);
+    }
+
+    /// <summary>
+    /// Core regression test for the cold-open scenario:
+    /// Episode A has a short cold open (150 pts ≈ 18.6s), Episode B has a long cold open
+    /// (480 pts ≈ 59.4s). Both share an identical intro block of 200 pts (≈ 24.8s).
+    /// The sliding window must locate the intro at the correct offset in each fingerprint.
+    /// </summary>
+    [Fact]
+    public void TestVaryingColdOpenAlignment()
+    {
+        // 200 identical intro points shared by both episodes.
+        var introPts = GenerateFingerprint(seed: 99, length: 200);
+
+        // Independent cold opens with different lengths.
+        var coldOpenA = GenerateRandomFingerprint(seed: 10, length: 150);
+        var coldOpenB = GenerateRandomFingerprint(seed: 20, length: 480);
+
+        // Padding after the intro (different content, same length).
+        var restA = GenerateRandomFingerprint(seed: 30, length: 300);
+        var restB = GenerateRandomFingerprint(seed: 40, length: 300);
+
+        var lhsFp = Concat(coldOpenA, introPts, restA);  // total 650 pts
+        var rhsFp = Concat(coldOpenB, introPts, restB);  // total 980 pts
+
+        var matcher = CreateMatcher();
+        var (lhsRange, rhsRange) = matcher.FindBestMatch(lhsFp, rhsFp);
+
+        Assert.NotNull(lhsRange);
+        Assert.NotNull(rhsRange);
+
+        // Expected starts (in seconds): coldOpenA.Length * SamplesToSeconds and coldOpenB.Length * SamplesToSeconds.
+        // Allow ±2 strides of tolerance (default stride ≈ 1.0s).
+        const double samplesToSeconds = 0.1238;
+        var expectedLhsStart = coldOpenA.Length * samplesToSeconds;
+        var expectedRhsStart = coldOpenB.Length * samplesToSeconds;
+
+        Assert.InRange(lhsRange!.Start, expectedLhsStart - 2.0, expectedLhsStart + 2.0);
+        Assert.InRange(rhsRange!.Start, expectedRhsStart - 2.0, expectedRhsStart + 2.0);
+        Assert.True(lhsRange.Duration >= 15.0, $"LHS duration too short: {lhsRange.Duration}");
+        Assert.True(rhsRange.Duration >= 15.0, $"RHS duration too short: {rhsRange.Duration}");
+    }
+
+    /// <summary>
+    /// Fingerprints shorter than MinimumIntroDuration must return (null, null) without throwing.
+    /// </summary>
+    [Fact]
+    public void TestShortFingerprintReturnsNull()
+    {
+        // 50 points ≈ 6.2s, below the default MinimumIntroDuration of 15s (121 pts).
+        var lhs = GenerateFingerprint(seed: 1, length: 50);
+        var rhs = GenerateFingerprint(seed: 2, length: 50);
+        var matcher = CreateMatcher();
+
+        var (lhsRange, rhsRange) = matcher.FindBestMatch(lhs, rhs);
+
+        Assert.Null(lhsRange);
+        Assert.Null(rhsRange);
+    }
+
+    /// <summary>
+    /// When the intro is identical at the very beginning of both fingerprints, the first
+    /// window comparison (lhsStart=0, rhsStart=0) scores 1.0, triggering an early exit
+    /// (EarlyExitScore default 0.9). The resulting range start must snap to 0.
+    /// </summary>
+    [Fact]
+    public void TestEarlyExitAndStartSnapToZero()
+    {
+        var intro = GenerateFingerprint(seed: 7, length: 200);
+        var padding = GenerateRandomFingerprint(seed: 8, length: 600);
+
+        var lhsFp = Concat(intro, padding);
+        var rhsFp = Concat(intro, padding);
+
+        var matcher = CreateMatcher();
+        var (lhsRange, rhsRange) = matcher.FindBestMatch(lhsFp, rhsFp);
+
+        Assert.NotNull(lhsRange);
+        Assert.NotNull(rhsRange);
+
+        // The start-snap-to-zero logic in ChromaprintAnalyzer.CompareEpisodes applies <= 5s;
+        // the SlidingWindowMatcher itself doesn't snap – that is done by the caller.
+        // Here we verify the raw TimeRange is at or near 0.
+        Assert.InRange(lhsRange!.Start, 0.0, 5.0);
+        Assert.InRange(rhsRange!.Start, 0.0, 5.0);
+        Assert.True(lhsRange.Duration >= 15.0);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Generates a deterministic, low-entropy fingerprint where adjacent points differ
+    /// by at most 1–2 bits, simulating real Chromaprint continuity.
+    /// </summary>
+    private static uint[] GenerateFingerprint(int seed, int length)
+    {
+        var rng = new Random(seed);
+        var fp = new uint[length];
+        fp[0] = (uint)rng.Next();
+        for (var i = 1; i < length; i++)
+        {
+            // Flip 1 bit to maintain very high similarity between adjacent points.
+            fp[i] = fp[i - 1] ^ (1u << rng.Next(0, 3));
+        }
+
+        return fp;
+    }
+
+    /// <summary>
+    /// Generates a fully random fingerprint to simulate unrelated audio.
+    /// </summary>
+    private static uint[] GenerateRandomFingerprint(int seed, int length)
+    {
+        var rng = new Random(seed);
+        var fp = new uint[length];
+        for (var i = 0; i < length; i++)
+        {
+            fp[i] = (uint)rng.Next();
+        }
+
+        return fp;
+    }
+
+    private static uint[] Concat(params uint[][] arrays)
+    {
+        var result = new uint[arrays.Sum(a => a.Length)];
+        var offset = 0;
+        foreach (var a in arrays)
+        {
+            a.CopyTo(result, offset);
+            offset += a.Length;
+        }
+
+        return result;
+    }
+
+    private static SlidingWindowMatcher CreateMatcher()
+    {
+        var config = new PluginConfiguration();
+        var logger = new LoggerFactory().CreateLogger<SlidingWindowMatcher>();
+        return new SlidingWindowMatcher(config, logger);
+    }
+}

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -208,6 +208,31 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
 
         LogSharedIntroNotFound(lhsId, rhsId);
 
+        if (_config.SlidingWindowEnabled && lhsPoints.Length > 0 && rhsPoints.Length > 0)
+        {
+            LogSlidingWindowFallback(lhsId, rhsId);
+            var matcher = new SlidingWindowMatcher(_config, _logger);
+            var (lhsRange, rhsRange) = matcher.FindBestMatch(lhsPoints, rhsPoints);
+
+            if (lhsRange is not null && rhsRange is not null)
+            {
+                LogSlidingWindowSuccessful(lhsId, rhsId);
+
+                // Mirror the start-snap-to-zero logic of GetLongestTimeRange.
+                if (lhsRange.Start <= 5)
+                {
+                    lhsRange.Start = 0;
+                }
+
+                if (rhsRange.Start <= 5)
+                {
+                    rhsRange.Start = 0;
+                }
+
+                return (new Segment(lhsId, lhsRange), new Segment(rhsId, rhsRange));
+            }
+        }
+
         return (new Segment(lhsId), new Segment(rhsId));
     }
 
@@ -308,10 +333,36 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
     /// <param name="lhs">First fingerprint to compare.</param>
     /// <param name="rhs">Second fingerprint to compare.</param>
     /// <param name="shiftAmount">Amount to shift one fingerprint by.</param>
+    /// <returns>Matching time ranges for both fingerprints, or empty ranges if no match is found.</returns>
     private (TimeRange Lhs, TimeRange Rhs) FindContiguous(
         uint[] lhs,
         uint[] rhs,
         int shiftAmount)
+        => FindContiguous(
+            lhs,
+            rhs,
+            shiftAmount,
+            _config.MaximumFingerprintPointDifferences,
+            _config.MaximumTimeSkip,
+            _config.MinimumIntroDuration);
+
+    /// <summary>
+    /// Finds the longest contiguous region of similar audio between two fingerprints using the provided shift amount.
+    /// </summary>
+    /// <param name="lhs">First fingerprint to compare.</param>
+    /// <param name="rhs">Second fingerprint to compare.</param>
+    /// <param name="shiftAmount">Amount to shift one fingerprint by.</param>
+    /// <param name="maximumFingerprintPointDifferences">Max bits that may differ per point.</param>
+    /// <param name="maximumTimeSkip">Max gap in seconds within a contiguous match.</param>
+    /// <param name="minimumIntroDuration">Minimum duration in seconds for a valid match.</param>
+    /// <returns>Matching time ranges for both fingerprints, or empty ranges if no match is found.</returns>
+    internal static (TimeRange Lhs, TimeRange Rhs) FindContiguous(
+        uint[] lhs,
+        uint[] rhs,
+        int shiftAmount,
+        int maximumFingerprintPointDifferences,
+        double maximumTimeSkip,
+        double minimumIntroDuration)
     {
         var leftOffset = 0;
         var rightOffset = 0;
@@ -340,7 +391,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
             var diff = lhs[lhsPosition] ^ rhs[rhsPosition];
 
             // If the difference between the samples is small, flag both times as similar.
-            if (CountBits(diff) > _config.MaximumFingerprintPointDifferences)
+            if (CountBits(diff) > maximumFingerprintPointDifferences)
             {
                 continue;
             }
@@ -357,14 +408,14 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
         rhsTimes.Add(double.MaxValue);
 
         // Now that both fingerprints have been compared at this shift, see if there's a contiguous time range.
-        var lContiguous = TimeRangeHelpers.FindContiguous([.. lhsTimes], _config.MaximumTimeSkip);
-        if (lContiguous is null || lContiguous.Duration < _config.MinimumIntroDuration)
+        var lContiguous = TimeRangeHelpers.FindContiguous([.. lhsTimes], maximumTimeSkip);
+        if (lContiguous is null || lContiguous.Duration < minimumIntroDuration)
         {
             return (new TimeRange(), new TimeRange());
         }
 
         // Since LHS had a contiguous time range, RHS must have one also.
-        var rContiguous = TimeRangeHelpers.FindContiguous([.. rhsTimes], _config.MaximumTimeSkip)!;
+        var rContiguous = TimeRangeHelpers.FindContiguous([.. rhsTimes], maximumTimeSkip)!;
         return (lContiguous, rContiguous);
     }
 
@@ -415,4 +466,10 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Unable to find a shared introduction sequence between {LHS} and {RHS}")]
     private partial void LogSharedIntroNotFound(Guid lhs, Guid rhs);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Inverted index found no valid segment for {LHS} vs {RHS}, trying sliding window")]
+    private partial void LogSlidingWindowFallback(Guid lhs, Guid rhs);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Sliding window match successful for {LHS} vs {RHS}")]
+    private partial void LogSlidingWindowSuccessful(Guid lhs, Guid rhs);
 }

--- a/IntroSkipper/Analyzers/SlidingWindowMatcher.cs
+++ b/IntroSkipper/Analyzers/SlidingWindowMatcher.cs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Analyzers;
+
+/// <summary>
+/// Finds shared audio segments between two Chromaprint fingerprints using a coarse-to-fine
+/// sliding window approach. Used as a fallback when the inverted index approach fails,
+/// for example when episodes have cold opens of varying lengths that cause the inverted
+/// index to map fingerprint points to incorrect positions.
+/// </summary>
+public sealed class SlidingWindowMatcher
+{
+    /// <summary>
+    /// Seconds of audio per Chromaprint fingerprint point.
+    /// Must match <see cref="ChromaprintAnalyzer"/>'s constant.
+    /// </summary>
+    private const double SamplesToSeconds = 0.1238;
+
+    private readonly PluginConfiguration _config;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SlidingWindowMatcher"/> class.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="logger">Logger.</param>
+    public SlidingWindowMatcher(PluginConfiguration config, ILogger logger)
+    {
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Finds the best matching pair of windows between two fingerprints by scanning all
+    /// possible start positions at a configurable stride, then refining the best candidate
+    /// with a full contiguous-range search.
+    /// </summary>
+    /// <param name="lhsFingerprint">Left-hand-side fingerprint points.</param>
+    /// <param name="rhsFingerprint">Right-hand-side fingerprint points.</param>
+    /// <returns>
+    /// A matched (Lhs, Rhs) <see cref="TimeRange"/> pair if a shared segment of at least
+    /// <see cref="PluginConfiguration.MinimumIntroDuration"/> seconds is found;
+    /// otherwise <c>(null, null)</c>.
+    /// </returns>
+    public (TimeRange? Lhs, TimeRange? Rhs) FindBestMatch(uint[] lhsFingerprint, uint[] rhsFingerprint)
+    {
+        var stride = Math.Max(1, (int)Math.Round(_config.SlidingWindowStepSeconds / SamplesToSeconds));
+        var minWindow = Math.Max(1, (int)Math.Round(_config.MinimumIntroDuration / SamplesToSeconds));
+
+        if (lhsFingerprint.Length < minWindow || rhsFingerprint.Length < minWindow)
+        {
+            return (null, null);
+        }
+
+        var bestScore = 0.0;
+        var bestLhsStart = -1;
+        var bestRhsStart = -1;
+        var earlyExit = false;
+
+        var lhsLimit = lhsFingerprint.Length - minWindow;
+        var rhsLimit = rhsFingerprint.Length - minWindow;
+
+        for (var lhsStart = 0; lhsStart <= lhsLimit && !earlyExit; lhsStart += stride)
+        {
+            for (var rhsStart = 0; rhsStart <= rhsLimit; rhsStart += stride)
+            {
+                var score = ScoreWindow(lhsFingerprint, lhsStart, rhsFingerprint, rhsStart, minWindow);
+
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    bestLhsStart = lhsStart;
+                    bestRhsStart = rhsStart;
+
+                    if (score >= _config.SlidingWindowEarlyExitScore)
+                    {
+                        earlyExit = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (bestLhsStart < 0)
+        {
+            return (null, null);
+        }
+
+        // Derive the alignment shift and do a full contiguous-range search for precise boundaries.
+        var shift = bestRhsStart - bestLhsStart;
+        var (lhsRange, rhsRange) = ChromaprintAnalyzer.FindContiguous(
+            lhsFingerprint,
+            rhsFingerprint,
+            shift,
+            _config.MaximumFingerprintPointDifferences,
+            _config.MaximumTimeSkip,
+            _config.MinimumIntroDuration);
+
+        if (lhsRange.End == 0 || rhsRange.End == 0)
+        {
+            return (null, null);
+        }
+
+        return (lhsRange, rhsRange);
+    }
+
+    /// <summary>
+    /// Computes the similarity score for a window pair: the fraction of fingerprint points
+    /// within the window that satisfy the bit-difference threshold.
+    /// </summary>
+    private double ScoreWindow(uint[] lhs, int lhsStart, uint[] rhs, int rhsStart, int windowLength)
+    {
+        var upperLimit = Math.Min(windowLength, Math.Min(lhs.Length - lhsStart, rhs.Length - rhsStart));
+
+        if (upperLimit <= 0)
+        {
+            return 0.0;
+        }
+
+        var matches = 0;
+        for (var i = 0; i < upperLimit; i++)
+        {
+            var diff = lhs[lhsStart + i] ^ rhs[rhsStart + i];
+            if (ChromaprintAnalyzer.CountBits(diff) <= _config.MaximumFingerprintPointDifferences)
+            {
+                matches++;
+            }
+        }
+
+        return (double)matches / upperLimit;
+    }
+}

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -291,6 +291,25 @@ public class PluginConfiguration : BasePluginConfiguration
     public int InvertedIndexShift { get; set; } = 2;
 
     /// <summary>
+    /// Gets or sets a value indicating whether the sliding window fallback matcher is enabled.
+    /// When the inverted index approach finds no valid shared segment, the sliding window matcher
+    /// attempts to locate one by scanning all possible start positions in both fingerprints.
+    /// </summary>
+    public bool SlidingWindowEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the step size in seconds for the sliding window coarse scan.
+    /// Smaller values are more accurate but increase scan time quadratically. Default: 1.0s.
+    /// </summary>
+    public double SlidingWindowStepSeconds { get; set; } = 1.0;
+
+    /// <summary>
+    /// Gets or sets the similarity score threshold (0.0–1.0) at which the coarse scan exits early.
+    /// Score is the fraction of window points satisfying MaximumFingerprintPointDifferences.
+    /// </summary>
+    public double SlidingWindowEarlyExitScore { get; set; } = 0.9;
+
+    /// <summary>
     /// Gets or sets the maximum amount of noise (in dB) that is considered silent.
     /// Lowering this number will increase the filter's sensitivity to noise.
     /// </summary>


### PR DESCRIPTION
Adds a new SlidingWindowMatcher class that serves as a fallback when the inverted index approach fails to find valid shared segments. This handles episodes with varying cold open lengths that cause the inverted index to map fingerprint points to incorrect positions. The matcher performs a coarse-to-fine scan of possible window positions, then refines boundaries using the existing FindContiguous logic. Includes three new configuration options: SlidingWindowEnabled, SlidingWindowStepSeconds, and SlidingWindowEarlyExitScore. Also adds comprehensive unit tests.

## Summary by Sourcery

Add a sliding window–based fallback matcher for Chromaprint intro detection and wire it into the analyzer when the inverted index fails to find a shared segment.

New Features:
- Introduce a SlidingWindowMatcher that scans fingerprints with a coarse-to-fine sliding window to detect shared audio segments as a fallback to the inverted index matcher.
- Add configuration options to control the sliding window matcher behavior, including enable/disable, scan step size, and early-exit score threshold.

Enhancements:
- Refactor ChromaprintAnalyzer.FindContiguous to expose a configurable static variant usable by other components such as the sliding window matcher.
- Improve logging around intro matching by recording when the sliding window fallback is used and when it succeeds.

Tests:
- Add unit tests covering sliding window matching behavior, including identical fingerprints, unrelated fingerprints, varying cold-open lengths, short fingerprints, and early-exit snapping behavior.