### PR TITLE
Migrate legacy fingerprint cache to DB

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -694,6 +694,34 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
+    public void MigrateLegacyFingerprintCache_DeletesLegacyFileWhenCurrentRangeInvalid()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            IntroFingerprintEnd = 0,
+        };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var legacyPath = Path.Join(cacheDir, episode.EpisodeId.ToString("N"));
+
+        File.WriteAllText(legacyPath, "1");
+
+        int migrated;
+        string cacheDbPath;
+        using (var scope = new CachingPluginScope(cacheDir))
+        {
+            cacheDbPath = scope.CacheDbPath;
+            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+        }
+
+        Assert.Equal(0, migrated);
+        Assert.False(File.Exists(legacyPath));
+
+        using var db = new DetectionCacheDbContext(cacheDbPath);
+        Assert.False(db.DetectionCache.Any(e => e.ItemId == episode.EpisodeId));
+    }
+
+    [Fact]
     public void MigrateLegacyFingerprintCache_DoesNothingWhenChromaprintFolderMissing()
     {
         var missingCacheDir = Path.Join(

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -19,36 +19,6 @@ using Xunit;
 public sealed class TestCacheOperations
 {
     [Fact]
-    public void AnalyzerOpportunisticLegacyFingerprintMigration_AllowsOnlyOneBeginUntilHandledOrAborted()
-    {
-        var plugin = EntrypointTestHelpers.CreateUninitialized<Plugin>();
-
-        Assert.True(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
-        Assert.False(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
-
-        plugin.AbortAnalyzerOpportunisticLegacyFingerprintMigration();
-
-        Assert.True(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
-
-        plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
-
-        Assert.False(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
-    }
-
-    [Fact]
-    public void AnalyzerOpportunisticLegacyFingerprintMigration_HandledStateSurvivesAbort()
-    {
-        var plugin = EntrypointTestHelpers.CreateUninitialized<Plugin>();
-
-        Assert.True(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
-
-        plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
-        plugin.AbortAnalyzerOpportunisticLegacyFingerprintMigration();
-
-        Assert.False(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
-    }
-
-    [Fact]
     public void DeleteCacheFiles_Introduction_DeletesIntroFilesOnly()
     {
         var itemId = Guid.NewGuid();

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -19,6 +19,36 @@ using Xunit;
 public sealed class TestCacheOperations
 {
     [Fact]
+    public void AnalyzerOpportunisticLegacyFingerprintMigration_AllowsOnlyOneBeginUntilHandledOrAborted()
+    {
+        var plugin = EntrypointTestHelpers.CreateUninitialized<Plugin>();
+
+        Assert.True(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
+        Assert.False(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
+
+        plugin.AbortAnalyzerOpportunisticLegacyFingerprintMigration();
+
+        Assert.True(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
+
+        plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
+
+        Assert.False(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
+    }
+
+    [Fact]
+    public void AnalyzerOpportunisticLegacyFingerprintMigration_HandledStateSurvivesAbort()
+    {
+        var plugin = EntrypointTestHelpers.CreateUninitialized<Plugin>();
+
+        Assert.True(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
+
+        plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
+        plugin.AbortAnalyzerOpportunisticLegacyFingerprintMigration();
+
+        Assert.False(plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration());
+    }
+
+    [Fact]
     public void DeleteCacheFiles_Introduction_DeletesIntroFilesOnly()
     {
         var itemId = Guid.NewGuid();

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -618,6 +618,68 @@ public sealed class TestCacheOperations
         Assert.Equal(1800, entry.End);
     }
 
+    [Fact]
+    public void MigrateLegacyFingerprintCache_MigratesOnlyQueuedItemIds()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            IntroFingerprintEnd = 60,
+        };
+        var staleEpisodeId = Guid.NewGuid();
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var lineCount = (int)Math.Round((60.0 - ChromaprintConstants.HashWindowDuration) / ChromaprintConstants.SampleDuration);
+        var validLegacyPath = Path.Combine(cacheDir, episode.EpisodeId.ToString("N"));
+        var staleLegacyPath = Path.Combine(cacheDir, staleEpisodeId.ToString("N"));
+        var lines = Enumerable.Range(1, lineCount)
+            .Select(i => ((uint)i).ToString(CultureInfo.InvariantCulture))
+            .ToArray();
+
+        File.WriteAllLines(validLegacyPath, lines);
+        File.WriteAllLines(staleLegacyPath, lines);
+
+        int migrated;
+        string cacheDbPath;
+        using (var scope = new CachingPluginScope(cacheDir))
+        {
+            cacheDbPath = scope.CacheDbPath;
+            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+        }
+
+        Assert.Equal(1, migrated);
+        Assert.False(File.Exists(validLegacyPath));
+        Assert.True(File.Exists(staleLegacyPath));
+
+        using var db = new DetectionCacheDbContext(cacheDbPath);
+        Assert.True(db.DetectionCache.Any(e => e.ItemId == episode.EpisodeId));
+        Assert.False(db.DetectionCache.Any(e => e.ItemId == staleEpisodeId));
+    }
+
+    [Fact]
+    public void MigrateLegacyFingerprintCache_DoesNothingWhenChromaprintFolderMissing()
+    {
+        var missingCacheDir = Path.Combine(
+            Path.GetTempPath(),
+            "IntroSkipper.Tests",
+            "chromaprints",
+            Guid.NewGuid().ToString("N"));
+        var cacheDbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + "-cache.db");
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            IntroFingerprintEnd = 60,
+        };
+
+        int migrated;
+        using (new CachingPluginScope(missingCacheDir, cacheDbPath))
+        {
+            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+        }
+
+        Assert.Equal(0, migrated);
+        Assert.False(Directory.Exists(missingCacheDir));
+    }
+
     [Theory]
     [InlineData(CompressionLevel.NoCompression)]
     [InlineData(CompressionLevel.Fastest)]

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -629,11 +629,12 @@ public sealed class TestCacheOperations
         var staleEpisodeId = Guid.NewGuid();
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
         var lineCount = (int)Math.Round((60.0 - ChromaprintConstants.HashWindowDuration) / ChromaprintConstants.SampleDuration);
-        var validLegacyPath = Path.Combine(cacheDir, episode.EpisodeId.ToString("N"));
-        var staleLegacyPath = Path.Combine(cacheDir, staleEpisodeId.ToString("N"));
-        var lines = Enumerable.Range(1, lineCount)
-            .Select(i => ((uint)i).ToString(CultureInfo.InvariantCulture))
-            .ToArray();
+        var validLegacyPath = Path.Join(cacheDir, episode.EpisodeId.ToString("N"));
+        var staleLegacyPath = Path.Join(cacheDir, staleEpisodeId.ToString("N"));
+        string[] lines = [
+            .. Enumerable.Range(1, lineCount)
+                .Select(i => ((uint)i).ToString(CultureInfo.InvariantCulture))
+        ];
 
         File.WriteAllLines(validLegacyPath, lines);
         File.WriteAllLines(staleLegacyPath, lines);
@@ -656,14 +657,51 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
+    public void MigrateLegacyFingerprintCache_MigratesMovieIntroductionWhenRangePresent()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Category = QueuedMediaCategory.Movie,
+            IntroFingerprintEnd = 60,
+        };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var lineCount = (int)Math.Round((60.0 - ChromaprintConstants.HashWindowDuration) / ChromaprintConstants.SampleDuration);
+        var legacyPath = Path.Join(cacheDir, episode.EpisodeId.ToString("N"));
+        string[] lines = [
+            .. Enumerable.Range(1, lineCount)
+                .Select(i => ((uint)i).ToString(CultureInfo.InvariantCulture))
+        ];
+
+        File.WriteAllLines(legacyPath, lines);
+
+        int migrated;
+        string cacheDbPath;
+        using (var scope = new CachingPluginScope(cacheDir))
+        {
+            cacheDbPath = scope.CacheDbPath;
+            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+        }
+
+        Assert.Equal(1, migrated);
+        Assert.False(File.Exists(legacyPath));
+
+        using var db = new DetectionCacheDbContext(cacheDbPath);
+        Assert.True(db.DetectionCache.Any(e =>
+            e.ItemId == episode.EpisodeId &&
+            e.Mode == AnalysisMode.Introduction &&
+            e.Type == CacheEntryType.Chromaprint));
+    }
+
+    [Fact]
     public void MigrateLegacyFingerprintCache_DoesNothingWhenChromaprintFolderMissing()
     {
-        var missingCacheDir = Path.Combine(
+        var missingCacheDir = Path.Join(
             Path.GetTempPath(),
             "IntroSkipper.Tests",
             "chromaprints",
             Guid.NewGuid().ToString("N"));
-        var cacheDbPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + "-cache.db");
+        var cacheDbPath = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N") + "-cache.db");
         var episode = new QueuedEpisode
         {
             EpisodeId = Guid.NewGuid(),

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -811,7 +811,6 @@ public static partial class FFmpegWrapper
         }
 
         var migrated = 0;
-        var processed = new HashSet<(Guid ItemId, AnalysisMode Mode)>();
 
         foreach (var episode in episodes)
         {
@@ -822,14 +821,12 @@ public static partial class FFmpegWrapper
                 continue;
             }
 
-            if (processed.Add((episode.EpisodeId, AnalysisMode.Introduction)) &&
-                TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Introduction))
+            if (TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Introduction))
             {
                 migrated++;
             }
 
-            if (processed.Add((episode.EpisodeId, AnalysisMode.Credits)) &&
-                TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Credits))
+            if (TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Credits))
             {
                 migrated++;
             }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -651,9 +651,7 @@ public static partial class FFmpegWrapper
             return false;
         }
 
-        var id = episode.EpisodeId.ToString("N");
-        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
-        var legacyCacheKey = id + suffix;
+        var legacyCacheKey = GetLegacyFingerprintCacheKey(episode.EpisodeId, mode);
 
         return TryReadJsonCache(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, out fingerprint) ||
             TryLoadLegacyCache(legacyCacheKey, episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, ParseFingerprintRaw, out fingerprint);
@@ -786,11 +784,112 @@ public static partial class FFmpegWrapper
             }
         }
 
-        var id = episode.EpisodeId.ToString("N");
-        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
-        var legacyPath = GetLegacyFilePath(id + suffix);
+        var legacyPath = GetLegacyFilePath(GetLegacyFingerprintCacheKey(episode.EpisodeId, mode));
 
         return File.Exists(legacyPath);
+    }
+
+    /// <summary>
+    /// Migrates legacy on-disk chromaprint fingerprint cache files for queued media items into the SQLite cache.
+    /// </summary>
+    /// <param name="episodes">Queued media items whose IDs are still present in enabled libraries.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of legacy fingerprint files migrated.</returns>
+    internal static int MigrateLegacyFingerprintCache(IEnumerable<QueuedEpisode> episodes, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(episodes);
+
+        if (!IsCachingEnabled())
+        {
+            return 0;
+        }
+
+        var cacheDir = Plugin.Instance?.FingerprintCachePath;
+        if (string.IsNullOrEmpty(cacheDir) || !Directory.Exists(cacheDir))
+        {
+            return 0;
+        }
+
+        var migrated = 0;
+        var processed = new HashSet<(Guid ItemId, AnalysisMode Mode)>();
+
+        foreach (var episode in episodes)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (episode.EpisodeId == Guid.Empty)
+            {
+                continue;
+            }
+
+            if (episode.Category != QueuedMediaCategory.Movie &&
+                processed.Add((episode.EpisodeId, AnalysisMode.Introduction)) &&
+                TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Introduction))
+            {
+                migrated++;
+            }
+
+            if (processed.Add((episode.EpisodeId, AnalysisMode.Credits)) &&
+                TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Credits))
+            {
+                migrated++;
+            }
+        }
+
+        return migrated;
+    }
+
+    private static bool TryMigrateLegacyFingerprintCache(QueuedEpisode episode, AnalysisMode mode)
+    {
+        var (start, end) = GetFingerprintRange(episode, mode);
+        if (end <= start)
+        {
+            return false;
+        }
+
+        var legacyCacheKey = GetLegacyFingerprintCacheKey(episode.EpisodeId, mode);
+        if (!File.Exists(GetLegacyFilePath(legacyCacheKey)))
+        {
+            return false;
+        }
+
+        if (TryReadJsonCache(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, out uint[] _))
+        {
+            DeleteLegacyCacheFile(legacyCacheKey);
+            return false;
+        }
+
+        return TryLoadLegacyCache(
+            legacyCacheKey,
+            episode.EpisodeId,
+            mode,
+            CacheEntryType.Chromaprint,
+            start,
+            end,
+            ParseFingerprintRaw,
+            out uint[] _);
+    }
+
+    private static string GetLegacyFingerprintCacheKey(Guid itemId, AnalysisMode mode)
+    {
+        var suffix = mode == AnalysisMode.Credits ? "-credits" : string.Empty;
+        return itemId.ToString("N") + suffix;
+    }
+
+    private static void DeleteLegacyCacheFile(string legacyCacheKey)
+    {
+        var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
+        try
+        {
+            File.Delete(legacyTextPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (Logger is { } logger)
+            {
+                LogDeleteLegacyCacheFileFailed(logger, ex, legacyTextPath);
+            }
+        }
     }
 
     private static bool TryReadJsonCache<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -844,15 +844,16 @@ public static partial class FFmpegWrapper
 
     private static bool TryMigrateLegacyFingerprintCache(QueuedEpisode episode, AnalysisMode mode)
     {
-        var (start, end) = GetFingerprintRange(episode, mode);
-        if (end <= start)
+        var legacyCacheKey = GetLegacyFingerprintCacheKey(episode.EpisodeId, mode);
+        if (!File.Exists(GetLegacyFilePath(legacyCacheKey)))
         {
             return false;
         }
 
-        var legacyCacheKey = GetLegacyFingerprintCacheKey(episode.EpisodeId, mode);
-        if (!File.Exists(GetLegacyFilePath(legacyCacheKey)))
+        var (start, end) = GetFingerprintRange(episode, mode);
+        if (end <= start)
         {
+            DeleteLegacyCacheFile(legacyCacheKey);
             return false;
         }
 

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -822,8 +822,7 @@ public static partial class FFmpegWrapper
                 continue;
             }
 
-            if (episode.Category != QueuedMediaCategory.Movie &&
-                processed.Add((episode.EpisodeId, AnalysisMode.Introduction)) &&
+            if (processed.Add((episode.EpisodeId, AnalysisMode.Introduction)) &&
                 TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Introduction))
             {
                 migrated++;
@@ -867,7 +866,8 @@ public static partial class FFmpegWrapper
             start,
             end,
             ParseFingerprintRaw,
-            out uint[] _);
+            out uint[] _,
+            out var persistedToCache) && persistedToCache;
     }
 
     private static string GetLegacyFingerprintCacheKey(Guid itemId, AnalysisMode mode)
@@ -937,11 +937,11 @@ public static partial class FFmpegWrapper
         }
     }
 
-    private static void WriteJsonCache<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
+    private static bool WriteJsonCache<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
     {
         if (!IsCachingEnabled())
         {
-            return;
+            return false;
         }
 
         var data = CompressBrotli(items);
@@ -965,6 +965,7 @@ public static partial class FFmpegWrapper
             }
 
             db.SaveChanges();
+            return true;
         }
         catch (Exception ex) when (ex is DbUpdateException or DbException)
         {
@@ -975,6 +976,7 @@ public static partial class FFmpegWrapper
 
             // Suppress duplicate-insert races and database-level cache failures. The cache is a
             // performance optimization; write failures should never discard valid analysis results.
+            return false;
         }
     }
 
@@ -1005,8 +1007,30 @@ public static partial class FFmpegWrapper
         double end,
         Func<string, T[]> rawParser,
         out T[] result)
+        => TryLoadLegacyCache(
+            legacyCacheKey,
+            itemId,
+            mode,
+            type,
+            start,
+            end,
+            rawParser,
+            out result,
+            out _);
+
+    private static bool TryLoadLegacyCache<T>(
+        string legacyCacheKey,
+        Guid itemId,
+        AnalysisMode mode,
+        CacheEntryType type,
+        double start,
+        double end,
+        Func<string, T[]> rawParser,
+        out T[] result,
+        out bool persistedToCache)
     {
         result = [];
+        persistedToCache = false;
 
         if (!IsCachingEnabled())
         {
@@ -1028,7 +1052,7 @@ public static partial class FFmpegWrapper
             // An empty chromaprint legacy file is corrupt; empty detection result caches are valid.
             if (type == CacheEntryType.Chromaprint && result.Length == 0)
             {
-                File.Delete(legacyTextPath);
+                DeleteLegacyCacheFile(legacyCacheKey);
                 return false;
             }
 
@@ -1045,7 +1069,7 @@ public static partial class FFmpegWrapper
                         LogLegacyDurationMismatch(mismatchLogger, legacyCacheKey, inferredDuration, expectedDuration);
                     }
 
-                    File.Delete(legacyTextPath);
+                    DeleteLegacyCacheFile(legacyCacheKey);
                     return false;
                 }
             }
@@ -1055,8 +1079,13 @@ public static partial class FFmpegWrapper
                 LogMigratingLegacyCache(logger, legacyCacheKey, $"{itemId:N}-{mode}-{type}");
             }
 
-            WriteJsonCache(itemId, mode, type, start, end, result);
-            File.Delete(legacyTextPath);
+            if (!WriteJsonCache(itemId, mode, type, start, end, result))
+            {
+                return true;
+            }
+
+            DeleteLegacyCacheFile(legacyCacheKey);
+            persistedToCache = true;
 
             return true;
         }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -34,6 +34,13 @@ public static partial class FFmpegWrapper
     /// </summary>
     private static readonly Regex _blackFrameRegex = BlackFrameRegex();
 
+    private enum LegacyCacheLoadStatus
+    {
+        Miss,
+        Loaded,
+        Migrated
+    }
+
     /// <summary>
     /// Gets or sets the logger.
     /// </summary>
@@ -855,7 +862,7 @@ public static partial class FFmpegWrapper
             return false;
         }
 
-        return TryLoadLegacyCache(
+        return LoadLegacyCache(
             legacyCacheKey,
             episode.EpisodeId,
             mode,
@@ -863,8 +870,7 @@ public static partial class FFmpegWrapper
             start,
             end,
             ParseFingerprintRaw,
-            out uint[] _,
-            out var persistedToCache) && persistedToCache;
+            out uint[] _) == LegacyCacheLoadStatus.Migrated;
     }
 
     private static string GetLegacyFingerprintCacheKey(Guid itemId, AnalysisMode mode)
@@ -1004,7 +1010,7 @@ public static partial class FFmpegWrapper
         double end,
         Func<string, T[]> rawParser,
         out T[] result)
-        => TryLoadLegacyCache(
+        => LoadLegacyCache(
             legacyCacheKey,
             itemId,
             mode,
@@ -1012,10 +1018,9 @@ public static partial class FFmpegWrapper
             start,
             end,
             rawParser,
-            out result,
-            out _);
+            out result) != LegacyCacheLoadStatus.Miss;
 
-    private static bool TryLoadLegacyCache<T>(
+    private static LegacyCacheLoadStatus LoadLegacyCache<T>(
         string legacyCacheKey,
         Guid itemId,
         AnalysisMode mode,
@@ -1023,22 +1028,20 @@ public static partial class FFmpegWrapper
         double start,
         double end,
         Func<string, T[]> rawParser,
-        out T[] result,
-        out bool persistedToCache)
+        out T[] result)
     {
         result = [];
-        persistedToCache = false;
 
         if (!IsCachingEnabled())
         {
-            return false;
+            return LegacyCacheLoadStatus.Miss;
         }
 
         // Migrate legacy on-disk text files into the SQLite cache.
         var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
         if (!File.Exists(legacyTextPath))
         {
-            return false;
+            return LegacyCacheLoadStatus.Miss;
         }
 
         try
@@ -1050,7 +1053,7 @@ public static partial class FFmpegWrapper
             if (type == CacheEntryType.Chromaprint && result.Length == 0)
             {
                 DeleteLegacyCacheFile(legacyCacheKey);
-                return false;
+                return LegacyCacheLoadStatus.Miss;
             }
 
             // Crosscheck chromaprint fingerprint duration against current settings.
@@ -1067,7 +1070,7 @@ public static partial class FFmpegWrapper
                     }
 
                     DeleteLegacyCacheFile(legacyCacheKey);
-                    return false;
+                    return LegacyCacheLoadStatus.Miss;
                 }
             }
 
@@ -1078,13 +1081,11 @@ public static partial class FFmpegWrapper
 
             if (!WriteJsonCache(itemId, mode, type, start, end, result))
             {
-                return true;
+                return LegacyCacheLoadStatus.Loaded;
             }
 
             DeleteLegacyCacheFile(legacyCacheKey);
-            persistedToCache = true;
-
-            return true;
+            return LegacyCacheLoadStatus.Migrated;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -1095,7 +1096,7 @@ public static partial class FFmpegWrapper
                 LogDetectionCacheReadError(logger, ex, legacyTextPath);
             }
 
-            return false;
+            return LegacyCacheLoadStatus.Miss;
         }
     }
 

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -128,7 +128,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public bool AnalyzeAgain { get; set; }
 
-    internal bool AnalyzerOpportunisticLegacyFingerprintMigrationCompleted { get; set; }
+    internal bool LegacyFingerprintMigrationDone { get; set; }
 
     /// <summary>
     /// Gets the most recent media item queue.

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -35,12 +35,16 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     private const double SegmentComparisonEpsilon = 0.001;
     private const int SqliteParameterBatchSize = 500;
+    private const int AnalyzerOpportunisticLegacyFingerprintMigrationPending = 0;
+    private const int AnalyzerOpportunisticLegacyFingerprintMigrationInProgress = 1;
+    private const int AnalyzerOpportunisticLegacyFingerprintMigrationHandled = 2;
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
     private readonly IPluginManager _pluginManager;
     private readonly ILogger<Plugin> _logger;
     private readonly string _dbPath;
     private readonly string _cacheDbPath;
+    private int _analyzerOpportunisticLegacyFingerprintMigrationState;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -184,6 +188,29 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
         ArgumentNullException.ThrowIfNull(Instance);
         return new DetectionCacheDbContext(Instance.CacheDbPath);
+    }
+
+    internal bool TryBeginAnalyzerOpportunisticLegacyFingerprintMigration()
+    {
+        return Interlocked.CompareExchange(
+            ref _analyzerOpportunisticLegacyFingerprintMigrationState,
+            AnalyzerOpportunisticLegacyFingerprintMigrationInProgress,
+            AnalyzerOpportunisticLegacyFingerprintMigrationPending) == AnalyzerOpportunisticLegacyFingerprintMigrationPending;
+    }
+
+    internal void MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled()
+    {
+        Volatile.Write(
+            ref _analyzerOpportunisticLegacyFingerprintMigrationState,
+            AnalyzerOpportunisticLegacyFingerprintMigrationHandled);
+    }
+
+    internal void AbortAnalyzerOpportunisticLegacyFingerprintMigration()
+    {
+        _ = Interlocked.CompareExchange(
+            ref _analyzerOpportunisticLegacyFingerprintMigrationState,
+            AnalyzerOpportunisticLegacyFingerprintMigrationPending,
+            AnalyzerOpportunisticLegacyFingerprintMigrationInProgress);
     }
 
     /// <inheritdoc />

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -35,16 +35,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     private const double SegmentComparisonEpsilon = 0.001;
     private const int SqliteParameterBatchSize = 500;
-    private const int AnalyzerOpportunisticLegacyFingerprintMigrationPending = 0;
-    private const int AnalyzerOpportunisticLegacyFingerprintMigrationInProgress = 1;
-    private const int AnalyzerOpportunisticLegacyFingerprintMigrationHandled = 2;
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
     private readonly IPluginManager _pluginManager;
     private readonly ILogger<Plugin> _logger;
     private readonly string _dbPath;
     private readonly string _cacheDbPath;
-    private int _analyzerOpportunisticLegacyFingerprintMigrationState;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -132,6 +128,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public bool AnalyzeAgain { get; set; }
 
+    internal bool AnalyzerOpportunisticLegacyFingerprintMigrationCompleted { get; set; }
+
     /// <summary>
     /// Gets the most recent media item queue.
     /// </summary>
@@ -188,29 +186,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
         ArgumentNullException.ThrowIfNull(Instance);
         return new DetectionCacheDbContext(Instance.CacheDbPath);
-    }
-
-    internal bool TryBeginAnalyzerOpportunisticLegacyFingerprintMigration()
-    {
-        return Interlocked.CompareExchange(
-            ref _analyzerOpportunisticLegacyFingerprintMigrationState,
-            AnalyzerOpportunisticLegacyFingerprintMigrationInProgress,
-            AnalyzerOpportunisticLegacyFingerprintMigrationPending) == AnalyzerOpportunisticLegacyFingerprintMigrationPending;
-    }
-
-    internal void MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled()
-    {
-        Volatile.Write(
-            ref _analyzerOpportunisticLegacyFingerprintMigrationState,
-            AnalyzerOpportunisticLegacyFingerprintMigrationHandled);
-    }
-
-    internal void AbortAnalyzerOpportunisticLegacyFingerprintMigration()
-    {
-        _ = Interlocked.CompareExchange(
-            ref _analyzerOpportunisticLegacyFingerprintMigrationState,
-            AnalyzerOpportunisticLegacyFingerprintMigrationPending,
-            AnalyzerOpportunisticLegacyFingerprintMigrationInProgress);
     }
 
     /// <inheritdoc />

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -43,6 +43,8 @@ public partial class BaseItemAnalyzerTask(
     /// </summary>
     private const double AnimePreviewStartTolerance = 0.5;
 
+    private static bool _legacyFingerprintMigrationCompleted;
+
     private readonly ILogger _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private readonly ILibraryManager _libraryManager = libraryManager;
@@ -86,9 +88,13 @@ public partial class BaseItemAnalyzerTask(
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        FFmpegWrapper.MigrateLegacyFingerprintCache(
-            queue.Values.SelectMany(static episodes => episodes),
-            cancellationToken);
+        if (!_legacyFingerprintMigrationCompleted)
+        {
+            FFmpegWrapper.MigrateLegacyFingerprintCache(
+                queue.Values.SelectMany(static episodes => episodes),
+                cancellationToken);
+            _legacyFingerprintMigrationCompleted = true;
+        }
 
         int totalQueued = queue.Sum(kvp => kvp.Value.Count) * modes.Count;
         if (totalQueued == 0)

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -88,12 +88,12 @@ public partial class BaseItemAnalyzerTask(
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        if (!plugin.AnalyzerOpportunisticLegacyFingerprintMigrationCompleted)
+        if (!plugin.LegacyFingerprintMigrationDone)
         {
             FFmpegWrapper.MigrateLegacyFingerprintCache(
                 queue.Values.SelectMany(static episodes => episodes),
                 cancellationToken);
-            plugin.AnalyzerOpportunisticLegacyFingerprintMigrationCompleted = true;
+            plugin.LegacyFingerprintMigrationDone = true;
         }
 
         int totalQueued = queue.Sum(kvp => kvp.Value.Count) * modes.Count;

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -88,20 +88,12 @@ public partial class BaseItemAnalyzerTask(
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        if (plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration())
+        if (!plugin.AnalyzerOpportunisticLegacyFingerprintMigrationCompleted)
         {
-            try
-            {
-                FFmpegWrapper.MigrateLegacyFingerprintCache(
-                    queue.Values.SelectMany(static episodes => episodes),
-                    cancellationToken);
-                plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
-            }
-            catch
-            {
-                plugin.AbortAnalyzerOpportunisticLegacyFingerprintMigration();
-                throw;
-            }
+            FFmpegWrapper.MigrateLegacyFingerprintCache(
+                queue.Values.SelectMany(static episodes => episodes),
+                cancellationToken);
+            plugin.AnalyzerOpportunisticLegacyFingerprintMigrationCompleted = true;
         }
 
         int totalQueued = queue.Sum(kvp => kvp.Value.Count) * modes.Count;

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -86,6 +86,10 @@ public partial class BaseItemAnalyzerTask(
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
+        FFmpegWrapper.MigrateLegacyFingerprintCache(
+            queue.Values.SelectMany(static episodes => episodes),
+            cancellationToken);
+
         int totalQueued = queue.Sum(kvp => kvp.Value.Count) * modes.Count;
         if (totalQueued == 0)
         {

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -43,8 +43,6 @@ public partial class BaseItemAnalyzerTask(
     /// </summary>
     private const double AnimePreviewStartTolerance = 0.5;
 
-    private static bool _legacyFingerprintMigrationCompleted;
-
     private readonly ILogger _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private readonly ILibraryManager _libraryManager = libraryManager;
@@ -74,6 +72,8 @@ public partial class BaseItemAnalyzerTask(
             .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager,
@@ -88,12 +88,20 @@ public partial class BaseItemAnalyzerTask(
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        if (!_legacyFingerprintMigrationCompleted)
+        if (plugin.TryBeginAnalyzerOpportunisticLegacyFingerprintMigration())
         {
-            FFmpegWrapper.MigrateLegacyFingerprintCache(
-                queue.Values.SelectMany(static episodes => episodes),
-                cancellationToken);
-            _legacyFingerprintMigrationCompleted = true;
+            try
+            {
+                FFmpegWrapper.MigrateLegacyFingerprintCache(
+                    queue.Values.SelectMany(static episodes => episodes),
+                    cancellationToken);
+                plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
+            }
+            catch
+            {
+                plugin.AbortAnalyzerOpportunisticLegacyFingerprintMigration();
+                throw;
+            }
         }
 
         int totalQueued = queue.Sum(kvp => kvp.Value.Count) * modes.Count;
@@ -114,8 +122,6 @@ public partial class BaseItemAnalyzerTask(
             MaxDegreeOfParallelism = Math.Max(1, _config.MaxParallelism),
             CancellationToken = cancellationToken
         };
-
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
 
         await Parallel.ForEachAsync(queue, options, async (season, ct) =>
         {

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -85,7 +85,7 @@ public partial class CleanCacheTask(
         var enabledLibraryEpisodes = queue.Values.SelectMany(static episodes => episodes).ToList();
 
         FFmpegWrapper.MigrateLegacyFingerprintCache(enabledLibraryEpisodes, cancellationToken);
-        plugin.AnalyzerOpportunisticLegacyFingerprintMigrationCompleted = true;
+        plugin.LegacyFingerprintMigrationDone = true;
 
         var enabledLibraryEpisodeIds = enabledLibraryEpisodes
             .Select(e => e.EpisodeId)

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -85,7 +85,7 @@ public partial class CleanCacheTask(
         var enabledLibraryEpisodes = queue.Values.SelectMany(static episodes => episodes).ToList();
 
         FFmpegWrapper.MigrateLegacyFingerprintCache(enabledLibraryEpisodes, cancellationToken);
-        plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
+        plugin.AnalyzerOpportunisticLegacyFingerprintMigrationCompleted = true;
 
         var enabledLibraryEpisodeIds = enabledLibraryEpisodes
             .Select(e => e.EpisodeId)

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -82,9 +82,12 @@ public partial class CleanCacheTask(
         // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders (same mechanism LegacyMigrations writes to).
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
+        var enabledLibraryEpisodes = queue.Values.SelectMany(static episodes => episodes).ToList();
 
-        var enabledLibraryEpisodeIds = queue.Values
-            .SelectMany(episodes => episodes.Select(e => e.EpisodeId))
+        FFmpegWrapper.MigrateLegacyFingerprintCache(enabledLibraryEpisodes, cancellationToken);
+
+        var enabledLibraryEpisodeIds = enabledLibraryEpisodes
+            .Select(e => e.EpisodeId)
             .ToHashSet();
 
         await plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
@@ -131,9 +134,9 @@ public partial class CleanCacheTask(
                     continue;
                 }
 
-                // Valid episode with a legacy file — delete it now; on-demand migration in
-                // TryLoadLegacyCache will repopulate the DB entry when the episode is next accessed.
-                LogDeletingNonMigratableLegacyFile(_logger, filePath);
+                // Valid episode with a remaining legacy file — fingerprint entries were already
+                // migrated above, and the clean task removes leftover file-based cache entries.
+                LogDeletingRemainingLegacyCacheFile(_logger, filePath);
                 try
                 {
                     File.Delete(filePath);
@@ -217,6 +220,6 @@ public partial class CleanCacheTask(
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete stale detection cache rows")]
     private static partial void LogDeletingCacheRowsFailed(ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting non-migratable legacy cache file: {FilePath}")]
-    private static partial void LogDeletingNonMigratableLegacyFile(ILogger logger, string filePath);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting remaining legacy cache file: {FilePath}")]
+    private static partial void LogDeletingRemainingLegacyCacheFile(ILogger logger, string filePath);
 }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -127,29 +127,18 @@ public partial class CleanCacheTask(
                     continue;
                 }
 
-                if (!enabledLibraryEpisodeIds.Contains(legacyId))
+                if (enabledLibraryEpisodeIds.Contains(legacyId))
                 {
-                    // Invalid episode — track for deletion once the DB rows are cleaned up.
-                    invalidEpisodeIds.Add(legacyId);
-                    invalidLegacyFiles.Add(filePath);
                     continue;
                 }
 
-                // Valid episode with a remaining legacy file — fingerprint entries were already
-                // migrated above, and the clean task removes leftover file-based cache entries.
-                LogDeletingRemainingLegacyCacheFile(_logger, filePath);
-                try
-                {
-                    File.Delete(filePath);
-                }
-                catch (IOException ex)
-                {
-                    LogDeletingLegacyFileFailed(_logger, ex, filePath);
-                }
+                // Invalid episode — track for deletion once the DB rows are cleaned up.
+                invalidEpisodeIds.Add(legacyId);
+                invalidLegacyFiles.Add(filePath);
             }
 
-            // Try to remove the legacy directory. Throws IOException when non-empty (invalid-episode
-            // files are still present) — those will be removed below and the directory on the next run.
+            // Try to remove the legacy directory. Throws IOException when non-empty (for example,
+            // valid files intentionally left for on-demand migration or invalid files pending deletion).
             try
             {
                 Directory.Delete(plugin.FingerprintCachePath);
@@ -220,7 +209,4 @@ public partial class CleanCacheTask(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete stale detection cache rows")]
     private static partial void LogDeletingCacheRowsFailed(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting remaining legacy cache file: {FilePath}")]
-    private static partial void LogDeletingRemainingLegacyCacheFile(ILogger logger, string filePath);
 }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -85,6 +85,7 @@ public partial class CleanCacheTask(
         var enabledLibraryEpisodes = queue.Values.SelectMany(static episodes => episodes).ToList();
 
         FFmpegWrapper.MigrateLegacyFingerprintCache(enabledLibraryEpisodes, cancellationToken);
+        plugin.MarkAnalyzerOpportunisticLegacyFingerprintMigrationHandled();
 
         var enabledLibraryEpisodeIds = enabledLibraryEpisodes
             .Select(e => e.EpisodeId)


### PR DESCRIPTION
Add logic to migrate legacy on-disk chromaprint fingerprint files into the SQLite detection cache for queued items. Introduces FFmpegWrapper.MigrateLegacyFingerprintCache with helpers to detect, migrate, and safely delete legacy files (with guarded logging on delete failures), and refactors cache key construction into GetLegacyFingerprintCacheKey. Invoke the migration from BaseItemAnalyzerTask and CleanCacheTask before processing, update the clean task to delete any remaining legacy files and adjust logging text. Also add unit tests covering successful migration of queued items and behavior when the chromaprint folder is missing.

## Summary by Sourcery

Migrate legacy on-disk chromaprint fingerprint files into the SQLite detection cache for queued items and coordinate this migration from analyzer and cache-cleaning tasks.

New Features:
- Add FFmpegWrapper.MigrateLegacyFingerprintCache to import legacy chromaprint fingerprint files for queued media items into the SQLite cache.
- Track completion of opportunistic legacy fingerprint migration via a new Plugin flag to avoid repeated work.

Enhancements:
- Refine legacy cache loading to distinguish between misses, loaded values, and successfully migrated entries, and to avoid deleting legacy files when DB writes fail.
- Centralize legacy fingerprint cache key construction and add guarded deletion logic with structured logging for failures.
- Trigger legacy fingerprint cache migration from BaseItemAnalyzerTask and CleanCacheTask before further processing, and simplify CleanCacheTask handling of legacy files.

Tests:
- Add unit tests verifying migration only for queued item IDs, correct handling of movie introductions, and no-op behavior when the chromaprint folder is missing.