### PR TITLE
Fix legacy database initialization order

### DIFF
--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -90,21 +90,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         try
         {
             using var db = CreateDbContext();
-            db.ApplyMigrations();
             db.EnsureLegacySchemaCompatibility();
+            db.ApplyMigrations();
         }
         catch (Exception ex)
         {
             LogDatabaseInitializationError(_logger, ex);
-            try
-            {
-                using var db = CreateDbContext();
-                db.EnsureLegacySchemaCompatibility();
-            }
-            catch (Exception compatEx)
-            {
-                LogDatabaseCompatibilityInitializationError(_logger, compatEx);
-            }
         }
 
         // Initialize detection cache database.
@@ -616,9 +607,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
     private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error applying legacy database compatibility updates")]
-    private static partial void LogDatabaseCompatibilityInitializationError(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
     private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -90,6 +90,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         try
         {
             using var db = CreateDbContext();
+            // Legacy databases may be missing migration history or columns that EF migrations expect.
+            // Normalize those schemas first so recovery does not log a false initialization failure.
             db.EnsureLegacySchemaCompatibility();
             db.ApplyMigrations();
         }


### PR DESCRIPTION
## Summary
- Run legacy schema compatibility before EF migrations during plugin startup
- Remove the fallback compatibility pass and duplicate warning log so recovered legacy databases do not log a false initialization failure

## Verification
- dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj --filter "FullyQualifiedName~TestDbSegmentStorage"

## Summary by Sourcery

Ensure legacy schema compatibility is applied before EF migrations during plugin startup and simplify error handling for database initialization.

Bug Fixes:
- Prevent false initialization failure warnings for recovered legacy databases by removing the fallback compatibility pass and duplicate log message.

Enhancements:
- Streamline plugin database startup by enforcing a single initialization path with ordered legacy compatibility and migrations.