### PR TITLE
Migrate all legacy detection cache files

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -766,6 +766,7 @@ public sealed class TestCacheOperations
             Path.Join(cacheDir, $"{id}-silence-10.5-20.5-v1"),
             Path.Join(cacheDir, $"{id}-unknown-10.5-20.5-v2"),
             Path.Join(cacheDir, $"{id}-silence-invalid-20.5-v2"),
+            Path.Join(cacheDir, $"{id.ToUpperInvariant()}-silence-10.5-20.5-v2"),
             Path.Join(cacheDir, $"{Guid.NewGuid():D}-silence-10.5-20.5-v2"),
         ];
 

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -619,7 +619,7 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void MigrateLegacyFingerprintCache_MigratesOnlyQueuedItemIds()
+    public void MigrateLegacyDetectionCache_MigratesOnlyQueuedItemIds()
     {
         var episode = new QueuedEpisode
         {
@@ -644,7 +644,7 @@ public sealed class TestCacheOperations
         using (var scope = new CachingPluginScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+            migrated = FFmpegWrapper.MigrateLegacyDetectionCache([episode]);
         }
 
         Assert.Equal(1, migrated);
@@ -657,7 +657,7 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void MigrateLegacyFingerprintCache_MigratesRecognizedDetectionFiles()
+    public void MigrateLegacyDetectionCache_MigratesRecognizedDetectionFiles()
     {
         var episode = new QueuedEpisode
         {
@@ -687,7 +687,7 @@ public sealed class TestCacheOperations
         using (var scope = new CachingPluginScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+            migrated = FFmpegWrapper.MigrateLegacyDetectionCache([episode]);
         }
 
         Assert.Equal(4, migrated);
@@ -753,7 +753,7 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void MigrateLegacyFingerprintCache_MigratesMovieIntroductionWhenRangePresent()
+    public void MigrateLegacyDetectionCache_MigratesMovieIntroductionWhenRangePresent()
     {
         var episode = new QueuedEpisode
         {
@@ -776,7 +776,7 @@ public sealed class TestCacheOperations
         using (var scope = new CachingPluginScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+            migrated = FFmpegWrapper.MigrateLegacyDetectionCache([episode]);
         }
 
         Assert.Equal(1, migrated);
@@ -790,7 +790,7 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void MigrateLegacyFingerprintCache_DeletesLegacyFileWhenCurrentRangeInvalid()
+    public void MigrateLegacyDetectionCache_DeletesLegacyFileWhenCurrentRangeInvalid()
     {
         var episode = new QueuedEpisode
         {
@@ -807,7 +807,7 @@ public sealed class TestCacheOperations
         using (var scope = new CachingPluginScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+            migrated = FFmpegWrapper.MigrateLegacyDetectionCache([episode]);
         }
 
         Assert.Equal(0, migrated);
@@ -818,7 +818,7 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void MigrateLegacyFingerprintCache_DoesNothingWhenChromaprintFolderMissing()
+    public void MigrateLegacyDetectionCache_DoesNothingWhenChromaprintFolderMissing()
     {
         var missingCacheDir = Path.Join(
             Path.GetTempPath(),
@@ -835,7 +835,7 @@ public sealed class TestCacheOperations
         int migrated;
         using (new CachingPluginScope(missingCacheDir, cacheDbPath))
         {
-            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+            migrated = FFmpegWrapper.MigrateLegacyDetectionCache([episode]);
         }
 
         Assert.Equal(0, migrated);

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -657,6 +657,102 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
+    public void MigrateLegacyFingerprintCache_MigratesRecognizedDetectionFiles()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+        };
+        var staleEpisodeId = Guid.NewGuid();
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var id = episode.EpisodeId.ToString("N");
+        var staleId = staleEpisodeId.ToString("N");
+
+        var silencePath = Path.Join(cacheDir, $"{id}-silence-10.5-20.5-v2");
+        var keyframesPath = Path.Join(cacheDir, $"{id}-keyframes-30.25-40.75-v1");
+        var blackframesPath = Path.Join(cacheDir, $"{id}-blackframes-100.5-120.5-v1");
+        var altBlackframesPath = Path.Join(cacheDir, $"{id}-blackframes-1560.5-alt");
+        var invalidPath = Path.Join(cacheDir, $"{id}-silence-invalid-20.5-v2");
+        var stalePath = Path.Join(cacheDir, $"{staleId}-silence-10.5-20.5-v2");
+
+        File.WriteAllText(silencePath, "silence_start: 1.0\nsilence_end: 2.5\n");
+        File.WriteAllText(keyframesPath, "[Parsed_showinfo_0 @ 0x0] n:0 pts:0 pts_time:3.25 pos:0\n");
+        File.WriteAllText(blackframesPath, "[Parsed_blackframe_0 @ 0xabc] frame:12 pblack:95 pts:1 t:12.34 type:P last_keyframe:0\n");
+        File.WriteAllText(altBlackframesPath, "[Parsed_blackframe_0 @ 0xdef] frame:34 pblack:88 pts:2 t:56.78 type:I last_keyframe:34\n");
+        File.WriteAllText(invalidPath, "silence_start: 1.0\nsilence_end: 2.5\n");
+        File.WriteAllText(stalePath, "silence_start: 1.0\nsilence_end: 2.5\n");
+
+        int migrated;
+        string cacheDbPath;
+        using (var scope = new CachingPluginScope(cacheDir))
+        {
+            cacheDbPath = scope.CacheDbPath;
+            migrated = FFmpegWrapper.MigrateLegacyFingerprintCache([episode]);
+        }
+
+        Assert.Equal(4, migrated);
+        Assert.False(File.Exists(silencePath));
+        Assert.False(File.Exists(keyframesPath));
+        Assert.False(File.Exists(blackframesPath));
+        Assert.False(File.Exists(altBlackframesPath));
+        Assert.True(File.Exists(invalidPath));
+        Assert.True(File.Exists(stalePath));
+
+        using var db = new DetectionCacheDbContext(cacheDbPath);
+        var modes = Enum.GetValues<AnalysisMode>();
+        Assert.Equal(
+            modes.Length,
+            db.DetectionCache.Count(e => e.ItemId == episode.EpisodeId && e.Type == CacheEntryType.Silence));
+        Assert.Equal(
+            modes.Length,
+            db.DetectionCache.Count(e => e.ItemId == episode.EpisodeId && e.Type == CacheEntryType.Keyframe));
+
+        foreach (var mode in modes)
+        {
+            var silence = ReadDetectionCache<TimeRange>(
+                db,
+                episode.EpisodeId,
+                mode,
+                CacheEntryType.Silence,
+                10.5,
+                20.5);
+            var silenceRange = Assert.Single(silence);
+            Assert.Equal(11.5, silenceRange.Start);
+            Assert.Equal(13.0, silenceRange.End);
+
+            var keyframes = ReadDetectionCache<double>(
+                db,
+                episode.EpisodeId,
+                mode,
+                CacheEntryType.Keyframe,
+                30.25,
+                40.75);
+            var keyframe = Assert.Single(keyframes);
+            Assert.Equal(33.5, keyframe);
+        }
+
+        var rangeBlackframes = ReadDetectionCache<BlackFrame>(
+            db,
+            episode.EpisodeId,
+            AnalysisMode.Credits,
+            CacheEntryType.BlackFrame,
+            100.5,
+            120.5);
+        Assert.Equal(new BlackFrame(95, 12.34, 12), Assert.Single(rangeBlackframes));
+
+        var altBlackframes = ReadDetectionCache<BlackFrame>(
+            db,
+            episode.EpisodeId,
+            AnalysisMode.Credits,
+            CacheEntryType.BlackFrame,
+            1560.5,
+            0);
+        Assert.Equal(new BlackFrame(88, 56.78, 34), Assert.Single(altBlackframes));
+
+        Assert.False(db.DetectionCache.Any(e => e.ItemId == staleEpisodeId));
+    }
+
+    [Fact]
     public void MigrateLegacyFingerprintCache_MigratesMovieIntroductionWhenRangePresent()
     {
         var episode = new QueuedEpisode
@@ -785,6 +881,30 @@ public sealed class TestCacheOperations
         }
 
         var result = FFmpegWrapper.DecompressBrotli<uint[]>(entry.Data);
+        return result ?? [];
+    }
+
+    private static T[] ReadDetectionCache<T>(
+        DetectionCacheDbContext db,
+        Guid itemId,
+        AnalysisMode mode,
+        CacheEntryType type,
+        double start,
+        double end)
+    {
+        var entry = db.DetectionCache.FirstOrDefault(e =>
+            e.ItemId == itemId &&
+            e.Mode == mode &&
+            e.Type == type &&
+            e.Start == start &&
+            e.End == end);
+
+        if (entry is null)
+        {
+            return [];
+        }
+
+        var result = FFmpegWrapper.DecompressBrotli<T[]>(entry.Data);
         return result ?? [];
     }
 

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -753,6 +753,43 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
+    public void MigrateLegacyDetectionCache_LeavesInvalidDetectionFilenamesUntouched()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+        };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var id = episode.EpisodeId.ToString("N");
+        string[] invalidPaths = [
+            Path.Join(cacheDir, $"{id}-silence-10.5-v2"),
+            Path.Join(cacheDir, $"{id}-silence-10.5-20.5-v1"),
+            Path.Join(cacheDir, $"{id}-unknown-10.5-20.5-v2"),
+            Path.Join(cacheDir, $"{id}-silence-invalid-20.5-v2"),
+            Path.Join(cacheDir, $"{Guid.NewGuid():D}-silence-10.5-20.5-v2"),
+        ];
+
+        foreach (var path in invalidPaths)
+        {
+            File.WriteAllText(path, "silence_start: 1.0\nsilence_end: 2.5\n");
+        }
+
+        int migrated;
+        string cacheDbPath;
+        using (var scope = new CachingPluginScope(cacheDir))
+        {
+            cacheDbPath = scope.CacheDbPath;
+            migrated = FFmpegWrapper.MigrateLegacyDetectionCache([episode]);
+        }
+
+        Assert.Equal(0, migrated);
+        Assert.All(invalidPaths, path => Assert.True(File.Exists(path)));
+
+        using var db = new DetectionCacheDbContext(cacheDbPath);
+        Assert.False(db.DetectionCache.Any(e => e.ItemId == episode.EpisodeId));
+    }
+
+    [Fact]
     public void MigrateLegacyDetectionCache_MigratesMovieIntroductionWhenRangePresent()
     {
         var episode = new QueuedEpisode

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -857,7 +857,8 @@ public static partial class FFmpegWrapper
             foreach (var filePath in Directory.EnumerateFiles(cacheDir, prefix + "*"))
             {
                 var filename = Path.GetFileName(filePath);
-                if (TryMigrateLegacyDetectionCacheFile(filename, filename[prefix.Length..], episode.EpisodeId))
+                var suffix = filename.Length >= prefix.Length ? filename[prefix.Length..] : string.Empty;
+                if (TryMigrateLegacyDetectionCacheFile(filePath, filename, suffix, episode.EpisodeId))
                 {
                     migrated++;
                 }
@@ -871,7 +872,7 @@ public static partial class FFmpegWrapper
         return migrated;
     }
 
-    private static bool TryMigrateLegacyDetectionCacheFile(string legacyCacheKey, string suffix, Guid itemId)
+    private static bool TryMigrateLegacyDetectionCacheFile(string legacyTextPath, string legacyCacheKey, string suffix, Guid itemId)
     {
         var parts = suffix.Split('-');
 
@@ -881,6 +882,7 @@ public static partial class FFmpegWrapper
         {
             return TryMigrateLegacyCacheForAllModes(
                 legacyCacheKey,
+                legacyTextPath,
                 itemId,
                 CacheEntryType.Silence,
                 parsedSilenceStart,
@@ -894,6 +896,7 @@ public static partial class FFmpegWrapper
         {
             return TryMigrateLegacyCacheForAllModes(
                 legacyCacheKey,
+                legacyTextPath,
                 itemId,
                 CacheEntryType.Keyframe,
                 parsedKeyframesStart,
@@ -907,6 +910,7 @@ public static partial class FFmpegWrapper
         {
             return LoadLegacyCache(
                 legacyCacheKey,
+                legacyTextPath,
                 itemId,
                 AnalysisMode.Credits,
                 CacheEntryType.BlackFrame,
@@ -921,6 +925,7 @@ public static partial class FFmpegWrapper
         {
             return LoadLegacyCache(
                 legacyCacheKey,
+                legacyTextPath,
                 itemId,
                 AnalysisMode.Credits,
                 CacheEntryType.BlackFrame,
@@ -935,13 +940,13 @@ public static partial class FFmpegWrapper
 
     private static bool TryMigrateLegacyCacheForAllModes<T>(
         string legacyCacheKey,
+        string legacyTextPath,
         Guid itemId,
         CacheEntryType type,
         double start,
         double end,
         Func<string, T[]> rawParser)
     {
-        var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
         if (!File.Exists(legacyTextPath))
         {
             return false;
@@ -952,21 +957,22 @@ public static partial class FFmpegWrapper
             var raw = File.ReadAllText(legacyTextPath, Encoding.UTF8);
             var result = rawParser(raw);
 
-            foreach (var mode in Enum.GetValues<AnalysisMode>())
+            var modes = Enum.GetValues<AnalysisMode>();
+            foreach (var mode in modes)
             {
                 if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
                 {
                     var cacheKey = $"{itemId:N}-{mode}-{type}";
                     LogMigratingLegacyCache(logger, legacyCacheKey, cacheKey);
                 }
-
-                if (!WriteJsonCache(itemId, mode, type, start, end, result))
-                {
-                    return false;
-                }
             }
 
-            DeleteLegacyCacheFile(legacyCacheKey);
+            if (!WriteJsonCacheForAllModes(itemId, type, start, end, result, modes))
+            {
+                return false;
+            }
+
+            DeleteLegacyCacheFilePath(legacyTextPath);
             return true;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -981,7 +987,7 @@ public static partial class FFmpegWrapper
     }
 
     private static bool TryParseLegacyCacheTime(string value, out double result)
-        => double.TryParse(value, CultureInfo.InvariantCulture, out result);
+        => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
 
     private static bool TryMigrateLegacyFingerprintCache(QueuedEpisode episode, AnalysisMode mode)
     {
@@ -1022,8 +1028,10 @@ public static partial class FFmpegWrapper
     }
 
     private static void DeleteLegacyCacheFile(string legacyCacheKey)
+        => DeleteLegacyCacheFilePath(GetLegacyFilePath(legacyCacheKey));
+
+    private static void DeleteLegacyCacheFilePath(string legacyTextPath)
     {
-        var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
         try
         {
             File.Delete(legacyTextPath);
@@ -1127,6 +1135,57 @@ public static partial class FFmpegWrapper
         }
     }
 
+    private static bool WriteJsonCacheForAllModes<T>(
+        Guid itemId,
+        CacheEntryType type,
+        double start,
+        double end,
+        T[] items,
+        AnalysisMode[] modes)
+    {
+        if (!IsCachingEnabled())
+        {
+            return false;
+        }
+
+        var data = CompressBrotli(items);
+
+        try
+        {
+            using var db = Plugin.CreateCacheDbContext();
+            using var transaction = db.Database.BeginTransaction();
+
+            foreach (var mode in modes)
+            {
+                var existing = db.DetectionCache
+                    .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+
+                if (existing is not null)
+                {
+                    existing.Data = data;
+                }
+                else
+                {
+                    db.DetectionCache.Add(new DbDetectionCache(itemId, mode, type, data, start, end));
+                }
+            }
+
+            db.SaveChanges();
+            transaction.Commit();
+            return true;
+        }
+        catch (Exception ex) when (ex is DbUpdateException or DbException)
+        {
+            if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
+            {
+                var cacheKey = $"{itemId:N}-{type}";
+                LogDetectionCacheWriteError(logger, ex, cacheKey);
+            }
+
+            return false;
+        }
+    }
+
     private static uint[] ParseFingerprintRaw(string raw)
     {
         var lines = raw.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
@@ -1173,6 +1232,27 @@ public static partial class FFmpegWrapper
         double end,
         Func<string, T[]> rawParser,
         out T[] result)
+        => LoadLegacyCache(
+            legacyCacheKey,
+            GetLegacyFilePath(legacyCacheKey),
+            itemId,
+            mode,
+            type,
+            start,
+            end,
+            rawParser,
+            out result);
+
+    private static LegacyCacheLoadStatus LoadLegacyCache<T>(
+        string legacyCacheKey,
+        string legacyTextPath,
+        Guid itemId,
+        AnalysisMode mode,
+        CacheEntryType type,
+        double start,
+        double end,
+        Func<string, T[]> rawParser,
+        out T[] result)
     {
         result = [];
 
@@ -1182,7 +1262,6 @@ public static partial class FFmpegWrapper
         }
 
         // Migrate legacy on-disk text files into the SQLite cache.
-        var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
         if (!File.Exists(legacyTextPath))
         {
             return LegacyCacheLoadStatus.Miss;
@@ -1196,7 +1275,7 @@ public static partial class FFmpegWrapper
             // An empty chromaprint legacy file is corrupt; empty detection result caches are valid.
             if (type == CacheEntryType.Chromaprint && result.Length == 0)
             {
-                DeleteLegacyCacheFile(legacyCacheKey);
+                DeleteLegacyCacheFilePath(legacyTextPath);
                 return LegacyCacheLoadStatus.Miss;
             }
 
@@ -1213,7 +1292,7 @@ public static partial class FFmpegWrapper
                         LogLegacyDurationMismatch(mismatchLogger, legacyCacheKey, inferredDuration, expectedDuration);
                     }
 
-                    DeleteLegacyCacheFile(legacyCacheKey);
+                    DeleteLegacyCacheFilePath(legacyTextPath);
                     return LegacyCacheLoadStatus.Miss;
                 }
             }
@@ -1229,7 +1308,7 @@ public static partial class FFmpegWrapper
                 return LegacyCacheLoadStatus.Loaded;
             }
 
-            DeleteLegacyCacheFile(legacyCacheKey);
+            DeleteLegacyCacheFilePath(legacyTextPath);
             return LegacyCacheLoadStatus.Migrated;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -877,8 +877,7 @@ public static partial class FFmpegWrapper
         var parts = suffix.Split('-');
 
         if (parts is ["silence", var silenceStart, var silenceEnd, "v2"] &&
-            TryParseLegacyCacheTime(silenceStart, out var parsedSilenceStart) &&
-            TryParseLegacyCacheTime(silenceEnd, out var parsedSilenceEnd))
+            TryParseLegacyCacheRange(silenceStart, silenceEnd, out var parsedSilenceStart, out var parsedSilenceEnd))
         {
             return TryMigrateLegacyCacheForAllModes(
                 legacyCacheKey,
@@ -891,8 +890,7 @@ public static partial class FFmpegWrapper
         }
 
         if (parts is ["keyframes", var keyframesStart, var keyframesEnd, "v1"] &&
-            TryParseLegacyCacheTime(keyframesStart, out var parsedKeyframesStart) &&
-            TryParseLegacyCacheTime(keyframesEnd, out var parsedKeyframesEnd))
+            TryParseLegacyCacheRange(keyframesStart, keyframesEnd, out var parsedKeyframesStart, out var parsedKeyframesEnd))
         {
             return TryMigrateLegacyCacheForAllModes(
                 legacyCacheKey,
@@ -905,8 +903,7 @@ public static partial class FFmpegWrapper
         }
 
         if (parts is ["blackframes", var blackframesStart, var blackframesEnd, "v1"] &&
-            TryParseLegacyCacheTime(blackframesStart, out var parsedBlackframesStart) &&
-            TryParseLegacyCacheTime(blackframesEnd, out var parsedBlackframesEnd))
+            TryParseLegacyCacheRange(blackframesStart, blackframesEnd, out var parsedBlackframesStart, out var parsedBlackframesEnd))
         {
             return TryMigrateLegacyBlackFrameCache(
                 legacyCacheKey,
@@ -987,6 +984,13 @@ public static partial class FFmpegWrapper
 
     private static bool TryParseLegacyCacheTime(string value, out double result)
         => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+
+    private static bool TryParseLegacyCacheRange(string startValue, string endValue, out double start, out double end)
+    {
+        var parsedStart = TryParseLegacyCacheTime(startValue, out start);
+        var parsedEnd = TryParseLegacyCacheTime(endValue, out end);
+        return parsedStart && parsedEnd;
+    }
 
     private static bool TryMigrateLegacyChromaprintCache(QueuedEpisode episode, AnalysisMode mode)
     {
@@ -1141,14 +1145,14 @@ public static partial class FFmpegWrapper
             using var db = Plugin.CreateCacheDbContext();
             using var transaction = db.Database.BeginTransaction();
 
+            if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
+            {
+                var cacheKey = $"{itemId:N}-all-modes-{type}";
+                LogMigratingLegacyCache(logger, legacyCacheKey, cacheKey);
+            }
+
             foreach (var mode in Enum.GetValues<AnalysisMode>())
             {
-                if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
-                {
-                    var cacheKey = $"{itemId:N}-{mode}-{type}";
-                    LogMigratingLegacyCache(logger, legacyCacheKey, cacheKey);
-                }
-
                 UpsertJsonCacheEntry(db, itemId, mode, type, start, end, data);
             }
 

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -831,12 +831,12 @@ public static partial class FFmpegWrapper
                 continue;
             }
 
-            if (TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Introduction))
+            if (TryMigrateLegacyChromaprintCache(episode, AnalysisMode.Introduction))
             {
                 migrated++;
             }
 
-            if (TryMigrateLegacyFingerprintCache(episode, AnalysisMode.Credits))
+            if (TryMigrateLegacyChromaprintCache(episode, AnalysisMode.Credits))
             {
                 migrated++;
             }
@@ -857,7 +857,7 @@ public static partial class FFmpegWrapper
             foreach (var filePath in Directory.EnumerateFiles(cacheDir, prefix + "*"))
             {
                 var filename = Path.GetFileName(filePath);
-                var suffix = filename.Length >= prefix.Length ? filename[prefix.Length..] : string.Empty;
+                var suffix = filename[prefix.Length..];
                 if (TryMigrateLegacyDetectionCacheFile(filePath, filename, suffix, episode.EpisodeId))
                 {
                     migrated++;
@@ -908,35 +908,44 @@ public static partial class FFmpegWrapper
             TryParseLegacyCacheTime(blackframesStart, out var parsedBlackframesStart) &&
             TryParseLegacyCacheTime(blackframesEnd, out var parsedBlackframesEnd))
         {
-            return LoadLegacyCache(
+            return TryMigrateLegacyBlackFrameCache(
                 legacyCacheKey,
                 legacyTextPath,
                 itemId,
-                AnalysisMode.Credits,
-                CacheEntryType.BlackFrame,
                 parsedBlackframesStart,
-                parsedBlackframesEnd,
-                static raw => ParseBlackFrame(raw),
-                out BlackFrame[] _) == LegacyCacheLoadStatus.Migrated;
+                parsedBlackframesEnd);
         }
 
         if (parts is ["blackframes", var altBlackframesStart, "alt"] &&
             TryParseLegacyCacheTime(altBlackframesStart, out var parsedAltBlackframesStart))
         {
-            return LoadLegacyCache(
+            return TryMigrateLegacyBlackFrameCache(
                 legacyCacheKey,
                 legacyTextPath,
                 itemId,
-                AnalysisMode.Credits,
-                CacheEntryType.BlackFrame,
                 parsedAltBlackframesStart,
-                0,
-                static raw => ParseBlackFrame(raw),
-                out BlackFrame[] _) == LegacyCacheLoadStatus.Migrated;
+                0);
         }
 
         return false;
     }
+
+    private static bool TryMigrateLegacyBlackFrameCache(
+        string legacyCacheKey,
+        string legacyTextPath,
+        Guid itemId,
+        double start,
+        double end)
+        => LoadLegacyCache(
+            legacyCacheKey,
+            legacyTextPath,
+            itemId,
+            AnalysisMode.Credits,
+            CacheEntryType.BlackFrame,
+            start,
+            end,
+            static raw => ParseBlackFrame(raw),
+            out BlackFrame[] _) == LegacyCacheLoadStatus.Migrated;
 
     private static bool TryMigrateLegacyCacheForAllModes<T>(
         string legacyCacheKey,
@@ -957,17 +966,7 @@ public static partial class FFmpegWrapper
             var raw = File.ReadAllText(legacyTextPath, Encoding.UTF8);
             var result = rawParser(raw);
 
-            var modes = Enum.GetValues<AnalysisMode>();
-            foreach (var mode in modes)
-            {
-                if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
-                {
-                    var cacheKey = $"{itemId:N}-{mode}-{type}";
-                    LogMigratingLegacyCache(logger, legacyCacheKey, cacheKey);
-                }
-            }
-
-            if (!WriteJsonCacheForAllModes(itemId, type, start, end, result, modes))
+            if (!WriteJsonCacheForAllModes(legacyCacheKey, itemId, type, start, end, result))
             {
                 return false;
             }
@@ -989,7 +988,7 @@ public static partial class FFmpegWrapper
     private static bool TryParseLegacyCacheTime(string value, out double result)
         => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
 
-    private static bool TryMigrateLegacyFingerprintCache(QueuedEpisode episode, AnalysisMode mode)
+    private static bool TryMigrateLegacyChromaprintCache(QueuedEpisode episode, AnalysisMode mode)
     {
         var legacyCacheKey = GetLegacyFingerprintCacheKey(episode.EpisodeId, mode);
         if (!File.Exists(GetLegacyFilePath(legacyCacheKey)))
@@ -1104,20 +1103,7 @@ public static partial class FFmpegWrapper
         {
             using var db = Plugin.CreateCacheDbContext();
 
-            // NOTE: Start/End are compared with == which is safe only because the exact same
-            // double values that were written are used for lookup (no intermediate arithmetic).
-            var existing = db.DetectionCache
-                .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
-
-            if (existing is not null)
-            {
-                existing.Data = data;
-            }
-            else
-            {
-                db.DetectionCache.Add(new DbDetectionCache(itemId, mode, type, data, start, end));
-            }
-
+            UpsertJsonCacheEntry(db, itemId, mode, type, start, end, data);
             db.SaveChanges();
             return true;
         }
@@ -1136,12 +1122,12 @@ public static partial class FFmpegWrapper
     }
 
     private static bool WriteJsonCacheForAllModes<T>(
+        string legacyCacheKey,
         Guid itemId,
         CacheEntryType type,
         double start,
         double end,
-        T[] items,
-        AnalysisMode[] modes)
+        T[] items)
     {
         if (!IsCachingEnabled())
         {
@@ -1155,19 +1141,15 @@ public static partial class FFmpegWrapper
             using var db = Plugin.CreateCacheDbContext();
             using var transaction = db.Database.BeginTransaction();
 
-            foreach (var mode in modes)
+            foreach (var mode in Enum.GetValues<AnalysisMode>())
             {
-                var existing = db.DetectionCache
-                    .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+                if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
+                {
+                    var cacheKey = $"{itemId:N}-{mode}-{type}";
+                    LogMigratingLegacyCache(logger, legacyCacheKey, cacheKey);
+                }
 
-                if (existing is not null)
-                {
-                    existing.Data = data;
-                }
-                else
-                {
-                    db.DetectionCache.Add(new DbDetectionCache(itemId, mode, type, data, start, end));
-                }
+                UpsertJsonCacheEntry(db, itemId, mode, type, start, end, data);
             }
 
             db.SaveChanges();
@@ -1183,6 +1165,30 @@ public static partial class FFmpegWrapper
             }
 
             return false;
+        }
+    }
+
+    private static void UpsertJsonCacheEntry(
+        DetectionCacheDbContext db,
+        Guid itemId,
+        AnalysisMode mode,
+        CacheEntryType type,
+        double start,
+        double end,
+        byte[] data)
+    {
+        // NOTE: Start/End are compared with == which is safe only because the exact same
+        // double values that were written are used for lookup (no intermediate arithmetic).
+        var existing = db.DetectionCache
+            .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+
+        if (existing is not null)
+        {
+            existing.Data = data;
+        }
+        else
+        {
+            db.DetectionCache.Add(new DbDetectionCache(itemId, mode, type, data, start, end));
         }
     }
 

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -805,7 +805,7 @@ public static partial class FFmpegWrapper
     /// <param name="episodes">Queued media items whose IDs are still present in enabled libraries.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The number of legacy cache files migrated.</returns>
-    internal static int MigrateLegacyFingerprintCache(IEnumerable<QueuedEpisode> episodes, CancellationToken cancellationToken = default)
+    internal static int MigrateLegacyDetectionCache(IEnumerable<QueuedEpisode> episodes, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(episodes);
 
@@ -849,20 +849,14 @@ public static partial class FFmpegWrapper
 
     private static int MigrateLegacyDetectionCacheFiles(string cacheDir, QueuedEpisode episode)
     {
-        var id = episode.EpisodeId.ToString("N");
+        var prefix = episode.EpisodeId.ToString("N") + "-";
         var migrated = 0;
 
         try
         {
-            foreach (var filePath in Directory.EnumerateFiles(cacheDir, id + "-*"))
+            foreach (var filePath in Directory.EnumerateFiles(cacheDir, prefix + "*"))
             {
                 var filename = Path.GetFileName(filePath);
-                var prefix = id + "-";
-                if (!filename.StartsWith(prefix, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
                 if (TryMigrateLegacyDetectionCacheFile(filename, filename[prefix.Length..], episode.EpisodeId))
                 {
                     migrated++;

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -820,16 +820,23 @@ public static partial class FFmpegWrapper
             return 0;
         }
 
+        var queuedEpisodes = episodes
+            .Where(static episode => episode.EpisodeId != Guid.Empty)
+            .ToList();
+        if (queuedEpisodes.Count == 0)
+        {
+            return 0;
+        }
+
+        var queuedEpisodeIds = queuedEpisodes
+            .Select(static episode => episode.EpisodeId)
+            .ToHashSet();
+        var detectionCacheFiles = GetLegacyDetectionCacheFiles(cacheDir, queuedEpisodeIds, cancellationToken);
         var migrated = 0;
 
-        foreach (var episode in episodes)
+        foreach (var episode in queuedEpisodes)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            if (episode.EpisodeId == Guid.Empty)
-            {
-                continue;
-            }
 
             if (TryMigrateLegacyChromaprintCache(episode, AnalysisMode.Introduction))
             {
@@ -841,91 +848,171 @@ public static partial class FFmpegWrapper
                 migrated++;
             }
 
-            migrated += MigrateLegacyDetectionCacheFiles(cacheDir, episode);
-        }
-
-        return migrated;
-    }
-
-    private static int MigrateLegacyDetectionCacheFiles(string cacheDir, QueuedEpisode episode)
-    {
-        var prefix = episode.EpisodeId.ToString("N") + "-";
-        var migrated = 0;
-
-        try
-        {
-            foreach (var filePath in Directory.EnumerateFiles(cacheDir, prefix + "*"))
+            if (!detectionCacheFiles.TryGetValue(episode.EpisodeId, out var legacyFiles))
             {
-                var filename = Path.GetFileName(filePath);
-                var suffix = filename[prefix.Length..];
-                if (TryMigrateLegacyDetectionCacheFile(filePath, filename, suffix, episode.EpisodeId))
+                continue;
+            }
+
+            foreach (var legacyFile in legacyFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (TryMigrateLegacyDetectionCacheFile(legacyFile))
                 {
                     migrated++;
                 }
             }
         }
-        catch (DirectoryNotFoundException)
-        {
-            return migrated;
-        }
 
         return migrated;
     }
 
-    private static bool TryMigrateLegacyDetectionCacheFile(string legacyTextPath, string legacyCacheKey, string suffix, Guid itemId)
+    private static Dictionary<Guid, List<LegacyDetectionCacheFile>> GetLegacyDetectionCacheFiles(
+        string cacheDir,
+        HashSet<Guid> queuedEpisodeIds,
+        CancellationToken cancellationToken)
     {
+        var result = new Dictionary<Guid, List<LegacyDetectionCacheFile>>();
+
+        try
+        {
+            foreach (var filePath in Directory.EnumerateFiles(cacheDir))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!TryParseLegacyDetectionCacheFile(filePath, out var file) ||
+                    !queuedEpisodeIds.Contains(file.ItemId))
+                {
+                    continue;
+                }
+
+                if (!result.TryGetValue(file.ItemId, out var files))
+                {
+                    files = [];
+                    result[file.ItemId] = files;
+                }
+
+                files.Add(file);
+            }
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return result;
+        }
+
+        return result;
+    }
+
+    private static bool TryParseLegacyDetectionCacheFile(string legacyTextPath, out LegacyDetectionCacheFile file)
+    {
+        file = default;
+
+        var legacyCacheKey = Path.GetFileName(legacyTextPath);
+        var separatorIndex = legacyCacheKey.IndexOf('-', StringComparison.Ordinal);
+        if (separatorIndex <= 0)
+        {
+            return false;
+        }
+
+        var itemIdText = legacyCacheKey[..separatorIndex];
+        if (!Guid.TryParseExact(itemIdText, "N", out var itemId) ||
+            !string.Equals(itemIdText, itemId.ToString("N"), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var suffix = legacyCacheKey[(separatorIndex + 1)..];
         var parts = suffix.Split('-');
 
         if (parts is ["silence", var silenceStart, var silenceEnd, "v2"] &&
             TryParseLegacyCacheRange(silenceStart, silenceEnd, out var parsedSilenceStart, out var parsedSilenceEnd))
         {
-            return TryMigrateLegacyCacheForAllModes(
+            file = new LegacyDetectionCacheFile(
+                itemId,
                 legacyCacheKey,
                 legacyTextPath,
-                itemId,
                 CacheEntryType.Silence,
                 parsedSilenceStart,
                 parsedSilenceEnd,
-                raw => ParseSilenceRaw(raw, parsedSilenceStart));
+                null);
+            return true;
         }
 
         if (parts is ["keyframes", var keyframesStart, var keyframesEnd, "v1"] &&
             TryParseLegacyCacheRange(keyframesStart, keyframesEnd, out var parsedKeyframesStart, out var parsedKeyframesEnd))
         {
-            return TryMigrateLegacyCacheForAllModes(
+            file = new LegacyDetectionCacheFile(
+                itemId,
                 legacyCacheKey,
                 legacyTextPath,
-                itemId,
                 CacheEntryType.Keyframe,
                 parsedKeyframesStart,
                 parsedKeyframesEnd,
-                raw => ParseKeyFramesRaw(raw, parsedKeyframesStart));
+                null);
+            return true;
         }
 
         if (parts is ["blackframes", var blackframesStart, var blackframesEnd, "v1"] &&
             TryParseLegacyCacheRange(blackframesStart, blackframesEnd, out var parsedBlackframesStart, out var parsedBlackframesEnd))
         {
-            return TryMigrateLegacyBlackFrameCache(
+            file = new LegacyDetectionCacheFile(
+                itemId,
                 legacyCacheKey,
                 legacyTextPath,
-                itemId,
+                CacheEntryType.BlackFrame,
                 parsedBlackframesStart,
-                parsedBlackframesEnd);
+                parsedBlackframesEnd,
+                AnalysisMode.Credits);
+            return true;
         }
 
         if (parts is ["blackframes", var altBlackframesStart, "alt"] &&
             TryParseLegacyCacheTime(altBlackframesStart, out var parsedAltBlackframesStart))
         {
-            return TryMigrateLegacyBlackFrameCache(
+            file = new LegacyDetectionCacheFile(
+                itemId,
                 legacyCacheKey,
                 legacyTextPath,
-                itemId,
+                CacheEntryType.BlackFrame,
                 parsedAltBlackframesStart,
-                0);
+                0,
+                AnalysisMode.Credits);
+            return true;
         }
 
         return false;
     }
+
+    private static bool TryMigrateLegacyDetectionCacheFile(LegacyDetectionCacheFile file)
+        => file.Type switch
+        {
+            CacheEntryType.Silence when file.Mode is null => TryMigrateLegacyCacheForAllModes(
+                file.LegacyCacheKey,
+                file.LegacyTextPath,
+                file.ItemId,
+                file.Type,
+                file.Start,
+                file.End,
+                raw => ParseSilenceRaw(raw, file.Start)),
+
+            CacheEntryType.Keyframe when file.Mode is null => TryMigrateLegacyCacheForAllModes(
+                file.LegacyCacheKey,
+                file.LegacyTextPath,
+                file.ItemId,
+                file.Type,
+                file.Start,
+                file.End,
+                raw => ParseKeyFramesRaw(raw, file.Start)),
+
+            CacheEntryType.BlackFrame when file.Mode == AnalysisMode.Credits => TryMigrateLegacyBlackFrameCache(
+                file.LegacyCacheKey,
+                file.LegacyTextPath,
+                file.ItemId,
+                file.Start,
+                file.End),
+
+            _ => false,
+        };
 
     private static bool TryMigrateLegacyBlackFrameCache(
         string legacyCacheKey,
@@ -1453,4 +1540,13 @@ public static partial class FFmpegWrapper
 
     [GeneratedRegex(@"\[Parsed_blackframe_0 @ [^\]]+\] frame:(\d+) pblack:(\d+) .*? t:([\d.]+)")]
     private static partial Regex BlackFrameRegex();
+
+    private readonly record struct LegacyDetectionCacheFile(
+        Guid ItemId,
+        string LegacyCacheKey,
+        string LegacyTextPath,
+        CacheEntryType Type,
+        double Start,
+        double End,
+        AnalysisMode? Mode);
 }

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -881,9 +881,9 @@ public static partial class FFmpegWrapper
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var filename = Path.GetFileName(filePath);
-                if (!TryGetLegacyDetectionCacheItemId(filename, out var itemId) ||
+                if (!TryGetLegacyDetectionCacheParts(filename, out var itemId, out var suffix) ||
                     !queuedEpisodeIds.Contains(itemId) ||
-                    !TryParseLegacyDetectionCacheFile(filePath, out var file))
+                    !TryParseLegacyDetectionCacheFile(filePath, filename, itemId, suffix, out var file))
                 {
                     continue;
                 }
@@ -910,36 +910,34 @@ public static partial class FFmpegWrapper
         return result;
     }
 
-    private static bool TryGetLegacyDetectionCacheItemId(string filename, out Guid itemId)
+    private static bool TryGetLegacyDetectionCacheParts(string filename, out Guid itemId, out string suffix)
     {
         itemId = Guid.Empty;
+        suffix = string.Empty;
         if (filename.Length <= 32 || filename[32] != '-')
         {
             return false;
         }
 
-        return Guid.TryParseExact(filename[..32], "N", out itemId);
-    }
-
-    private static bool TryParseLegacyDetectionCacheFile(string legacyTextPath, out LegacyDetectionCacheFile file)
-    {
-        file = default;
-
-        var legacyCacheKey = Path.GetFileName(legacyTextPath);
-        var separatorIndex = legacyCacheKey.IndexOf('-', StringComparison.Ordinal);
-        if (separatorIndex <= 0)
-        {
-            return false;
-        }
-
-        var itemIdText = legacyCacheKey[..separatorIndex];
-        if (!Guid.TryParseExact(itemIdText, "N", out var itemId) ||
+        var itemIdText = filename[..32];
+        if (!Guid.TryParseExact(itemIdText, "N", out itemId) ||
             !string.Equals(itemIdText, itemId.ToString("N"), StringComparison.Ordinal))
         {
             return false;
         }
 
-        var suffix = legacyCacheKey[(separatorIndex + 1)..];
+        suffix = filename[33..];
+        return true;
+    }
+
+    private static bool TryParseLegacyDetectionCacheFile(
+        string legacyTextPath,
+        string legacyCacheKey,
+        Guid itemId,
+        string suffix,
+        out LegacyDetectionCacheFile file)
+    {
+        file = default;
         var parts = suffix.Split('-');
 
         if (parts is ["silence", var silenceStart, var silenceEnd, "v2"] &&

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -800,11 +800,11 @@ public static partial class FFmpegWrapper
     }
 
     /// <summary>
-    /// Migrates legacy on-disk chromaprint fingerprint cache files for queued media items into the SQLite cache.
+    /// Migrates recognized legacy on-disk detection cache files for queued media items into the SQLite cache.
     /// </summary>
     /// <param name="episodes">Queued media items whose IDs are still present in enabled libraries.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The number of legacy fingerprint files migrated.</returns>
+    /// <returns>The number of legacy cache files migrated.</returns>
     internal static int MigrateLegacyFingerprintCache(IEnumerable<QueuedEpisode> episodes, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(episodes);
@@ -840,10 +840,154 @@ public static partial class FFmpegWrapper
             {
                 migrated++;
             }
+
+            migrated += MigrateLegacyDetectionCacheFiles(cacheDir, episode);
         }
 
         return migrated;
     }
+
+    private static int MigrateLegacyDetectionCacheFiles(string cacheDir, QueuedEpisode episode)
+    {
+        var id = episode.EpisodeId.ToString("N");
+        var migrated = 0;
+
+        try
+        {
+            foreach (var filePath in Directory.EnumerateFiles(cacheDir, id + "-*"))
+            {
+                var filename = Path.GetFileName(filePath);
+                var prefix = id + "-";
+                if (!filename.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (TryMigrateLegacyDetectionCacheFile(filename, filename[prefix.Length..], episode.EpisodeId))
+                {
+                    migrated++;
+                }
+            }
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return migrated;
+        }
+
+        return migrated;
+    }
+
+    private static bool TryMigrateLegacyDetectionCacheFile(string legacyCacheKey, string suffix, Guid itemId)
+    {
+        var parts = suffix.Split('-');
+
+        if (parts is ["silence", var silenceStart, var silenceEnd, "v2"] &&
+            TryParseLegacyCacheTime(silenceStart, out var parsedSilenceStart) &&
+            TryParseLegacyCacheTime(silenceEnd, out var parsedSilenceEnd))
+        {
+            return TryMigrateLegacyCacheForAllModes(
+                legacyCacheKey,
+                itemId,
+                CacheEntryType.Silence,
+                parsedSilenceStart,
+                parsedSilenceEnd,
+                raw => ParseSilenceRaw(raw, parsedSilenceStart));
+        }
+
+        if (parts is ["keyframes", var keyframesStart, var keyframesEnd, "v1"] &&
+            TryParseLegacyCacheTime(keyframesStart, out var parsedKeyframesStart) &&
+            TryParseLegacyCacheTime(keyframesEnd, out var parsedKeyframesEnd))
+        {
+            return TryMigrateLegacyCacheForAllModes(
+                legacyCacheKey,
+                itemId,
+                CacheEntryType.Keyframe,
+                parsedKeyframesStart,
+                parsedKeyframesEnd,
+                raw => ParseKeyFramesRaw(raw, parsedKeyframesStart));
+        }
+
+        if (parts is ["blackframes", var blackframesStart, var blackframesEnd, "v1"] &&
+            TryParseLegacyCacheTime(blackframesStart, out var parsedBlackframesStart) &&
+            TryParseLegacyCacheTime(blackframesEnd, out var parsedBlackframesEnd))
+        {
+            return LoadLegacyCache(
+                legacyCacheKey,
+                itemId,
+                AnalysisMode.Credits,
+                CacheEntryType.BlackFrame,
+                parsedBlackframesStart,
+                parsedBlackframesEnd,
+                static raw => ParseBlackFrame(raw),
+                out BlackFrame[] _) == LegacyCacheLoadStatus.Migrated;
+        }
+
+        if (parts is ["blackframes", var altBlackframesStart, "alt"] &&
+            TryParseLegacyCacheTime(altBlackframesStart, out var parsedAltBlackframesStart))
+        {
+            return LoadLegacyCache(
+                legacyCacheKey,
+                itemId,
+                AnalysisMode.Credits,
+                CacheEntryType.BlackFrame,
+                parsedAltBlackframesStart,
+                0,
+                static raw => ParseBlackFrame(raw),
+                out BlackFrame[] _) == LegacyCacheLoadStatus.Migrated;
+        }
+
+        return false;
+    }
+
+    private static bool TryMigrateLegacyCacheForAllModes<T>(
+        string legacyCacheKey,
+        Guid itemId,
+        CacheEntryType type,
+        double start,
+        double end,
+        Func<string, T[]> rawParser)
+    {
+        var legacyTextPath = GetLegacyFilePath(legacyCacheKey);
+        if (!File.Exists(legacyTextPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var raw = File.ReadAllText(legacyTextPath, Encoding.UTF8);
+            var result = rawParser(raw);
+
+            foreach (var mode in Enum.GetValues<AnalysisMode>())
+            {
+                if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
+                {
+                    var cacheKey = $"{itemId:N}-{mode}-{type}";
+                    LogMigratingLegacyCache(logger, legacyCacheKey, cacheKey);
+                }
+
+                if (!WriteJsonCache(itemId, mode, type, start, end, result))
+                {
+                    return false;
+                }
+            }
+
+            DeleteLegacyCacheFile(legacyCacheKey);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (ex is not FileNotFoundException && Logger is { } logger)
+            {
+                LogDetectionCacheReadError(logger, ex, legacyTextPath);
+            }
+
+            return false;
+        }
+    }
+
+    private static bool TryParseLegacyCacheTime(string value, out double result)
+        => double.TryParse(value, CultureInfo.InvariantCulture, out result);
 
     private static bool TryMigrateLegacyFingerprintCache(QueuedEpisode episode, AnalysisMode mode)
     {

--- a/IntroSkipper/FFmpegWrapper.cs
+++ b/IntroSkipper/FFmpegWrapper.cs
@@ -880,8 +880,10 @@ public static partial class FFmpegWrapper
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (!TryParseLegacyDetectionCacheFile(filePath, out var file) ||
-                    !queuedEpisodeIds.Contains(file.ItemId))
+                var filename = Path.GetFileName(filePath);
+                if (!TryGetLegacyDetectionCacheItemId(filename, out var itemId) ||
+                    !queuedEpisodeIds.Contains(itemId) ||
+                    !TryParseLegacyDetectionCacheFile(filePath, out var file))
                 {
                     continue;
                 }
@@ -895,12 +897,28 @@ public static partial class FFmpegWrapper
                 files.Add(file);
             }
         }
-        catch (DirectoryNotFoundException)
+        catch (Exception ex) when (ex is DirectoryNotFoundException or IOException or UnauthorizedAccessException)
         {
+            if (Logger is { } logger)
+            {
+                LogLegacyDetectionCacheScanFailed(logger, ex, cacheDir);
+            }
+
             return result;
         }
 
         return result;
+    }
+
+    private static bool TryGetLegacyDetectionCacheItemId(string filename, out Guid itemId)
+    {
+        itemId = Guid.Empty;
+        if (filename.Length <= 32 || filename[32] != '-')
+        {
+            return false;
+        }
+
+        return Guid.TryParseExact(filename[..32], "N", out itemId);
     }
 
     private static bool TryParseLegacyDetectionCacheFile(string legacyTextPath, out LegacyDetectionCacheFile file)
@@ -1226,6 +1244,7 @@ public static partial class FFmpegWrapper
         }
 
         var data = CompressBrotli(items);
+        var cacheKey = $"{itemId:N}-all-modes-{type}";
 
         try
         {
@@ -1234,13 +1253,24 @@ public static partial class FFmpegWrapper
 
             if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
             {
-                var cacheKey = $"{itemId:N}-all-modes-{type}";
                 LogMigratingLegacyCache(logger, legacyCacheKey, cacheKey);
             }
 
+            var existingEntries = db.DetectionCache
+                .Where(e => e.ItemId == itemId && e.Type == type && e.Start == start && e.End == end)
+                .ToList();
+
             foreach (var mode in Enum.GetValues<AnalysisMode>())
             {
-                UpsertJsonCacheEntry(db, itemId, mode, type, start, end, data);
+                var existing = existingEntries.FirstOrDefault(e => e.Mode == mode);
+                if (existing is not null)
+                {
+                    existing.Data = data;
+                }
+                else
+                {
+                    db.DetectionCache.Add(new DbDetectionCache(itemId, mode, type, data, start, end));
+                }
             }
 
             db.SaveChanges();
@@ -1251,7 +1281,6 @@ public static partial class FFmpegWrapper
         {
             if (Logger is { } logger && logger.IsEnabled(LogLevel.Debug))
             {
-                var cacheKey = $"{itemId:N}-{type}";
                 LogDetectionCacheWriteError(logger, ex, cacheKey);
             }
 
@@ -1500,6 +1529,9 @@ public static partial class FFmpegWrapper
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Migrating legacy cache {LegacyKey} to {NewKey}")]
     private static partial void LogMigratingLegacyCache(ILogger logger, string legacyKey, string newKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to scan legacy detection cache directory {CacheDir}")]
+    private static partial void LogLegacyDetectionCacheScanFailed(ILogger logger, Exception ex, string cacheDir);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Legacy fingerprint {CacheKey} duration mismatch (inferred {Inferred}s vs expected {Expected}s), re-fingerprinting")]
     private static partial void LogLegacyDurationMismatch(ILogger logger, string cacheKey, double inferred, double expected);

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -90,7 +90,7 @@ public partial class BaseItemAnalyzerTask(
 
         if (!plugin.LegacyFingerprintMigrationDone)
         {
-            FFmpegWrapper.MigrateLegacyFingerprintCache(
+            FFmpegWrapper.MigrateLegacyDetectionCache(
                 queue.Values.SelectMany(static episodes => episodes),
                 cancellationToken);
             plugin.LegacyFingerprintMigrationDone = true;

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -84,7 +84,7 @@ public partial class CleanCacheTask(
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
         var enabledLibraryEpisodes = queue.Values.SelectMany(static episodes => episodes).ToList();
 
-        FFmpegWrapper.MigrateLegacyFingerprintCache(enabledLibraryEpisodes, cancellationToken);
+        FFmpegWrapper.MigrateLegacyDetectionCache(enabledLibraryEpisodes, cancellationToken);
         plugin.LegacyFingerprintMigrationDone = true;
 
         var enabledLibraryEpisodeIds = enabledLibraryEpisodes


### PR DESCRIPTION
This PR extends the front-loaded legacy cache migration to cover all recognized on-disk detection cache file types (silence, keyframes, blackframes), not only chromaprint fingerprints. Multi-mode legacy files (silence, keyframes) that did not encode analysis mode are written for all `AnalysisMode` values to preserve cache semantics after the file is deleted. Invalid or unrecognized filenames are left untouched for on-demand fallback.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/4c464a65-e1b8-4220-b3eb-21ab4ab42de5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-012" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/4c464a65-e1b8-4220-b3eb-21ab4ab42de5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-012&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-012"><img alt="INTRO-012" src="https://capy.ai/api/badge/thread.svg?label=INTRO-012"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Extend legacy cache migration to handle all supported detection cache file types and centralize multi-mode migration into the SQLite detection cache.

New Features:
- Support migration of legacy silence, keyframe, and blackframe detection cache files into the SQLite cache for queued items.

Enhancements:
- Ensure multi-mode legacy detection files are migrated for all analysis modes while preserving existing cache semantics.
- Leave invalid or unrecognized legacy detection cache files untouched to fall back to on-demand migration.
- Refactor cache writing to support upserting detection cache entries and bulk-writing shared data across analysis modes.
- Improve robustness of legacy cache scanning and migration with better error handling and logging.

Tests:
- Add comprehensive tests covering detection cache migration behavior, including recognized files, invalid filenames, and stale item IDs.