### PR TITLE
Respect config flag when updating media segments

### DIFF
--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -151,7 +151,7 @@ public partial class BaseItemAnalyzerTask(
                 throw;
             }
 
-            if (updateMediaSegments)
+            if (updateMediaSegments && _config.UpdateMediaSegments)
             {
                 await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, ct).ConfigureAwait(false);
             }


### PR DESCRIPTION
Gate the media segment update behind the _config.UpdateMediaSegments option. The code now checks both updateMediaSegments and the configuration flag before calling UpdateMediaSegmentsAsync, preventing unwanted updates when the feature is disabled in settings.

## Summary by Sourcery

Bug Fixes:
- Prevent media segments from being updated when the UpdateMediaSegments configuration option is disabled.