### PR TITLE
Add SQLite-backed FFmpeg detection cache and migrate legacy files

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -6,9 +6,9 @@ namespace IntroSkipper.Tests;
 using System;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using Xunit;
 
 public sealed class TestCacheOperations
@@ -21,35 +21,47 @@ public sealed class TestCacheOperations
 
         var shouldKeep = new[]
         {
-            Path.Combine(cacheDir, $"{id}-credits-chromaprint-v1"),
-            Path.Combine(cacheDir, $"{id}-credits-blackframes-100.5-v2"),
+            id + "-credits-chromaprint-v1",
+            id + "-credits-blackframes-100.5-v2",
         };
         var shouldDelete = new[]
         {
-            Path.Combine(cacheDir, $"{id}-chromaprint-v1"),
-            Path.Combine(cacheDir, $"{id}-silence-0-30-v3"),
-            Path.Combine(cacheDir, $"{id}-keyframes-0-30-v2"),
-            Path.Combine(cacheDir, $"{id}-blackframes-0-30-v2"),
+            id + "-chromaprint-v1",
+            id + "-silence-0-30-v3",
+            id + "-keyframes-0-30-v2",
+            id + "-blackframes-0-30-v2",
         };
 
-        foreach (var f in shouldKeep.Concat(shouldDelete))
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
+        using (var db = Plugin.CreateCacheDb())
         {
-            File.WriteAllText(f, "x");
+            foreach (var key in shouldKeep)
+            {
+                db.Write(key, [0x01]);
+            }
+
+            foreach (var key in shouldDelete)
+            {
+                db.Write(key, [0x01]);
+            }
         }
 
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new CachingPluginScope(cacheDir, scope.CacheDbPath))
         {
             FFmpegWrapper.DeleteCacheFiles(AnalysisMode.Introduction);
         }
 
-        foreach (var f in shouldDelete)
+        using (var db = Plugin.CreateCacheDb())
         {
-            Assert.False(File.Exists(f), $"{Path.GetFileName(f)} should be deleted");
-        }
+            foreach (var key in shouldDelete)
+            {
+                Assert.False(db.ExistsByKey(key), $"DB row '{key}' should be deleted");
+            }
 
-        foreach (var f in shouldKeep)
-        {
-            Assert.True(File.Exists(f), $"{Path.GetFileName(f)} should be kept");
+            foreach (var key in shouldKeep)
+            {
+                Assert.True(db.ExistsByKey(key), $"DB row '{key}' should be kept");
+            }
         }
     }
 
@@ -61,47 +73,66 @@ public sealed class TestCacheOperations
 
         var shouldKeep = new[]
         {
-            Path.Combine(cacheDir, $"{id}-chromaprint-v1"),
-            Path.Combine(cacheDir, $"{id}-silence-0-30-v3"),
-            Path.Combine(cacheDir, $"{id}-keyframes-0-30-v2"),
-            Path.Combine(cacheDir, $"{id}-blackframes-0-30-v2"),
+            id + "-chromaprint-v1",
+            id + "-silence-0-30-v3",
+            id + "-keyframes-0-30-v2",
+            id + "-blackframes-0-30-v2",
         };
         var shouldDelete = new[]
         {
-            Path.Combine(cacheDir, $"{id}-credits-chromaprint-v1"),
-            Path.Combine(cacheDir, $"{id}-credits-blackframes-100.5-v2"),
+            id + "-credits-chromaprint-v1",
+            id + "-credits-blackframes-100.5-v2",
         };
 
-        foreach (var f in shouldKeep.Concat(shouldDelete))
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
+        using (var db = Plugin.CreateCacheDb())
         {
-            File.WriteAllText(f, "x");
+            foreach (var key in shouldKeep)
+            {
+                db.Write(key, [0x01]);
+            }
+
+            foreach (var key in shouldDelete)
+            {
+                db.Write(key, [0x01]);
+            }
         }
 
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new CachingPluginScope(cacheDir, scope.CacheDbPath))
         {
             FFmpegWrapper.DeleteCacheFiles(AnalysisMode.Credits);
         }
 
-        foreach (var f in shouldDelete)
+        using (var db = Plugin.CreateCacheDb())
         {
-            Assert.False(File.Exists(f), $"{Path.GetFileName(f)} should be deleted");
-        }
+            foreach (var key in shouldDelete)
+            {
+                Assert.False(db.ExistsByKey(key), $"DB row '{key}' should be deleted");
+            }
 
-        foreach (var f in shouldKeep)
-        {
-            Assert.True(File.Exists(f), $"{Path.GetFileName(f)} should be kept");
+            foreach (var key in shouldKeep)
+            {
+                Assert.True(db.ExistsByKey(key), $"DB row '{key}' should be kept");
+            }
         }
     }
 
     [Fact]
-    public void HasCachedFingerprint_ReturnsTrueForBinaryFile()
+    public void HasCachedFingerprint_ReturnsTrueForDbRow()
     {
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid() };
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
-        File.WriteAllText(Path.Combine(cacheDir, episode.EpisodeId.ToString("N") + "-chromaprint-v1"), "x");
 
-        using var _ = new CachingPluginScope(cacheDir);
-        Assert.True(FFmpegWrapper.HasCachedFingerprint(episode, AnalysisMode.Introduction));
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
+        using (var db = Plugin.CreateCacheDb())
+        {
+            db.Write(episode.EpisodeId.ToString("N") + "-chromaprint-v1", [0x01]);
+        }
+
+        using (new CachingPluginScope(cacheDir, scope.CacheDbPath))
+        {
+            Assert.True(FFmpegWrapper.HasCachedFingerprint(episode, AnalysisMode.Introduction));
+        }
     }
 
     [Fact]
@@ -109,7 +140,8 @@ public sealed class TestCacheOperations
     {
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid() };
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
-        // Legacy path: just the episode ID, no suffix
+
+        // Legacy path: just the episode ID, no suffix (text format on disk)
         File.WriteAllText(Path.Combine(cacheDir, episode.EpisodeId.ToString("N")), "x");
 
         using var _ = new CachingPluginScope(cacheDir);
@@ -127,7 +159,7 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void LegacyFingerprintCache_MigratedToBinaryAndDeleted()
+    public void LegacyFingerprintCache_MigratedToDbAndDeleted()
     {
         var episode = new QueuedEpisode
         {
@@ -139,7 +171,7 @@ public sealed class TestCacheOperations
 
         var id = episode.EpisodeId.ToString("N");
         var legacyPath = Path.Combine(cacheDir, id);
-        var binaryPath = Path.Combine(cacheDir, id + "-chromaprint-v1");
+        var dbKey = id + "-chromaprint-v1";
 
         // Write a valid legacy text-format fingerprint (one uint per line)
         uint[] expectedFingerprint = [1234567890u, 987654321u, 42u];
@@ -148,14 +180,77 @@ public sealed class TestCacheOperations
             Array.ConvertAll(expectedFingerprint, v => v.ToString(CultureInfo.InvariantCulture)));
 
         uint[] result;
-        using (new CachingPluginScope(cacheDir))
+        string cacheDbPath;
+        using (var scope = new CachingPluginScope(cacheDir))
         {
+            cacheDbPath = scope.CacheDbPath;
             result = FFmpegWrapper.Fingerprint(episode, AnalysisMode.Introduction);
         }
 
         Assert.False(File.Exists(legacyPath), "Legacy text cache file should be deleted after migration");
-        Assert.True(File.Exists(binaryPath), "Binary cache file should be created");
+
+        // Use DetectionCacheDb directly since Plugin.Instance is no longer set after scope disposal.
+        using var db = new IntroSkipper.Db.DetectionCacheDb(cacheDbPath);
+        Assert.True(db.ExistsByKey(dbKey), "DB row should be created after migration");
+
+        // Verify the fingerprint was correctly round-tripped.
+        var migrated = ReadFingerprintFromDb(db, dbKey);
         Assert.Equal(expectedFingerprint, result);
+        Assert.Equal(expectedFingerprint, migrated);
+    }
+
+    [Fact]
+    public void CorruptLegacyFingerprintCache_DeletedAndReanalyzed()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Path = "/does/not/exist.mkv",
+            IntroFingerprintEnd = 60,
+        };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+
+        var id = episode.EpisodeId.ToString("N");
+        var legacyPath = Path.Combine(cacheDir, id);
+        var dbKey = id + "-chromaprint-v1";
+
+        // Write a corrupt legacy file (binary content, not parseable as uint lines)
+        File.WriteAllBytes(legacyPath, [0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE]);
+
+        string cacheDbPath;
+        using (var scope = new CachingPluginScope(cacheDir))
+        {
+            cacheDbPath = scope.CacheDbPath;
+
+            // Fingerprint() will fail because the path doesn't exist, but that's fine —
+            // we only care that the corrupt legacy file was deleted and no DB row was written.
+            try { FFmpegWrapper.Fingerprint(episode, AnalysisMode.Introduction); }
+            catch (FingerprintException) { }
+        }
+
+        Assert.False(File.Exists(legacyPath), "Corrupt legacy cache file should be deleted");
+
+        using var db = new IntroSkipper.Db.DetectionCacheDb(cacheDbPath);
+        Assert.False(db.ExistsByKey(dbKey), "No DB row should be written for a corrupt legacy file");
+    }
+
+    private static uint[] ReadFingerprintFromDb(IntroSkipper.Db.DetectionCacheDb db, string cacheKey)
+    {
+        if (!db.TryRead(cacheKey, out var data))
+        {
+            return [];
+        }
+
+        using var ms = new MemoryStream(data);
+        using var reader = new System.IO.BinaryReader(ms);
+        var count = reader.ReadInt32();
+        var result = new uint[count];
+        for (var i = 0; i < count; i++)
+        {
+            result[i] = reader.ReadUInt32();
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -165,9 +260,9 @@ public sealed class TestCacheOperations
     {
         private readonly EntrypointTestHelpers.PluginInstanceScope _inner;
 
-        public CachingPluginScope(string cacheDir)
+        public CachingPluginScope(string cacheDir, string? cacheDbPath = null)
         {
-            _inner = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
+            _inner = new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath);
             var plugin = Plugin.Instance;
             if (plugin is not null)
             {
@@ -177,6 +272,8 @@ public sealed class TestCacheOperations
                     new PluginConfiguration { CacheFingerprints = true });
             }
         }
+
+        public string CacheDbPath => _inner.CacheDbPath;
 
         public void Dispose() => _inner.Dispose();
     }

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -170,7 +170,7 @@ public sealed class TestCacheOperations
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
 
         var id = episode.EpisodeId.ToString("N");
-        var legacyPath = Path.Combine(cacheDir, id);
+        var legacyPath = Path.Combine(cacheDir, Path.GetFileName(id));
         var dbKey = id + "-chromaprint-v1";
 
         // Write a valid legacy text-format fingerprint (one uint per line)

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -142,7 +142,7 @@ public sealed class TestCacheOperations
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
 
         // Legacy path: just the episode ID, no suffix (text format on disk)
-        File.WriteAllText(Path.Combine(cacheDir, episode.EpisodeId.ToString("N")), "x");
+        File.WriteAllText(cacheDir + Path.DirectorySeparatorChar + episode.EpisodeId.ToString("N"), "x");
 
         using var _ = new CachingPluginScope(cacheDir);
         Assert.True(FFmpegWrapper.HasCachedFingerprint(episode, AnalysisMode.Introduction));

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -225,7 +225,11 @@ public sealed class TestCacheOperations
             // Fingerprint() will fail because the path doesn't exist, but that's fine —
             // we only care that the corrupt legacy file was deleted and no DB row was written.
             try { FFmpegWrapper.Fingerprint(episode, AnalysisMode.Introduction); }
-            catch (FingerprintException) { }
+            catch (FingerprintException ex)
+            {
+                // Expected in this test for non-existent paths; ignore and verify side effects instead.
+                _ = ex;
+            }
         }
 
         Assert.False(File.Exists(legacyPath), "Corrupt legacy cache file should be deleted");

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -33,17 +33,15 @@ public sealed class TestCacheOperations
         };
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
-        using (var db = Plugin.CreateCacheDb())
+        var db = Plugin.CreateCacheDb();
+        foreach (var key in shouldKeep)
         {
-            foreach (var key in shouldKeep)
-            {
-                db.Write(key, [0x01]);
-            }
+            db.Write(key, [0x01]);
+        }
 
-            foreach (var key in shouldDelete)
-            {
-                db.Write(key, [0x01]);
-            }
+        foreach (var key in shouldDelete)
+        {
+            db.Write(key, [0x01]);
         }
 
         using (new CachingPluginScope(cacheDir, scope.CacheDbPath))
@@ -51,17 +49,15 @@ public sealed class TestCacheOperations
             FFmpegWrapper.DeleteCacheFiles(AnalysisMode.Introduction);
         }
 
-        using (var db = Plugin.CreateCacheDb())
+        db = Plugin.CreateCacheDb();
+        foreach (var key in shouldDelete)
         {
-            foreach (var key in shouldDelete)
-            {
-                Assert.False(db.ExistsByKey(key), $"DB row '{key}' should be deleted");
-            }
+            Assert.False(db.ExistsByKey(key), $"DB row '{key}' should be deleted");
+        }
 
-            foreach (var key in shouldKeep)
-            {
-                Assert.True(db.ExistsByKey(key), $"DB row '{key}' should be kept");
-            }
+        foreach (var key in shouldKeep)
+        {
+            Assert.True(db.ExistsByKey(key), $"DB row '{key}' should be kept");
         }
     }
 
@@ -85,17 +81,15 @@ public sealed class TestCacheOperations
         };
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
-        using (var db = Plugin.CreateCacheDb())
+        var db = Plugin.CreateCacheDb();
+        foreach (var key in shouldKeep)
         {
-            foreach (var key in shouldKeep)
-            {
-                db.Write(key, [0x01]);
-            }
+            db.Write(key, [0x01]);
+        }
 
-            foreach (var key in shouldDelete)
-            {
-                db.Write(key, [0x01]);
-            }
+        foreach (var key in shouldDelete)
+        {
+            db.Write(key, [0x01]);
         }
 
         using (new CachingPluginScope(cacheDir, scope.CacheDbPath))
@@ -103,17 +97,15 @@ public sealed class TestCacheOperations
             FFmpegWrapper.DeleteCacheFiles(AnalysisMode.Credits);
         }
 
-        using (var db = Plugin.CreateCacheDb())
+        db = Plugin.CreateCacheDb();
+        foreach (var key in shouldDelete)
         {
-            foreach (var key in shouldDelete)
-            {
-                Assert.False(db.ExistsByKey(key), $"DB row '{key}' should be deleted");
-            }
+            Assert.False(db.ExistsByKey(key), $"DB row '{key}' should be deleted");
+        }
 
-            foreach (var key in shouldKeep)
-            {
-                Assert.True(db.ExistsByKey(key), $"DB row '{key}' should be kept");
-            }
+        foreach (var key in shouldKeep)
+        {
+            Assert.True(db.ExistsByKey(key), $"DB row '{key}' should be kept");
         }
     }
 
@@ -124,10 +116,7 @@ public sealed class TestCacheOperations
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
-        using (var db = Plugin.CreateCacheDb())
-        {
-            db.Write(episode.EpisodeId.ToString("N") + "-chromaprint-v1", [0x01]);
-        }
+        Plugin.CreateCacheDb().Write(episode.EpisodeId.ToString("N") + "-chromaprint-v1", [0x01]);
 
         using (new CachingPluginScope(cacheDir, scope.CacheDbPath))
         {
@@ -190,7 +179,7 @@ public sealed class TestCacheOperations
         Assert.False(File.Exists(legacyPath), "Legacy text cache file should be deleted after migration");
 
         // Use DetectionCacheDb directly since Plugin.Instance is no longer set after scope disposal.
-        using var db = new IntroSkipper.Db.DetectionCacheDb(cacheDbPath);
+        var db = new IntroSkipper.Db.DetectionCacheDb(cacheDbPath);
         Assert.True(db.ExistsByKey(dbKey), "DB row should be created after migration");
 
         // Verify the fingerprint was correctly round-tripped.
@@ -234,7 +223,7 @@ public sealed class TestCacheOperations
 
         Assert.False(File.Exists(legacyPath), "Corrupt legacy cache file should be deleted");
 
-        using var db = new IntroSkipper.Db.DetectionCacheDb(cacheDbPath);
+        var db = new IntroSkipper.Db.DetectionCacheDb(cacheDbPath);
         Assert.False(db.ExistsByKey(dbKey), "No DB row should be written for a corrupt legacy file");
     }
 

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using Xunit;
+
+public sealed class TestCacheOperations
+{
+    [Fact]
+    public void DeleteCacheFiles_Introduction_DeletesIntroFilesOnly()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+
+        var shouldKeep = new[]
+        {
+            Path.Combine(cacheDir, $"{id}-credits-chromaprint-v1"),
+            Path.Combine(cacheDir, $"{id}-credits-blackframes-100.5-v2"),
+        };
+        var shouldDelete = new[]
+        {
+            Path.Combine(cacheDir, $"{id}-chromaprint-v1"),
+            Path.Combine(cacheDir, $"{id}-silence-0-30-v3"),
+            Path.Combine(cacheDir, $"{id}-keyframes-0-30-v2"),
+            Path.Combine(cacheDir, $"{id}-blackframes-0-30-v2"),
+        };
+
+        foreach (var f in shouldKeep.Concat(shouldDelete))
+        {
+            File.WriteAllText(f, "x");
+        }
+
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        {
+            FFmpegWrapper.DeleteCacheFiles(AnalysisMode.Introduction);
+        }
+
+        foreach (var f in shouldDelete)
+        {
+            Assert.False(File.Exists(f), $"{Path.GetFileName(f)} should be deleted");
+        }
+
+        foreach (var f in shouldKeep)
+        {
+            Assert.True(File.Exists(f), $"{Path.GetFileName(f)} should be kept");
+        }
+    }
+
+    [Fact]
+    public void DeleteCacheFiles_Credits_DeletesCreditsFilesOnly()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+
+        var shouldKeep = new[]
+        {
+            Path.Combine(cacheDir, $"{id}-chromaprint-v1"),
+            Path.Combine(cacheDir, $"{id}-silence-0-30-v3"),
+            Path.Combine(cacheDir, $"{id}-keyframes-0-30-v2"),
+            Path.Combine(cacheDir, $"{id}-blackframes-0-30-v2"),
+        };
+        var shouldDelete = new[]
+        {
+            Path.Combine(cacheDir, $"{id}-credits-chromaprint-v1"),
+            Path.Combine(cacheDir, $"{id}-credits-blackframes-100.5-v2"),
+        };
+
+        foreach (var f in shouldKeep.Concat(shouldDelete))
+        {
+            File.WriteAllText(f, "x");
+        }
+
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        {
+            FFmpegWrapper.DeleteCacheFiles(AnalysisMode.Credits);
+        }
+
+        foreach (var f in shouldDelete)
+        {
+            Assert.False(File.Exists(f), $"{Path.GetFileName(f)} should be deleted");
+        }
+
+        foreach (var f in shouldKeep)
+        {
+            Assert.True(File.Exists(f), $"{Path.GetFileName(f)} should be kept");
+        }
+    }
+
+    [Fact]
+    public void HasCachedFingerprint_ReturnsTrueForBinaryFile()
+    {
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid() };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        File.WriteAllText(Path.Combine(cacheDir, episode.EpisodeId.ToString("N") + "-chromaprint-v1"), "x");
+
+        using var _ = new CachingPluginScope(cacheDir);
+        Assert.True(FFmpegWrapper.HasCachedFingerprint(episode, AnalysisMode.Introduction));
+    }
+
+    [Fact]
+    public void HasCachedFingerprint_ReturnsTrueForLegacyFile()
+    {
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid() };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        // Legacy path: just the episode ID, no suffix
+        File.WriteAllText(Path.Combine(cacheDir, episode.EpisodeId.ToString("N")), "x");
+
+        using var _ = new CachingPluginScope(cacheDir);
+        Assert.True(FFmpegWrapper.HasCachedFingerprint(episode, AnalysisMode.Introduction));
+    }
+
+    [Fact]
+    public void HasCachedFingerprint_ReturnsFalseWhenNoFile()
+    {
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid() };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+
+        using var _ = new CachingPluginScope(cacheDir);
+        Assert.False(FFmpegWrapper.HasCachedFingerprint(episode, AnalysisMode.Introduction));
+    }
+
+    [Fact]
+    public void LegacyFingerprintCache_MigratedToBinaryAndDeleted()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Path = "/does/not/exist.mkv",
+            IntroFingerprintEnd = 60,
+        };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+
+        var id = episode.EpisodeId.ToString("N");
+        var legacyPath = Path.Combine(cacheDir, id);
+        var binaryPath = Path.Combine(cacheDir, id + "-chromaprint-v1");
+
+        // Write a valid legacy text-format fingerprint (one uint per line)
+        uint[] expectedFingerprint = [1234567890u, 987654321u, 42u];
+        File.WriteAllLines(
+            legacyPath,
+            Array.ConvertAll(expectedFingerprint, v => v.ToString(CultureInfo.InvariantCulture)));
+
+        uint[] result;
+        using (new CachingPluginScope(cacheDir))
+        {
+            result = FFmpegWrapper.Fingerprint(episode, AnalysisMode.Introduction);
+        }
+
+        Assert.False(File.Exists(legacyPath), "Legacy text cache file should be deleted after migration");
+        Assert.True(File.Exists(binaryPath), "Binary cache file should be created");
+        Assert.Equal(expectedFingerprint, result);
+    }
+
+    /// <summary>
+    /// Sets up Plugin.Instance with a real cache dir and CacheFingerprints enabled.
+    /// </summary>
+    private sealed class CachingPluginScope : IDisposable
+    {
+        private readonly EntrypointTestHelpers.PluginInstanceScope _inner;
+
+        public CachingPluginScope(string cacheDir)
+        {
+            _inner = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
+            var plugin = Plugin.Instance;
+            if (plugin is not null)
+            {
+                EntrypointTestHelpers.SetPropertyOrField(
+                    plugin,
+                    "Configuration",
+                    new PluginConfiguration { CacheFingerprints = true });
+            }
+        }
+
+        public void Dispose() => _inner.Dispose();
+    }
+}

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using IntroSkipper.ScheduledTasks;
+using Xunit;
+
+public sealed class TestCleanCacheTask
+{
+    private const string Id = "aabbccdd00112233aabbccdd00112233";
+
+    [Theory]
+    [InlineData(Id, null)]
+    [InlineData(Id + "-credits", null)]
+    public void GetMigratedDbKey_TextFormat_ReturnsNull(string filename, string? expected)
+    {
+        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
+    }
+
+    [Theory]
+    [InlineData(Id + "-blackframes-0-v1", Id + "-blackframes-0-v2")]
+    [InlineData(Id + "-blackframes-1-v2", Id + "-blackframes-1-v2")]
+    [InlineData(Id + "-blackframes-0-credits-v1", Id + "-blackframes-0-credits-v2")]
+    public void GetMigratedDbKey_Blackframes(string filename, string expected)
+    {
+        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
+    }
+
+    [Theory]
+    [InlineData(Id + "-silence-0-v2", Id + "-silence-0-v3")]
+    [InlineData(Id + "-silence-1-v3", Id + "-silence-1-v3")]
+    public void GetMigratedDbKey_Silence(string filename, string expected)
+    {
+        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
+    }
+
+    [Theory]
+    [InlineData(Id + "-keyframes-0-v1", Id + "-keyframes-0-v2")]
+    [InlineData(Id + "-keyframes-1-v2", Id + "-keyframes-1-v2")]
+    public void GetMigratedDbKey_Keyframes(string filename, string expected)
+    {
+        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
+    }
+
+    [Theory]
+    [InlineData(Id + "-credits-blackframes-90-alt", Id + "-credits-blackframes-90-v2")]
+    [InlineData(Id + "-blackframes-0-alt", Id + "-blackframes-0-v2")]
+    public void GetMigratedDbKey_AltSuffix_UpgradesToV2(string filename, string expected)
+    {
+        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
+    }
+
+    [Theory]
+    [InlineData(Id + "-chromaprint-v1")]
+    [InlineData(Id + "-credits-chromaprint-v1")]
+    public void GetMigratedDbKey_CurrentFormat_ReturnsUnchanged(string filename)
+    {
+        Assert.Equal(filename, CleanCacheTask.GetMigratedDbKey(filename, Id));
+    }
+}

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -11,49 +11,28 @@ public sealed class TestCleanCacheTask
     private const string Id = "aabbccdd00112233aabbccdd00112233";
 
     [Theory]
-    [InlineData(Id, null)]
-    [InlineData(Id + "-credits", null)]
-    public void GetMigratedDbKey_TextFormat_ReturnsNull(string filename, string? expected)
+    // Text-format (very old) fingerprint files — no usable binary data.
+    [InlineData(Id)]
+    [InlineData(Id + "-credits")]
+    // Stale-format detection files — version bump means format may have changed; delete and repopulate.
+    [InlineData(Id + "-blackframes-0-v1")]
+    [InlineData(Id + "-blackframes-0-credits-v1")]
+    [InlineData(Id + "-silence-0-v2")]
+    [InlineData(Id + "-keyframes-0-v1")]
+    [InlineData(Id + "-credits-blackframes-90-alt")]
+    [InlineData(Id + "-blackframes-0-alt")]
+    public void GetMigratedDbKey_NonMigratable_ReturnsNull(string filename)
     {
-        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
+        Assert.Null(CleanCacheTask.GetMigratedDbKey(filename, Id));
     }
 
     [Theory]
-    [InlineData(Id + "-blackframes-0-v1", Id + "-blackframes-0-v2")]
-    [InlineData(Id + "-blackframes-1-v2", Id + "-blackframes-1-v2")]
-    [InlineData(Id + "-blackframes-0-credits-v1", Id + "-blackframes-0-credits-v2")]
-    public void GetMigratedDbKey_Blackframes(string filename, string expected)
-    {
-        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
-    }
-
-    [Theory]
-    [InlineData(Id + "-silence-0-v2", Id + "-silence-0-v3")]
-    [InlineData(Id + "-silence-1-v3", Id + "-silence-1-v3")]
-    public void GetMigratedDbKey_Silence(string filename, string expected)
-    {
-        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
-    }
-
-    [Theory]
-    [InlineData(Id + "-keyframes-0-v1", Id + "-keyframes-0-v2")]
-    [InlineData(Id + "-keyframes-1-v2", Id + "-keyframes-1-v2")]
-    public void GetMigratedDbKey_Keyframes(string filename, string expected)
-    {
-        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
-    }
-
-    [Theory]
-    [InlineData(Id + "-credits-blackframes-90-alt", Id + "-credits-blackframes-90-v2")]
-    [InlineData(Id + "-blackframes-0-alt", Id + "-blackframes-0-v2")]
-    public void GetMigratedDbKey_AltSuffix_UpgradesToV2(string filename, string expected)
-    {
-        Assert.Equal(expected, CleanCacheTask.GetMigratedDbKey(filename, Id));
-    }
-
-    [Theory]
+    // Current-format files can be raw-copied into the DB as-is.
     [InlineData(Id + "-chromaprint-v1")]
     [InlineData(Id + "-credits-chromaprint-v1")]
+    [InlineData(Id + "-blackframes-1-v2")]
+    [InlineData(Id + "-silence-1-v3")]
+    [InlineData(Id + "-keyframes-1-v2")]
     public void GetMigratedDbKey_CurrentFormat_ReturnsUnchanged(string filename)
     {
         Assert.Equal(filename, CleanCacheTask.GetMigratedDbKey(filename, Id));

--- a/IntroSkipper.Tests/TestDetectionCacheDb.cs
+++ b/IntroSkipper.Tests/TestDetectionCacheDb.cs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.IO;
+using System.Linq;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using Xunit;
+
+public sealed class TestDetectionCacheDb : IDisposable
+{
+    private readonly string _dbPath;
+
+    public TestDetectionCacheDb()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", $"cache-{Guid.NewGuid():N}.db");
+        Directory.CreateDirectory(Path.GetDirectoryName(_dbPath)!);
+        DetectionCacheDb.EnsureSchema(_dbPath);
+    }
+
+    public void Dispose()
+    {
+        foreach (var f in new[] { _dbPath, _dbPath + "-wal", _dbPath + "-shm" })
+        {
+            if (File.Exists(f))
+            {
+                try { File.Delete(f); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void Write_ThenRead_ReturnsSameBlob()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        byte[] payload = [0x01, 0x02, 0x03, 0xFF];
+
+        db.Write("test-key", payload);
+
+        Assert.True(db.TryRead("test-key", out var result));
+        Assert.Equal(payload, result);
+    }
+
+    [Fact]
+    public void TryRead_ReturnsFalse_WhenKeyAbsent()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+
+        Assert.False(db.TryRead("nonexistent-key", out var result));
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Write_OverwritesExistingKey()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        db.Write("overwrite-key", [0x01]);
+        db.Write("overwrite-key", [0x02, 0x03]);
+
+        Assert.True(db.TryRead("overwrite-key", out var result));
+        Assert.Equal(new byte[] { 0x02, 0x03 }, result);
+    }
+
+    [Fact]
+    public void ExistsByKey_ReturnsTrueForExistingKey()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        db.Write("exists-key", [0xAA]);
+
+        Assert.True(db.ExistsByKey("exists-key"));
+    }
+
+    [Fact]
+    public void ExistsByKey_ReturnsFalse_WhenKeyAbsent()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+
+        Assert.False(db.ExistsByKey("missing-key"));
+    }
+
+    [Fact]
+    public void DeleteByEpisodeId_RemovesAllRowsForEpisode()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        var id = Guid.NewGuid();
+        var prefix = id.ToString("N");
+
+        db.Write(prefix + "-chromaprint-v1", [0x01]);
+        db.Write(prefix + "-credits-chromaprint-v1", [0x02]);
+        db.Write(prefix + "-silence-0-30-v3", [0x03]);
+
+        db.DeleteByEpisodeId(id);
+
+        Assert.False(db.ExistsByKey(prefix + "-chromaprint-v1"));
+        Assert.False(db.ExistsByKey(prefix + "-credits-chromaprint-v1"));
+        Assert.False(db.ExistsByKey(prefix + "-silence-0-30-v3"));
+    }
+
+    [Fact]
+    public void DeleteByEpisodeId_DoesNotAffectOtherEpisodes()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        db.Write(id1.ToString("N") + "-chromaprint-v1", [0x01]);
+        db.Write(id2.ToString("N") + "-chromaprint-v1", [0x02]);
+
+        db.DeleteByEpisodeId(id1);
+
+        Assert.False(db.ExistsByKey(id1.ToString("N") + "-chromaprint-v1"));
+        Assert.True(db.ExistsByKey(id2.ToString("N") + "-chromaprint-v1"));
+    }
+
+    [Fact]
+    public void DeleteByMode_Introduction_RemovesNonCreditsRows()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        var prefix = Guid.NewGuid().ToString("N");
+
+        var introKey = prefix + "-chromaprint-v1";
+        var creditsKey = prefix + "-credits-chromaprint-v1";
+
+        db.Write(introKey, [0x01]);
+        db.Write(creditsKey, [0x02]);
+
+        db.DeleteByMode(AnalysisMode.Introduction);
+
+        Assert.False(db.ExistsByKey(introKey), "Intro row should be deleted");
+        Assert.True(db.ExistsByKey(creditsKey), "Credits row should be kept");
+    }
+
+    [Fact]
+    public void DeleteByMode_Credits_RemovesCreditsRows()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        var prefix = Guid.NewGuid().ToString("N");
+
+        var introKey = prefix + "-chromaprint-v1";
+        var creditsKey = prefix + "-credits-chromaprint-v1";
+
+        db.Write(introKey, [0x01]);
+        db.Write(creditsKey, [0x02]);
+
+        db.DeleteByMode(AnalysisMode.Credits);
+
+        Assert.True(db.ExistsByKey(introKey), "Intro row should be kept");
+        Assert.False(db.ExistsByKey(creditsKey), "Credits row should be deleted");
+    }
+
+    [Fact]
+    public void GetAllEpisodeIds_ReturnsDistinctIds()
+    {
+        var db = new DetectionCacheDb(_dbPath);
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+
+        db.Write(id1.ToString("N") + "-chromaprint-v1", [0x01]);
+        db.Write(id1.ToString("N") + "-credits-chromaprint-v1", [0x02]);
+        db.Write(id2.ToString("N") + "-chromaprint-v1", [0x03]);
+
+        var ids = db.GetAllEpisodeIds().ToHashSet();
+
+        Assert.Contains(id1, ids);
+        Assert.Contains(id2, ids);
+        Assert.Equal(2, ids.Count);
+    }
+}

--- a/IntroSkipper.Tests/TestDetectionCacheDb.cs
+++ b/IntroSkipper.Tests/TestDetectionCacheDb.cs
@@ -16,7 +16,7 @@ public sealed class TestDetectionCacheDb : IDisposable
 
     public TestDetectionCacheDb()
     {
-        var baseDir = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
+        var baseDir = Path.Combine(Path.GetTempPath(), Path.GetFileName("IntroSkipper.Tests"));
         var fileName = $"cache-{Guid.NewGuid():N}.db";
         _dbPath = Path.Combine(baseDir, fileName);
         Directory.CreateDirectory(Path.GetDirectoryName(_dbPath)!);

--- a/IntroSkipper.Tests/TestDetectionCacheDb.cs
+++ b/IntroSkipper.Tests/TestDetectionCacheDb.cs
@@ -16,7 +16,8 @@ public sealed class TestDetectionCacheDb : IDisposable
 
     public TestDetectionCacheDb()
     {
-        _dbPath = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", $"cache-{Guid.NewGuid():N}.db");
+        var baseDir = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
+        _dbPath = Path.Combine(baseDir, $"cache-{Guid.NewGuid():N}.db");
         Directory.CreateDirectory(Path.GetDirectoryName(_dbPath)!);
         DetectionCacheDb.EnsureSchema(_dbPath);
     }

--- a/IntroSkipper.Tests/TestDetectionCacheDb.cs
+++ b/IntroSkipper.Tests/TestDetectionCacheDb.cs
@@ -23,22 +23,19 @@ public sealed class TestDetectionCacheDb : IDisposable
 
     public void Dispose()
     {
-        foreach (var f in new[] { _dbPath, _dbPath + "-wal", _dbPath + "-shm" })
+        foreach (var f in new[] { _dbPath, _dbPath + "-wal", _dbPath + "-shm" }.Where(File.Exists))
         {
-            if (File.Exists(f))
+            try
             {
-                try
-                {
-                    File.Delete(f);
-                }
-                catch (IOException)
-                {
-                    // Best-effort cleanup for test database files; ignore I/O errors on delete.
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    // Best-effort cleanup for test database files; ignore permission issues on delete.
-                }
+                File.Delete(f);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup for test database files; ignore I/O errors on delete.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Best-effort cleanup for test database files; ignore permission issues on delete.
             }
         }
     }

--- a/IntroSkipper.Tests/TestDetectionCacheDb.cs
+++ b/IntroSkipper.Tests/TestDetectionCacheDb.cs
@@ -17,7 +17,8 @@ public sealed class TestDetectionCacheDb : IDisposable
     public TestDetectionCacheDb()
     {
         var baseDir = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
-        _dbPath = Path.Combine(baseDir, $"cache-{Guid.NewGuid():N}.db");
+        var fileName = $"cache-{Guid.NewGuid():N}.db";
+        _dbPath = Path.Combine(baseDir, fileName);
         Directory.CreateDirectory(Path.GetDirectoryName(_dbPath)!);
         DetectionCacheDb.EnsureSchema(_dbPath);
     }

--- a/IntroSkipper.Tests/TestDetectionCacheDb.cs
+++ b/IntroSkipper.Tests/TestDetectionCacheDb.cs
@@ -27,7 +27,18 @@ public sealed class TestDetectionCacheDb : IDisposable
         {
             if (File.Exists(f))
             {
-                try { File.Delete(f); } catch { }
+                try
+                {
+                    File.Delete(f);
+                }
+                catch (IOException)
+                {
+                    // Best-effort cleanup for test database files; ignore I/O errors on delete.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Best-effort cleanup for test database files; ignore permission issues on delete.
+                }
             }
         }
     }

--- a/IntroSkipper.Tests/TestDetectionCacheDb.cs
+++ b/IntroSkipper.Tests/TestDetectionCacheDb.cs
@@ -16,7 +16,7 @@ public sealed class TestDetectionCacheDb : IDisposable
 
     public TestDetectionCacheDb()
     {
-        var baseDir = Path.Combine(Path.GetTempPath(), Path.GetFileName("IntroSkipper.Tests"));
+        var baseDir = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
         var fileName = $"cache-{Guid.NewGuid():N}.db";
         _dbPath = Path.Combine(baseDir, fileName);
         Directory.CreateDirectory(Path.GetDirectoryName(_dbPath)!);

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -423,8 +423,9 @@ internal static class EntrypointTestHelpers
         {
             CacheDir = cacheDir;
             // Place the cache DB outside cacheDir to avoid accidental inclusion in legacy file sweeps.
+            var cacheBaseDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "IntroSkipper.Tests");
             CacheDbPath = cacheDbPath ?? System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + "-cache.db");
+                cacheBaseDir, Guid.NewGuid().ToString("N") + "-cache.db");
 
             var instanceProp = typeof(Plugin).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
             Assert.NotNull(instanceProp);

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -423,7 +423,9 @@ internal static class EntrypointTestHelpers
         {
             CacheDir = cacheDir;
             // Place the cache DB outside cacheDir to avoid accidental inclusion in legacy file sweeps.
-            var cacheBaseDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "IntroSkipper.Tests");
+            var cacheBaseDir = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                System.IO.Path.GetFileName("IntroSkipper.Tests"));
             CacheDbPath = cacheDbPath ?? System.IO.Path.Combine(
                 cacheBaseDir, Guid.NewGuid().ToString("N") + "-cache.db");
 

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -419,9 +419,12 @@ internal static class EntrypointTestHelpers
     {
         private readonly Plugin? _original;
 
-        public PluginInstanceScope(string cacheDir)
+        public PluginInstanceScope(string cacheDir, string? cacheDbPath = null)
         {
             CacheDir = cacheDir;
+            // Place the cache DB outside cacheDir to avoid accidental inclusion in legacy file sweeps.
+            CacheDbPath = cacheDbPath ?? System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + "-cache.db");
 
             var instanceProp = typeof(Plugin).GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
             Assert.NotNull(instanceProp);
@@ -433,14 +436,20 @@ internal static class EntrypointTestHelpers
 #pragma warning restore SYSLIB0050
 
             SetPropertyOrField(plugin, "FingerprintCachePath", CacheDir);
+            SetPropertyOrField(plugin, "_cacheDbPath", CacheDbPath);
 
             // Plugin.Instance has a private setter; invoke it via reflection.
             var setter = instanceProp.SetMethod ?? instanceProp.GetSetMethod(nonPublic: true);
             Assert.NotNull(setter);
             setter!.Invoke(null, [plugin]);
+
+            // Ensure the schema exists so tests can write to the cache DB.
+            IntroSkipper.Db.DetectionCacheDb.EnsureSchema(CacheDbPath);
         }
 
         public string CacheDir { get; }
+
+        public string CacheDbPath { get; }
 
         public void Dispose()
         {

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -43,7 +42,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger) : 
         // episodes that still have a fingerprint cache and can be re-analyzed.
         var episodeAnalysisQueue = analysisQueue.Where(e =>
             e.NeedsAnalysis(mode) ||
-            (e.GetAnalyzed(mode) == EpisodeState.Analyzed && File.Exists(FFmpegWrapper.GetFingerprintCachePath(e, mode)))).ToList();
+            (e.GetAnalyzed(mode) == EpisodeState.Analyzed && FFmpegWrapper.HasCachedFingerprint(e, mode))).ToList();
 
         if (analysisQueue.Count <= 1 || episodeAnalysisQueue.All(e => e.GetAnalyzed(mode) == EpisodeState.Analyzed))
         {

--- a/IntroSkipper/AssemblyInfo.cs
+++ b/IntroSkipper/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("IntroSkipper.Tests")]

--- a/IntroSkipper/Db/DetectionCacheDb.cs
+++ b/IntroSkipper/Db/DetectionCacheDb.cs
@@ -13,10 +13,8 @@ namespace IntroSkipper.Db;
 /// Lightweight SQLite key-value store for FFmpeg detection cache blobs.
 /// Uses Microsoft.Data.Sqlite directly; no EF Core overhead.
 /// Each method opens a short-lived connection, consistent with <see cref="IntroSkipperDbContext"/> usage patterns.
-/// Implements <see cref="IDisposable"/> so callers can use <c>using var db = Plugin.CreateCacheDb()</c>;
-/// the actual disposal is a no-op because no long-lived resources are held.
 /// </summary>
-public sealed partial class DetectionCacheDb : IDisposable
+public sealed partial class DetectionCacheDb
 {
     private readonly string _dbPath;
     private readonly ILogger? _logger;
@@ -136,9 +134,10 @@ public sealed partial class DetectionCacheDb : IDisposable
     /// <param name="mode">The analysis mode to delete cache for.</param>
     public void DeleteByMode(AnalysisMode mode)
     {
-        // CacheKey format: {guid32}-{type}-... where credits keys have '-credits-' immediately after the 32-char guid.
-        const string DeleteIntroSql = "DELETE FROM DetectionCache WHERE substr(CacheKey, 33, 9) != '-credits-'";
-        const string DeleteCreditsSql = "DELETE FROM DetectionCache WHERE substr(CacheKey, 33, 9) = '-credits-'";
+        // CacheKey format: {guid32}-{type}-... where credits keys contain '-credits-' after the GUID.
+        // GUIDs are hex-only so '-credits-' can never appear in the GUID portion.
+        const string DeleteIntroSql = "DELETE FROM DetectionCache WHERE CacheKey NOT LIKE '%-credits-%'";
+        const string DeleteCreditsSql = "DELETE FROM DetectionCache WHERE CacheKey LIKE '%-credits-%'";
 
         try
         {
@@ -218,15 +217,6 @@ public sealed partial class DetectionCacheDb : IDisposable
         }
 
         return ids;
-    }
-
-    /// <summary>
-    /// No-op disposal. No long-lived resources are held; each method opens its own connection.
-    /// Provided so callers can use <c>using var db = Plugin.CreateCacheDb()</c>.
-    /// </summary>
-    public void Dispose()
-    {
-        // No resources to release.
     }
 
     private static SqliteConnection OpenConnection(string dbPath)

--- a/IntroSkipper/Db/DetectionCacheDb.cs
+++ b/IntroSkipper/Db/DetectionCacheDb.cs
@@ -240,9 +240,12 @@ public sealed partial class DetectionCacheDb : IDisposable
         var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate");
         connection.Open();
 
-        // Enable WAL mode for better concurrent read performance.
+        // Enable WAL mode for better concurrent read performance,
+        // and set a busy_timeout so parallel writers retry instead of failing immediately.
         using var pragmaCmd = connection.CreateCommand();
         pragmaCmd.CommandText = "PRAGMA journal_mode=WAL;";
+        pragmaCmd.ExecuteNonQuery();
+        pragmaCmd.CommandText = "PRAGMA busy_timeout=5000;";
         pragmaCmd.ExecuteNonQuery();
 
         return connection;

--- a/IntroSkipper/Db/DetectionCacheDb.cs
+++ b/IntroSkipper/Db/DetectionCacheDb.cs
@@ -92,7 +92,7 @@ public sealed partial class DetectionCacheDb : IDisposable
         {
             using var connection = OpenConnection(_dbPath);
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = "INSERT OR REPLACE INTO DetectionCache (CacheKey, Data) VALUES ($key, $data)";
+            cmd.CommandText = "INSERT INTO DetectionCache (CacheKey, Data) VALUES ($key, $data) ON CONFLICT(CacheKey) DO UPDATE SET Data = excluded.Data";
             cmd.Parameters.AddWithValue("$key", cacheKey);
             cmd.Parameters.AddWithValue("$data", data);
             cmd.ExecuteNonQuery();
@@ -136,8 +136,9 @@ public sealed partial class DetectionCacheDb : IDisposable
     /// <param name="mode">The analysis mode to delete cache for.</param>
     public void DeleteByMode(AnalysisMode mode)
     {
-        const string DeleteIntroSql = "DELETE FROM DetectionCache WHERE instr(lower(CacheKey), '-credits') = 0";
-        const string DeleteCreditsSql = "DELETE FROM DetectionCache WHERE instr(lower(CacheKey), '-credits') > 0";
+        // CacheKey format: {guid32}-{type}-... where credits keys have '-credits-' immediately after the 32-char guid.
+        const string DeleteIntroSql = "DELETE FROM DetectionCache WHERE substr(CacheKey, 33, 9) != '-credits-'";
+        const string DeleteCreditsSql = "DELETE FROM DetectionCache WHERE substr(CacheKey, 33, 9) = '-credits-'";
 
         try
         {

--- a/IntroSkipper/Db/DetectionCacheDb.cs
+++ b/IntroSkipper/Db/DetectionCacheDb.cs
@@ -41,14 +41,7 @@ public sealed partial class DetectionCacheDb : IDisposable
     {
         using var connection = OpenConnection(dbPath);
         using var cmd = connection.CreateCommand();
-        cmd.CommandText = """
-            CREATE TABLE IF NOT EXISTS DetectionCache (
-                CacheKey TEXT NOT NULL PRIMARY KEY,
-                Data     BLOB NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS IX_DetectionCache_EpisodePrefix
-                ON DetectionCache (CacheKey);
-            """;
+        cmd.CommandText = "CREATE TABLE IF NOT EXISTS DetectionCache (CacheKey TEXT NOT NULL PRIMARY KEY, Data BLOB NOT NULL);";
         cmd.ExecuteNonQuery();
     }
 
@@ -240,12 +233,11 @@ public sealed partial class DetectionCacheDb : IDisposable
         var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate");
         connection.Open();
 
-        // Enable WAL mode for better concurrent read performance,
-        // and set a busy_timeout so parallel writers retry instead of failing immediately.
+        // Set busy_timeout first so any subsequent PRAGMA (including journal_mode) retries on SQLITE_BUSY.
         using var pragmaCmd = connection.CreateCommand();
-        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL;";
-        pragmaCmd.ExecuteNonQuery();
         pragmaCmd.CommandText = "PRAGMA busy_timeout=5000;";
+        pragmaCmd.ExecuteNonQuery();
+        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL;";
         pragmaCmd.ExecuteNonQuery();
 
         return connection;

--- a/IntroSkipper/Db/DetectionCacheDb.cs
+++ b/IntroSkipper/Db/DetectionCacheDb.cs
@@ -232,14 +232,8 @@ public sealed partial class DetectionCacheDb : IDisposable
     {
         var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate");
         connection.Open();
-
-        // Set busy_timeout first so any subsequent PRAGMA (including journal_mode) retries on SQLITE_BUSY.
         using var pragmaCmd = connection.CreateCommand();
-        pragmaCmd.CommandText = "PRAGMA busy_timeout=5000;";
-        pragmaCmd.ExecuteNonQuery();
-        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL;";
-        pragmaCmd.ExecuteNonQuery();
-
+        SqlitePragmas.Apply(pragmaCmd);
         return connection;
     }
 

--- a/IntroSkipper/Db/DetectionCacheDb.cs
+++ b/IntroSkipper/Db/DetectionCacheDb.cs
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using IntroSkipper.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Lightweight SQLite key-value store for FFmpeg detection cache blobs.
+/// Uses Microsoft.Data.Sqlite directly; no EF Core overhead.
+/// Each method opens a short-lived connection, consistent with <see cref="IntroSkipperDbContext"/> usage patterns.
+/// Implements <see cref="IDisposable"/> so callers can use <c>using var db = Plugin.CreateCacheDb()</c>;
+/// the actual disposal is a no-op because no long-lived resources are held.
+/// </summary>
+public sealed partial class DetectionCacheDb : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly ILogger? _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DetectionCacheDb"/> class.
+    /// </summary>
+    /// <param name="dbPath">Path to the SQLite database file.</param>
+    /// <param name="logger">Optional logger.</param>
+    public DetectionCacheDb(string dbPath, ILogger? logger = null)
+    {
+        _dbPath = dbPath;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Creates the <c>DetectionCache</c> table and index if they do not already exist.
+    /// Call once at plugin startup before any read/write operations.
+    /// </summary>
+    /// <param name="dbPath">Path to the SQLite database file.</param>
+    public static void EnsureSchema(string dbPath)
+    {
+        using var connection = OpenConnection(dbPath);
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS DetectionCache (
+                CacheKey TEXT NOT NULL PRIMARY KEY,
+                Data     BLOB NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS IX_DetectionCache_EpisodePrefix
+                ON DetectionCache (CacheKey);
+            """;
+        cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Tries to read a cache entry by key.
+    /// </summary>
+    /// <param name="cacheKey">The cache key (previously the filename on disk).</param>
+    /// <param name="data">The raw binary payload if found.</param>
+    /// <returns><c>true</c> if the key was found; otherwise <c>false</c>.</returns>
+    public bool TryRead(string cacheKey, out byte[] data)
+    {
+        data = [];
+        try
+        {
+            using var connection = OpenConnection(_dbPath);
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT Data FROM DetectionCache WHERE CacheKey = $key";
+            cmd.Parameters.AddWithValue("$key", cacheKey);
+
+            using var reader = cmd.ExecuteReader();
+            if (!reader.Read())
+            {
+                return false;
+            }
+
+            data = (byte[])reader["Data"];
+            return true;
+        }
+        catch (SqliteException ex)
+        {
+            if (_logger is { } logger)
+            {
+                LogReadError(logger, ex, cacheKey);
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Writes (or overwrites) a cache entry.
+    /// </summary>
+    /// <param name="cacheKey">The cache key.</param>
+    /// <param name="data">The raw binary payload to store.</param>
+    public void Write(string cacheKey, byte[] data)
+    {
+        try
+        {
+            using var connection = OpenConnection(_dbPath);
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT OR REPLACE INTO DetectionCache (CacheKey, Data) VALUES ($key, $data)";
+            cmd.Parameters.AddWithValue("$key", cacheKey);
+            cmd.Parameters.AddWithValue("$data", data);
+            cmd.ExecuteNonQuery();
+        }
+        catch (SqliteException ex)
+        {
+            if (_logger is { } logger)
+            {
+                LogWriteError(logger, ex, cacheKey);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes all cache entries whose key starts with the given episode ID prefix.
+    /// </summary>
+    /// <param name="episodeId">The episode GUID.</param>
+    public void DeleteByEpisodeId(Guid episodeId)
+    {
+        try
+        {
+            using var connection = OpenConnection(_dbPath);
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "DELETE FROM DetectionCache WHERE CacheKey LIKE $prefix";
+            cmd.Parameters.AddWithValue("$prefix", episodeId.ToString("N") + "%");
+            cmd.ExecuteNonQuery();
+        }
+        catch (SqliteException ex)
+        {
+            if (_logger is { } logger)
+            {
+                LogDeleteError(logger, ex, episodeId.ToString("N"));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes cache entries matching the given analysis mode.
+    /// Introduction mode deletes all non-credits entries; Credits mode deletes all credits entries.
+    /// </summary>
+    /// <param name="mode">The analysis mode to delete cache for.</param>
+    public void DeleteByMode(AnalysisMode mode)
+    {
+        const string DeleteIntroSql = "DELETE FROM DetectionCache WHERE instr(lower(CacheKey), '-credits') = 0";
+        const string DeleteCreditsSql = "DELETE FROM DetectionCache WHERE instr(lower(CacheKey), '-credits') > 0";
+
+        try
+        {
+            using var connection = OpenConnection(_dbPath);
+            using var cmd = connection.CreateCommand();
+#pragma warning disable CA2100 // SQL comes from compile-time constants, not user input.
+            cmd.CommandText = mode == AnalysisMode.Introduction ? DeleteIntroSql : DeleteCreditsSql;
+#pragma warning restore CA2100
+            cmd.ExecuteNonQuery();
+        }
+        catch (SqliteException ex)
+        {
+            if (_logger is { } logger)
+            {
+                LogDeleteModeError(logger, ex, mode);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if a cache entry with the given key exists.
+    /// </summary>
+    /// <param name="cacheKey">The cache key to check.</param>
+    /// <returns><c>true</c> if the key exists in the database.</returns>
+    public bool ExistsByKey(string cacheKey)
+    {
+        try
+        {
+            using var connection = OpenConnection(_dbPath);
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT EXISTS(SELECT 1 FROM DetectionCache WHERE CacheKey = $key)";
+            cmd.Parameters.AddWithValue("$key", cacheKey);
+            return Convert.ToInt64(cmd.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture) == 1;
+        }
+        catch (SqliteException ex)
+        {
+            if (_logger is { } logger)
+            {
+                LogReadError(logger, ex, cacheKey);
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns the distinct episode GUIDs of all entries currently stored in the cache.
+    /// </summary>
+    /// <returns>An enumerable of episode GUIDs.</returns>
+    public IEnumerable<Guid> GetAllEpisodeIds()
+    {
+        var ids = new List<Guid>();
+        try
+        {
+            using var connection = OpenConnection(_dbPath);
+            using var cmd = connection.CreateCommand();
+
+            // First 32 chars of each CacheKey are the guid formatted as "N" (no hyphens).
+            cmd.CommandText = "SELECT DISTINCT substr(CacheKey, 1, 32) FROM DetectionCache";
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                var raw = reader.GetString(0);
+                if (Guid.TryParseExact(raw, "N", out var id))
+                {
+                    ids.Add(id);
+                }
+            }
+        }
+        catch (SqliteException ex)
+        {
+            if (_logger is { } logger)
+            {
+                LogReadAllError(logger, ex);
+            }
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// No-op disposal. No long-lived resources are held; each method opens its own connection.
+    /// Provided so callers can use <c>using var db = Plugin.CreateCacheDb()</c>.
+    /// </summary>
+    public void Dispose()
+    {
+        // No resources to release.
+    }
+
+    private static SqliteConnection OpenConnection(string dbPath)
+    {
+        var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadWriteCreate");
+        connection.Open();
+
+        // Enable WAL mode for better concurrent read performance.
+        using var pragmaCmd = connection.CreateCommand();
+        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL;";
+        pragmaCmd.ExecuteNonQuery();
+
+        return connection;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to read detection cache entry '{CacheKey}'")]
+    private static partial void LogReadError(ILogger logger, Exception ex, string cacheKey);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to write detection cache entry '{CacheKey}'")]
+    private static partial void LogWriteError(ILogger logger, Exception ex, string cacheKey);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete detection cache entries for episode '{EpisodeId}'")]
+    private static partial void LogDeleteError(ILogger logger, Exception ex, string episodeId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete detection cache entries for mode {Mode}")]
+    private static partial void LogDeleteModeError(ILogger logger, Exception ex, AnalysisMode mode);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to enumerate detection cache episode IDs")]
+    private static partial void LogReadAllError(ILogger logger, Exception ex);
+}

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -274,19 +274,13 @@ public class IntroSkipperDbContext : DbContext
         public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
         {
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = "PRAGMA busy_timeout=5000;";
-            cmd.ExecuteNonQuery();
-            cmd.CommandText = "PRAGMA journal_mode=WAL;";
-            cmd.ExecuteNonQuery();
+            SqlitePragmas.Apply(cmd);
         }
 
         public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
         {
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = "PRAGMA busy_timeout=5000;";
-            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            cmd.CommandText = "PRAGMA journal_mode=WAL;";
-            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await SqlitePragmas.ApplyAsync(cmd, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -14,6 +15,7 @@ using IntroSkipper.Data;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace IntroSkipper.Db;
 
@@ -65,7 +67,8 @@ public class IntroSkipperDbContext : DbContext
         if (!optionsBuilder.IsConfigured)
         {
             optionsBuilder
-                .UseSqlite($"Data Source={_dbPath}");
+                .UseSqlite($"Data Source={_dbPath}")
+                .AddInterceptors(new SqlitePragmaInterceptor());
         }
     }
 
@@ -264,5 +267,26 @@ public class IntroSkipperDbContext : DbContext
 
         var builder = new SqliteConnectionStringBuilder(connectionString);
         return builder.DataSource is not (null or "" or ":memory:") ? builder.DataSource : null;
+    }
+
+    private sealed class SqlitePragmaInterceptor : DbConnectionInterceptor
+    {
+        public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "PRAGMA journal_mode=WAL;";
+            cmd.ExecuteNonQuery();
+            cmd.CommandText = "PRAGMA busy_timeout=5000;";
+            cmd.ExecuteNonQuery();
+        }
+
+        public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "PRAGMA journal_mode=WAL;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            cmd.CommandText = "PRAGMA busy_timeout=5000;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -274,18 +274,18 @@ public class IntroSkipperDbContext : DbContext
         public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
         {
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = "PRAGMA journal_mode=WAL;";
-            cmd.ExecuteNonQuery();
             cmd.CommandText = "PRAGMA busy_timeout=5000;";
+            cmd.ExecuteNonQuery();
+            cmd.CommandText = "PRAGMA journal_mode=WAL;";
             cmd.ExecuteNonQuery();
         }
 
         public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
         {
             using var cmd = connection.CreateCommand();
-            cmd.CommandText = "PRAGMA journal_mode=WAL;";
-            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             cmd.CommandText = "PRAGMA busy_timeout=5000;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            cmd.CommandText = "PRAGMA journal_mode=WAL;";
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
     }

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -274,13 +274,27 @@ public class IntroSkipperDbContext : DbContext
         public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
         {
             using var cmd = connection.CreateCommand();
-            SqlitePragmas.Apply(cmd);
+            try
+            {
+                SqlitePragmas.Apply(cmd);
+            }
+            catch (SqliteException)
+            {
+                // Fall back to SQLite defaults when optional pragmas such as WAL cannot be applied.
+            }
         }
 
         public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
         {
             using var cmd = connection.CreateCommand();
-            await SqlitePragmas.ApplyAsync(cmd, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await SqlitePragmas.ApplyAsync(cmd, cancellationToken).ConfigureAwait(false);
+            }
+            catch (SqliteException)
+            {
+                // Fall back to SQLite defaults when optional pragmas such as WAL cannot be applied.
+            }
         }
     }
 }

--- a/IntroSkipper/Db/SqlitePragmas.cs
+++ b/IntroSkipper/Db/SqlitePragmas.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Shared PRAGMA configuration applied to every SQLite connection on open.
+/// Used by both <see cref="DetectionCacheDb"/> (raw ADO.NET) and the
+/// <c>SqlitePragmaInterceptor</c> inside <see cref="IntroSkipperDbContext"/> (EF Core).
+/// </summary>
+internal static class SqlitePragmas
+{
+    internal static void Apply(DbCommand cmd)
+    {
+        // busy_timeout must be set before journal_mode=WAL: changing WAL mode
+        // requires an exclusive lock, so the timeout must already be in place.
+        cmd.CommandText = "PRAGMA busy_timeout=5000;";
+        cmd.ExecuteNonQuery();
+        cmd.CommandText = "PRAGMA journal_mode=WAL;";
+        cmd.ExecuteNonQuery();
+    }
+
+    internal static async Task ApplyAsync(DbCommand cmd, CancellationToken cancellationToken = default)
+    {
+        cmd.CommandText = "PRAGMA busy_timeout=5000;";
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        cmd.CommandText = "PRAGMA journal_mode=WAL;";
+        await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -992,7 +992,14 @@ public static partial class FFmpegWrapper
                     }
 
                     dbWriter(newCacheKey, items);
-                    File.Delete(legacyBinaryPath);
+                    using (var cacheDb = Plugin.CreateCacheDb())
+                    {
+                        if (cacheDb.ExistsByKey(newCacheKey))
+                        {
+                            File.Delete(legacyBinaryPath);
+                        }
+                    }
+
                     result = items;
                     return true;
                 }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -937,8 +937,18 @@ public static partial class FFmpegWrapper
                 }
                 else
                 {
-                    // Empty binary file — delete it and fall through to Phase 2.
-                    File.Delete(legacyBinaryPath);
+                    // Empty binary file — best-effort delete and fall through to Phase 2.
+                    try
+                    {
+                        File.Delete(legacyBinaryPath);
+                    }
+                    catch (IOException deleteEx)
+                    {
+                        if (Logger is { } migLogger)
+                        {
+                            LogFailedToDeleteCorruptLegacyCache(migLogger, deleteEx, legacyBinaryPath);
+                        }
+                    }
                 }
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or EndOfStreamException)

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -340,6 +340,7 @@ public static partial class FFmpegWrapper
 
             var ptsTimeStr = line[(ptsIndex + 9)..].Split(' ', 2)[0];
 
+            // AllowThousands is required by the four-parameter overload; FFmpeg never emits thousands separators.
             if (double.TryParse(ptsTimeStr, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double timestamp))
             {
                 keyframes.Add(timestamp + rangeStart);
@@ -772,10 +773,11 @@ public static partial class FFmpegWrapper
     {
         foreach (var filePath in Directory.EnumerateFiles(Plugin.Instance!.FingerprintCachePath)
             .Where(f => mode == AnalysisMode.Introduction
-                ? !f.Contains("credit", StringComparison.OrdinalIgnoreCase)
-                    && !f.Contains("blackframes", StringComparison.OrdinalIgnoreCase)
-                : f.Contains("credit", StringComparison.OrdinalIgnoreCase)
-                    || f.Contains("blackframes", StringComparison.OrdinalIgnoreCase)))
+                ? Path.GetFileName(f).Contains("-chromaprint-", StringComparison.OrdinalIgnoreCase)
+                    || Path.GetFileName(f).Contains("-silence-", StringComparison.OrdinalIgnoreCase)
+                    || Path.GetFileName(f).Contains("-keyframes-", StringComparison.OrdinalIgnoreCase)
+                : Path.GetFileName(f).Contains("-credits-", StringComparison.OrdinalIgnoreCase)
+                    || Path.GetFileName(f).Contains("-blackframes-", StringComparison.OrdinalIgnoreCase)))
         {
             File.Delete(filePath);
         }
@@ -825,10 +827,13 @@ public static partial class FFmpegWrapper
         var result = new List<uint>(lines.Length);
         foreach (var line in lines)
         {
-            if (uint.TryParse(line, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            if (!uint.TryParse(line, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
             {
-                result.Add(value);
+                // Any invalid entry means the file is corrupt — abort so FFmpeg re-analyzes.
+                return [];
             }
+
+            result.Add(value);
         }
 
         return [.. result];
@@ -951,7 +956,13 @@ public static partial class FFmpegWrapper
             }
 
             binaryWriter(newCacheKey, result);
-            File.Delete(legacyPath);
+
+            // Only delete the legacy file if the new binary cache was actually written.
+            if (File.Exists(GetDetectionCachePath(newCacheKey)))
+            {
+                File.Delete(legacyPath);
+            }
+
             return true;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -40,6 +40,12 @@ public static partial class FFmpegWrapper
 
     private static Dictionary<string, string> ChromaprintLogs { get; set; } = [];
 
+    private static bool IsCachingEnabled()
+        => Plugin.Instance?.Configuration.CacheFingerprints ?? false;
+
+    private static string GetDetectionCachePath(string cacheKey)
+        => Path.Join(Plugin.Instance!.FingerprintCachePath, cacheKey);
+
     /// <summary>
     /// Check that the installed version of ffmpeg supports chromaprint.
     /// </summary>
@@ -165,16 +171,25 @@ public static partial class FFmpegWrapper
             "-f", "null", "-",
         };
 
-        // Cache the output of this command to "GUID-intro-silence-v2"
         var cacheKey = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}-silence-{1}-{2}-v3",
+            episode.EpisodeId.ToString("N"),
+            range.Start,
+            range.End);
+
+        var legacyCacheKey = string.Format(
             CultureInfo.InvariantCulture,
             "{0}-silence-{1}-{2}-v2",
             episode.EpisodeId.ToString("N"),
             range.Start,
             range.End);
 
-        var currentRange = new TimeRange();
-        var silenceRanges = new List<TimeRange>();
+        if (ReadSilenceCache(cacheKey, out var cached) ||
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, raw => ParseSilenceRaw(raw, range.Start), WriteSilenceCache, out cached))
+        {
+            return cached;
+        }
 
         /* Each match will have a type (either "start" or "end") and a timecode (a double).
          *
@@ -182,24 +197,11 @@ public static partial class FFmpegWrapper
          * [silencedetect @ 0x000000000000] silence_start: 12.34
          * [silencedetect @ 0x000000000000] silence_end: 56.123 | silence_duration: 43.783
         */
-        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, true));
-        foreach (Match match in _silenceDetectionExpression.Matches(raw))
-        {
-            var isStart = match.Groups["type"].Value == "start";
-            var time = Convert.ToDouble(match.Groups["time"].Value, CultureInfo.InvariantCulture);
+        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, true));
+        var result = ParseSilenceRaw(raw, range.Start);
+        WriteSilenceCache(cacheKey, result);
 
-            if (isStart)
-            {
-                currentRange.Start = time + range.Start;
-            }
-            else
-            {
-                currentRange.End = time + range.Start;
-                silenceRanges.Add(new TimeRange(currentRange));
-            }
-        }
-
-        return [.. silenceRanges];
+        return result;
     }
 
     /// <summary>
@@ -227,17 +229,31 @@ public static partial class FFmpegWrapper
             "-f", "null", "-",
         };
 
-        // Cache the results to GUID-blackframes-START-END-v1.
         var cacheKey = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}-blackframes-{1}-{2}-v2",
+            episode.EpisodeId.ToString("N"),
+            range.Start,
+            range.End);
+
+        var legacyCacheKey = string.Format(
             CultureInfo.InvariantCulture,
             "{0}-blackframes-{1}-{2}-v1",
             episode.EpisodeId.ToString("N"),
             range.Start,
             range.End);
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, true));
+        if (ReadBlackFrameCache(cacheKey, out var cached) ||
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, static raw => ParseBlackFrame(raw), WriteBlackFrameCache, out cached))
+        {
+            return cached.Where(bf => bf.Percentage >= minimum).ToArray();
+        }
 
-        return ParseBlackFrame(raw, minimum);
+        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, true));
+        var allFrames = ParseBlackFrame(raw);
+        WriteBlackFrameCache(cacheKey, allFrames);
+
+        return allFrames.Where(bf => bf.Percentage >= minimum).ToArray();
     }
 
     /// <summary>
@@ -261,19 +277,86 @@ public static partial class FFmpegWrapper
             "-f", "null", "-",
         };
 
-        // Cache the results to GUID-blackframes-START-END-v1.
         var cacheKey = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}-blackframes-{1}-alt-v2",
+            episode.EpisodeId.ToString("N"),
+            episode.CreditsFingerprintStart);
+
+        var legacyCacheKey = string.Format(
             CultureInfo.InvariantCulture,
             "{0}-blackframes-{1}-alt",
             episode.EpisodeId.ToString("N"),
             episode.CreditsFingerprintStart);
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, true));
+        if (ReadBlackFrameCache(cacheKey, out var cached) ||
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, static raw => ParseBlackFrame(raw), WriteBlackFrameCache, out cached))
+        {
+            return cached;
+        }
 
-        return ParseBlackFrame(raw);
+        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, true));
+        var allFrames = ParseBlackFrame(raw);
+        WriteBlackFrameCache(cacheKey, allFrames);
+
+        return allFrames;
     }
 
-    private static BlackFrame[] ParseBlackFrame(string raw, int minimum = 0)
+    private static TimeRange[] ParseSilenceRaw(string raw, double rangeStart)
+    {
+        var currentRange = new TimeRange();
+        var silenceRanges = new List<TimeRange>();
+
+        foreach (Match match in _silenceDetectionExpression.Matches(raw))
+        {
+            var isStart = match.Groups["type"].Value == "start";
+            var time = Convert.ToDouble(match.Groups["time"].Value, CultureInfo.InvariantCulture);
+
+            if (isStart)
+            {
+                currentRange.Start = time + rangeStart;
+            }
+            else
+            {
+                currentRange.End = time + rangeStart;
+                silenceRanges.Add(new TimeRange(currentRange));
+            }
+        }
+
+        return [.. silenceRanges];
+    }
+
+    private static double[] ParseKeyFramesRaw(string raw, double rangeStart)
+    {
+        var keyframes = new List<double>();
+
+        foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var ptsIndex = line.IndexOf("pts_time:", StringComparison.OrdinalIgnoreCase);
+            if (ptsIndex == -1)
+            {
+                continue;
+            }
+
+            var ptsTimeStr = line[(ptsIndex + 9)..].Split(' ', 2)[0];
+
+            if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out double timestamp))
+            {
+                keyframes.Add(timestamp + rangeStart);
+            }
+            else
+            {
+                if (Logger is { } parseLogger)
+                {
+                    LogFailedToParseTimestamp(parseLogger, ptsTimeStr, line);
+                }
+            }
+        }
+
+        return [.. keyframes];
+    }
+
+    private static BlackFrame[] ParseBlackFrame(string raw)
     {
         var blackFrames = new List<BlackFrame>();
         /* Run the blackframe filter.
@@ -294,12 +377,7 @@ public static partial class FFmpegWrapper
             var percentage = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
             var time = double.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture);
 
-            var bf = new BlackFrame(percentage, time, frame);
-
-            if (bf.Percentage >= minimum)
-            {
-                blackFrames.Add(bf);
-            }
+            blackFrames.Add(new BlackFrame(percentage, time, frame));
         }
 
         return [.. blackFrames];
@@ -326,38 +404,29 @@ public static partial class FFmpegWrapper
 
         var cacheKey = string.Format(
             CultureInfo.InvariantCulture,
+            "{0}-keyframes-{1}-{2}-v2",
+            episode.EpisodeId.ToString("N"),
+            range.Start,
+            range.End);
+
+        var legacyCacheKey = string.Format(
+            CultureInfo.InvariantCulture,
             "{0}-keyframes-{1}-{2}-v1",
             episode.EpisodeId.ToString("N"),
             range.Start,
             range.End);
 
-        var keyframes = new List<double>();
-        var raw = Encoding.UTF8.GetString(GetOutput(args, cacheKey, stderr: true));
-
-        foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        if (ReadKeyFrameCache(cacheKey, out var cached) ||
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, raw => ParseKeyFramesRaw(raw, range.Start), WriteKeyFrameCache, out cached))
         {
-            var ptsIndex = line.IndexOf("pts_time:", StringComparison.OrdinalIgnoreCase);
-            if (ptsIndex == -1)
-            {
-                continue;
-            }
-
-            var ptsTimeStr = line[(ptsIndex + 9)..].Split(' ', 2)[0];
-
-            if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out double timestamp))
-            {
-                keyframes.Add(timestamp + range.Start);
-            }
-            else
-            {
-                if (Logger is { } parseLogger)
-                {
-                    LogFailedToParseTimestamp(parseLogger, ptsTimeStr, line);
-                }
-            }
+            return cached;
         }
 
-        return [.. keyframes];
+        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, stderr: true));
+        var result = ParseKeyFramesRaw(raw, range.Start);
+        WriteKeyFrameCache(cacheKey, result);
+
+        return result;
     }
 
     /// <summary>
@@ -458,7 +527,7 @@ public static partial class FFmpegWrapper
         var logLevel = useInfoLevel ? "info" : "warning";
 
         var cacheOutput =
-            (Plugin.Instance?.Configuration.CacheFingerprints ?? false) &&
+            IsCachingEnabled() &&
             !string.IsNullOrEmpty(cacheFilename);
 
         // If caching is enabled, try to load the output of this command from the cached file.
@@ -640,7 +709,7 @@ public static partial class FFmpegWrapper
         fingerprint = [];
 
         // If fingerprint caching isn't enabled, don't try to load anything.
-        if (!(Plugin.Instance?.Configuration.CacheFingerprints ?? false))
+        if (!IsCachingEnabled())
         {
             return false;
         }
@@ -713,7 +782,7 @@ public static partial class FFmpegWrapper
         List<uint> fingerprint)
     {
         // Bail out if caching isn't enabled.
-        if (!(Plugin.Instance?.Configuration.CacheFingerprints ?? false))
+        if (!IsCachingEnabled())
         {
             return;
         }
@@ -801,6 +870,136 @@ public static partial class FFmpegWrapper
         throw new ArgumentException("Unknown analysis mode " + mode);
     }
 
+    private static bool ReadSilenceCache(string cacheKey, out TimeRange[] result)
+        => TryReadBinaryCache(cacheKey, static r => new TimeRange(r.ReadDouble(), r.ReadDouble()), out result);
+
+    private static void WriteSilenceCache(string cacheKey, TimeRange[] ranges)
+        => WriteBinaryCache(cacheKey, ranges, static (w, r) =>
+        {
+            w.Write(r.Start);
+            w.Write(r.End);
+        });
+
+    private static bool ReadBlackFrameCache(string cacheKey, out BlackFrame[] result)
+        => TryReadBinaryCache(cacheKey, static r => new BlackFrame(r.ReadInt32(), r.ReadDouble(), r.ReadInt32()), out result);
+
+    private static void WriteBlackFrameCache(string cacheKey, BlackFrame[] frames)
+        => WriteBinaryCache(cacheKey, frames, static (w, f) =>
+        {
+            w.Write(f.Percentage);
+            w.Write(f.Time);
+            w.Write(f.Frame);
+        });
+
+    private static bool ReadKeyFrameCache(string cacheKey, out double[] result)
+        => TryReadBinaryCache(cacheKey, static r => r.ReadDouble(), out result);
+
+    private static void WriteKeyFrameCache(string cacheKey, double[] timestamps)
+        => WriteBinaryCache(cacheKey, timestamps, static (w, t) => w.Write(t));
+
+    private static bool TryReadBinaryCache<T>(string cacheKey, Func<BinaryReader, T> deserializer, out T[] result)
+    {
+        result = [];
+
+        if (!IsCachingEnabled())
+        {
+            return false;
+        }
+
+        var path = GetDetectionCachePath(cacheKey);
+        try
+        {
+            using var reader = new BinaryReader(File.Open(path, FileMode.Open, FileAccess.Read));
+            var count = reader.ReadInt32();
+            var items = new T[count];
+            for (var i = 0; i < count; i++)
+            {
+                items[i] = deserializer(reader);
+            }
+
+            if (Logger is { } logger)
+            {
+                LogDetectionCacheHit(logger, cacheKey);
+            }
+
+            result = items;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or EndOfStreamException)
+        {
+            if (ex is not FileNotFoundException && Logger is { } logger)
+            {
+                LogDetectionCacheReadError(logger, ex, path);
+            }
+
+            return false;
+        }
+    }
+
+    private static void WriteBinaryCache<T>(string cacheKey, T[] items, Action<BinaryWriter, T> serializer)
+    {
+        if (!IsCachingEnabled())
+        {
+            return;
+        }
+
+        try
+        {
+            using var writer = new BinaryWriter(File.Open(GetDetectionCachePath(cacheKey), FileMode.Create, FileAccess.Write));
+            writer.Write(items.Length);
+            foreach (var item in items)
+            {
+                serializer(writer, item);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (Logger is { } logger)
+            {
+                LogDetectionCacheWriteError(logger, ex, cacheKey);
+            }
+        }
+    }
+
+    private static bool TryLoadLegacyCache<T>(
+        string legacyCacheKey,
+        string newCacheKey,
+        Func<string, T[]> rawParser,
+        Action<string, T[]> binaryWriter,
+        out T[] result)
+    {
+        result = [];
+
+        if (!IsCachingEnabled())
+        {
+            return false;
+        }
+
+        var legacyPath = GetDetectionCachePath(legacyCacheKey);
+        try
+        {
+            var raw = File.ReadAllText(legacyPath, Encoding.UTF8);
+            result = rawParser(raw);
+
+            if (Logger is { } logger)
+            {
+                LogMigratingLegacyCache(logger, legacyCacheKey, newCacheKey);
+            }
+
+            binaryWriter(newCacheKey, result);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (ex is not FileNotFoundException && Logger is { } logger)
+            {
+                LogDetectionCacheReadError(logger, ex, legacyPath);
+            }
+
+            return false;
+        }
+    }
+
     private static string FormatFFmpegLog(string key)
     {
         /* Format:
@@ -877,6 +1076,18 @@ public static partial class FFmpegWrapper
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "DeleteEpisodeCache {FilePath}")]
     private static partial void LogDeleteEpisodeCache(ILogger logger, string filePath);
+
+    [LoggerMessage(Level = LogLevel.Trace, Message = "Detection cache hit for {CacheKey}")]
+    private static partial void LogDetectionCacheHit(ILogger logger, string cacheKey);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error reading detection cache from {Path}")]
+    private static partial void LogDetectionCacheReadError(ILogger logger, Exception ex, string path);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error writing detection cache for {CacheKey}")]
+    private static partial void LogDetectionCacheWriteError(ILogger logger, Exception ex, string cacheKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Migrating legacy cache {LegacyKey} to {NewKey}")]
+    private static partial void LogMigratingLegacyCache(ILogger logger, string legacyKey, string newKey);
 
     [GeneratedRegex("silence_(?<type>start|end): (?<time>[0-9\\.]+)")]
     private static partial Regex SilenceRegex();

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -946,11 +946,29 @@ public static partial class FFmpegWrapper
                 {
                     if (Logger is { } migLogger)
                     {
-                const int MaxLegacyCacheItems = 1_000_000;
-                var count = reader.ReadInt32();
-                if (count < 0 || count > MaxLegacyCacheItems)
+                        LogMigratingLegacyCache(migLogger, newCacheKey, "DB");
+                    }
+
+                    dbWriter(newCacheKey, items);
+                    result = items;
+
+                    try
+                    {
+                        File.Delete(legacyBinaryPath);
+                    }
+                    catch (IOException ex)
+                    {
+                        if (Logger is { } deleteLogger)
+                        {
+                            LogFailedToDeleteCorruptLegacyCache(deleteLogger, ex, legacyBinaryPath);
+                        }
+                    }
+
+                    return true;
+                }
+                else
                 {
-                    // Invalid item count indicates a corrupt legacy binary file — best-effort delete and fall through to Phase 2.
+                    // Empty binary file — best-effort delete and fall through to Phase 2.
                     try
                     {
                         File.Delete(legacyBinaryPath);
@@ -960,43 +978,6 @@ public static partial class FFmpegWrapper
                         if (Logger is { } migLogger)
                         {
                             LogFailedToDeleteCorruptLegacyCache(migLogger, deleteEx, legacyBinaryPath);
-                        }
-                    }
-                }
-                else
-                {
-                    var items = new T[count];
-                    for (var i = 0; i < count; i++)
-                    {
-                        items[i] = itemReader(reader);
-                    }
-
-                    if (items.Length > 0)
-                    {
-                        if (Logger is { } migLogger)
-                        {
-                            LogMigratingLegacyCache(migLogger, newCacheKey, "DB");
-                        }
-
-                        dbWriter(newCacheKey, items);
-                        File.Delete(legacyBinaryPath);
-
-                        result = items;
-                        return true;
-                    }
-                    else
-                    {
-                        // Empty binary file — best-effort delete and fall through to Phase 2.
-                        try
-                        {
-                            File.Delete(legacyBinaryPath);
-                        }
-                        catch (IOException deleteEx)
-                        {
-                            if (Logger is { } migLogger)
-                            {
-                                LogFailedToDeleteCorruptLegacyCache(migLogger, deleteEx, legacyBinaryPath);
-                            }
                         }
                     }
                 }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -44,7 +44,7 @@ public static partial class FFmpegWrapper
         => Plugin.Instance?.Configuration.CacheFingerprints ?? false;
 
     private static string GetDetectionCachePath(string cacheKey)
-        => Path.Join(Plugin.Instance!.FingerprintCachePath, cacheKey);
+        => Path.Join(Plugin.Instance?.FingerprintCachePath ?? string.Empty, cacheKey);
 
     /// <summary>
     /// Check that the installed version of ffmpeg supports chromaprint.
@@ -246,14 +246,14 @@ public static partial class FFmpegWrapper
         if (ReadBlackFrameCache(cacheKey, out var cached) ||
             TryLoadLegacyCache(legacyCacheKey, cacheKey, static raw => ParseBlackFrame(raw), WriteBlackFrameCache, out cached))
         {
-            return cached.Where(bf => bf.Percentage >= minimum).ToArray();
+            return [.. cached.Where(bf => bf.Percentage >= minimum)];
         }
 
         var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, true));
         var allFrames = ParseBlackFrame(raw);
         WriteBlackFrameCache(cacheKey, allFrames);
 
-        return allFrames.Where(bf => bf.Percentage >= minimum).ToArray();
+        return [.. allFrames.Where(bf => bf.Percentage >= minimum)];
     }
 
     /// <summary>
@@ -340,7 +340,7 @@ public static partial class FFmpegWrapper
 
             var ptsTimeStr = line[(ptsIndex + 9)..].Split(' ', 2)[0];
 
-            if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out double timestamp))
+            if (double.TryParse(ptsTimeStr, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double timestamp))
             {
                 keyframes.Add(timestamp + rangeStart);
             }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -14,6 +14,8 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper;
@@ -43,7 +45,7 @@ public static partial class FFmpegWrapper
     private static bool IsCachingEnabled()
         => Plugin.Instance?.Configuration.CacheFingerprints ?? false;
 
-    private static string GetDetectionCachePath(string cacheKey)
+    private static string GetLegacyFilePath(string cacheKey)
         => Path.Join(Plugin.Instance?.FingerprintCachePath ?? string.Empty, cacheKey);
 
     /// <summary>
@@ -186,7 +188,7 @@ public static partial class FFmpegWrapper
             range.End);
 
         if (ReadSilenceCache(cacheKey, out var cached) ||
-            TryLoadLegacyCache(legacyCacheKey, cacheKey, raw => ParseSilenceRaw(raw, range.Start), WriteSilenceCache, out cached))
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, raw => ParseSilenceRaw(raw, range.Start), static r => new TimeRange(r.ReadDouble(), r.ReadDouble()), WriteSilenceCache, out cached))
         {
             return cached;
         }
@@ -244,7 +246,7 @@ public static partial class FFmpegWrapper
             range.End);
 
         if (ReadBlackFrameCache(cacheKey, out var cached) ||
-            TryLoadLegacyCache(legacyCacheKey, cacheKey, static raw => ParseBlackFrame(raw), WriteBlackFrameCache, out cached))
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, static raw => ParseBlackFrame(raw), static r => new BlackFrame(r.ReadInt32(), r.ReadDouble(), r.ReadInt32()), WriteBlackFrameCache, out cached))
         {
             return [.. cached.Where(bf => bf.Percentage >= minimum)];
         }
@@ -290,7 +292,7 @@ public static partial class FFmpegWrapper
             episode.CreditsFingerprintStart);
 
         if (ReadBlackFrameCache(cacheKey, out var cached) ||
-            TryLoadLegacyCache(legacyCacheKey, cacheKey, static raw => ParseBlackFrame(raw), WriteBlackFrameCache, out cached))
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, static raw => ParseBlackFrame(raw), static r => new BlackFrame(r.ReadInt32(), r.ReadDouble(), r.ReadInt32()), WriteBlackFrameCache, out cached))
         {
             return cached;
         }
@@ -418,7 +420,7 @@ public static partial class FFmpegWrapper
             range.End);
 
         if (ReadKeyFrameCache(cacheKey, out var cached) ||
-            TryLoadLegacyCache(legacyCacheKey, cacheKey, raw => ParseKeyFramesRaw(raw, range.Start), WriteKeyFrameCache, out cached))
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, raw => ParseKeyFramesRaw(raw, range.Start), static r => r.ReadDouble(), WriteKeyFrameCache, out cached))
         {
             return cached;
         }
@@ -720,7 +722,7 @@ public static partial class FFmpegWrapper
         var legacyCacheKey = id + suffix;
 
         return ReadFingerprintCache(cacheKey, out fingerprint) ||
-            TryLoadLegacyCache(legacyCacheKey, cacheKey, ParseFingerprintRaw, WriteFingerprintCache, out fingerprint);
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, ParseFingerprintRaw, static r => r.ReadUInt32(), WriteFingerprintCache, out fingerprint);
     }
 
     /// <summary>
@@ -745,23 +747,24 @@ public static partial class FFmpegWrapper
     /// <param name="id">Media item ID to remove from cache.</param>
     public static void DeleteFingerprintCache(Guid id)
     {
-        var cachePath = Path.Join(
-            Plugin.Instance!.FingerprintCachePath,
-            id.ToString("N"));
+        // Delete from the SQLite cache database.
+        using var db = Plugin.CreateCacheDb();
+        db.DeleteByEpisodeId(id);
 
-        // File.Delete(cachePath);
-        // File.Delete(cachePath + "-intro-silence-v1");
-        // File.Delete(cachePath + "-credits");
-
-        var filePattern = Path.GetFileName(cachePath) + "*";
-        foreach (var filePath in Directory.EnumerateFiles(Plugin.Instance!.FingerprintCachePath, filePattern))
+        // Also sweep any legacy binary files still on disk (pre-migration installs).
+        var cacheDir = Plugin.Instance?.FingerprintCachePath;
+        if (cacheDir is not null && Directory.Exists(cacheDir))
         {
-            if (Logger is { } deleteLogger)
+            var filePattern = id.ToString("N") + "*";
+            foreach (var filePath in Directory.EnumerateFiles(cacheDir, filePattern))
             {
-                LogDeleteEpisodeCache(deleteLogger, filePath);
-            }
+                if (Logger is { } deleteLogger)
+                {
+                    LogDeleteEpisodeCache(deleteLogger, filePath);
+                }
 
-            File.Delete(filePath);
+                File.Delete(filePath);
+            }
         }
     }
 
@@ -771,26 +774,36 @@ public static partial class FFmpegWrapper
     /// <param name="mode">Analysis mode.</param>
     public static void DeleteCacheFiles(AnalysisMode mode)
     {
-        foreach (var filePath in Directory.EnumerateFiles(Plugin.Instance!.FingerprintCachePath)
-            .Where(f => mode == AnalysisMode.Introduction
-                ? !Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)
-                : Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)))
+        // Delete from the SQLite cache database.
+        using var db = Plugin.CreateCacheDb();
+        db.DeleteByMode(mode);
+
+        // Also sweep any legacy binary files still on disk (pre-migration installs).
+        var cacheDir = Plugin.Instance?.FingerprintCachePath;
+        if (cacheDir is not null && Directory.Exists(cacheDir))
         {
-            File.Delete(filePath);
+            foreach (var filePath in Directory.EnumerateFiles(cacheDir)
+                .Where(f => mode == AnalysisMode.Introduction
+                    ? !Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)
+                    : Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)))
+            {
+                File.Delete(filePath);
+            }
         }
     }
 
     /// <summary>
-    /// Determines the binary cache path for an episode's fingerprint.
+    /// Determines the legacy on-disk path for an episode's fingerprint cache file.
     /// </summary>
     /// <param name="episode">Episode.</param>
     /// <param name="mode">Analysis mode.</param>
-    /// <returns>Path to the binary fingerprint cache file.</returns>
+    /// <returns>Path to the legacy binary fingerprint cache file (may not exist after migration to SQLite).</returns>
+    [Obsolete("Fingerprints are now stored in the SQLite detection cache database. This path may not exist.")]
     public static string GetFingerprintCachePath(QueuedEpisode episode, AnalysisMode mode)
     {
         var id = episode.EpisodeId.ToString("N");
         var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
-        return GetDetectionCachePath(id + suffix + "-chromaprint-v1");
+        return GetLegacyFilePath(id + suffix + "-chromaprint-v1");
     }
 
     /// <summary>
@@ -808,8 +821,11 @@ public static partial class FFmpegWrapper
 
         var id = episode.EpisodeId.ToString("N");
         var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
-        return File.Exists(GetDetectionCachePath(id + suffix + "-chromaprint-v1")) ||
-               File.Exists(GetDetectionCachePath(id + suffix));
+
+        using var db = Plugin.CreateCacheDb();
+        return db.ExistsByKey(id + suffix + "-chromaprint-v1") ||
+               File.Exists(GetLegacyFilePath(id + suffix + "-chromaprint-v1")) ||
+               File.Exists(GetLegacyFilePath(id + suffix));
     }
 
     private static bool ReadFingerprintCache(string cacheKey, out uint[] result)
@@ -872,10 +888,16 @@ public static partial class FFmpegWrapper
             return false;
         }
 
-        var path = GetDetectionCachePath(cacheKey);
         try
         {
-            using var reader = new BinaryReader(File.Open(path, FileMode.Open, FileAccess.Read));
+            using var db = Plugin.CreateCacheDb();
+            if (!db.TryRead(cacheKey, out var data))
+            {
+                return false;
+            }
+
+            using var ms = new MemoryStream(data);
+            using var reader = new BinaryReader(ms);
             var count = reader.ReadInt32();
             var items = new T[count];
             for (var i = 0; i < count; i++)
@@ -891,11 +913,11 @@ public static partial class FFmpegWrapper
             result = items;
             return true;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or EndOfStreamException)
+        catch (Exception ex) when (ex is SqliteException or EndOfStreamException)
         {
-            if (ex is not FileNotFoundException && Logger is { } logger)
+            if (Logger is { } logger)
             {
-                LogDetectionCacheReadError(logger, ex, path);
+                LogDetectionCacheReadError(logger, ex, cacheKey);
             }
 
             return false;
@@ -911,14 +933,19 @@ public static partial class FFmpegWrapper
 
         try
         {
-            using var writer = new BinaryWriter(File.Open(GetDetectionCachePath(cacheKey), FileMode.Create, FileAccess.Write));
+            using var ms = new MemoryStream();
+            using var writer = new BinaryWriter(ms);
             writer.Write(items.Length);
             foreach (var item in items)
             {
                 serializer(writer, item);
             }
+
+            writer.Flush();
+            using var db = Plugin.CreateCacheDb();
+            db.Write(cacheKey, ms.ToArray());
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (SqliteException ex)
         {
             if (Logger is { } logger)
             {
@@ -931,7 +958,8 @@ public static partial class FFmpegWrapper
         string legacyCacheKey,
         string newCacheKey,
         Func<string, T[]> rawParser,
-        Action<string, T[]> binaryWriter,
+        Func<BinaryReader, T> itemReader,
+        Action<string, T[]> dbWriter,
         out T[] result)
     {
         result = [];
@@ -941,23 +969,77 @@ public static partial class FFmpegWrapper
             return false;
         }
 
-        var legacyPath = GetDetectionCachePath(legacyCacheKey);
+        // Phase 1: migrate old binary files from disk into SQLite.
+        // The old binary filename matched newCacheKey exactly (before SQLite was introduced).
+        var legacyBinaryPath = GetLegacyFilePath(newCacheKey);
+        if (File.Exists(legacyBinaryPath))
+        {
+            try
+            {
+                using var fs = File.Open(legacyBinaryPath, FileMode.Open, FileAccess.Read);
+                using var reader = new BinaryReader(fs);
+                var count = reader.ReadInt32();
+                var items = new T[count];
+                for (var i = 0; i < count; i++)
+                {
+                    items[i] = itemReader(reader);
+                }
+
+                if (items.Length > 0)
+                {
+                    if (Logger is { } migLogger)
+                    {
+                        LogMigratingLegacyCache(migLogger, newCacheKey, newCacheKey);
+                    }
+
+                    dbWriter(newCacheKey, items);
+                    File.Delete(legacyBinaryPath);
+                    result = items;
+                    return true;
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or EndOfStreamException)
+            {
+                // Corrupt or unreadable binary file — delete it and fall through to text-format check.
+                try
+                {
+                    File.Delete(legacyBinaryPath);
+                }
+                catch (IOException)
+                {
+                }
+            }
+        }
+
+        // Phase 2: migrate even-older text-format files from disk into SQLite.
+        // Only fingerprints had a text format; other detection types had a versioned binary format
+        // (e.g. silence-v2) which is handled by re-analysis if missing.
+        var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
         try
         {
-            var raw = File.ReadAllText(legacyPath, Encoding.UTF8);
+            var raw = File.ReadAllText(legacyTextPath, Encoding.UTF8);
             result = rawParser(raw);
+
+            // If the parser returned nothing the legacy file is corrupt or unreadable.
+            // Delete it so it doesn't block future attempts, then fall through to re-analysis.
+            if (result.Length == 0)
+            {
+                File.Delete(legacyTextPath);
+                return false;
+            }
 
             if (Logger is { } logger)
             {
                 LogMigratingLegacyCache(logger, legacyCacheKey, newCacheKey);
             }
 
-            binaryWriter(newCacheKey, result);
+            dbWriter(newCacheKey, result);
 
-            // Only delete the legacy file if the new binary cache was actually written.
-            if (File.Exists(GetDetectionCachePath(newCacheKey)))
+            // Only delete the legacy file after the DB write has been attempted.
+            using var db = Plugin.CreateCacheDb();
+            if (db.ExistsByKey(newCacheKey))
             {
-                File.Delete(legacyPath);
+                File.Delete(legacyTextPath);
             }
 
             return true;
@@ -966,7 +1048,7 @@ public static partial class FFmpegWrapper
         {
             if (ex is not FileNotFoundException && Logger is { } logger)
             {
-                LogDetectionCacheReadError(logger, ex, legacyPath);
+                LogDetectionCacheReadError(logger, ex, legacyTextPath);
             }
 
             return false;

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -1019,9 +1019,10 @@ public static partial class FFmpegWrapper
             }
         }
 
-        // Phase 2: migrate even-older text-format files from disk into SQLite.
-        // Only fingerprints had a text format; other detection types had a versioned binary format
-        // (e.g. silence-v2) which is handled by re-analysis if missing.
+        // Phase 2: attempt legacy migration by reading the legacy cache file as UTF-8 text and
+        // running rawParser on it. This fallback is intentionally used for legacy cache migration
+        // across detection types (including fingerprints, silence, blackframe, and keyframe),
+        // not just fingerprints.
         var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
         try
         {

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -342,8 +342,7 @@ public static partial class FFmpegWrapper
 
             var ptsTimeStr = line[(ptsIndex + 9)..].Split(' ', 2)[0];
 
-            // AllowThousands is required by the four-parameter overload; FFmpeg never emits thousands separators.
-            if (double.TryParse(ptsTimeStr, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double timestamp))
+            if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out double timestamp))
             {
                 keyframes.Add(timestamp + rangeStart);
             }
@@ -989,7 +988,7 @@ public static partial class FFmpegWrapper
                 {
                     if (Logger is { } migLogger)
                     {
-                        LogMigratingLegacyCache(migLogger, newCacheKey, newCacheKey);
+                        LogMigratingLegacyCache(migLogger, newCacheKey, "DB");
                     }
 
                     dbWriter(newCacheKey, items);
@@ -1135,10 +1134,10 @@ public static partial class FFmpegWrapper
     [LoggerMessage(Level = LogLevel.Trace, Message = "Detection cache hit for {CacheKey}")]
     private static partial void LogDetectionCacheHit(ILogger logger, string cacheKey);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error reading detection cache from {Path}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error reading detection cache from {Path}")]
     private static partial void LogDetectionCacheReadError(ILogger logger, Exception ex, string path);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error writing detection cache for {CacheKey}")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error writing detection cache for {CacheKey}")]
     private static partial void LogDetectionCacheWriteError(ILogger logger, Exception ex, string cacheKey);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Migrating legacy cache {LegacyKey} to {NewKey}")]

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -950,9 +950,20 @@ public static partial class FFmpegWrapper
                     }
 
                     dbWriter(newCacheKey, items);
-                    File.Delete(legacyBinaryPath);
-
                     result = items;
+
+                    try
+                    {
+                        File.Delete(legacyBinaryPath);
+                    }
+                    catch (IOException ex)
+                    {
+                        if (Logger is { } deleteLogger)
+                        {
+                            LogFailedToDeleteCorruptLegacyCache(deleteLogger, ex, legacyBinaryPath);
+                        }
+                    }
+
                     return true;
                 }
                 else

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -987,6 +987,7 @@ public static partial class FFmpegWrapper
             }
 
             binaryWriter(newCacheKey, result);
+            File.Delete(legacyPath);
             return true;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -199,7 +199,7 @@ public static partial class FFmpegWrapper
          * [silencedetect @ 0x000000000000] silence_start: 12.34
          * [silencedetect @ 0x000000000000] silence_end: 56.123 | silence_duration: 43.783
         */
-        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, true));
+        var raw = Encoding.UTF8.GetString(GetOutput(args, true));
         var result = ParseSilenceRaw(raw, range.Start);
         WriteSilenceCache(cacheKey, result);
 
@@ -251,7 +251,7 @@ public static partial class FFmpegWrapper
             return [.. cached.Where(bf => bf.Percentage >= minimum)];
         }
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, true));
+        var raw = Encoding.UTF8.GetString(GetOutput(args, true));
         var allFrames = ParseBlackFrame(raw);
         WriteBlackFrameCache(cacheKey, allFrames);
 
@@ -297,7 +297,7 @@ public static partial class FFmpegWrapper
             return cached;
         }
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, true));
+        var raw = Encoding.UTF8.GetString(GetOutput(args, true));
         var allFrames = ParseBlackFrame(raw);
         WriteBlackFrameCache(cacheKey, allFrames);
 
@@ -424,7 +424,7 @@ public static partial class FFmpegWrapper
             return cached;
         }
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, string.Empty, stderr: true));
+        var raw = Encoding.UTF8.GetString(GetOutput(args, stderr: true));
         var result = ParseKeyFramesRaw(raw, range.Start);
         WriteKeyFrameCache(cacheKey, result);
 
@@ -478,7 +478,7 @@ public static partial class FFmpegWrapper
             LogCheckingRequirement(requirementLogger, arguments);
         }
 
-        var output = Encoding.UTF8.GetString(GetOutput(arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries), string.Empty, false, 2000));
+        var output = Encoding.UTF8.GetString(GetOutput(arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries), false, 2000));
         if (requirementLogger is not null)
         {
             LogFfmpegOutput(requirementLogger, arguments, output);
@@ -506,15 +506,12 @@ public static partial class FFmpegWrapper
 
     /// <summary>
     /// Runs ffmpeg and returns standard output (or error).
-    /// If caching is enabled, will use cacheFilename to cache the output of this command.
     /// </summary>
     /// <param name="args">Arguments to pass to ffmpeg as individual tokens.</param>
-    /// <param name="cacheFilename">Filename to cache the output of this command to, or string.Empty if this command should not be cached.</param>
     /// <param name="stderr">If standard error should be returned.</param>
     /// <param name="timeout">Timeout (in miliseconds) to wait for ffmpeg to exit.</param>
     private static ReadOnlySpan<byte> GetOutput(
         IReadOnlyList<string> args,
-        string cacheFilename,
         bool stderr = false,
         int timeout = 60 * 1000)
     {
@@ -527,33 +524,6 @@ public static partial class FFmpegWrapper
             a.Contains("showinfo", StringComparison.OrdinalIgnoreCase));
 
         var logLevel = useInfoLevel ? "info" : "warning";
-
-        var cacheOutput =
-            IsCachingEnabled() &&
-            !string.IsNullOrEmpty(cacheFilename);
-
-        // If caching is enabled, try to load the output of this command from the cached file.
-        if (cacheOutput)
-        {
-            // Calculate the absolute path to the cached file.
-            cacheFilename = Path.Join(Plugin.Instance!.FingerprintCachePath, cacheFilename);
-
-            // If the cached file exists, return whatever it holds.
-            if (File.Exists(cacheFilename))
-            {
-                if (Logger is { } cacheLogger)
-                {
-                    LogReturningCacheContents(cacheLogger, cacheFilename);
-                }
-
-                return File.ReadAllBytes(cacheFilename);
-            }
-
-            if (Logger is { } cacheMissLogger)
-            {
-                LogCacheNotFound(cacheMissLogger, cacheFilename);
-            }
-        }
 
         // For FFmpeg info queries (-version, -muxers, -h), don't add the thread count flag
         // to avoid "Trailing option(s) found" warning. These are quick queries.
@@ -622,15 +592,7 @@ public static partial class FFmpegWrapper
 
         ffmpeg.WaitForExit(timeout);
 
-        var output = ms.ToArray();
-
-        // If caching is enabled, cache the output of this command.
-        if (cacheOutput)
-        {
-            File.WriteAllBytes(cacheFilename, output);
-        }
-
-        return output;
+        return ms.ToArray();
     }
 
     /// <summary>
@@ -671,7 +633,7 @@ public static partial class FFmpegWrapper
         };
 
         // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).
-        var rawPoints = GetOutput(args, string.Empty);
+        var rawPoints = GetOutput(args);
         if (rawPoints.Length == 0 || rawPoints.Length % 4 != 0)
         {
             if (Logger is { } chromaLogger)
@@ -789,20 +751,6 @@ public static partial class FFmpegWrapper
                 File.Delete(filePath);
             }
         }
-    }
-
-    /// <summary>
-    /// Determines the legacy on-disk path for an episode's fingerprint cache file.
-    /// </summary>
-    /// <param name="episode">Episode.</param>
-    /// <param name="mode">Analysis mode.</param>
-    /// <returns>Path to the legacy binary fingerprint cache file (may not exist after migration to SQLite).</returns>
-    [Obsolete("Fingerprints are now stored in the SQLite detection cache database. This path may not exist.")]
-    public static string GetFingerprintCachePath(QueuedEpisode episode, AnalysisMode mode)
-    {
-        var id = episode.EpisodeId.ToString("N");
-        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
-        return GetLegacyFilePath(id + suffix + "-chromaprint-v1");
     }
 
     /// <summary>
@@ -930,27 +878,17 @@ public static partial class FFmpegWrapper
             return;
         }
 
-        try
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        writer.Write(items.Length);
+        foreach (var item in items)
         {
-            using var ms = new MemoryStream();
-            using var writer = new BinaryWriter(ms);
-            writer.Write(items.Length);
-            foreach (var item in items)
-            {
-                serializer(writer, item);
-            }
+            serializer(writer, item);
+        }
 
-            writer.Flush();
-            using var db = Plugin.CreateCacheDb();
-            db.Write(cacheKey, ms.ToArray());
-        }
-        catch (SqliteException ex)
-        {
-            if (Logger is { } logger)
-            {
-                LogDetectionCacheWriteError(logger, ex, cacheKey);
-            }
-        }
+        writer.Flush();
+        using var db = Plugin.CreateCacheDb();
+        db.Write(cacheKey, ms.ToArray());
     }
 
     private static bool TryLoadLegacyCache<T>(
@@ -1003,6 +941,11 @@ public static partial class FFmpegWrapper
                     result = items;
                     return true;
                 }
+                else
+                {
+                    // Empty binary file — delete it and fall through to Phase 2.
+                    File.Delete(legacyBinaryPath);
+                }
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or EndOfStreamException)
             {
@@ -1016,7 +959,7 @@ public static partial class FFmpegWrapper
                     // Best-effort cleanup; failure to delete should not stop migration, but log for diagnostics.
                     if (Logger is { } migLogger)
                     {
-                        migLogger.LogDebug(deleteEx, "Failed to delete corrupt legacy cache file at path '{LegacyPath}'.", legacyBinaryPath);
+                        LogFailedToDeleteCorruptLegacyCache(migLogger, deleteEx, legacyBinaryPath);
                     }
                 }
             }
@@ -1110,12 +1053,6 @@ public static partial class FFmpegWrapper
     [LoggerMessage(Level = LogLevel.Debug, Message = "FFmpeg requirement {Arguments} met")]
     private static partial void LogFfmpegRequirementMet(ILogger logger, string arguments);
 
-    [LoggerMessage(Level = LogLevel.Trace, Message = "Returning contents of cache {Cache}")]
-    private static partial void LogReturningCacheContents(ILogger logger, string cache);
-
-    [LoggerMessage(Level = LogLevel.Trace, Message = "Not returning contents of cache {Cache} (not found)")]
-    private static partial void LogCacheNotFound(ILogger logger, string cache);
-
     [LoggerMessage(Level = LogLevel.Debug, Message = "Starting ffmpeg with the following arguments: {Arguments}")]
     private static partial void LogStartingFfmpeg(ILogger logger, string arguments);
 
@@ -1149,11 +1086,11 @@ public static partial class FFmpegWrapper
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error reading detection cache from {Path}")]
     private static partial void LogDetectionCacheReadError(ILogger logger, Exception ex, string path);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error writing detection cache for {CacheKey}")]
-    private static partial void LogDetectionCacheWriteError(ILogger logger, Exception ex, string cacheKey);
-
     [LoggerMessage(Level = LogLevel.Debug, Message = "Migrating legacy cache {LegacyKey} to {NewKey}")]
     private static partial void LogMigratingLegacyCache(ILogger logger, string legacyKey, string newKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete corrupt legacy cache file at path '{LegacyPath}'")]
+    private static partial void LogFailedToDeleteCorruptLegacyCache(ILogger logger, Exception ex, string legacyPath);
 
     [GeneratedRegex("silence_(?<type>start|end): (?<time>[0-9\\.]+)")]
     private static partial Regex SilenceRegex();

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -279,7 +279,7 @@ public static partial class FFmpegWrapper
 
         var cacheKey = string.Format(
             CultureInfo.InvariantCulture,
-            "{0}-blackframes-{1}-alt-v2",
+            "{0}-credits-blackframes-{1}-v2",
             episode.EpisodeId.ToString("N"),
             episode.CreditsFingerprintStart);
 
@@ -773,11 +773,8 @@ public static partial class FFmpegWrapper
     {
         foreach (var filePath in Directory.EnumerateFiles(Plugin.Instance!.FingerprintCachePath)
             .Where(f => mode == AnalysisMode.Introduction
-                ? Path.GetFileName(f).Contains("-chromaprint-", StringComparison.OrdinalIgnoreCase)
-                    || Path.GetFileName(f).Contains("-silence-", StringComparison.OrdinalIgnoreCase)
-                    || Path.GetFileName(f).Contains("-keyframes-", StringComparison.OrdinalIgnoreCase)
-                : Path.GetFileName(f).Contains("-credits-", StringComparison.OrdinalIgnoreCase)
-                    || Path.GetFileName(f).Contains("-blackframes-", StringComparison.OrdinalIgnoreCase)))
+                ? !Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)
+                : Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)))
         {
             File.Delete(filePath);
         }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -709,8 +709,7 @@ public static partial class FFmpegWrapper
     public static void DeleteFingerprintCache(Guid id)
     {
         // Delete from the SQLite cache database.
-        using var db = Plugin.CreateCacheDb();
-        db.DeleteByEpisodeId(id);
+        Plugin.CreateCacheDb().DeleteByEpisodeId(id);
 
         // Also sweep any legacy binary files still on disk (pre-migration installs).
         var cacheDir = Plugin.Instance?.FingerprintCachePath;
@@ -746,8 +745,7 @@ public static partial class FFmpegWrapper
     public static void DeleteCacheFiles(AnalysisMode mode)
     {
         // Delete from the SQLite cache database.
-        using var db = Plugin.CreateCacheDb();
-        db.DeleteByMode(mode);
+        Plugin.CreateCacheDb().DeleteByMode(mode);
 
         // Also sweep any legacy binary files still on disk (pre-migration installs).
         var cacheDir = Plugin.Instance?.FingerprintCachePath;
@@ -789,7 +787,7 @@ public static partial class FFmpegWrapper
         var id = episode.EpisodeId.ToString("N");
         var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
 
-        using var db = Plugin.CreateCacheDb();
+        var db = Plugin.CreateCacheDb();
         return db.ExistsByKey(id + suffix + "-chromaprint-v1") ||
                File.Exists(GetLegacyFilePath(id + suffix + "-chromaprint-v1")) ||
                File.Exists(GetLegacyFilePath(id + suffix));
@@ -857,7 +855,7 @@ public static partial class FFmpegWrapper
 
         try
         {
-            using var db = Plugin.CreateCacheDb();
+            var db = Plugin.CreateCacheDb();
             if (!db.TryRead(cacheKey, out var data))
             {
                 return false;
@@ -907,8 +905,7 @@ public static partial class FFmpegWrapper
         }
 
         writer.Flush();
-        using var db = Plugin.CreateCacheDb();
-        db.Write(cacheKey, ms.ToArray());
+        Plugin.CreateCacheDb().Write(cacheKey, ms.ToArray());
     }
 
     private static bool TryLoadLegacyCache<T>(
@@ -1122,7 +1119,7 @@ public static partial class FFmpegWrapper
     [LoggerMessage(Level = LogLevel.Debug, Message = "Migrating legacy cache {LegacyKey} to {NewKey}")]
     private static partial void LogMigratingLegacyCache(ILogger logger, string legacyKey, string newKey);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete corrupt legacy cache file at path '{LegacyPath}'")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete legacy cache file at path '{LegacyPath}'")]
     private static partial void LogFailedToDeleteCorruptLegacyCache(ILogger logger, Exception ex, string legacyPath);
 
     [GeneratedRegex("silence_(?<type>start|end): (?<time>[0-9\\.]+)")]

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -1004,8 +1004,13 @@ public static partial class FFmpegWrapper
                 {
                     File.Delete(legacyBinaryPath);
                 }
-                catch (IOException)
+                catch (IOException deleteEx)
                 {
+                    // Best-effort cleanup; failure to delete should not stop migration, but log for diagnostics.
+                    if (Logger is { } migLogger)
+                    {
+                        migLogger.LogDebug(deleteEx, "Failed to delete corrupt legacy cache file at path '{LegacyPath}'.", legacyBinaryPath);
+                    }
                 }
             }
         }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -930,13 +930,7 @@ public static partial class FFmpegWrapper
                     }
 
                     dbWriter(newCacheKey, items);
-                    using (var cacheDb = Plugin.CreateCacheDb())
-                    {
-                        if (cacheDb.ExistsByKey(newCacheKey))
-                        {
-                            File.Delete(legacyBinaryPath);
-                        }
-                    }
+                    File.Delete(legacyBinaryPath);
 
                     result = items;
                     return true;
@@ -988,13 +982,7 @@ public static partial class FFmpegWrapper
             }
 
             dbWriter(newCacheKey, result);
-
-            // Only delete the legacy file after the DB write has been attempted.
-            using var db = Plugin.CreateCacheDb();
-            if (db.ExistsByKey(newCacheKey))
-            {
-                File.Delete(legacyTextPath);
-            }
+            File.Delete(legacyTextPath);
 
             return true;
         }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -695,7 +695,7 @@ public static partial class FFmpegWrapper
 
     /// <summary>
     /// Tries to load an episode's fingerprint from cache. If caching is not enabled, calling this function is a no-op.
-    /// This function was created before the unified caching mechanism was introduced (in v0.1.7).
+    /// Tries the current binary format first, then migrates legacy text-format files on the fly.
     /// </summary>
     /// <param name="episode">Episode to try to load from cache.</param>
     /// <param name="mode">Analysis mode.</param>
@@ -708,70 +708,22 @@ public static partial class FFmpegWrapper
     {
         fingerprint = [];
 
-        // If fingerprint caching isn't enabled, don't try to load anything.
         if (!IsCachingEnabled())
         {
             return false;
         }
 
-        var path = GetFingerprintCachePath(episode, mode);
+        var id = episode.EpisodeId.ToString("N");
+        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
+        var cacheKey = id + suffix + "-chromaprint-v1";
+        var legacyCacheKey = id + suffix;
 
-        // If this episode isn't cached, bail out.
-        if (!File.Exists(path))
-        {
-            return false;
-        }
-
-        string[] raw;
-        try
-        {
-            raw = File.ReadAllLines(path, Encoding.UTF8);
-        }
-        catch (IOException ex)
-        {
-            if (Logger is { } ioLogger)
-            {
-                LogFingerprintCacheReadIoError(ioLogger, ex, path);
-            }
-
-            return false;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            if (Logger is { } accessLogger)
-            {
-                LogFingerprintCacheReadAccessError(accessLogger, ex, path);
-            }
-
-            return false;
-        }
-
-        var result = new List<uint>(raw.Length);
-
-        foreach (var rawNumber in raw)
-        {
-            if (uint.TryParse(rawNumber, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint number))
-            {
-                result.Add(number);
-            }
-            else
-            {
-                if (Logger is { } invalidLogger)
-                {
-                    LogInvalidFingerprintEntry(invalidLogger, rawNumber, episode.Path, episode.EpisodeId);
-                }
-
-                return false;
-            }
-        }
-
-        fingerprint = [.. result];
-        return true;
+        return ReadFingerprintCache(cacheKey, out fingerprint) ||
+            TryLoadLegacyCache(legacyCacheKey, cacheKey, ParseFingerprintRaw, WriteFingerprintCache, out fingerprint);
     }
 
     /// <summary>
-    /// Cache an episode's fingerprint to disk. If caching is not enabled, calling this function is a no-op.
-    /// This function was created before the unified caching mechanism was introduced (in v0.1.7).
+    /// Cache an episode's fingerprint to disk in binary format. If caching is not enabled, calling this function is a no-op.
     /// </summary>
     /// <param name="episode">Episode to store in cache.</param>
     /// <param name="mode">Analysis mode.</param>
@@ -781,24 +733,9 @@ public static partial class FFmpegWrapper
         AnalysisMode mode,
         List<uint> fingerprint)
     {
-        // Bail out if caching isn't enabled.
-        if (!IsCachingEnabled())
-        {
-            return;
-        }
-
-        // Stringify each data point.
-        var lines = new List<string>();
-        foreach (var number in fingerprint)
-        {
-            lines.Add(number.ToString(CultureInfo.InvariantCulture));
-        }
-
-        // Cache the episode.
-        File.WriteAllLinesAsync(
-            GetFingerprintCachePath(episode, mode),
-            lines,
-            Encoding.UTF8).ConfigureAwait(false);
+        var id = episode.EpisodeId.ToString("N");
+        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
+        WriteFingerprintCache(id + suffix + "-chromaprint-v1", [.. fingerprint]);
     }
 
     /// <summary>
@@ -845,29 +782,56 @@ public static partial class FFmpegWrapper
     }
 
     /// <summary>
-    /// Determines the path an episode should be cached at.
-    /// This function was created before the unified caching mechanism was introduced (in v0.1.7).
+    /// Determines the binary cache path for an episode's fingerprint.
     /// </summary>
     /// <param name="episode">Episode.</param>
     /// <param name="mode">Analysis mode.</param>
-    /// <returns>Path.</returns>
+    /// <returns>Path to the binary fingerprint cache file.</returns>
     public static string GetFingerprintCachePath(QueuedEpisode episode, AnalysisMode mode)
     {
-        var basePath = Path.Join(
-            Plugin.Instance!.FingerprintCachePath,
-            episode.EpisodeId.ToString("N"));
+        var id = episode.EpisodeId.ToString("N");
+        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
+        return GetDetectionCachePath(id + suffix + "-chromaprint-v1");
+    }
 
-        if (mode == AnalysisMode.Introduction)
+    /// <summary>
+    /// Returns true if a fingerprint cache exists for the episode in either binary or legacy text format.
+    /// </summary>
+    /// <param name="episode">Episode.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <returns>true if any fingerprint cache file exists.</returns>
+    public static bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode)
+    {
+        if (!IsCachingEnabled())
         {
-            return basePath;
+            return false;
         }
 
-        if (mode == AnalysisMode.Credits)
+        var id = episode.EpisodeId.ToString("N");
+        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
+        return File.Exists(GetDetectionCachePath(id + suffix + "-chromaprint-v1")) ||
+               File.Exists(GetDetectionCachePath(id + suffix));
+    }
+
+    private static bool ReadFingerprintCache(string cacheKey, out uint[] result)
+        => TryReadBinaryCache(cacheKey, static r => r.ReadUInt32(), out result);
+
+    private static void WriteFingerprintCache(string cacheKey, uint[] fingerprint)
+        => WriteBinaryCache(cacheKey, fingerprint, static (w, v) => w.Write(v));
+
+    private static uint[] ParseFingerprintRaw(string raw)
+    {
+        var lines = raw.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        var result = new List<uint>(lines.Length);
+        foreach (var line in lines)
         {
-            return basePath + "-credits";
+            if (uint.TryParse(line, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            {
+                result.Add(value);
+            }
         }
 
-        throw new ArgumentException("Unknown analysis mode " + mode);
+        return [.. result];
     }
 
     private static bool ReadSilenceCache(string cacheKey, out TimeRange[] result)

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -724,7 +724,17 @@ public static partial class FFmpegWrapper
                     LogDeleteEpisodeCache(deleteLogger, filePath);
                 }
 
-                File.Delete(filePath);
+                try
+                {
+                    File.Delete(filePath);
+                }
+                catch (IOException ex)
+                {
+                    if (Logger is { } errLogger)
+                    {
+                        LogDeleteLegacyCacheFileFailed(errLogger, ex, filePath);
+                    }
+                }
             }
         }
     }
@@ -748,7 +758,17 @@ public static partial class FFmpegWrapper
                     ? !Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)
                     : Path.GetFileName(f).Contains("-credits", StringComparison.OrdinalIgnoreCase)))
             {
-                File.Delete(filePath);
+                try
+                {
+                    File.Delete(filePath);
+                }
+                catch (IOException ex)
+                {
+                    if (Logger is { } errLogger)
+                    {
+                        LogDeleteLegacyCacheFileFailed(errLogger, ex, filePath);
+                    }
+                }
             }
         }
     }
@@ -1077,6 +1097,9 @@ public static partial class FFmpegWrapper
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "DeleteEpisodeCache {FilePath}")]
     private static partial void LogDeleteEpisodeCache(ILogger logger, string filePath);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete legacy cache file '{FilePath}'")]
+    private static partial void LogDeleteLegacyCacheFileFailed(ILogger logger, Exception ex, string filePath);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Detection cache hit for {CacheKey}")]
     private static partial void LogDetectionCacheHit(ILogger logger, string cacheKey);

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -946,29 +946,11 @@ public static partial class FFmpegWrapper
                 {
                     if (Logger is { } migLogger)
                     {
-                        LogMigratingLegacyCache(migLogger, newCacheKey, "DB");
-                    }
-
-                    dbWriter(newCacheKey, items);
-                    result = items;
-
-                    try
-                    {
-                        File.Delete(legacyBinaryPath);
-                    }
-                    catch (IOException ex)
-                    {
-                        if (Logger is { } deleteLogger)
-                        {
-                            LogFailedToDeleteCorruptLegacyCache(deleteLogger, ex, legacyBinaryPath);
-                        }
-                    }
-
-                    return true;
-                }
-                else
+                const int MaxLegacyCacheItems = 1_000_000;
+                var count = reader.ReadInt32();
+                if (count < 0 || count > MaxLegacyCacheItems)
                 {
-                    // Empty binary file — best-effort delete and fall through to Phase 2.
+                    // Invalid item count indicates a corrupt legacy binary file — best-effort delete and fall through to Phase 2.
                     try
                     {
                         File.Delete(legacyBinaryPath);
@@ -978,6 +960,43 @@ public static partial class FFmpegWrapper
                         if (Logger is { } migLogger)
                         {
                             LogFailedToDeleteCorruptLegacyCache(migLogger, deleteEx, legacyBinaryPath);
+                        }
+                    }
+                }
+                else
+                {
+                    var items = new T[count];
+                    for (var i = 0; i < count; i++)
+                    {
+                        items[i] = itemReader(reader);
+                    }
+
+                    if (items.Length > 0)
+                    {
+                        if (Logger is { } migLogger)
+                        {
+                            LogMigratingLegacyCache(migLogger, newCacheKey, "DB");
+                        }
+
+                        dbWriter(newCacheKey, items);
+                        File.Delete(legacyBinaryPath);
+
+                        result = items;
+                        return true;
+                    }
+                    else
+                    {
+                        // Empty binary file — best-effort delete and fall through to Phase 2.
+                        try
+                        {
+                            File.Delete(legacyBinaryPath);
+                        }
+                        catch (IOException deleteEx)
+                        {
+                            if (Logger is { } migLogger)
+                            {
+                                LogFailedToDeleteCorruptLegacyCache(migLogger, deleteEx, legacyBinaryPath);
+                            }
                         }
                     }
                 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -87,12 +87,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         _dbPath = Path.Join(introsDirectory, "introskipper.db");
         _cacheDbPath = Path.Join(introsDirectory, "introskipper-cache.db");
 
-        // Create the base & cache directories (if needed).
-        if (!Directory.Exists(FingerprintCachePath))
-        {
-            Directory.CreateDirectory(FingerprintCachePath);
-        }
-
         // Initialize segment database.
         try
         {

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -109,11 +109,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         {
             DetectionCacheDb.EnsureSchema(_cacheDbPath);
         }
-        catch (IOException ex)
-        {
-            LogCacheDbInitializationError(_logger, ex);
-        }
-        catch (SqliteException ex)
+        catch (Exception ex) when (ex is IOException or SqliteException)
         {
             LogCacheDbInitializationError(_logger, ex);
         }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -44,6 +44,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     private readonly IPluginManager _pluginManager;
     private readonly ILogger<Plugin> _logger;
     private readonly string _dbPath;
+    private readonly string _cacheDbPath;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -82,7 +83,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         var introsDirectory = Path.Join(applicationPaths.DataPath, pluginDirName);
         FingerprintCachePath = Path.Join(introsDirectory, pluginCachePath);
 
-        _dbPath = Path.Join(applicationPaths.DataPath, pluginDirName, "introskipper.db");
+        _dbPath = Path.Join(introsDirectory, "introskipper.db");
+        _cacheDbPath = Path.Join(introsDirectory, "introskipper-cache.db");
 
         // Create the base & cache directories (if needed).
         if (!Directory.Exists(FingerprintCachePath))
@@ -90,7 +92,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             Directory.CreateDirectory(FingerprintCachePath);
         }
 
-        // Initialize database, restore timestamps if available.
+        // Initialize segment database.
         try
         {
             using var db = CreateDbContext();
@@ -101,15 +103,30 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             LogDatabaseInitializationError(_logger, ex);
         }
 
+        // Initialize detection cache database.
+        try
+        {
+            DetectionCacheDb.EnsureSchema(_cacheDbPath);
+        }
+        catch (Exception ex)
+        {
+            LogCacheDbInitializationError(_logger, ex);
+        }
+
         Configuration.FileTransformationPluginEnabled = _pluginManager
             .Plugins
             .Any(p => p.Id == Guid.Parse("5e87cc92-571a-4d8d-8d98-d2d4147f9f90")); // File Transformation plugin ID
     }
 
     /// <summary>
-    /// Gets the path to the database.
+    /// Gets the path to the segment database.
     /// </summary>
     public string DbPath => _dbPath;
+
+    /// <summary>
+    /// Gets the path to the detection cache database.
+    /// </summary>
+    public string CacheDbPath => _cacheDbPath;
 
     /// <summary>
     /// Gets or sets a value indicating whether to analyze again.
@@ -161,6 +178,17 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
         ArgumentNullException.ThrowIfNull(Instance);
         return new IntroSkipperDbContext(Instance.DbPath);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="DetectionCacheDb"/> instance configured for the plugin cache database.
+    /// </summary>
+    /// <returns>A new <see cref="DetectionCacheDb"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
+    public static DetectionCacheDb CreateCacheDb()
+    {
+        ArgumentNullException.ThrowIfNull(Instance);
+        return new DetectionCacheDb(Instance.CacheDbPath);
     }
 
     /// <inheritdoc />
@@ -503,6 +531,9 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
     private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
+    private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update timestamp for episode {EpisodeId}")]
     private static partial void LogFailedToUpdateTimestamp(ILogger logger, Exception ex, Guid episodeId);

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -87,6 +87,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         _dbPath = Path.Join(introsDirectory, "introskipper.db");
         _cacheDbPath = Path.Join(introsDirectory, "introskipper-cache.db");
 
+        // Create the base directories (if needed).
+        if (!Directory.Exists(introsDirectory))
+        {
+            Directory.CreateDirectory(introsDirectory);
+        }
+
         // Initialize segment database.
         try
         {

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -108,7 +108,11 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         {
             DetectionCacheDb.EnsureSchema(_cacheDbPath);
         }
-        catch (Exception ex)
+        catch (IOException ex)
+        {
+            LogCacheDbInitializationError(_logger, ex);
+        }
+        catch (DbUpdateException ex)
         {
             LogCacheDbInitializationError(_logger, ex);
         }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -28,6 +28,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -112,7 +113,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         {
             LogCacheDbInitializationError(_logger, ex);
         }
-        catch (DbUpdateException ex)
+        catch (SqliteException ex)
         {
             LogCacheDbInitializationError(_logger, ex);
         }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -93,19 +93,15 @@ public partial class CleanCacheTask(
 
         await plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
 
-        // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
-        HashSet<Guid> invalidEpisodeIds;
-        using (var cacheDb = Plugin.CreateCacheDb())
-        {
-            invalidEpisodeIds = cacheDb.GetAllEpisodeIds()
-                .Where(id => !enabledLibraryEpisodeIds.Contains(id))
-                .ToHashSet();
-        }
+        // Identify episode IDs in the SQLite cache that are no longer in enabled libraries,
+        // and migrate any legacy binary files still on disk (pre-migration installs).
+        var cacheDb = Plugin.CreateCacheDb();
+        var invalidEpisodeIds = cacheDb.GetAllEpisodeIds()
+            .Where(id => !enabledLibraryEpisodeIds.Contains(id))
+            .ToHashSet();
 
-        // Also sweep any legacy binary files still on disk (pre-migration installs).
         if (Directory.Exists(plugin.FingerprintCachePath))
         {
-            using var cacheDb = Plugin.CreateCacheDb();
             foreach (var filePath in Directory.EnumerateFiles(plugin.FingerprintCachePath))
             {
                 var filename = Path.GetFileName(filePath);
@@ -144,7 +140,6 @@ public partial class CleanCacheTask(
 
                 try
                 {
-                    LogDeletingLegacyFile(_logger, filePath);
                     File.Delete(filePath);
                 }
                 catch (IOException ex)
@@ -199,9 +194,6 @@ public partial class CleanCacheTask(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to migrate legacy cache file '{FilePath}'")]
     private static partial void LogMigrationFailed(ILogger logger, Exception exception, string filePath);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting stale legacy cache file: {FilePath}")]
-    private static partial void LogDeletingLegacyFile(ILogger logger, string filePath);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete stale legacy cache file '{FilePath}'")]
     private static partial void LogDeletingLegacyFileFailed(ILogger logger, Exception exception, string filePath);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -94,16 +94,12 @@ public partial class CleanCacheTask(
         await plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
 
         // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
-        var invalidEpisodeIds = new HashSet<Guid>();
+        HashSet<Guid> invalidEpisodeIds;
         using (var cacheDb = Plugin.CreateCacheDb())
         {
-            foreach (var id in cacheDb.GetAllEpisodeIds())
-            {
-                if (!enabledLibraryEpisodeIds.Contains(id))
-                {
-                    invalidEpisodeIds.Add(id);
-                }
-            }
+            invalidEpisodeIds = cacheDb.GetAllEpisodeIds()
+                .Where(id => !enabledLibraryEpisodeIds.Contains(id))
+                .ToHashSet();
         }
 
         // Also sweep any legacy binary files still on disk (pre-migration installs).

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -108,7 +108,8 @@ public partial class CleanCacheTask(
             using var cacheDb = Plugin.CreateCacheDb();
             foreach (var filePath in Directory.EnumerateFiles(plugin.FingerprintCachePath))
             {
-                var parts = Path.GetFileName(filePath).Split('-');
+                var filename = Path.GetFileName(filePath);
+                var parts = filename.Split('-');
                 if (parts.Length == 0 || !Guid.TryParse(parts[0], out var legacyId))
                 {
                     continue;
@@ -122,7 +123,6 @@ public partial class CleanCacheTask(
                 }
 
                 // Valid episode — migrate binary data to the DB if not already there, then delete the disk file.
-                var filename = Path.GetFileName(filePath);
                 var dbKey = GetMigratedDbKey(filename, legacyId.ToString("N"));
                 if (dbKey is not null)
                 {
@@ -215,8 +215,9 @@ public partial class CleanCacheTask(
             return null;
         }
 
-        // blackframes v1 → v2
-        if (filename.Contains("-blackframes-", StringComparison.Ordinal) &&
+        // blackframes and keyframes v1 → v2
+        if ((filename.Contains("-blackframes-", StringComparison.Ordinal) ||
+             filename.Contains("-keyframes-", StringComparison.Ordinal)) &&
             filename.EndsWith("-v1", StringComparison.Ordinal))
         {
             return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v2");
@@ -227,13 +228,6 @@ public partial class CleanCacheTask(
             filename.EndsWith("-v2", StringComparison.Ordinal))
         {
             return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v3");
-        }
-
-        // keyframes v1 → v2
-        if (filename.Contains("-keyframes-", StringComparison.Ordinal) &&
-            filename.EndsWith("-v1", StringComparison.Ordinal))
-        {
-            return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v2");
         }
 
         // credits blackframes -alt → -v2

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -141,8 +141,8 @@ public partial class CleanCacheTask(
                 }
                 else
                 {
-                    // Text-format fingerprint file — data cannot be migrated and will be lost on deletion.
-                    LogDeletingTextFormatFile(_logger, filePath);
+                    // Non-migratable file (text-format fingerprint or stale detection format) — delete and let re-analysis repopulate.
+                    LogDeletingNonMigratableLegacyFile(_logger, filePath);
                 }
 
                 try
@@ -196,8 +196,8 @@ public partial class CleanCacheTask(
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete stale legacy cache file '{FilePath}'")]
     private static partial void LogDeletingLegacyFileFailed(ILogger logger, Exception exception, string filePath);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Deleting unmigratable text-format legacy cache file (data will be lost): {FilePath}")]
-    private static partial void LogDeletingTextFormatFile(ILogger logger, string filePath);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting non-migratable legacy cache file: {FilePath}")]
+    private static partial void LogDeletingNonMigratableLegacyFile(ILogger logger, string filePath);
 
     /// <summary>
     /// Maps a legacy on-disk cache filename to the current SQLite cache DB key.
@@ -220,20 +220,23 @@ public partial class CleanCacheTask(
              filename.Contains("-keyframes-", StringComparison.Ordinal)) &&
             filename.EndsWith("-v1", StringComparison.Ordinal))
         {
-            return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v2");
+            // Version bump represents a cache-format invalidation; copying raw bytes under the
+            // new key would write old-format data that TryReadBinaryCache cannot deserialize.
+            // Delete and let the next analysis repopulate in the current format.
+            return null;
         }
 
         // silence v2 → v3
         if (filename.Contains("-silence-", StringComparison.Ordinal) &&
             filename.EndsWith("-v2", StringComparison.Ordinal))
         {
-            return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v3");
+            return null;
         }
 
         // credits blackframes -alt → -v2
         if (filename.EndsWith("-alt", StringComparison.Ordinal))
         {
-            return string.Concat(filename.AsSpan(0, filename.Length - 4), "-v2");
+            return null;
         }
 
         // Already in current DB key format (chromaprint-v1, blackframes-v2, silence-v3, keyframes-v2, etc.)

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -105,6 +105,7 @@ public partial class CleanCacheTask(
         // Also sweep any legacy binary files still on disk (pre-migration installs).
         if (Directory.Exists(plugin.FingerprintCachePath))
         {
+            using var cacheDb = Plugin.CreateCacheDb();
             foreach (var filePath in Directory.EnumerateFiles(plugin.FingerprintCachePath))
             {
                 var parts = Path.GetFileName(filePath).Split('-');
@@ -125,7 +126,6 @@ public partial class CleanCacheTask(
                 var dbKey = GetMigratedDbKey(filename, legacyId.ToString("N"));
                 if (dbKey is not null)
                 {
-                    using var cacheDb = Plugin.CreateCacheDb();
                     if (!cacheDb.ExistsByKey(dbKey))
                     {
                         try
@@ -138,6 +138,11 @@ public partial class CleanCacheTask(
                             LogMigrationFailed(_logger, ex, filePath);
                         }
                     }
+                }
+                else
+                {
+                    // Text-format fingerprint file — data cannot be migrated and will be lost on deletion.
+                    LogDeletingTextFormatFile(_logger, filePath);
                 }
 
                 try
@@ -191,6 +196,9 @@ public partial class CleanCacheTask(
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete stale legacy cache file '{FilePath}'")]
     private static partial void LogDeletingLegacyFileFailed(ILogger logger, Exception exception, string filePath);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Deleting unmigratable text-format legacy cache file (data will be lost): {FilePath}")]
+    private static partial void LogDeletingTextFormatFile(ILogger logger, string filePath);
+
     /// <summary>
     /// Maps a legacy on-disk cache filename to the current SQLite cache DB key.
     /// Returns <c>null</c> for text-format fingerprint files (too old to migrate binary-style).
@@ -198,7 +206,7 @@ public partial class CleanCacheTask(
     /// <param name="filename">The filename of the legacy cache file (without directory).</param>
     /// <param name="episodeIdN">The episode GUID formatted as 32 lowercase hex digits.</param>
     /// <returns>The DB key to use, or <c>null</c> if the file cannot be migrated.</returns>
-    private static string? GetMigratedDbKey(string filename, string episodeIdN)
+    internal static string? GetMigratedDbKey(string filename, string episodeIdN)
     {
         // Plain GUID or GUID-credits: very old text-format fingerprint — delete without migrating.
         if (string.Equals(filename, episodeIdN, StringComparison.Ordinal) ||

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -122,21 +122,18 @@ public partial class CleanCacheTask(
                     continue;
                 }
 
-                // Valid episode — migrate binary data to the DB if not already there, then delete the disk file.
+                // Valid episode — migrate binary data to the DB, then delete the disk file.
                 var dbKey = GetMigratedDbKey(filename, legacyId.ToString("N"));
                 if (dbKey is not null)
                 {
-                    if (!cacheDb.ExistsByKey(dbKey))
+                    try
                     {
-                        try
-                        {
-                            LogMigratingLegacyFile(_logger, filePath);
-                            cacheDb.Write(dbKey, await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false));
-                        }
-                        catch (IOException ex)
-                        {
-                            LogMigrationFailed(_logger, ex, filePath);
-                        }
+                        LogMigratingLegacyFile(_logger, filePath);
+                        cacheDb.Write(dbKey, await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false));
+                    }
+                    catch (IOException ex)
+                    {
+                        LogMigrationFailed(_logger, ex, filePath);
                     }
                 }
                 else

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -105,9 +105,15 @@ public partial class CleanCacheTask(
         // Also sweep any legacy binary files still on disk (pre-migration installs).
         if (Directory.Exists(plugin.FingerprintCachePath))
         {
-            foreach (var filePath in Directory.EnumerateFiles(plugin.FingerprintCachePath))
+            var prefixes = Directory.EnumerateFiles(plugin.FingerprintCachePath)
+                .Select(filePath =>
+                {
+                    var parts = Path.GetFileName(filePath).Split('-');
+                    return parts.Length > 0 ? parts[0] : string.Empty;
+                });
+
+            foreach (var prefix in prefixes)
             {
-                var prefix = Path.GetFileName(filePath).Split('-')[0];
                 if (Guid.TryParse(prefix, out var legacyId) && !enabledLibraryEpisodeIds.Contains(legacyId))
                 {
                     invalidEpisodeIds.Add(legacyId);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -93,14 +93,33 @@ public partial class CleanCacheTask(
 
         await plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
 
-        // Identify episode IDs with cached files that are no longer in enabled libraries
-        var invalidEpisodeIds = Directory.EnumerateFiles(plugin.FingerprintCachePath)
-            .Select(filePath => Path.GetFileNameWithoutExtension(filePath).Split('-')[0])
-            .Where(episodeIdStr => Guid.TryParse(episodeIdStr, out var episodeId) && !enabledLibraryEpisodeIds.Contains(episodeId))
-            .Select(Guid.Parse)
-            .ToHashSet();
+        // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
+        var invalidEpisodeIds = new HashSet<Guid>();
+        using (var cacheDb = Plugin.CreateCacheDb())
+        {
+            foreach (var id in cacheDb.GetAllEpisodeIds())
+            {
+                if (!enabledLibraryEpisodeIds.Contains(id))
+                {
+                    invalidEpisodeIds.Add(id);
+                }
+            }
+        }
 
-        // Delete cache files for invalid episode IDs
+        // Also sweep any legacy binary files still on disk (pre-migration installs).
+        if (Directory.Exists(plugin.FingerprintCachePath))
+        {
+            foreach (var filePath in Directory.EnumerateFiles(plugin.FingerprintCachePath))
+            {
+                var prefix = Path.GetFileName(filePath).Split('-')[0];
+                if (Guid.TryParse(prefix, out var legacyId) && !enabledLibraryEpisodeIds.Contains(legacyId))
+                {
+                    invalidEpisodeIds.Add(legacyId);
+                }
+            }
+        }
+
+        // Delete cache entries for invalid episode IDs (DB rows + any leftover files).
         foreach (var episodeId in invalidEpisodeIds)
         {
             LogDeletingCacheFiles(_logger, episodeId);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -155,6 +155,19 @@ public partial class CleanCacheTask(
                     LogDeletingLegacyFileFailed(_logger, ex, filePath);
                 }
             }
+
+            // Remove the directory itself once it is empty (all legacy files migrated or deleted).
+            if (!Directory.EnumerateFileSystemEntries(plugin.FingerprintCachePath).Any())
+            {
+                try
+                {
+                    Directory.Delete(plugin.FingerprintCachePath);
+                }
+                catch (IOException ex)
+                {
+                    LogDeletingLegacyDirectoryFailed(_logger, ex, plugin.FingerprintCachePath);
+                }
+            }
         }
 
         // Delete cache entries for invalid episode IDs (DB rows + any leftover files).
@@ -195,6 +208,9 @@ public partial class CleanCacheTask(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete stale legacy cache file '{FilePath}'")]
     private static partial void LogDeletingLegacyFileFailed(ILogger logger, Exception exception, string filePath);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete legacy fingerprint cache directory '{DirectoryPath}'")]
+    private static partial void LogDeletingLegacyDirectoryFailed(ILogger logger, Exception exception, string directoryPath);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting non-migratable legacy cache file: {FilePath}")]
     private static partial void LogDeletingNonMigratableLegacyFile(ILogger logger, string filePath);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -95,29 +95,49 @@ public partial class CleanCacheTask(
 
         // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
         HashSet<Guid> invalidEpisodeIds;
+        HashSet<Guid> migratedEpisodeIds;
         using (var cacheDb = Plugin.CreateCacheDb())
         {
-            invalidEpisodeIds = cacheDb.GetAllEpisodeIds()
+            var allCachedIds = cacheDb.GetAllEpisodeIds().ToList();
+            invalidEpisodeIds = allCachedIds
                 .Where(id => !enabledLibraryEpisodeIds.Contains(id))
+                .ToHashSet();
+            migratedEpisodeIds = allCachedIds
+                .Where(id => enabledLibraryEpisodeIds.Contains(id))
                 .ToHashSet();
         }
 
         // Also sweep any legacy binary files still on disk (pre-migration installs).
         if (Directory.Exists(plugin.FingerprintCachePath))
         {
-            var prefixes = Directory.EnumerateFiles(plugin.FingerprintCachePath)
-                .Select(filePath =>
-                {
-                    var parts = Path.GetFileName(filePath).Split('-');
-                    return parts.Length > 0 ? parts[0] : string.Empty;
-                });
-
-            foreach (var prefix in prefixes)
+            foreach (var filePath in Directory.EnumerateFiles(plugin.FingerprintCachePath))
             {
-                if (Guid.TryParse(prefix, out var legacyId) && !enabledLibraryEpisodeIds.Contains(legacyId))
+                var parts = Path.GetFileName(filePath).Split('-');
+                if (parts.Length == 0 || !Guid.TryParse(parts[0], out var legacyId))
                 {
+                    continue;
+                }
+
+                if (!enabledLibraryEpisodeIds.Contains(legacyId))
+                {
+                    // Invalid episode — queue for full cache deletion via DeleteFingerprintCache.
                     invalidEpisodeIds.Add(legacyId);
                 }
+                else if (migratedEpisodeIds.Contains(legacyId))
+                {
+                    // Valid episode already in the cache DB — disk file is a stale legacy copy.
+                    LogDeletingLegacyFile(_logger, filePath);
+                    try
+                    {
+                        File.Delete(filePath);
+                    }
+                    catch (IOException ex)
+                    {
+                        LogDeletingLegacyFileFailed(_logger, ex, filePath);
+                    }
+                }
+
+                // else: valid episode not yet in DB — leave the file for analysis to migrate on next run.
             }
         }
 
@@ -147,4 +167,10 @@ public partial class CleanCacheTask(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting cache files for episode ID: {EpisodeId}")]
     private static partial void LogDeletingCacheFiles(ILogger logger, Guid episodeId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting stale legacy cache file: {FilePath}")]
+    private static partial void LogDeletingLegacyFile(ILogger logger, string filePath);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete stale legacy cache file '{FilePath}'")]
+    private static partial void LogDeletingLegacyFileFailed(ILogger logger, Exception exception, string filePath);
 }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -95,15 +95,10 @@ public partial class CleanCacheTask(
 
         // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
         HashSet<Guid> invalidEpisodeIds;
-        HashSet<Guid> migratedEpisodeIds;
         using (var cacheDb = Plugin.CreateCacheDb())
         {
-            var allCachedIds = cacheDb.GetAllEpisodeIds().ToList();
-            invalidEpisodeIds = allCachedIds
+            invalidEpisodeIds = cacheDb.GetAllEpisodeIds()
                 .Where(id => !enabledLibraryEpisodeIds.Contains(id))
-                .ToHashSet();
-            migratedEpisodeIds = allCachedIds
-                .Where(id => enabledLibraryEpisodeIds.Contains(id))
                 .ToHashSet();
         }
 
@@ -122,22 +117,38 @@ public partial class CleanCacheTask(
                 {
                     // Invalid episode — queue for full cache deletion via DeleteFingerprintCache.
                     invalidEpisodeIds.Add(legacyId);
+                    continue;
                 }
-                else if (migratedEpisodeIds.Contains(legacyId))
+
+                // Valid episode — migrate binary data to the DB if not already there, then delete the disk file.
+                var filename = Path.GetFileName(filePath);
+                var dbKey = GetMigratedDbKey(filename, legacyId.ToString("N"));
+                if (dbKey is not null)
                 {
-                    // Valid episode already in the cache DB — disk file is a stale legacy copy.
-                    LogDeletingLegacyFile(_logger, filePath);
-                    try
+                    using var cacheDb = Plugin.CreateCacheDb();
+                    if (!cacheDb.ExistsByKey(dbKey))
                     {
-                        File.Delete(filePath);
-                    }
-                    catch (IOException ex)
-                    {
-                        LogDeletingLegacyFileFailed(_logger, ex, filePath);
+                        try
+                        {
+                            LogMigratingLegacyFile(_logger, filePath);
+                            cacheDb.Write(dbKey, await File.ReadAllBytesAsync(filePath, cancellationToken).ConfigureAwait(false));
+                        }
+                        catch (IOException ex)
+                        {
+                            LogMigrationFailed(_logger, ex, filePath);
+                        }
                     }
                 }
 
-                // else: valid episode not yet in DB — leave the file for analysis to migrate on next run.
+                try
+                {
+                    LogDeletingLegacyFile(_logger, filePath);
+                    File.Delete(filePath);
+                }
+                catch (IOException ex)
+                {
+                    LogDeletingLegacyFileFailed(_logger, ex, filePath);
+                }
             }
         }
 
@@ -168,9 +179,62 @@ public partial class CleanCacheTask(
     [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting cache files for episode ID: {EpisodeId}")]
     private static partial void LogDeletingCacheFiles(ILogger logger, Guid episodeId);
 
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Migrating legacy cache file to DB: {FilePath}")]
+    private static partial void LogMigratingLegacyFile(ILogger logger, string filePath);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to migrate legacy cache file '{FilePath}'")]
+    private static partial void LogMigrationFailed(ILogger logger, Exception exception, string filePath);
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting stale legacy cache file: {FilePath}")]
     private static partial void LogDeletingLegacyFile(ILogger logger, string filePath);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete stale legacy cache file '{FilePath}'")]
     private static partial void LogDeletingLegacyFileFailed(ILogger logger, Exception exception, string filePath);
+
+    /// <summary>
+    /// Maps a legacy on-disk cache filename to the current SQLite cache DB key.
+    /// Returns <c>null</c> for text-format fingerprint files (too old to migrate binary-style).
+    /// </summary>
+    /// <param name="filename">The filename of the legacy cache file (without directory).</param>
+    /// <param name="episodeIdN">The episode GUID formatted as 32 lowercase hex digits.</param>
+    /// <returns>The DB key to use, or <c>null</c> if the file cannot be migrated.</returns>
+    private static string? GetMigratedDbKey(string filename, string episodeIdN)
+    {
+        // Plain GUID or GUID-credits: very old text-format fingerprint — delete without migrating.
+        if (string.Equals(filename, episodeIdN, StringComparison.Ordinal) ||
+            string.Equals(filename, episodeIdN + "-credits", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // blackframes v1 → v2
+        if (filename.Contains("-blackframes-", StringComparison.Ordinal) &&
+            filename.EndsWith("-v1", StringComparison.Ordinal))
+        {
+            return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v2");
+        }
+
+        // silence v2 → v3
+        if (filename.Contains("-silence-", StringComparison.Ordinal) &&
+            filename.EndsWith("-v2", StringComparison.Ordinal))
+        {
+            return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v3");
+        }
+
+        // keyframes v1 → v2
+        if (filename.Contains("-keyframes-", StringComparison.Ordinal) &&
+            filename.EndsWith("-v1", StringComparison.Ordinal))
+        {
+            return string.Concat(filename.AsSpan(0, filename.Length - 3), "-v2");
+        }
+
+        // credits blackframes -alt → -v2
+        if (filename.EndsWith("-alt", StringComparison.Ordinal))
+        {
+            return string.Concat(filename.AsSpan(0, filename.Length - 4), "-v2");
+        }
+
+        // Already in current DB key format (chromaprint-v1, blackframes-v2, silence-v3, keyframes-v2, etc.)
+        return filename;
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a SQLite-backed detection cache for FFmpeg analysis results and migrate existing file-based cache data, while updating cache management logic to operate on the new store.

Enhancements:
- Replace per-command file-based FFmpeg detection caching with a centralized SQLite-backed cache layer for silence, blackframe, keyframe, and fingerprint data.
- Refine cache key versions and parsing helpers for detection outputs to support structured binary storage and future migrations.
- Extend plugin and database infrastructure to manage a dedicated detection cache database with appropriate SQLite pragmas for reliability and concurrency.
- Improve cache cleanup logic to migrate legacy cache files into the database when possible and to accurately delete cache entries by episode or analysis mode.

Tests:
- Add unit tests for the new detection cache database operations, cache file deletion semantics, and migration logic for legacy cache files and fingerprints.
- Update test scaffolding to provision an isolated detection cache database alongside the existing plugin instance for cache-related tests.