### PR TITLE
Refresh anime Preview segment when credits shift on re-analyze

### DIFF
--- a/IntroSkipper.Tests/TestAnimePreviewRefresh.cs
+++ b/IntroSkipper.Tests/TestAnimePreviewRefresh.cs
@@ -93,6 +93,24 @@ public class TestAnimePreviewRefresh
     }
 
     [Fact]
+    public void RefreshesPreview_WhenEpisodeDurationChanges()
+    {
+        // Episode file replaced with a longer cut: credits.End is unchanged but Preview.End is stale.
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.0)),
+            [AnalysisMode.Preview] = new Segment(EpisodeId, new TimeRange(1260.0, EpisodeDuration)),
+        };
+
+        const double newDuration = EpisodeDuration + 60.0;
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, newDuration, timestamps);
+
+        Assert.NotNull(result);
+        Assert.Equal(1260.0, result!.Start);
+        Assert.Equal(newDuration, result.End);
+    }
+
+    [Fact]
     public void RefreshesPreview_WhenDriftExceedsTolerance()
     {
         var timestamps = new Dictionary<AnalysisMode, Segment>

--- a/IntroSkipper.Tests/TestAnimePreviewRefresh.cs
+++ b/IntroSkipper.Tests/TestAnimePreviewRefresh.cs
@@ -78,6 +78,21 @@ public class TestAnimePreviewRefresh
     }
 
     [Fact]
+    public void TreatsExactBoundaryDriftAsEqual()
+    {
+        // A drift of exactly 0.5s should be treated as equal (matches the "within or equal to" doc).
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.5)),
+            [AnalysisMode.Preview] = new Segment(EpisodeId, new TimeRange(1260.0, EpisodeDuration)),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void RefreshesPreview_WhenDriftExceedsTolerance()
     {
         var timestamps = new Dictionary<AnalysisMode, Segment>

--- a/IntroSkipper.Tests/TestAnimePreviewRefresh.cs
+++ b/IntroSkipper.Tests/TestAnimePreviewRefresh.cs
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using IntroSkipper.Data;
+using IntroSkipper.ScheduledTasks;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public class TestAnimePreviewRefresh
+{
+    private static readonly Guid EpisodeId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private const double EpisodeDuration = 1320.0; // 22 minutes
+
+    [Fact]
+    public void ReturnsNewSegment_WhenNoPreviewExistsYet()
+    {
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.0)),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.NotNull(result);
+        Assert.Equal(EpisodeId, result!.EpisodeId);
+        Assert.Equal(1260.0, result.Start);
+        Assert.Equal(EpisodeDuration, result.End);
+    }
+
+    [Fact]
+    public void RefreshesPreview_WhenCreditsEndShifts()
+    {
+        // Scenario: previous analysis produced Credits ending at 1080s and a Preview [1080, 1320].
+        // A settings change triggered re-analysis, Credits is now [..., 1260] — the old Preview is stale.
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.0)),
+            [AnalysisMode.Preview] = new Segment(EpisodeId, new TimeRange(1080.0, EpisodeDuration)),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.NotNull(result);
+        Assert.Equal(1260.0, result!.Start);
+        Assert.Equal(EpisodeDuration, result.End);
+    }
+
+    [Fact]
+    public void IsIdempotent_WhenExistingPreviewMatchesCreditsEnd()
+    {
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.0)),
+            [AnalysisMode.Preview] = new Segment(EpisodeId, new TimeRange(1260.0, EpisodeDuration)),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void TreatsSubSecondDriftAsEqual()
+    {
+        // Chromaprint quantises timestamps to ~0.124s — a 0.3s delta between runs is noise, not a real change.
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.3)),
+            [AnalysisMode.Preview] = new Segment(EpisodeId, new TimeRange(1260.0, EpisodeDuration)),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void RefreshesPreview_WhenDriftExceedsTolerance()
+    {
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.0)),
+            [AnalysisMode.Preview] = new Segment(EpisodeId, new TimeRange(1259.0, EpisodeDuration)),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.NotNull(result);
+        Assert.Equal(1260.0, result!.Start);
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenNoCreditsPresent()
+    {
+        var timestamps = new Dictionary<AnalysisMode, Segment>();
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenCreditsAreInvalid()
+    {
+        // A default-constructed Segment has End == 0 → Valid is false.
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenCreditsReachEndOfEpisode()
+    {
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, EpisodeDuration)),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void IgnoresInvalidExistingPreview()
+    {
+        // A stored Preview with End==0 is invalid (e.g. leftover DB row); should be overwritten.
+        var timestamps = new Dictionary<AnalysisMode, Segment>
+        {
+            [AnalysisMode.Credits] = new Segment(EpisodeId, new TimeRange(1200.0, 1260.0)),
+            [AnalysisMode.Preview] = new Segment(EpisodeId),
+        };
+
+        var result = BaseItemAnalyzerTask.ComputeAnimePreviewFromCredits(EpisodeId, EpisodeDuration, timestamps);
+
+        Assert.NotNull(result);
+        Assert.Equal(1260.0, result!.Start);
+        Assert.Equal(EpisodeDuration, result.End);
+    }
+}

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -259,10 +259,12 @@ public partial class BaseItemAnalyzerTask(
     /// Decide whether an anime Preview segment needs to be written for an episode, and build it.
     /// </summary>
     /// <remarks>
-    /// Returns a new Segment when the Preview is missing or its Start no longer matches the current
-    /// credits.End (e.g. because settings changed and Credits was re-analyzed). Returns <see langword="null"/>
-    /// when there are no valid credits, the credits already cover the episode, or an existing Preview
-    /// already matches the current credits.End within or equal to <see cref="AnimePreviewStartTolerance"/>.
+    /// Returns a new Segment when the Preview is missing, its Start no longer matches the current
+    /// credits.End (e.g. because settings changed and Credits was re-analyzed), or its End no longer
+    /// matches the episode duration (e.g. because the underlying media file was replaced).
+    /// Returns <see langword="null"/> when there are no valid credits, the credits already cover the
+    /// episode, or an existing Preview already matches both the current credits.End and the episode
+    /// duration within or equal to <see cref="AnimePreviewStartTolerance"/>.
     /// </remarks>
     /// <param name="episodeId">Episode id.</param>
     /// <param name="episodeDuration">Episode duration in seconds.</param>
@@ -287,7 +289,8 @@ public partial class BaseItemAnalyzerTask(
 
         if (existingTimestamps.TryGetValue(AnalysisMode.Preview, out var existing)
             && existing.Valid
-            && Math.Abs(existing.Start - credits.End) <= AnimePreviewStartTolerance)
+            && Math.Abs(existing.Start - credits.End) <= AnimePreviewStartTolerance
+            && Math.Abs(existing.End - episodeDuration) <= AnimePreviewStartTolerance)
         {
             return null;
         }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -41,6 +41,13 @@ public partial class BaseItemAnalyzerTask(
     IFileSystem fileSystem,
     MediaSegmentUpdateManager mediaSegmentUpdateManager)
 {
+    /// <summary>
+    /// Tolerance (seconds) when comparing an existing anime Preview's start to a newly-computed
+    /// credits.End. Chromaprint timestamps are quantised to ~0.124 s and a sub-second delta has
+    /// no user-visible effect, so treat "close enough" as equal for idempotency.
+    /// </summary>
+    private const double AnimePreviewStartTolerance = 0.5;
+
     private readonly ILogger _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private readonly ILibraryManager _libraryManager = libraryManager;
@@ -103,6 +110,8 @@ public partial class BaseItemAnalyzerTask(
             CancellationToken = cancellationToken
         };
 
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+
         await Parallel.ForEachAsync(queue, options, async (season, ct) =>
         {
             var updateMediaSegments = false;
@@ -128,6 +137,7 @@ public partial class BaseItemAnalyzerTask(
                 {
                     ct.ThrowIfCancellationRequested();
                     int analyzed = await AnalyzeItemsAsync(
+                        plugin,
                         episodes,
                         mode,
                         ct).ConfigureAwait(false);
@@ -157,17 +167,19 @@ public partial class BaseItemAnalyzerTask(
             }
         }).ConfigureAwait(false);
 
-        Plugin.Instance!.AnalyzeAgain = false;
+        plugin.AnalyzeAgain = false;
     }
 
     /// <summary>
     /// Analyze a group of media items for skippable segments.
     /// </summary>
+    /// <param name="plugin">Plugin instance.</param>
     /// <param name="items">Media items to analyze.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Number of items successfully analyzed.</returns>
     private async Task<int> AnalyzeItemsAsync(
+        Plugin plugin,
         IReadOnlyList<QueuedEpisode> items,
         AnalysisMode mode,
         CancellationToken cancellationToken)
@@ -188,7 +200,6 @@ public partial class BaseItemAnalyzerTask(
         }
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var action = await plugin.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
 
         var chromaprintOnly = _ffmpegValid && _config.PreferChromaprint && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint;
@@ -234,21 +245,63 @@ public partial class BaseItemAnalyzerTask(
         // For anime, optionally create a Preview segment from the end of credits to the end of the episode.
         if (mode == AnalysisMode.Credits && isAnime && _config.AnimePreviewFromCreditsEnd)
         {
-            await CreateAnimePreviewFromCreditsAsync(items, cancellationToken).ConfigureAwait(false);
+            await CreateAnimePreviewFromCreditsAsync(plugin, items, cancellationToken).ConfigureAwait(false);
         }
 
         // Set the episode IDs for the analyzed items
-        await Plugin.Instance!.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), cancellationToken).ConfigureAwait(false);
+        await plugin.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), cancellationToken).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
     }
 
     /// <summary>
-    /// For anime episodes, creates a Preview segment covering the remaining content after the credits end.
+    /// Decide whether an anime Preview segment needs to be written for an episode, and build it.
     /// </summary>
+    /// <remarks>
+    /// Returns a new Segment when the Preview is missing or its Start no longer matches the current
+    /// credits.End (e.g. because settings changed and Credits was re-analyzed). Returns <see langword="null"/>
+    /// when there are no valid credits, the credits already cover the episode, or an existing Preview
+    /// already matches the current credits.End within <see cref="AnimePreviewStartTolerance"/>.
+    /// </remarks>
+    /// <param name="episodeId">Episode id.</param>
+    /// <param name="episodeDuration">Episode duration in seconds.</param>
+    /// <param name="existingTimestamps">Current segments keyed by mode for this episode.</param>
+    /// <returns>Segment to write, or <see langword="null"/> when no write is needed.</returns>
+    public static Segment? ComputeAnimePreviewFromCredits(
+        Guid episodeId,
+        double episodeDuration,
+        IReadOnlyDictionary<AnalysisMode, Segment> existingTimestamps)
+    {
+        ArgumentNullException.ThrowIfNull(existingTimestamps);
+
+        if (!existingTimestamps.TryGetValue(AnalysisMode.Credits, out var credits) || !credits.Valid)
+        {
+            return null;
+        }
+
+        if (credits.End >= episodeDuration)
+        {
+            return null;
+        }
+
+        if (existingTimestamps.TryGetValue(AnalysisMode.Preview, out var existing)
+            && existing.Valid
+            && Math.Abs(existing.Start - credits.End) < AnimePreviewStartTolerance)
+        {
+            return null;
+        }
+
+        return new Segment(episodeId, new TimeRange(credits.End, episodeDuration));
+    }
+
+    /// <summary>
+    /// For anime episodes, creates or refreshes a Preview segment covering the remaining content after the credits end.
+    /// </summary>
+    /// <param name="plugin">Plugin instance.</param>
     /// <param name="items">Media items to process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     private async Task CreateAnimePreviewFromCreditsAsync(
+        Plugin plugin,
         IReadOnlyList<QueuedEpisode> items,
         CancellationToken cancellationToken)
     {
@@ -259,30 +312,17 @@ public partial class BaseItemAnalyzerTask(
                 break;
             }
 
-            var timestamps = await Plugin.Instance!.GetTimestampsAsync(episode.EpisodeId, cancellationToken).ConfigureAwait(false);
-
-            // Skip episodes that already have a preview
-            if (timestamps.TryGetValue(AnalysisMode.Preview, out var existing) && existing.Valid)
+            var timestamps = await plugin.GetTimestampsAsync(episode.EpisodeId, cancellationToken).ConfigureAwait(false);
+            var preview = ComputeAnimePreviewFromCredits(episode.EpisodeId, episode.Duration, timestamps);
+            if (preview is null)
             {
                 continue;
             }
 
-            if (!timestamps.TryGetValue(AnalysisMode.Credits, out var credits) || !credits.Valid)
-            {
-                continue;
-            }
-
-            // Only create a preview when there is content remaining after the credits
-            if (credits.End >= episode.Duration)
-            {
-                continue;
-            }
-
-            var preview = new Segment(episode.EpisodeId, new TimeRange(credits.End, episode.Duration));
-            await Plugin.Instance!.UpdateTimestampAsync(preview, AnalysisMode.Preview, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await plugin.UpdateTimestampAsync(preview, AnalysisMode.Preview, cancellationToken: cancellationToken).ConfigureAwait(false);
             episode.SetAnalyzed(AnalysisMode.Preview, EpisodeState.Analyzed);
 
-            LogCreatedAnimePreview(_logger, episode.Name, credits.End, episode.Duration);
+            LogCreatedAnimePreview(_logger, episode.Name, preview.Start, preview.End);
         }
     }
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
@@ -261,7 +262,7 @@ public partial class BaseItemAnalyzerTask(
     /// Returns a new Segment when the Preview is missing or its Start no longer matches the current
     /// credits.End (e.g. because settings changed and Credits was re-analyzed). Returns <see langword="null"/>
     /// when there are no valid credits, the credits already cover the episode, or an existing Preview
-    /// already matches the current credits.End within <see cref="AnimePreviewStartTolerance"/>.
+    /// already matches the current credits.End within or equal to <see cref="AnimePreviewStartTolerance"/>.
     /// </remarks>
     /// <param name="episodeId">Episode id.</param>
     /// <param name="episodeDuration">Episode duration in seconds.</param>
@@ -286,7 +287,7 @@ public partial class BaseItemAnalyzerTask(
 
         if (existingTimestamps.TryGetValue(AnalysisMode.Preview, out var existing)
             && existing.Valid
-            && Math.Abs(existing.Start - credits.End) < AnimePreviewStartTolerance)
+            && Math.Abs(existing.Start - credits.End) <= AnimePreviewStartTolerance)
         {
             return null;
         }
@@ -312,7 +313,21 @@ public partial class BaseItemAnalyzerTask(
                 break;
             }
 
-            var timestamps = await plugin.GetTimestampsAsync(episode.EpisodeId, cancellationToken).ConfigureAwait(false);
+            // Use GetSegmentsAsync (not GetTimestampsAsync) so we can see IsUserProvided.
+            // UpdateTimestampAsync silently no-ops when a user-provided Preview exists, which would
+            // otherwise leave us emitting a misleading "Created anime preview" log + Analyzed state.
+            var dbSegments = await plugin.GetSegmentsAsync(episode.EpisodeId, cancellationToken).ConfigureAwait(false);
+
+            if (dbSegments.Any(s => s.Type == AnalysisMode.Preview && s.IsUserProvided))
+            {
+                LogSkippedUserProvidedPreview(_logger, episode.Name);
+                continue;
+            }
+
+            var timestamps = dbSegments
+                .GroupBy(s => s.Type)
+                .ToDictionary(g => g.Key, g => g.OrderBy(s => s.Start).First().ToSegment());
+
             var preview = ComputeAnimePreviewFromCredits(episode.EpisodeId, episode.Duration, timestamps);
             if (preview is null)
             {
@@ -328,6 +343,9 @@ public partial class BaseItemAnalyzerTask(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Created anime preview for {Episode}: {Start:F2}s to {End:F2}s")]
     private static partial void LogCreatedAnimePreview(ILogger logger, string episode, double start, double end);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping anime preview for {Episode}: a user-provided Preview already exists.")]
+    private static partial void LogSkippedUserProvidedPreview(ILogger logger, string episode);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "No libraries selected for analysis. To enable, check library configuration > Media Segment Providers.")]
     private static partial void LogNoLibrariesSelected(ILogger logger);


### PR DESCRIPTION
## Summary

- Fixes a correctness bug in the anime-preview flow: when #735's `AnalyzeAgain` path re-analyzes Credits after a settings change, the derived `Preview` segment kept its old boundaries instead of being rewritten to the new `credits.End`.
- Extracts the decision logic from `CreateAnimePreviewFromCreditsAsync` into a pure, testable `ComputeAnimePreviewFromCredits(...)` helper, and only skips when an existing Preview's `Start` is within 0.5 s of the current `credits.End` (chromaprint is quantised to ~0.124 s, so sub-second drift is noise — treat it as equal for idempotency).
- Threads a guarded `Plugin` local through `AnalyzeItemsAsync` so the remaining `Plugin.Instance!` null-forgiving sites in that file are gone.

## Why

The previous short-circuit (`if (existing.Valid) continue;`) meant that any stored Preview — including a stale one from a prior analysis — blocked the refresh. #735 started re-analyzing Credits when settings change; that PR correctly rewrites the Credits row but the anime Preview silently opts out of the fix, so users see `[oldCreditsEnd, duration]` Preview markers even after Credits move.

Comparing `existing.Start ≈ credits.End` is stricter than gating on `AnalyzeAgain`: it catches any drift (including manual DB edits) and keeps the anime flow decoupled from that flag.

## Reviewer notes

- `ComputeAnimePreviewFromCredits` is `public static` because the test project does not have `InternalsVisibleTo` configured (matches the existing convention for `ChromaprintAnalyzer.CountBits`, `TimeRangeHelpers.FindContiguous`, etc.).
- No behaviour change on the first-analysis or idempotent-re-run path: the new check still returns `null` when a matching Preview already exists.
- `Plugin.Instance!` → guarded `plugin` local is a style-only change; no runtime diff unless the plugin is unloaded mid-task (which would now throw `InvalidOperationException` at the top of `AnalyzeItemsAsync` instead of faulting later).

## Test plan

- [x] `dotnet build IntroSkipper/IntroSkipper.csproj` — clean, 0 warnings, 0 errors.
- [x] `dotnet test IntroSkipper.Tests/` — 70/70 passing (9 new in `TestAnimePreviewRefresh`, 61 existing green).
- [x] New tests cover: no-preview-yet, stale-preview refresh, idempotent match, sub-second drift tolerance, over-tolerance drift, missing credits, invalid credits, credits fill episode, invalid existing preview.
- [ ] Manual sanity (optional, reviewer): enable `AnimePreviewFromCreditsEnd`, analyse an anime series, change a setting that alters credits (e.g. `MaximumEndTime`), re-run `DetectSegmentsTask`, confirm Preview.Start tracks the new `credits.End` in the plugin DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh anime preview segments when credits analysis changes and remove remaining direct Plugin.Instance usages in the analyzer task.

Bug Fixes:
- Ensure anime Preview segments are recalculated when credits timing changes instead of being skipped due to an existing stale Preview.
- Avoid treating minor sub-second timestamp drift between credits.End and preview.Start as a real change when deciding whether to rewrite the Preview segment.

Enhancements:
- Extract the anime preview-from-credits decision logic into a reusable ComputeAnimePreviewFromCredits helper with clear semantics around when a Preview should be created or refreshed.
- Thread a validated Plugin instance through BaseItemAnalyzerTask.AnalyzeItemsAsync and related helpers instead of using Plugin.Instance directly, improving null safety and failure behavior.

Tests:
- Add unit tests covering anime Preview creation, refresh behavior on shifted credits, idempotency, drift tolerance, and various edge cases like missing or invalid credits and previews.