### PR TITLE
refactor: replace analyzer filter logic with priority-based chain

### DIFF
--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -203,40 +203,81 @@ public partial class BaseItemAnalyzerTask(
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
         var action = await plugin.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
 
-        var chromaprintOnly = _ffmpegValid && _config.PreferChromaprint && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint;
+        if (action == AnalyzerAction.None)
+        {
+            return 0;
+        }
 
         LogAnalyzingFiles(_logger, mode, items.Count, first.SeriesName, first.SeasonNumber);
 
-        // Create analyzers list
-        var analyzers = new List<IMediaFileAnalyzer>();
-
-        IMediaFileAnalyzer blackFrameAnalyzer = _config.UseAlternativeBlackFrameAnalyzer
-            ? new BlackFrameAltAnalyzer(_loggerFactory.CreateLogger<BlackFrameAltAnalyzer>())
-            : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>());
-
-        // Add analyzers based on conditions
-        if (!chromaprintOnly && action is AnalyzerAction.Chapter or AnalyzerAction.Default)
+        // Build the default analyzer chain for this mode and content type.
+        // All applicable analyzers are always included — the order determines priority,
+        // and each analyzer skips episodes already handled by earlier ones via NeedsAnalysis().
+        var analyzers = new List<IMediaFileAnalyzer>
         {
-            analyzers.Add(new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()));
+            // ChapterAnalyzer: supports all modes and content types
+            new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>())
+        };
+
+        if (mode is AnalysisMode.Credits)
+        {
+            if (isAnime)
+            {
+                // Anime credits: Chromaprint before BlackFrame (fingerprint matching preferred)
+                if (_ffmpegValid)
+                {
+                    analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
+                }
+
+                analyzers.Add(CreateBlackFrameAnalyzer());
+            }
+            else
+            {
+                // Non-anime credits: BlackFrame before Chromaprint
+                analyzers.Add(CreateBlackFrameAnalyzer());
+
+                if (!isMovie && _ffmpegValid)
+                {
+                    analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
+                }
+            }
+        }
+        else if (mode is AnalysisMode.Introduction)
+        {
+            // Introduction: Chromaprint is the only non-chapter analyzer
+            if (!isMovie && _ffmpegValid)
+            {
+                analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
+            }
         }
 
-        if (isAnime && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
+        // Recap, Preview, Commercial: only ChapterAnalyzer (already added above)
+
+        // Apply priority overrides to reorder the analyzer chain.
+        // The specified analyzer moves to the front; others keep their relative order.
+        // AnalyzerAction per-season override takes precedence over PreferChromaprint config.
+        switch (action)
         {
-            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
+            case AnalyzerAction.Chapter:
+                PromoteAnalyzer(analyzers, static a => a is ChapterAnalyzer);
+                break;
+            case AnalyzerAction.Chromaprint:
+                PromoteAnalyzer(analyzers, static a => a is ChromaprintAnalyzer);
+                break;
+            case AnalyzerAction.BlackFrame:
+                PromoteAnalyzer(analyzers, static a => a is BlackFrameAnalyzer or BlackFrameAltAnalyzer);
+                break;
+            default:
+                if (_config.PreferChromaprint && _ffmpegValid)
+                {
+                    PromoteAnalyzer(analyzers, static a => a is ChromaprintAnalyzer);
+                }
+
+                break;
         }
 
-        if (!chromaprintOnly && mode is AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.BlackFrame)
-        {
-            analyzers.Add(blackFrameAnalyzer);
-        }
-
-        if (!isAnime && !isMovie && mode is AnalysisMode.Introduction or AnalysisMode.Credits && action is AnalyzerAction.Default or AnalyzerAction.Chromaprint && _ffmpegValid)
-        {
-            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
-        }
-
-        // Use each analyzer to find skippable ranges in all media files, removing successfully
-        // analyzed items from the queue.
+        // Execute each analyzer in order. Analyzers skip episodes already
+        // marked as analyzed by earlier ones via NeedsAnalysis().
         foreach (var analyzer in analyzers)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -296,6 +337,31 @@ public partial class BaseItemAnalyzerTask(
         }
 
         return new Segment(episodeId, new TimeRange(credits.End, episodeDuration));
+    }
+
+    /// <summary>
+    /// Creates the configured black frame analyzer variant.
+    /// </summary>
+    /// <returns>A <see cref="BlackFrameAnalyzer"/> or <see cref="BlackFrameAltAnalyzer"/> based on configuration.</returns>
+    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => _config.UseAlternativeBlackFrameAnalyzer
+        ? new BlackFrameAltAnalyzer(_loggerFactory.CreateLogger<BlackFrameAltAnalyzer>())
+        : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>());
+
+    /// <summary>
+    /// Moves the first analyzer matching <paramref name="predicate"/> to the front of the list,
+    /// preserving the relative order of all other analyzers.
+    /// </summary>
+    /// <param name="analyzers">The analyzer list to reorder in place.</param>
+    /// <param name="predicate">Predicate identifying the analyzer to promote.</param>
+    private static void PromoteAnalyzer(List<IMediaFileAnalyzer> analyzers, Func<IMediaFileAnalyzer, bool> predicate)
+    {
+        var index = analyzers.FindIndex(a => predicate(a));
+        if (index > 0)
+        {
+            var analyzer = analyzers[index];
+            analyzers.RemoveAt(index);
+            analyzers.Insert(0, analyzer);
+        }
     }
 
     /// <summary>

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -205,6 +205,7 @@ public partial class BaseItemAnalyzerTask(
 
         if (action == AnalyzerAction.None)
         {
+            LogSkippingNoneAction(_logger, mode, first.SeriesName, first.SeasonNumber);
             return 0;
         }
 
@@ -436,4 +437,7 @@ public partial class BaseItemAnalyzerTask(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "[Mode: {Mode}] Analyzing {Count} files from {Name} season {Season}")]
     private static partial void LogAnalyzingFiles(ILogger logger, AnalysisMode mode, int count, string name, int season);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "[Mode: {Mode}] Skipping {Name} season {Season}: analyzer action is set to None")]
+    private static partial void LogSkippingNoneAction(ILogger logger, AnalysisMode mode, string name, int season);
 }


### PR DESCRIPTION
## Summary

- Refactors analyzer selection from a filter-based approach to a priority-based chain — all applicable analyzers are always included, with `AnalyzerAction` and `PreferChromaprint` controlling ordering rather than inclusion.
- Each analyzer skips episodes already handled by earlier ones via `NeedsAnalysis()`, providing automatic fallback coverage.
- Extracts `CreateBlackFrameAnalyzer()` and `PromoteAnalyzer()` helper methods for clarity and to eliminate an unconditional allocation.

## Behavioral Changes

- `AnalyzerAction` settings (e.g., `Chromaprint`, `BlackFrame`) now **promote** the specified analyzer to the front of the chain rather than **excluding** all others. Remaining analyzers still run as fallbacks for unmatched episodes.
- `PreferChromaprint` now promotes Chromaprint to first position instead of suppressing Chapter and BlackFrame entirely.
- `AnalyzerAction.None` returns early before building the chain.

## Summary by Sourcery

Refactor episode analyzer selection to use a fixed, mode-specific analyzer chain with priority-based reordering instead of filter-style inclusion/exclusion.

Bug Fixes:
- Ensure AnalyzerAction.None short-circuits analysis without constructing or running any analyzers.

Enhancements:
- Always include all applicable analyzers for a given mode/content type and rely on chain ordering plus NeedsAnalysis() for fallback behavior.
- Change AnalyzerAction and PreferChromaprint semantics to promote the chosen analyzer to the front of the chain instead of disabling other analyzers.
- Extract helper methods for creating the configured black-frame analyzer and for promoting analyzers within the chain to improve clarity and avoid unnecessary allocations.