### PR TITLE
Make FFmpeg service process calls async

### DIFF
--- a/IntroSkipper.Tests/TestAudioFingerprinting.cs
+++ b/IntroSkipper.Tests/TestAudioFingerprinting.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
 using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
@@ -21,9 +22,9 @@ namespace IntroSkipper.Tests;
 public class TestAudioFingerprinting
 {
     [FactSkipFFmpegTests]
-    public void TestInstallationCheck()
+    public async Task TestInstallationCheck()
     {
-        Assert.True(CreateFFmpegService().CheckFFmpegVersion());
+        Assert.True(await CreateFFmpegService().CheckFFmpegVersionAsync());
     }
 
     [Theory]
@@ -39,7 +40,7 @@ public class TestAudioFingerprinting
     }
 
     [FactSkipFFmpegTests]
-    public void TestFingerprinting()
+    public async Task TestFingerprinting()
     {
         // Generated with `fpcalc -raw audio/big_buck_bunny_intro.mp3`
         var expected = new uint[]{
@@ -68,7 +69,7 @@ public class TestAudioFingerprinting
         };
 
         var ffmpegService = CreateFFmpegService();
-        var actual = ffmpegService.Fingerprint(
+        var actual = await ffmpegService.FingerprintAsync(
             QueueEpisode("audio/big_buck_bunny_intro.mp3"),
             AnalysisMode.Introduction);
 
@@ -97,15 +98,15 @@ public class TestAudioFingerprinting
     }
 
     [FactSkipFFmpegTests]
-    public void TestIntroDetection()
+    public async Task TestIntroDetection()
     {
         var chromaprint = CreateChromaprintAnalyzer();
 
         var lhsEpisode = QueueEpisode("audio/big_buck_bunny_intro.mp3");
         var rhsEpisode = QueueEpisode("audio/big_buck_bunny_clip.mp3");
         var ffmpegService = CreateFFmpegService();
-        var lhsFingerprint = ffmpegService.Fingerprint(lhsEpisode, AnalysisMode.Introduction);
-        var rhsFingerprint = ffmpegService.Fingerprint(rhsEpisode, AnalysisMode.Introduction);
+        var lhsFingerprint = await ffmpegService.FingerprintAsync(lhsEpisode, AnalysisMode.Introduction);
+        var rhsFingerprint = await ffmpegService.FingerprintAsync(rhsEpisode, AnalysisMode.Introduction);
 
         var (lhs, rhs) = chromaprint.CompareEpisodes(
             lhsEpisode.EpisodeId,
@@ -127,7 +128,7 @@ public class TestAudioFingerprinting
     /// Test that the silencedetect wrapper is working.
     /// </summary>
     [FactSkipFFmpegTests]
-    public void TestSilenceDetection()
+    public async Task TestSilenceDetection()
     {
         var clip = QueueEpisode("audio/big_buck_bunny_clip.mp3");
 
@@ -142,7 +143,7 @@ public class TestAudioFingerprinting
         };
 
         var range = new TimeRange(0, 60);
-        var actual = CreateFFmpegService().DetectSilence(clip, range, AnalysisMode.Introduction);
+        var actual = await CreateFFmpegService().DetectSilenceAsync(clip, range, AnalysisMode.Introduction);
 
         Assert.Equal(expected, actual);
     }

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -9,6 +9,7 @@ namespace IntroSkipper.Tests;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
 using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
@@ -18,7 +19,7 @@ using Xunit;
 public class TestBlackFrames
 {
     [FactSkipFFmpegTests]
-    public void TestBlackFrameDetection()
+    public async Task TestBlackFrameDetection()
     {
         var range = 1e-5;
 
@@ -27,7 +28,7 @@ public class TestBlackFrames
         expected.AddRange(CreateFrameSequence(5, 6));
         expected.AddRange(CreateFrameSequence(8, 9.96));
 
-        var actual = CreateFFmpegService().DetectBlackFrames(QueueFile("rainbow.mp4"), new(0, 10), 85, 32, AnalysisMode.Introduction);
+        var actual = await CreateFFmpegService().DetectBlackFramesAsync(QueueFile("rainbow.mp4"), new(0, 10), 85, 32, AnalysisMode.Introduction);
 
         for (var i = 0; i < expected.Count; i++)
         {
@@ -38,7 +39,7 @@ public class TestBlackFrames
     }
 
     [FactSkipFFmpegTests]
-    public void TestEndCreditDetection()
+    public async Task TestEndCreditDetection()
     {
         // new strategy new range
         var range = 3;
@@ -48,7 +49,7 @@ public class TestBlackFrames
         var episode = QueueFile("credits.mp4");
         episode.Duration = (int)new TimeSpan(0, 5, 30).TotalSeconds;
 
-        var result = analyzer.AnalyzeMediaFile(episode, 240, 85, 32);
+        var result = await analyzer.AnalyzeMediaFileAsync(episode, 240, 85, 32);
         Assert.NotNull(result);
         Assert.InRange(result.Start, 300 - range, 300 + range);
     }

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
@@ -154,7 +155,7 @@ public sealed class TestCacheOperations
     /// Before the fix, cache reads returned false for empty arrays, causing unnecessary re-analysis.
     /// </summary>
     [Fact]
-    public void EmptyArrayCacheEntry_TreatedAsCacheHit()
+    public async Task EmptyArrayCacheEntry_TreatedAsCacheHit()
     {
         var episode = new QueuedEpisode
         {
@@ -179,14 +180,14 @@ public sealed class TestCacheOperations
                 compressedEmpty,
                 range.Start,
                 range.End));
-            db.SaveChanges();
+            await db.SaveChangesAsync();
         }
 
         TimeRange[] result;
         using (var cachingScope = new CachingPluginScope(cacheDir, scope.CacheDbPath))
         {
             // If the empty-array bug were present this would throw FingerprintException (file not found).
-            result = cachingScope.CreateFFmpegService().DetectSilence(episode, range, AnalysisMode.Introduction);
+            result = await cachingScope.CreateFFmpegService().DetectSilenceAsync(episode, range, AnalysisMode.Introduction);
         }
 
         Assert.Empty(result);
@@ -219,7 +220,7 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void CachedFingerprint_StoresRealStartEnd()
+    public async Task CachedFingerprint_StoresRealStartEnd()
     {
         var episode = new QueuedEpisode
         {
@@ -245,21 +246,21 @@ public sealed class TestCacheOperations
                 compressed,
                 0,        // start
                 600));    // end = IntroFingerprintEnd
-            db.SaveChanges();
+            await db.SaveChangesAsync();
         }
 
         uint[] result;
         using (var cachingScope = new CachingPluginScope(cacheDir, cacheDbPath))
         {
             // Should hit cache because start=0, end=600 matches
-            result = cachingScope.CreateFFmpegService().Fingerprint(episode, AnalysisMode.Introduction);
+            result = await cachingScope.CreateFFmpegService().FingerprintAsync(episode, AnalysisMode.Introduction);
         }
 
         Assert.Equal(fingerprint, result);
     }
 
     [Fact]
-    public void CachedFingerprint_ThrowsWhenCanceledBeforeCacheHit()
+    public async Task CachedFingerprint_ThrowsWhenCanceledBeforeCacheHit()
     {
         var episode = new QueuedEpisode
         {
@@ -282,19 +283,19 @@ public sealed class TestCacheOperations
                 compressed,
                 0,
                 600));
-            db.SaveChanges();
+            await db.SaveChangesAsync();
         }
 
         using var cts = new System.Threading.CancellationTokenSource();
-        cts.Cancel();
+        await cts.CancelAsync();
 
         using var cachingScope = new CachingPluginScope(cacheDir, cacheDbPath);
-        Assert.Throws<OperationCanceledException>(
-            () => cachingScope.CreateFFmpegService().Fingerprint(episode, AnalysisMode.Introduction, cts.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => cachingScope.CreateFFmpegService().FingerprintAsync(episode, AnalysisMode.Introduction, cts.Token));
     }
 
     [Fact]
-    public void CachedFingerprint_MissesOnDifferentEnd()
+    public async Task CachedFingerprint_MissesOnDifferentEnd()
     {
         var episode = new QueuedEpisode
         {
@@ -320,7 +321,7 @@ public sealed class TestCacheOperations
                 compressed,
                 0,      // start
                 600));  // old end
-            db.SaveChanges();
+            await db.SaveChangesAsync();
         }
 
         using (var cachingScope = new CachingPluginScope(cacheDir, cacheDbPath))
@@ -328,8 +329,8 @@ public sealed class TestCacheOperations
             // Should miss cache (end mismatch: 600 vs 900) and then throw
             // because the file doesn't actually exist for ffmpeg
             var svc = cachingScope.CreateFFmpegService();
-            Assert.Throws<FingerprintException>(
-                () => svc.Fingerprint(episode, AnalysisMode.Introduction));
+            await Assert.ThrowsAsync<FingerprintException>(
+                () => svc.FingerprintAsync(episode, AnalysisMode.Introduction));
         }
     }
 

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -34,12 +34,26 @@ public class TestFFmpegService
             runner.RunAsync(processPath, args, cancellationToken: cts.Token));
     }
 
+    [Fact]
+    public async Task RunAsync_ReturnsBeforeProcessExit()
+    {
+        var runner = new FFmpegProcess(NullLogger<FFmpegProcess>.Instance);
+        var (processPath, args) = CreateLongRunningCommand();
+        using var cts = new CancellationTokenSource();
+
+        var task = runner.RunAsync(processPath, args, cancellationToken: cts.Token);
+
+        Assert.False(task.IsCompleted);
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+    }
+
     [FactSkipFFmpegTests]
-    public void TestNoTrailingOptionsWarning()
+    public async Task TestNoTrailingOptionsWarning()
     {
         // Run FFmpeg version check to populate ChromaprintLogs
         var ffmpegService = CreateFFmpegService();
-        var result = ffmpegService.CheckFFmpegVersion();
+        var result = await ffmpegService.CheckFFmpegVersionAsync();
 
         // Get the logs and verify no "Trailing option" warning appears
         var logs = ffmpegService.GetChromaprintLogs();
@@ -51,9 +65,9 @@ public class TestFFmpegService
     }
 
     [FactSkipFFmpegTests]
-    public void TestFFmpegVersionCheck()
+    public async Task TestFFmpegVersionCheck()
     {
-        Assert.True(CreateFFmpegService().CheckFFmpegVersion());
+        Assert.True(await CreateFFmpegService().CheckFFmpegVersionAsync());
     }
 
     /// <summary>
@@ -119,21 +133,21 @@ public class TestFFmpegService
     #region Media Processing Tests
 
     [FactSkipFFmpegTests]
-    public void TestNoTrailingOptionsWithMediaFiles()
+    public async Task TestNoTrailingOptionsWithMediaFiles()
     {
         // Test with actual media file to ensure no trailing options warning
         var episode = QueueFile("rainbow.mp4");
         episode.Duration = 2;
 
         // Detect black frames - this should not produce "Trailing option" warning
-        var blackFrames = CreateFFmpegService().DetectBlackFrames(episode, new TimeRange(0, 2), 85, 32, AnalysisMode.Introduction);
+        var blackFrames = await CreateFFmpegService().DetectBlackFramesAsync(episode, new TimeRange(0, 2), 85, 32, AnalysisMode.Introduction);
 
         // Verify we got results (meaning FFmpeg ran successfully without warnings)
         Assert.NotNull(blackFrames);
     }
 
     [FactSkipFFmpegTests]
-    public void TestNoTrailingOptionsWithBlackFrameDetectionAlt()
+    public async Task TestNoTrailingOptionsWithBlackFrameDetectionAlt()
     {
         // Test alternative black frame detection
         var episode = QueueFile("credits.mp4");
@@ -141,13 +155,13 @@ public class TestFFmpegService
         episode.CreditsFingerprintStart = 0;
 
         // Alternative black frame detection
-        var blackFrames = CreateFFmpegService().DetectBlackFrames(episode, 32);
+        var blackFrames = await CreateFFmpegService().DetectBlackFramesAsync(episode, 32);
 
         Assert.NotNull(blackFrames);
     }
 
     [FactSkipFFmpegTests]
-    public void TestNoTrailingOptionsWithSilenceDetection()
+    public async Task TestNoTrailingOptionsWithSilenceDetection()
     {
         // Test silence detection with actual media file
         var episode = QueueFile("rainbow.mp4");
@@ -155,28 +169,28 @@ public class TestFFmpegService
         episode.IntroFingerprintEnd = 2;
 
         // Detect silence - this should not produce "Trailing option" warning
-        var silenceRanges = CreateFFmpegService().DetectSilence(episode, new TimeRange(0, 2), AnalysisMode.Introduction);
+        var silenceRanges = await CreateFFmpegService().DetectSilenceAsync(episode, new TimeRange(0, 2), AnalysisMode.Introduction);
 
         // Verify FFmpeg ran successfully (null or empty list is fine)
         Assert.NotNull(silenceRanges);
     }
 
     [FactSkipFFmpegTests]
-    public void TestNoTrailingOptionsWithKeyFrameDetection()
+    public async Task TestNoTrailingOptionsWithKeyFrameDetection()
     {
         // Test key frame detection with actual media file
         var episode = QueueFile("rainbow.mp4");
         episode.Duration = 2;
 
         // Detect key frames - this should not produce "Trailing option" warning
-        var keyFrames = CreateFFmpegService().DetectKeyFrames(episode, new TimeRange(0, 2), AnalysisMode.Introduction);
+        var keyFrames = await CreateFFmpegService().DetectKeyFramesAsync(episode, new TimeRange(0, 2), AnalysisMode.Introduction);
 
         // Verify FFmpeg ran successfully
         Assert.NotNull(keyFrames);
     }
 
     [FactSkipFFmpegTests]
-    public void TestNoTrailingOptionsWithChromaprintFingerprinting()
+    public async Task TestNoTrailingOptionsWithChromaprintFingerprinting()
     {
         // Test chromaprint fingerprinting with actual audio file
         var episode = new QueuedEpisode
@@ -192,7 +206,7 @@ public class TestFFmpegService
         // Fingerprint intro - this should not produce "Trailing option" warning
         try
         {
-            var fingerprint = CreateFFmpegService().Fingerprint(episode, AnalysisMode.Introduction);
+            var fingerprint = await CreateFFmpegService().FingerprintAsync(episode, AnalysisMode.Introduction);
 
             // Verify FFmpeg ran successfully
             Assert.NotNull(fingerprint);

--- a/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
+++ b/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
@@ -32,7 +33,7 @@ public class TestTimeAdjustmentHelper
     }
 
     [Fact]
-    public void StartOffset_IsIgnored_When_SnappingToEpisodeStart()
+    public async Task StartOffset_IsIgnored_When_SnappingToEpisodeStart()
     {
         var (helper, cfg) = CreateHelper();
         cfg.IntroStartOffset = 2; // user-configured offset
@@ -40,14 +41,14 @@ public class TestTimeAdjustmentHelper
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
         var original = new Segment(episode.EpisodeId) { Start = 1.2, End = 10 };
 
-        var adjusted = helper.AdjustIntroTimes(episode, original);
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
 
         Assert.Equal(0, adjusted.Start);
         Assert.Equal(10, adjusted.End);
     }
 
     [Fact]
-    public void StartOffset_IsApplied_When_NotSnapping()
+    public async Task StartOffset_IsApplied_When_NotSnapping()
     {
         var (helper, cfg) = CreateHelper();
         cfg.IntroStartOffset = 2;
@@ -55,14 +56,14 @@ public class TestTimeAdjustmentHelper
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
         var original = new Segment(episode.EpisodeId) { Start = 5, End = 12 };
 
-        var adjusted = helper.AdjustIntroTimes(episode, original);
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
 
         Assert.Equal(7, adjusted.Start);
         Assert.Equal(12, adjusted.End);
     }
 
     [Fact]
-    public void Start_And_End_Are_Clamped_To_Duration()
+    public async Task Start_And_End_Are_Clamped_To_Duration()
     {
         var (helper, cfg) = CreateHelper();
         cfg.IntroStartOffset = 0;
@@ -71,7 +72,7 @@ public class TestTimeAdjustmentHelper
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 30 };
         var original = new Segment(episode.EpisodeId) { Start = -5, End = 200 };
 
-        var adjusted = helper.AdjustIntroTimes(episode, original);
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
 
         Assert.Equal(0, adjusted.Start); // clamped from -5 to 0 and snapped
         Assert.Equal(30, adjusted.End);  // clamped from 200 to duration before end logic kicks in

--- a/IntroSkipper.Tests/WindowsFfmpegTestBootstrap.cs
+++ b/IntroSkipper.Tests/WindowsFfmpegTestBootstrap.cs
@@ -183,10 +183,11 @@ internal static class WindowsFfmpegTestBootstrap
     private static void DownloadFile(string url, string destinationFilePath)
     {
         using var httpClient = new HttpClient();
-        using var response = httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        using var response = httpClient.Send(request, HttpCompletionOption.ResponseHeadersRead);
         response.EnsureSuccessStatusCode();
 
-        using var httpStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+        using var httpStream = response.Content.ReadAsStream();
         using var fileStream = new FileStream(destinationFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
         httpStream.CopyTo(fileStream);
         fileStream.Flush(flushToDisk: true);

--- a/IntroSkipper.Tests/WindowsFfmpegTestBootstrap.cs
+++ b/IntroSkipper.Tests/WindowsFfmpegTestBootstrap.cs
@@ -71,7 +71,7 @@ internal static class WindowsFfmpegTestBootstrap
             var zipFileName = string.IsNullOrWhiteSpace(originalZipFileName) ? "ffmpeg.zip" : originalZipFileName;
             var zipPath = Path.Combine(rootDir, zipFileName);
             ExecuteWithRetry(
-                () => DownloadFile(FfmpegZipUrl, zipPath),
+                () => DownloadFileSynchronously(FfmpegZipUrl, zipPath),
                 maxAttempts: 6,
                 baseDelayMs: 150);
 
@@ -180,8 +180,10 @@ internal static class WindowsFfmpegTestBootstrap
         return fileName;
     }
 
-    private static void DownloadFile(string url, string destinationFilePath)
+    private static void DownloadFileSynchronously(string url, string destinationFilePath)
     {
+        // Module initializers cannot be async. Use synchronous HTTP APIs here instead of
+        // blocking on asynchronous APIs during assembly load.
         using var httpClient = new HttpClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         using var response = httpClient.Send(request, HttpCompletionOption.ResponseHeadersRead);

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -63,7 +63,7 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
 
             try
             {
-                var credit = DetectCredits(episode, minimumPercentage, threshold, minimumDuration, cancellationToken);
+                var credit = await DetectCreditsAsync(episode, minimumPercentage, threshold, minimumDuration, cancellationToken).ConfigureAwait(false);
 
                 if (credit is null || !credit.Valid)
                 {
@@ -71,7 +71,7 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
                     continue;
                 }
 
-                credit = timeAdjustmentHelper.AdjustIntroTimes(episode, credit, cancellationToken: cancellationToken);
+                credit = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, credit, cancellationToken: cancellationToken).ConfigureAwait(false);
                 LogFoundCredits(episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);
@@ -99,10 +99,10 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
     /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="minimumDuration">Minimum duration of the credits.</param>
     /// <param name="cancellationToken">Token used to cancel FFmpeg probing.</param>
-    /// <returns>Time range of the detected credits.</returns>
-    public Segment? DetectCredits(QueuedEpisode episode, int minimumPercentage, int threshold, int minimumDuration, CancellationToken cancellationToken = default)
+    /// <returns>A task that returns the time range of the detected credits.</returns>
+    public async Task<Segment?> DetectCreditsAsync(QueuedEpisode episode, int minimumPercentage, int threshold, int minimumDuration, CancellationToken cancellationToken = default)
     {
-        var blackFrames = _ffmpegService.DetectBlackFrames(episode, threshold, cancellationToken).ToList();
+        var blackFrames = (await _ffmpegService.DetectBlackFramesAsync(episode, threshold, cancellationToken).ConfigureAwait(false)).ToList();
 
         if (blackFrames.Count == 0)
         {
@@ -123,7 +123,7 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
 
             // Refine the start time using full-frame boundary probing
             var refinedStartTime = _config.RefineCreditsBoundary
-                ? RefineBoundary(episode, blackFrames, scene, sceneChange, threshold, minimumDuration, cancellationToken)
+                ? await RefineBoundaryAsync(episode, blackFrames, scene, sceneChange, threshold, minimumDuration, cancellationToken).ConfigureAwait(false)
                 : scene.StartTime;
 
             var segment = new Segment(episode.EpisodeId, new TimeRange(refinedStartTime + episode.CreditsFingerprintStart, scene.EndTime + episode.CreditsFingerprintStart));
@@ -208,8 +208,8 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
     /// <param name="threshold">Pixel luminance threshold for black detection.</param>
     /// <param name="minimumDuration">Minimum duration required for a credits segment.</param>
     /// <param name="cancellationToken">Token used to cancel FFmpeg probing.</param>
-    /// <returns>Refined start time in seconds (relative to CreditsFingerprintStart).</returns>
-    private double RefineBoundary(
+    /// <returns>A task that returns the refined start time in seconds (relative to CreditsFingerprintStart).</returns>
+    private async Task<double> RefineBoundaryAsync(
         QueuedEpisode episode,
         List<BlackFrame> frames,
         CreditScene scene,
@@ -239,7 +239,7 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
         var probeEnd = firstBlackTime + episode.CreditsFingerprintStart;
         var probeRange = new TimeRange(probeStart, probeEnd);
 
-        var probeFrames = _ffmpegService.DetectBlackFrames(episode, probeRange, probeMinimum, threshold, AnalysisMode.Credits, cancellationToken);
+        var probeFrames = await _ffmpegService.DetectBlackFramesAsync(episode, probeRange, probeMinimum, threshold, AnalysisMode.Credits, cancellationToken).ConfigureAwait(false);
 
         if (probeFrames.Length == 0)
         {

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -61,11 +61,15 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
             try
             {
                 // First try to use chapter markers if available
-                if (!_config.UseChapterMarkersBlackFrame || !TryAnalyzeChapters(episode, percentage, threshold, cancellationToken, out var credit))
+                var credit = _config.UseChapterMarkersBlackFrame
+                    ? await TryAnalyzeChaptersAsync(episode, percentage, threshold, cancellationToken).ConfigureAwait(false)
+                    : null;
+
+                if (credit is null)
                 {
                     // Reset searchStart if it exceeds the valid search range for this episode.
                     // This can happen when a previous longer episode sets a large searchStart that
-                    // causes lowerLimit > upperLimit in AnalyzeMediaFile, breaking the binary search.
+                    // causes lowerLimit > upperLimit in AnalyzeMediaFileAsync, breaking the binary search.
                     var maxSearchDistance = episode.Duration - episode.CreditsFingerprintStart;
                     if (searchStart > maxSearchDistance)
                     {
@@ -75,15 +79,15 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
                     // If no suitable chapters found, use black frame detection
                     if (searchStart < _config.MinimumCreditsDuration)
                     {
-                        searchStart = FindSearchStart(episode, percentage, threshold, cancellationToken);
+                        searchStart = await FindSearchStartAsync(episode, percentage, threshold, cancellationToken).ConfigureAwait(false);
                     }
 
-                    credit = AnalyzeMediaFile(
+                    credit = await AnalyzeMediaFileAsync(
                         episode,
                         searchStart,
                         percentage,
                         threshold,
-                        cancellationToken);
+                        cancellationToken).ConfigureAwait(false);
                 }
 
                 if (credit is null || !credit.Valid)
@@ -122,7 +126,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
     /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="cancellationToken">Token used to cancel FFmpeg probing.</param>
     /// <returns>Credits segment if found; otherwise null.</returns>
-    public Segment? AnalyzeMediaFile(QueuedEpisode episode, double initialStart, int minimumBlackPercentage, int threshold, CancellationToken cancellationToken = default)
+    public async Task<Segment?> AnalyzeMediaFileAsync(QueuedEpisode episode, double initialStart, int minimumBlackPercentage, int threshold, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(episode);
 
@@ -148,7 +152,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
                 var timeRange = new TimeRange(scanTime, scanTime + 2);
 
                 // Detect black frames in the current time range
-                var blackFrames = _ffmpegService.DetectBlackFrames(episode, timeRange, minimumBlackPercentage, threshold, AnalysisMode.Credits, cancellationToken);
+                var blackFrames = await _ffmpegService.DetectBlackFramesAsync(episode, timeRange, minimumBlackPercentage, threshold, AnalysisMode.Credits, cancellationToken).ConfigureAwait(false);
 
                 LogBlackFramesDetected(_logger, episode.Name, timeRange.Start, blackFrames.Length);
 
@@ -213,9 +217,8 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
     /// <param name="percentage">Minimum percentage of the frame that must be black.</param>
     /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="cancellationToken">Token used to cancel FFmpeg probing.</param>
-    /// <param name="segment">Output segment if credits are found.</param>
-    /// <returns>True if credits were found using chapters; otherwise false.</returns>
-    private bool TryAnalyzeChapters(QueuedEpisode episode, int percentage, int threshold, CancellationToken cancellationToken, out Segment? segment)
+    /// <returns>Credits segment if found using chapters; otherwise null.</returns>
+    private async Task<Segment?> TryAnalyzeChaptersAsync(QueuedEpisode episode, int percentage, int threshold, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(episode);
 
@@ -230,8 +233,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
         if (suitableChapters.Count == 0)
         {
             LogNoSuitableChaptersFound(_logger, episode.Name);
-            segment = null;
-            return false;
+            return null;
         }
 
         // Check each chapter to see if it marks the start of credits
@@ -239,13 +241,13 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
         {
             // Check for black frames at chapter start
             var startRange = new TimeRange(chapterStart, chapterStart + 1);
-            var hasBlackFramesAtStart = _ffmpegService.DetectBlackFrames(
+            var hasBlackFramesAtStart = (await _ffmpegService.DetectBlackFramesAsync(
                 episode,
                 startRange,
                 percentage,
                 threshold,
                 AnalysisMode.Credits,
-                cancellationToken).Length > 0;
+                cancellationToken).ConfigureAwait(false)).Length > 0;
 
             if (!hasBlackFramesAtStart)
             {
@@ -255,24 +257,22 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
 
             // Verify no black frames before chapter start (to confirm this is the actual start)
             var beforeRange = new TimeRange(chapterStart - 5, chapterStart - 4);
-            var hasBlackFramesBefore = _ffmpegService.DetectBlackFrames(
+            var hasBlackFramesBefore = (await _ffmpegService.DetectBlackFramesAsync(
                 episode,
                 beforeRange,
                 percentage,
                 threshold,
                 AnalysisMode.Credits,
-                cancellationToken).Length > 0;
+                cancellationToken).ConfigureAwait(false)).Length > 0;
 
             if (!hasBlackFramesBefore)
             {
                 LogFoundCreditsWithChapterMarker(_logger, chapterStart);
-                segment = new Segment(episode.EpisodeId, new TimeRange(chapterStart, episode.Duration));
-                return true;
+                return new Segment(episode.EpisodeId, new TimeRange(chapterStart, episode.Duration));
             }
         }
 
-        segment = null;
-        return false;
+        return null;
     }
 
     /// <summary>
@@ -283,7 +283,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
     /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="cancellationToken">Token used to cancel FFmpeg probing.</param>
     /// <returns>Search start position in seconds from the end of the file.</returns>
-    private double FindSearchStart(QueuedEpisode episode, int percentage, int threshold, CancellationToken cancellationToken)
+    private async Task<double> FindSearchStartAsync(QueuedEpisode episode, int percentage, int threshold, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(episode);
 
@@ -299,7 +299,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
 
             var timeRange = new TimeRange(scanTime - 1.0, scanTime);
 
-            var blackFrames = _ffmpegService.DetectBlackFrames(episode, timeRange, percentage, threshold, AnalysisMode.Credits, cancellationToken);
+            var blackFrames = await _ffmpegService.DetectBlackFramesAsync(episode, timeRange, percentage, threshold, AnalysisMode.Credits, cancellationToken).ConfigureAwait(false);
 
             LogSearchScanning(_logger, scanTime, searchStart, blackFrames.Length);
 

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -68,7 +68,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
                 continue;
             }
 
-            skipRange = timeAdjustmentHelper.AdjustIntroTimes(episode, skipRange, false, cancellationToken);
+            skipRange = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, skipRange, false, cancellationToken).ConfigureAwait(false);
 
             episode.SetAnalyzed(mode, EpisodeState.Analyzed);
             await Plugin.Instance!.UpdateTimestampAsync(skipRange, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -68,7 +68,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                fingerprintCache[episode.EpisodeId] = _ffmpegService.Fingerprint(episode, mode, cancellationToken);
+                fingerprintCache[episode.EpisodeId] = await _ffmpegService.FingerprintAsync(episode, mode, cancellationToken).ConfigureAwait(false);
             }
             catch (FingerprintException ex)
             {
@@ -111,7 +111,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
                     continue;
                 }
 
-                /* Since the Fingerprint() function returns an array of Chromaprint points without time
+                /* Since the FingerprintAsync() function returns an array of Chromaprint points without time
                  * information, the times reported from the index search function start from 0.
                  *
                  * While this is desired behavior for detecting introductions, it breaks credit
@@ -150,7 +150,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             // If an intro is found for this episode, adjust its times and save it else add it to the list of episodes without intros.
             if (seasonIntros.TryGetValue(currentEpisode.EpisodeId, out var intro))
             {
-                var adjustedIntro = timeAdjustmentHelper.AdjustIntroTimes(currentEpisode, intro, cancellationToken: cancellationToken);
+                var adjustedIntro = await timeAdjustmentHelper.AdjustIntroTimesAsync(currentEpisode, intro, cancellationToken: cancellationToken).ConfigureAwait(false);
                 currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
                 await Plugin.Instance!.UpdateTimestampAsync(adjustedIntro, mode, configHash: currentEpisode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
             }

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -29,9 +29,9 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
     /// <param name="originalIntro">The original intro segment.</param>
     /// <param name="adjustIntroBasedOnChapters">Whether to adjust based on chapters (overrides _config if true).</param>
     /// <param name="cancellationToken">Token used to cancel FFmpeg-based adjustment probes.</param>
-    /// <returns>A new Segment with adjusted intro times.</returns>
+    /// <returns>A task that returns a new Segment with adjusted intro times.</returns>
     /// <exception cref="ArgumentNullException">Thrown if episode or originalIntro is null.</exception>
-    public Segment AdjustIntroTimes(
+    public async Task<Segment> AdjustIntroTimesAsync(
         QueuedEpisode episode,
         Segment originalIntro,
         bool? adjustIntroBasedOnChapters = null,
@@ -114,7 +114,7 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
             var silenceRange = GetSearchRange(adjustedEnd, duration, _config.AdjustWindowInward, _config.AdjustWindowOutward);
             if (_config.AdjustIntroBasedOnSilence)
             {
-                var silenceAdjusted = AdjustIntroEndBasedOnSilence(episode, adjustedEnd, silenceRange, _config.SilenceDetectionMinimumDuration, cancellationToken);
+                var silenceAdjusted = await AdjustIntroEndBasedOnSilenceAsync(episode, adjustedEnd, silenceRange, _config.SilenceDetectionMinimumDuration, cancellationToken).ConfigureAwait(false);
                 if (silenceAdjusted != adjustedEnd)
                 {
                     adjustedEnd = silenceAdjusted;
@@ -127,7 +127,7 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
 
             if (_config.SnapToKeyframe)
             {
-                adjustedEnd = SnapToNearestKeyframe(episode, adjustedEnd, silenceRange, cancellationToken);
+                adjustedEnd = await SnapToNearestKeyframeAsync(episode, adjustedEnd, silenceRange, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -169,11 +169,11 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
     /// <summary>
     /// Adjusts the intro end based on detected silence within the search range.
     /// </summary>
-    private double AdjustIntroEndBasedOnSilence(QueuedEpisode episode, double currentEnd, TimeRange searchRange, double silenceDetectionMinimumDuration, CancellationToken cancellationToken)
+    private async Task<double> AdjustIntroEndBasedOnSilenceAsync(QueuedEpisode episode, double currentEnd, TimeRange searchRange, double silenceDetectionMinimumDuration, CancellationToken cancellationToken)
     {
         try
         {
-            var silence = _ffmpegService.DetectSilence(episode, searchRange, _mode, cancellationToken);
+            var silence = await _ffmpegService.DetectSilenceAsync(episode, searchRange, _mode, cancellationToken).ConfigureAwait(false);
             if (silence is not { Length: > 0 })
             {
                 LogNoSilenceDetected(_logger, episode.EpisodeId, episode.Name);
@@ -214,9 +214,9 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
     /// <summary>
     /// Snaps a timestamp to the nearest keyframe within the search range.
     /// </summary>
-    private double SnapToNearestKeyframe(QueuedEpisode episode, double time, TimeRange searchRange, CancellationToken cancellationToken)
+    private async Task<double> SnapToNearestKeyframeAsync(QueuedEpisode episode, double time, TimeRange searchRange, CancellationToken cancellationToken)
     {
-        var keyframes = _ffmpegService.DetectKeyFrames(episode, searchRange, _mode, cancellationToken);
+        var keyframes = await _ffmpegService.DetectKeyFramesAsync(episode, searchRange, _mode, cancellationToken).ConfigureAwait(false);
         return SelectNearest(keyframes, time);
     }
 

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -30,24 +30,24 @@ public sealed partial class FFmpegService(
     private readonly IDetectionCacheService _cacheService = cacheService;
     private readonly FFmpegProcess _process = new(logger);
 
-    // Written by CheckFFmpegVersion (serialized via ScheduledTaskSemaphore) but read concurrently
+    // Written by CheckFFmpegVersionAsync (serialized via ScheduledTaskSemaphore) but read concurrently
     // by the support bundle endpoint, so a concurrent dictionary is required.
     private readonly ConcurrentDictionary<string, string> _chromaprintLogs = new();
 
     /// <inheritdoc/>
-    public bool CheckFFmpegVersion(CancellationToken cancellationToken = default)
+    public async Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         try
         {
             // Always log ffmpeg's version information.
-            if (!CheckFFmpegRequirement(
+            if (!await CheckFFmpegRequirementAsync(
                 "-version",
                 "ffmpeg",
                 "version",
                 "Unknown error with FFmpeg version",
-                cancellationToken))
+                cancellationToken).ConfigureAwait(false))
             {
                 _chromaprintLogs["error"] = "unknown_error";
                 WarningManager.SetFlag(PluginWarning.IncompatibleFFmpegBuild);
@@ -55,12 +55,12 @@ public sealed partial class FFmpegService(
             }
 
             // First, validate that the installed version of ffmpeg supports chromaprint at all.
-            if (!CheckFFmpegRequirement(
+            if (!await CheckFFmpegRequirementAsync(
                 "-muxers",
                 "chromaprint",
                 "muxer list",
                 "The installed version of ffmpeg does not support chromaprint",
-                cancellationToken))
+                cancellationToken).ConfigureAwait(false))
             {
                 _chromaprintLogs["error"] = "chromaprint_not_supported";
                 WarningManager.SetFlag(PluginWarning.IncompatibleFFmpegBuild);
@@ -68,12 +68,12 @@ public sealed partial class FFmpegService(
             }
 
             // Second, validate that the Chromaprint muxer understands the "-fp_format raw" option.
-            if (!CheckFFmpegRequirement(
+            if (!await CheckFFmpegRequirementAsync(
                 "-h muxer=chromaprint",
                 "binary raw fingerprint",
                 "chromaprint options",
                 "The installed version of ffmpeg does not support raw binary fingerprints",
-                cancellationToken))
+                cancellationToken).ConfigureAwait(false))
             {
                 _chromaprintLogs["error"] = "fp_format_not_supported";
                 WarningManager.SetFlag(PluginWarning.IncompatibleFFmpegBuild);
@@ -81,12 +81,12 @@ public sealed partial class FFmpegService(
             }
 
             // Third, validate that ffmpeg supports all of the required silencedetect options.
-            if (!CheckFFmpegRequirement(
+            if (!await CheckFFmpegRequirementAsync(
                 "-h filter=silencedetect",
                 "noise tolerance",
                 "silencedetect options",
                 "The installed version of ffmpeg does not support the silencedetect filter",
-                cancellationToken))
+                cancellationToken).ConfigureAwait(false))
             {
                 _chromaprintLogs["error"] = "silencedetect_not_supported";
                 WarningManager.SetFlag(PluginWarning.IncompatibleFFmpegBuild);
@@ -112,16 +112,16 @@ public sealed partial class FFmpegService(
     }
 
     /// <inheritdoc/>
-    public uint[] Fingerprint(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
+    public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var (start, end) = episode.GetFingerprintRange(mode);
-        return Fingerprint(episode, mode, start, end, cancellationToken);
+        return FingerprintAsync(episode, mode, start, end, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public TimeRange[] DetectSilence(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+    public async Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -151,7 +151,7 @@ public sealed partial class FFmpegService(
          * [silencedetect @ 0x000000000000] silence_start: 12.34
          * [silencedetect @ 0x000000000000] silence_end: 56.123 | silence_duration: 43.783
         */
-        var raw = Encoding.UTF8.GetString(GetOutput(args, true, cancellationToken: cancellationToken));
+        var raw = Encoding.UTF8.GetString(await GetOutputAsync(args, true, cancellationToken: cancellationToken).ConfigureAwait(false));
         var result = FFmpegOutputParser.ParseSilence(raw, range.Start);
         cancellationToken.ThrowIfCancellationRequested();
         _cacheService.Write(episode.EpisodeId, mode, CacheEntryType.Silence, range.Start, range.End, result);
@@ -160,7 +160,7 @@ public sealed partial class FFmpegService(
     }
 
     /// <inheritdoc/>
-    public BlackFrame[] DetectBlackFrames(
+    public async Task<BlackFrame[]> DetectBlackFramesAsync(
         QueuedEpisode episode,
         TimeRange range,
         int minimum,
@@ -187,7 +187,7 @@ public sealed partial class FFmpegService(
             "-f", "null", "-",
         };
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, true, cancellationToken: cancellationToken));
+        var raw = Encoding.UTF8.GetString(await GetOutputAsync(args, true, cancellationToken: cancellationToken).ConfigureAwait(false));
         var allFrames = FFmpegOutputParser.ParseBlackFrames(raw);
         cancellationToken.ThrowIfCancellationRequested();
         _cacheService.Write(episode.EpisodeId, mode, CacheEntryType.BlackFrame, range.Start, range.End, allFrames);
@@ -196,7 +196,7 @@ public sealed partial class FFmpegService(
     }
 
     /// <inheritdoc/>
-    public BlackFrame[] DetectBlackFrames(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
+    public async Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(episode);
         cancellationToken.ThrowIfCancellationRequested();
@@ -218,7 +218,7 @@ public sealed partial class FFmpegService(
             "-f", "null", "-",
         };
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, true, cancellationToken: cancellationToken));
+        var raw = Encoding.UTF8.GetString(await GetOutputAsync(args, true, cancellationToken: cancellationToken).ConfigureAwait(false));
         var allFrames = FFmpegOutputParser.ParseBlackFrames(raw);
         cancellationToken.ThrowIfCancellationRequested();
         _cacheService.Write(episode.EpisodeId, AnalysisMode.Credits, CacheEntryType.BlackFrame, episode.CreditsFingerprintStart, 0, allFrames);
@@ -227,7 +227,7 @@ public sealed partial class FFmpegService(
     }
 
     /// <inheritdoc/>
-    public double[] DetectKeyFrames(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+    public async Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -248,7 +248,7 @@ public sealed partial class FFmpegService(
             "-f", "null", "-",
         };
 
-        var raw = Encoding.UTF8.GetString(GetOutput(args, stderr: true, cancellationToken: cancellationToken));
+        var raw = Encoding.UTF8.GetString(await GetOutputAsync(args, stderr: true, cancellationToken: cancellationToken).ConfigureAwait(false));
         var result = FFmpegOutputParser.ParseKeyFrames(raw, range.Start, _logger);
         cancellationToken.ThrowIfCancellationRequested();
         _cacheService.Write(episode.EpisodeId, mode, CacheEntryType.Keyframe, range.Start, range.End, result);
@@ -257,7 +257,7 @@ public sealed partial class FFmpegService(
     }
 
     /// <inheritdoc/>
-    public double? ProbeAudioDuration(string filePath, CancellationToken cancellationToken = default)
+    public async Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -273,7 +273,7 @@ public sealed partial class FFmpegService(
                 filePath,
             };
 
-            var output = Encoding.UTF8.GetString(GetProcessOutput(ffprobePath, args, stderr: false, timeout: 10 * 1000, cancellationToken: cancellationToken)).Trim();
+            var output = Encoding.UTF8.GetString(await GetProcessOutputAsync(ffprobePath, args, stderr: false, timeout: 10 * 1000, cancellationToken: cancellationToken).ConfigureAwait(false)).Trim();
             if (string.IsNullOrWhiteSpace(output))
             {
                 return null;
@@ -338,7 +338,7 @@ public sealed partial class FFmpegService(
     /// <param name="errorMessage">Error message to log if this requirement is not met.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
     /// <returns>true on success, false on error.</returns>
-    private bool CheckFFmpegRequirement(
+    private async Task<bool> CheckFFmpegRequirementAsync(
         string arguments,
         string mustContain,
         string bundleName,
@@ -347,7 +347,7 @@ public sealed partial class FFmpegService(
     {
         LogCheckingRequirement(_logger, arguments);
 
-        var output = Encoding.UTF8.GetString(GetOutput(arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries), false, 2000, cancellationToken));
+        var output = Encoding.UTF8.GetString(await GetOutputAsync(arguments.Split(' ', StringSplitOptions.RemoveEmptyEntries), false, 2000, cancellationToken).ConfigureAwait(false));
         LogFfmpegOutput(_logger, arguments, output);
 
         _chromaprintLogs[bundleName] = output;
@@ -369,7 +369,7 @@ public sealed partial class FFmpegService(
     /// <param name="stderr">If standard error should be returned.</param>
     /// <param name="timeout">Timeout (in miliseconds) to wait for ffmpeg to exit.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    private ReadOnlySpan<byte> GetOutput(
+    private Task<byte[]> GetOutputAsync(
         IReadOnlyList<string> args,
         bool stderr = false,
         int timeout = 60 * 1000,
@@ -401,17 +401,17 @@ public sealed partial class FFmpegService(
         processArgs.Add(logLevel);
         processArgs.AddRange(args);
 
-        return GetProcessOutput(Plugin.Instance?.FFmpegPath ?? "ffmpeg", processArgs, stderr, timeout, cancellationToken);
+        return GetProcessOutputAsync(Plugin.Instance?.FFmpegPath ?? "ffmpeg", processArgs, stderr, timeout, cancellationToken);
     }
 
-    private ReadOnlySpan<byte> GetProcessOutput(
+    private Task<byte[]> GetProcessOutputAsync(
         string processPath,
         IReadOnlyList<string> args,
         bool stderr = false,
         int timeout = 60 * 1000,
         CancellationToken cancellationToken = default)
     {
-        return _process.RunAsync(processPath, args, stderr, timeout, Plugin.Instance?.Configuration.ProcessPriority, cancellationToken).GetAwaiter().GetResult();
+        return _process.RunAsync(processPath, args, stderr, timeout, Plugin.Instance?.Configuration.ProcessPriority, cancellationToken);
     }
 
     private static string GetFFprobePath()
@@ -437,7 +437,7 @@ public sealed partial class FFmpegService(
     /// <param name="end">Time (in seconds) relative to the start of the file to stop fingerprinting at.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
     /// <returns>Numerical fingerprint points.</returns>
-    private uint[] Fingerprint(QueuedEpisode episode, AnalysisMode mode, double start, double end, CancellationToken cancellationToken)
+    private async Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, double start, double end, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -463,7 +463,7 @@ public sealed partial class FFmpegService(
         };
 
         // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).
-        var rawPoints = GetOutput(args, cancellationToken: cancellationToken);
+        var rawPoints = await GetOutputAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
         if (rawPoints.Length == 0 || rawPoints.Length % 4 != 0)
         {
             LogChromaprintReturnedPoints(_logger, rawPoints.Length, episode.Path);
@@ -473,7 +473,7 @@ public sealed partial class FFmpegService(
         var results = new List<uint>();
         for (var i = 0; i < rawPoints.Length; i += 4)
         {
-            var rawPoint = rawPoints.Slice(i, 4);
+            var rawPoint = rawPoints.AsSpan(i, 4);
             results.Add(BitConverter.ToUInt32(rawPoint));
         }
 

--- a/IntroSkipper/FFmpeg/IFFmpegService.cs
+++ b/IntroSkipper/FFmpeg/IFFmpegService.cs
@@ -15,8 +15,8 @@ public interface IFFmpegService
     /// Check that the installed version of ffmpeg supports chromaprint.
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel FFmpeg requirement checks.</param>
-    /// <returns><see langword="true"/> if a compatible version of ffmpeg is installed, <see langword="false"/> on any error.</returns>
-    bool CheckFFmpegVersion(CancellationToken cancellationToken = default);
+    /// <returns>A task that returns <see langword="true"/> if a compatible version of ffmpeg is installed, <see langword="false"/> on any error.</returns>
+    Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Fingerprint a queued episode.
@@ -24,8 +24,8 @@ public interface IFFmpegService
     /// <param name="episode">Queued episode to fingerprint.</param>
     /// <param name="mode">Portion of media file to fingerprint.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    /// <returns>Numerical fingerprint points.</returns>
-    uint[] Fingerprint(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default);
+    /// <returns>A task that returns numerical fingerprint points.</returns>
+    Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Detect ranges of silence in the provided episode.
@@ -34,8 +34,8 @@ public interface IFFmpegService
     /// <param name="range">Time range to search.</param>
     /// <param name="mode">Analysis mode, used to correctly key the cache entry.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    /// <returns>Array of TimeRange objects that are silent in the queued episode.</returns>
-    TimeRange[] DetectSilence(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default);
+    /// <returns>A task that returns TimeRange objects that are silent in the queued episode.</returns>
+    Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Finds the location of all black frames in a media file within a time range.
@@ -46,8 +46,8 @@ public interface IFFmpegService
     /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="mode">Analysis mode, used to correctly key the cache entry.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    /// <returns>Array of frames that are mostly black.</returns>
-    BlackFrame[] DetectBlackFrames(
+    /// <returns>A task that returns frames that are mostly black.</returns>
+    Task<BlackFrame[]> DetectBlackFramesAsync(
         QueuedEpisode episode,
         TimeRange range,
         int minimum,
@@ -61,8 +61,8 @@ public interface IFFmpegService
     /// <param name="episode">Media file to analyze.</param>
     /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    /// <returns>Array of frames that are mostly black.</returns>
-    BlackFrame[] DetectBlackFrames(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default);
+    /// <returns>A task that returns frames that are mostly black.</returns>
+    Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Detects key frames in a media file within a time range.
@@ -71,16 +71,16 @@ public interface IFFmpegService
     /// <param name="range">Time range to search.</param>
     /// <param name="mode">Analysis mode, used to correctly key the cache entry.</param>
     /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    /// <returns>Array of timestamps of key frames.</returns>
-    double[] DetectKeyFrames(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default);
+    /// <returns>A task that returns timestamps of key frames.</returns>
+    Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Probes the first audio stream's actual duration with ffprobe.
     /// </summary>
     /// <param name="filePath">Media path.</param>
     /// <param name="cancellationToken">Token used to cancel the ffprobe process.</param>
-    /// <returns>Audio duration in seconds, or null when unavailable.</returns>
-    double? ProbeAudioDuration(string filePath, CancellationToken cancellationToken = default);
+    /// <returns>A task that returns the audio duration in seconds, or null when unavailable.</returns>
+    Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets Chromaprint debugging logs.

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -163,7 +163,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return;
         }
 
-        // Queue all episodes on the server for fingerprinting.
+        // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
 
         foreach (var item in items)
@@ -270,7 +270,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             creditsDuration >= 5 * 60 ? creditsDuration * _analysisPercent : creditsDuration,
             60 * pluginInstance.Configuration.MaximumCreditsDuration);
 
-        // Queue the episode for analysis
+        // Queue the episode for analysis.
         seasonEpisodes.Add(new QueuedEpisode
         {
             SeriesName = episode.SeriesName,
@@ -318,7 +318,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return;
         }
 
-        // Allocate a new list for each Movie
+        // Allocate a new list for each movie.
         _queuedEpisodes.TryAdd(movie.Id, []);
 
         var duration = TimeSpan.FromTicks(movie.RunTimeTicks ?? 0).TotalSeconds;

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -183,7 +183,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 }
                 else if (item is Movie movie)
                 {
-                    QueueMovie(movie, cancellationToken);
+                    await QueueMovieAsync(movie, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -264,7 +264,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             duration >= 5 * 60 ? duration * _analysisPercent : duration,
             60 * pluginInstance.Configuration.AnalysisLengthLimit);
 
-        var creditsDuration = ResolveCreditsFingerprintEnd(episode.Path, duration, cancellationToken);
+        var creditsDuration = await ResolveCreditsFingerprintEndAsync(episode.Path, duration, cancellationToken).ConfigureAwait(false);
 
         var maxCreditsDuration = Math.Min(
             creditsDuration >= 5 * 60 ? creditsDuration * _analysisPercent : creditsDuration,
@@ -308,7 +308,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return QueuedMediaCategory.Episode;
     }
 
-    private void QueueMovie(Movie movie, CancellationToken cancellationToken)
+    private async Task QueueMovieAsync(Movie movie, CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
@@ -322,7 +322,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         _queuedEpisodes.TryAdd(movie.Id, []);
 
         var duration = TimeSpan.FromTicks(movie.RunTimeTicks ?? 0).TotalSeconds;
-        var creditsDuration = ResolveCreditsFingerprintEnd(movie.Path, duration, cancellationToken);
+        var creditsDuration = await ResolveCreditsFingerprintEndAsync(movie.Path, duration, cancellationToken).ConfigureAwait(false);
 
         _queuedEpisodes[movie.Id].Add(new QueuedEpisode
         {
@@ -342,7 +342,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         pluginInstance.TotalQueued++;
     }
 
-    private double ResolveCreditsFingerprintEnd(string path, double duration, CancellationToken cancellationToken)
+    private async Task<double> ResolveCreditsFingerprintEndAsync(string path, double duration, CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
         if (!pluginInstance.Configuration.ProbeAudioDuration)
@@ -350,7 +350,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return duration;
         }
 
-        var audioDuration = _ffmpegService.ProbeAudioDuration(path, cancellationToken);
+        var audioDuration = await _ffmpegService.ProbeAudioDurationAsync(path, cancellationToken).ConfigureAwait(false);
         return audioDuration is > 0 && audioDuration.Value < duration
             ? audioDuration.Value
             : duration;

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -80,7 +80,7 @@ public partial class BaseItemAnalyzerTask(
         ];
 
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
-        var ffmpegValid = _ffmpegService.CheckFFmpegVersion(cancellationToken);
+        var ffmpegValid = await _ffmpegService.CheckFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
 
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -108,7 +108,7 @@ namespace IntroSkipper.Services
         }
 
         /// <inheritdoc />
-        public Task StartAsync(CancellationToken cancellationToken)
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
             _libraryManager.ItemAdded += OnItemChanged;
             _libraryManager.ItemUpdated += OnItemChanged;
@@ -116,15 +116,13 @@ namespace IntroSkipper.Services
             _taskManager.TaskCompleted += OnLibraryRefresh;
             Plugin.Instance!.ConfigurationChanged += OnSettingsChanged;
 
-            _ffmpegService.CheckFFmpegVersion(cancellationToken);
+            await _ffmpegService.CheckFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
 
             // Initialize web injector for skip button timeout modification
             if (_config.FileTransformationPluginEnabled == true)
             {
                 InitializeWebInjector();
             }
-
-            return Task.CompletedTask;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- Cut over FFmpeg process-backed service APIs to Task-returning Async methods.
- Await ffmpeg/ffprobe process execution through production analyzers, queueing, startup, and tests.
- Remove remaining sync-over-async GetAwaiter().GetResult() usage from the Windows FFmpeg test bootstrap.

## Verification
- `dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj -p:SkipWebBuild=true --filter "FullyQualifiedName~TestFFmpegService|FullyQualifiedName~TestAudioFingerprinting|FullyQualifiedName~TestBlackFrames|FullyQualifiedName~TestCacheOperations|FullyQualifiedName~TestTimeAdjustmentHelper"`
- `dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj -p:SkipWebBuild=true --filter "FullyQualifiedName~TestFFmpegService.RunAsync_ReturnsBeforeProcessExit"`

## Summary by Sourcery

Convert FFmpeg-based processing and analyzers to fully asynchronous APIs and integrate the async flow through queueing, startup, and analysis tasks.

New Features:
- Expose asynchronous FFmpeg service methods for version checks, fingerprinting, silence, black frame, keyframe detection, and audio duration probing.

Enhancements:
- Refactor analyzers, queue manager, and scheduled tasks to await the new async FFmpeg service methods and time adjustment helpers.
- Ensure FFmpeg process execution does not block callers by returning tasks directly from the process runner.
- Update application startup to perform the FFmpeg compatibility check asynchronously.

Tests:
- Convert FFmpeg- and cache-related tests to async, updating them to use the new asynchronous service APIs and adding coverage to ensure FFmpeg process tasks can be canceled before process exit.