### PR TITLE
Repair failing segment database initialization

### DIFF
--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -250,7 +250,7 @@ public sealed class TestDbSegmentStorage
 
         try
         {
-            await CreateDatabaseAtLastMigrationBeforeConfigHashesAsync(dbPath);
+            CreateDatabaseAtLastMigrationBeforeConfigHashes(dbPath);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -265,6 +265,40 @@ public sealed class TestDbSegmentStorage
                 Assert.Equal(string.Empty, seasonInfo.ConfigHash);
 
                 var segment = Assert.Single(await db.DbSegment.AsNoTracking().ToListAsync());
+                Assert.Equal(string.Empty, segment.ConfigHash);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+
+    [Fact]
+    public void ApplyMigrations_RepairsMissingConfigHashColumnsWhenMigrationAlreadyMarkedApplied()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+
+        try
+        {
+            CreateDatabaseAtLastMigrationBeforeConfigHashes(dbPath, markConfigHashesApplied: true);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                db.ApplyMigrations();
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                Assert.Contains("20260519073000_AddConfigHashes", db.Database.GetAppliedMigrations());
+
+                var seasonInfo = Assert.Single(db.DbSeasonInfo.AsNoTracking().ToList());
+                Assert.Equal(string.Empty, seasonInfo.ConfigHash);
+
+                var segment = Assert.Single(db.DbSegment.AsNoTracking().ToList());
                 Assert.Equal(string.Empty, segment.ConfigHash);
             }
         }
@@ -326,12 +360,42 @@ public sealed class TestDbSegmentStorage
         }
     }
 
-    private static async Task CreateDatabaseAtLastMigrationBeforeConfigHashesAsync(string dbPath)
+    [Fact]
+    public void RebuildDatabase_RecreatesUnreadableDatabaseAfterMigrationFailure()
     {
-        await using var connection = new SqliteConnection($"Data Source={dbPath}");
-        await connection.OpenAsync();
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
 
-        await using var command = connection.CreateCommand();
+        try
+        {
+            CreateUnreadableSegmentDatabase(dbPath);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                Assert.ThrowsAny<Exception>(() => db.ApplyMigrations());
+                db.RebuildDatabase(() => new IntroSkipperDbContext(dbPath), forceCleanOnBackupFailure: true);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                Assert.Empty(db.Database.GetPendingMigrations());
+                Assert.Empty(db.DbSegment.AsNoTracking().ToList());
+                Assert.Empty(db.DbSeasonInfo.AsNoTracking().ToList());
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    private static void CreateDatabaseAtLastMigrationBeforeConfigHashes(string dbPath, bool markConfigHashesApplied = false)
+    {
+        using var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
         command.CommandText =
             """
             CREATE TABLE "__EFMigrationsHistory" (
@@ -378,7 +442,36 @@ public sealed class TestDbSegmentStorage
         command.Parameters.AddWithValue("$seasonId", Guid.NewGuid().ToString());
         command.Parameters.AddWithValue("$itemId", Guid.NewGuid().ToString());
 
-        await command.ExecuteNonQueryAsync();
+        command.ExecuteNonQuery();
+
+        if (markConfigHashesApplied)
+        {
+            command.CommandText =
+                """
+                INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+                VALUES ('20260519073000_AddConfigHashes', '9.0.11');
+                """;
+            command.Parameters.Clear();
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static void CreateUnreadableSegmentDatabase(string dbPath)
+    {
+        using var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            CREATE TABLE "DbSeasonInfo" (
+                "SeasonId" TEXT NOT NULL
+            );
+            CREATE TABLE "DbSegment" (
+                "ItemId" TEXT NOT NULL
+            );
+            """;
+        command.ExecuteNonQuery();
     }
 
     private static void ConfigurePluginLogger(Plugin plugin)

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -3,11 +3,13 @@
 // SPDX-FileCopyrightText: 2024-2026 rlauuzo
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System.Data;
 using System.Text.Json;
 using IntroSkipper.Data;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace IntroSkipper.Db;
 
@@ -138,6 +140,7 @@ public class IntroSkipperDbContext : DbContext
     public void ApplyMigrations()
     {
         Database.Migrate();
+        EnsureMissingConfigHashColumns();
     }
 
     /// <summary>
@@ -148,6 +151,65 @@ public class IntroSkipperDbContext : DbContext
     public async Task ApplyMigrationsAsync(CancellationToken cancellationToken = default)
     {
         await Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureMissingConfigHashColumnsAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Rebuilds the database while attempting to preserve valid segments and season information.
+    /// </summary>
+    /// <param name="contextFactory">Factory delegate to create sibling <see cref="IntroSkipperDbContext"/> instances.</param>
+    /// <param name="forceCleanOnBackupFailure">
+    /// When <c>true</c>, rebuild proceeds with an empty database if the backup read fails.
+    /// When <c>false</c>, the rebuild aborts to avoid data loss.
+    /// </param>
+    public void RebuildDatabase(Func<IntroSkipperDbContext> contextFactory, bool forceCleanOnBackupFailure = false)
+    {
+        var segments = new List<DbSegment>();
+        var seasonInfos = new List<DbSeasonInfo>();
+        var backupFailed = false;
+
+        try
+        {
+            using var db = contextFactory();
+            segments = [.. db.DbSegment.AsNoTracking().ToList().Where(s => s.ToSegment().Valid)];
+            seasonInfos = db.DbSeasonInfo.AsNoTracking().ToList();
+        }
+        catch (Exception ex) when (ex is SqliteException or DbUpdateException or JsonException)
+        {
+            if (!forceCleanOnBackupFailure)
+            {
+                throw new InvalidOperationException("Failed to back up the existing database before rebuild. Aborting rebuild to avoid data loss.", ex);
+            }
+
+            backupFailed = true;
+        }
+
+        if (backupFailed)
+        {
+            DeleteDatabaseFiles();
+        }
+        else
+        {
+            Database.EnsureDeleted();
+        }
+
+        ApplyMigrations();
+
+        if (segments.Count > 0 || seasonInfos.Count > 0)
+        {
+            using var db = contextFactory();
+            if (segments.Count > 0)
+            {
+                db.DbSegment.AddRange(segments);
+            }
+
+            if (seasonInfos.Count > 0)
+            {
+                db.DbSeasonInfo.AddRange(seasonInfos);
+            }
+
+            db.SaveChanges();
+        }
     }
 
     /// <summary>
@@ -268,5 +330,165 @@ public class IntroSkipperDbContext : DbContext
 
         var builder = new SqliteConnectionStringBuilder(connectionString);
         return builder.DataSource is not (null or "" or ":memory:") ? builder.DataSource : null;
+    }
+
+    private void EnsureMissingConfigHashColumns()
+    {
+        var connection = Database.GetDbConnection();
+        var wasOpen = connection.State == ConnectionState.Open;
+        if (!wasOpen)
+        {
+            Database.OpenConnection();
+        }
+
+        try
+        {
+            using var transaction = Database.BeginTransaction();
+            EnsureConfigHashColumn("DbSegment");
+            EnsureConfigHashColumn("DbSeasonInfo");
+            transaction.Commit();
+        }
+        finally
+        {
+            if (!wasOpen)
+            {
+                Database.CloseConnection();
+            }
+        }
+    }
+
+    private async Task EnsureMissingConfigHashColumnsAsync(CancellationToken cancellationToken)
+    {
+        var connection = Database.GetDbConnection();
+        var wasOpen = connection.State == ConnectionState.Open;
+        if (!wasOpen)
+        {
+            await Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            var transaction = await Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            await using (transaction.ConfigureAwait(false))
+            {
+                await EnsureConfigHashColumnAsync("DbSegment", cancellationToken).ConfigureAwait(false);
+                await EnsureConfigHashColumnAsync("DbSeasonInfo", cancellationToken).ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (!wasOpen)
+            {
+                await Database.CloseConnectionAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private void EnsureConfigHashColumn(string tableName)
+    {
+        if (!TableExists(tableName) || ColumnExists(tableName, "ConfigHash"))
+        {
+            return;
+        }
+
+        switch (tableName)
+        {
+            case "DbSegment":
+                Database.ExecuteSqlRaw("ALTER TABLE \"DbSegment\" ADD COLUMN \"ConfigHash\" TEXT NOT NULL DEFAULT ''");
+                break;
+            case "DbSeasonInfo":
+                Database.ExecuteSqlRaw("ALTER TABLE \"DbSeasonInfo\" ADD COLUMN \"ConfigHash\" TEXT NOT NULL DEFAULT ''");
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported table '{tableName}'.");
+        }
+    }
+
+    private async Task EnsureConfigHashColumnAsync(string tableName, CancellationToken cancellationToken)
+    {
+        if (!await TableExistsAsync(tableName, cancellationToken).ConfigureAwait(false)
+            || await ColumnExistsAsync(tableName, "ConfigHash", cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        switch (tableName)
+        {
+            case "DbSegment":
+                await Database.ExecuteSqlRawAsync("ALTER TABLE \"DbSegment\" ADD COLUMN \"ConfigHash\" TEXT NOT NULL DEFAULT ''", cancellationToken).ConfigureAwait(false);
+                break;
+            case "DbSeasonInfo":
+                await Database.ExecuteSqlRawAsync("ALTER TABLE \"DbSeasonInfo\" ADD COLUMN \"ConfigHash\" TEXT NOT NULL DEFAULT ''", cancellationToken).ConfigureAwait(false);
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported table '{tableName}'.");
+        }
+    }
+
+    private bool TableExists(string tableName)
+    {
+        using var command = Database.GetDbConnection().CreateCommand();
+        command.CommandText = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = $name LIMIT 1";
+        command.Transaction = Database.CurrentTransaction?.GetDbTransaction();
+
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = tableName;
+        command.Parameters.Add(parameter);
+
+        return command.ExecuteScalar() is not null;
+    }
+
+    private async Task<bool> TableExistsAsync(string tableName, CancellationToken cancellationToken)
+    {
+        using var command = Database.GetDbConnection().CreateCommand();
+        command.CommandText = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = $name LIMIT 1";
+        command.Transaction = Database.CurrentTransaction?.GetDbTransaction();
+
+        var parameter = command.CreateParameter();
+        parameter.ParameterName = "$name";
+        parameter.Value = tableName;
+        command.Parameters.Add(parameter);
+
+        return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
+    }
+
+    private bool ColumnExists(string tableName, string columnName)
+    {
+        using var command = Database.GetDbConnection().CreateCommand();
+        command.CommandText = "SELECT 1 FROM pragma_table_info($tableName) WHERE name = $columnName LIMIT 1";
+        command.Transaction = Database.CurrentTransaction?.GetDbTransaction();
+
+        var tableParameter = command.CreateParameter();
+        tableParameter.ParameterName = "$tableName";
+        tableParameter.Value = tableName;
+        command.Parameters.Add(tableParameter);
+
+        var columnParameter = command.CreateParameter();
+        columnParameter.ParameterName = "$columnName";
+        columnParameter.Value = columnName;
+        command.Parameters.Add(columnParameter);
+
+        return command.ExecuteScalar() is not null;
+    }
+
+    private async Task<bool> ColumnExistsAsync(string tableName, string columnName, CancellationToken cancellationToken)
+    {
+        using var command = Database.GetDbConnection().CreateCommand();
+        command.CommandText = "SELECT 1 FROM pragma_table_info($tableName) WHERE name = $columnName LIMIT 1";
+        command.Transaction = Database.CurrentTransaction?.GetDbTransaction();
+
+        var tableParameter = command.CreateParameter();
+        tableParameter.ParameterName = "$tableName";
+        tableParameter.Value = tableName;
+        command.Parameters.Add(tableParameter);
+
+        var columnParameter = command.CreateParameter();
+        columnParameter.ParameterName = "$columnName";
+        columnParameter.Value = columnName;
+        command.Parameters.Add(columnParameter);
+
+        return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
     }
 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -95,6 +95,16 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         catch (Exception ex)
         {
             LogDatabaseInitializationError(_logger, ex);
+            try
+            {
+                using var db = CreateDbContext();
+                db.RebuildDatabase(CreateDbContext, forceCleanOnBackupFailure: true);
+                LogDatabaseRebuiltAfterInitializationError(_logger);
+            }
+            catch (Exception rebuildEx)
+            {
+                LogDatabaseRebuildInitializationError(_logger, rebuildEx);
+            }
         }
 
         // Initialize detection cache database.
@@ -606,6 +616,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
     private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Rebuilt database after initialization failure")]
+    private static partial void LogDatabaseRebuiltAfterInitializationError(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error rebuilding database after initialization failure")]
+    private static partial void LogDatabaseRebuildInitializationError(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
     private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);


### PR DESCRIPTION
## Summary
- keep the ConfigHash post-migration repair for databases whose AddConfigHashes migration was marked applied without the columns
- add a fail-open startup fallback that rebuilds the segment database if migration initialization throws
- preserve readable segment/season rows during rebuild; fall back to a clean segment DB only when backup cannot read the broken database

## Why
A broken IntroSkipper segment DB should not keep Jellyfin in a startup failure loop. If the plugin DB cannot initialize, the plugin now attempts one bounded rebuild and catches rebuild failures instead of propagating them through startup.

## Tests
- dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj --filter "FullyQualifiedName~TestDbSegmentStorage"
- dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj