### PR TITLE
Refactor media segment refresh services

### DIFF
--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -10,11 +10,15 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
+using IntroSkipper.Manager;
 using IntroSkipper.Services;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
@@ -305,10 +309,6 @@ internal static class EntrypointTestHelpers
         var loggerFactory = LoggerFactory.Create(builder => { });
         var logger = loggerFactory.CreateLogger<Entrypoint>();
 
-#pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.
-        var mediaSegmentUpdateManager = (IntroSkipper.Manager.MediaSegmentUpdateManager)FormatterServices.GetUninitializedObject(typeof(IntroSkipper.Manager.MediaSegmentUpdateManager));
-#pragma warning restore SYSLIB0050
-
         var entrypoint = new Entrypoint(
             libraryManager: null!,
             providerManager: null!,
@@ -318,10 +318,17 @@ internal static class EntrypointTestHelpers
             ffmpegService: null!,
             logger: logger,
             loggerFactory: loggerFactory,
-            mediaSegmentUpdateManager: mediaSegmentUpdateManager);
+            mediaSegmentRefresher: new FakeMediaSegmentRefresher());
 
         SetPrivateField(entrypoint, "_config", new PluginConfiguration { AutoDetectIntros = autoDetectIntros });
         return entrypoint;
+    }
+
+    private sealed class FakeMediaSegmentRefresher : IMediaSegmentRefresher
+    {
+        public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 
     internal static HashSet<Guid> GetSeasonsToAnalyze(Entrypoint entrypoint)

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -331,6 +331,39 @@ internal static class EntrypointTestHelpers
         public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 
+    // Lightweight ILibraryManager stub that resolves the supplied items by id via GetItemById
+    // and returns null for any other id. Shared by the controller and refresh-service tests.
+    internal static ILibraryManager CreateLibraryManager(params BaseItem[] items)
+        => LibraryManagerProxy.Create(items);
+
+    private class LibraryManagerProxy : DispatchProxy
+    {
+        private Dictionary<Guid, BaseItem> _items = [];
+
+        public static ILibraryManager Create(BaseItem[] items)
+        {
+            var proxy = Create<ILibraryManager, LibraryManagerProxy>();
+            var map = new Dictionary<Guid, BaseItem>();
+            foreach (var item in items)
+            {
+                map[item.Id] = item;
+            }
+
+            ((LibraryManagerProxy)(object)proxy)._items = map;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(ILibraryManager.GetItemById) && args is [Guid id])
+            {
+                return _items.TryGetValue(id, out var item) ? item : null;
+            }
+
+            throw new NotImplementedException(targetMethod?.Name);
+        }
+    }
+
     internal static HashSet<Guid> GetSeasonsToAnalyze(Entrypoint entrypoint)
         => (HashSet<Guid>)GetPrivateField(entrypoint, "_seasonsToAnalyze");
 

--- a/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Manager;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.MediaSegments;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestMediaSegmentEditorService
+{
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_DoesNothing_WhenProviderNotFound()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var manager = new FakeMediaSegmentManager { Providers = [("Some Other Provider", "x")] };
+        var service = CreateService(manager);
+
+        await service.CreateOrReplaceSegmentAsync(CreateMovie(Guid.NewGuid()), CreateSegment(MediaSegmentType.Intro, 10, 20), CancellationToken.None);
+
+        Assert.Equal(0, manager.GetSegmentsCallCount);
+        Assert.Equal(0, manager.CreateCount);
+        Assert.Empty(manager.DeletedSegmentIds);
+    }
+
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_ReplacesExisting_ForNonCommercialType()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var itemId = Guid.NewGuid();
+        var existing1 = CreateSegment(MediaSegmentType.Intro, 0, 5, Guid.NewGuid());
+        var existing2 = CreateSegment(MediaSegmentType.Intro, 5, 9, Guid.NewGuid());
+        var manager = new FakeMediaSegmentManager
+        {
+            Providers = [(Plugin.Instance!.Name, "intro-skipper")],
+            ExistingSegments = [existing1, existing2]
+        };
+        var service = CreateService(manager);
+        var segment = CreateSegment(MediaSegmentType.Intro, 10, 20);
+
+        await service.CreateOrReplaceSegmentAsync(CreateMovie(itemId), segment, CancellationToken.None);
+
+        Assert.Equal(2, manager.DeletedSegmentIds.Count);
+        Assert.Contains(existing1.Id, manager.DeletedSegmentIds);
+        Assert.Contains(existing2.Id, manager.DeletedSegmentIds);
+        Assert.Equal(new[] { MediaSegmentType.Intro }, manager.LastTypeFilter);
+        Assert.Equal(1, manager.CreateCount);
+        Assert.Equal(itemId, manager.LastCreatedSegment!.ItemId);
+        Assert.Equal("intro-skipper", manager.LastCreatedProviderId);
+    }
+
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_SkipsCreate_WhenIdenticalCommercialExists()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var manager = new FakeMediaSegmentManager
+        {
+            Providers = [(Plugin.Instance!.Name, "intro-skipper")],
+            ExistingSegments = [CreateSegment(MediaSegmentType.Commercial, 10, 20, Guid.NewGuid())]
+        };
+        var service = CreateService(manager);
+
+        await service.CreateOrReplaceSegmentAsync(CreateMovie(Guid.NewGuid()), CreateSegment(MediaSegmentType.Commercial, 10, 20), CancellationToken.None);
+
+        Assert.Empty(manager.DeletedSegmentIds);
+        Assert.Equal(0, manager.CreateCount);
+    }
+
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_CreatesCommercial_WhenNoIdenticalExists()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var manager = new FakeMediaSegmentManager
+        {
+            Providers = [(Plugin.Instance!.Name, "intro-skipper")],
+            ExistingSegments = [CreateSegment(MediaSegmentType.Commercial, 10, 20, Guid.NewGuid())]
+        };
+        var service = CreateService(manager);
+
+        await service.CreateOrReplaceSegmentAsync(CreateMovie(Guid.NewGuid()), CreateSegment(MediaSegmentType.Commercial, 30, 40), CancellationToken.None);
+
+        // Commercial segments are never deleted; only the non-duplicate is added.
+        Assert.Empty(manager.DeletedSegmentIds);
+        Assert.Equal(1, manager.CreateCount);
+    }
+
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_StillCreates_WhenDeletingExistingFails()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var manager = new FakeMediaSegmentManager
+        {
+            Providers = [(Plugin.Instance!.Name, "intro-skipper")],
+            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 0, 5, Guid.NewGuid())],
+            DeleteException = new InvalidOperationException("delete failed")
+        };
+        var service = CreateService(manager);
+
+        await service.CreateOrReplaceSegmentAsync(CreateMovie(Guid.NewGuid()), CreateSegment(MediaSegmentType.Intro, 10, 20), CancellationToken.None);
+
+        Assert.Single(manager.DeletedSegmentIds);
+        Assert.Equal(1, manager.CreateCount);
+    }
+
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_SerializesConcurrentCallsForSameItem()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var item = CreateMovie(Guid.NewGuid());
+        var gate = new TaskCompletionSource<IEnumerable<MediaSegmentDto>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var manager = new FakeMediaSegmentManager
+        {
+            Providers = [(Plugin.Instance!.Name, "intro-skipper")],
+            FirstGetGate = gate
+        };
+        var service = CreateService(manager);
+
+        // First call enters the critical section and parks inside GetSegmentsAsync while holding the lock.
+        var first = service.CreateOrReplaceSegmentAsync(item, CreateSegment(MediaSegmentType.Intro, 10, 20), CancellationToken.None);
+
+        // Second call for the same item must block on the per-item lock and therefore must not have
+        // fetched segments yet.
+        var second = service.CreateOrReplaceSegmentAsync(item, CreateSegment(MediaSegmentType.Intro, 30, 40), CancellationToken.None);
+
+        Assert.False(first.IsCompleted);
+        Assert.False(second.IsCompleted);
+        Assert.Equal(1, manager.GetSegmentsCallCount);
+
+        gate.SetResult([]);
+        await first;
+        await second;
+
+        Assert.Equal(2, manager.GetSegmentsCallCount);
+        Assert.Equal(2, manager.CreateCount);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_ReturnsNull_ForEmptyItemId()
+    {
+        var manager = new FakeMediaSegmentManager();
+        var service = CreateService(manager);
+
+        var result = await service.GetSegmentAsync(Guid.Empty, Guid.NewGuid(), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(0, manager.GetSegmentsCallCount);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_ReturnsNull_WhenItemNotFound()
+    {
+        var manager = new FakeMediaSegmentManager();
+        var service = CreateService(manager, EntrypointTestHelpers.CreateLibraryManager());
+
+        var result = await service.GetSegmentAsync(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+
+        Assert.Null(result);
+        Assert.Equal(0, manager.GetSegmentsCallCount);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_ReturnsMatchingSegment()
+    {
+        var itemId = Guid.NewGuid();
+        var segmentId = Guid.NewGuid();
+        var item = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            ExistingSegments =
+            [
+                CreateSegment(MediaSegmentType.Outro, 30, 40, Guid.NewGuid()),
+                CreateSegment(MediaSegmentType.Intro, 10, 20, segmentId)
+            ]
+        };
+        var service = CreateService(manager, EntrypointTestHelpers.CreateLibraryManager(item));
+
+        var result = await service.GetSegmentAsync(itemId, segmentId, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(segmentId, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_ReturnsNull_WhenSegmentIdDoesNotMatch()
+    {
+        var itemId = Guid.NewGuid();
+        var item = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, Guid.NewGuid())]
+        };
+        var service = CreateService(manager, EntrypointTestHelpers.CreateLibraryManager(item));
+
+        var result = await service.GetSegmentAsync(itemId, Guid.NewGuid(), CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_Throws_WhenCancelled()
+    {
+        var itemId = Guid.NewGuid();
+        var item = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, Guid.NewGuid())]
+        };
+        var service = CreateService(manager, EntrypointTestHelpers.CreateLibraryManager(item));
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.GetSegmentAsync(itemId, Guid.NewGuid(), cts.Token));
+    }
+
+    [Fact]
+    public async Task DeleteSegmentAsync_DelegatesToManager()
+    {
+        var manager = new FakeMediaSegmentManager();
+        var service = CreateService(manager);
+        var segmentId = Guid.NewGuid();
+
+        await service.DeleteSegmentAsync(segmentId);
+
+        Assert.Equal([segmentId], manager.DeletedSegmentIds);
+    }
+
+    private static MediaSegmentEditorService CreateService(FakeMediaSegmentManager manager, ILibraryManager? libraryManager = null)
+        => new(manager, libraryManager ?? EntrypointTestHelpers.CreateLibraryManager(), NullLogger<MediaSegmentEditorService>.Instance);
+
+    private static Movie CreateMovie(Guid id)
+    {
+        var item = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
+        EntrypointTestHelpers.EnsureNonVirtual(item);
+        return item;
+    }
+
+    private static MediaSegmentDto CreateSegment(MediaSegmentType type, long startTicks, long endTicks, Guid id = default)
+        => new()
+        {
+            Id = id,
+            Type = type,
+            StartTicks = startTicks,
+            EndTicks = endTicks
+        };
+
+    private sealed class FakeMediaSegmentManager : IMediaSegmentManager
+    {
+        private int _getCount;
+
+        public IReadOnlyList<(string Name, string Id)> Providers { get; init; } = [];
+
+        public IReadOnlyList<MediaSegmentDto> ExistingSegments { get; init; } = [];
+
+        public Exception? DeleteException { get; init; }
+
+        public TaskCompletionSource<IEnumerable<MediaSegmentDto>>? FirstGetGate { get; init; }
+
+        public int GetSegmentsCallCount => _getCount;
+
+        public int CreateCount { get; private set; }
+
+        public MediaSegmentDto? LastCreatedSegment { get; private set; }
+
+        public string? LastCreatedProviderId { get; private set; }
+
+        public IReadOnlyList<MediaSegmentType>? LastTypeFilter { get; private set; }
+
+        public List<Guid> DeletedSegmentIds { get; } = [];
+
+        public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => Providers;
+
+        public Task<IEnumerable<MediaSegmentDto>> GetSegmentsAsync(BaseItem item, IEnumerable<MediaSegmentType>? typeFilter, LibraryOptions libraryOptions, bool filterByProvider = true)
+        {
+            var n = Interlocked.Increment(ref _getCount);
+            LastTypeFilter = typeFilter?.ToArray();
+
+            if (FirstGetGate is not null && n == 1)
+            {
+                return FirstGetGate.Task;
+            }
+
+            return Task.FromResult<IEnumerable<MediaSegmentDto>>(ExistingSegments);
+        }
+
+        public Task<MediaSegmentDto> CreateSegmentAsync(MediaSegmentDto mediaSegment, string segmentProviderId)
+        {
+            CreateCount++;
+            LastCreatedSegment = mediaSegment;
+            LastCreatedProviderId = segmentProviderId;
+            return Task.FromResult(mediaSegment);
+        }
+
+        public Task DeleteSegmentAsync(Guid segmentId)
+        {
+            lock (DeletedSegmentIds)
+            {
+                DeletedSegmentIds.Add(segmentId);
+            }
+
+            if (DeleteException is not null)
+            {
+                throw DeleteException;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public bool HasSegments(Guid itemId) => false;
+
+        public bool IsTypeSupported(BaseItem baseItem) => true;
+    }
+}

--- a/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using IntroSkipper.Configuration;
 using IntroSkipper.Manager;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.MediaSegments;
@@ -69,8 +72,25 @@ public sealed class TestMediaSegmentRefreshService
         Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
     }
 
-    private static MediaSegmentRefreshService CreateRefresher(FakeMediaSegmentManager manager)
-        => new(manager, NullLogger<MediaSegmentRefreshService>.Instance);
+    [Fact]
+    public async Task RefreshAsync_ByIds_ResolvesItemsViaLibraryManager_SkippingEmptyAndDuplicateIds()
+    {
+        var itemId = Guid.NewGuid();
+        var item = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager();
+        var libraryManager = StubLibraryManager.Create(item);
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { MaxParallelism = 2 });
+        var refresher = CreateRefresher(manager, libraryManager);
+
+        await refresher.RefreshAsync([itemId, Guid.Empty, itemId], CancellationToken.None);
+
+        Assert.Equal(1, manager.RunCount);
+        Assert.Equal(itemId, manager.LastItemId);
+    }
+
+    private static MediaSegmentRefreshService CreateRefresher(FakeMediaSegmentManager manager, ILibraryManager? libraryManager = null)
+        => new(manager, libraryManager ?? StubLibraryManager.Create(), NullLogger<MediaSegmentRefreshService>.Instance);
 
     private static Movie CreateMovie(Guid itemId)
     {
@@ -125,5 +145,32 @@ public sealed class TestMediaSegmentRefreshService
         public bool HasSegments(Guid itemId) => false;
 
         public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => [(Plugin.Instance!.Name, "intro-skipper")];
+    }
+
+    private class StubLibraryManager : DispatchProxy
+    {
+        private readonly Dictionary<Guid, BaseItem> _items = [];
+
+        public static ILibraryManager Create(params BaseItem[] items)
+        {
+            var proxy = Create<ILibraryManager, StubLibraryManager>();
+            var stub = (StubLibraryManager)(object)proxy;
+            foreach (var item in items)
+            {
+                stub._items[item.Id] = item;
+            }
+
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(ILibraryManager.GetItemById) && args is [Guid id])
+            {
+                return _items.TryGetValue(id, out var item) ? item : null;
+            }
+
+            throw new NotImplementedException(targetMethod?.Name);
+        }
     }
 }

--- a/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
@@ -73,12 +72,27 @@ public sealed class TestMediaSegmentRefreshService
     }
 
     [Fact]
+    public async Task RefreshAsync_RethrowsCriticalException()
+    {
+        var manager = new FakeMediaSegmentManager
+        {
+            RunException = new ThreadInterruptedException()
+        };
+        var refresher = CreateRefresher(manager);
+
+        await Assert.ThrowsAsync<ThreadInterruptedException>(
+            () => refresher.RefreshAsync(CreateMovie(Guid.NewGuid()), CancellationToken.None));
+
+        Assert.Equal(1, manager.RunCount);
+    }
+
+    [Fact]
     public async Task RefreshAsync_ByIds_ResolvesItemsViaLibraryManager_SkippingEmptyAndDuplicateIds()
     {
         var itemId = Guid.NewGuid();
         var item = CreateMovie(itemId);
         var manager = new FakeMediaSegmentManager();
-        var libraryManager = StubLibraryManager.Create(item);
+        var libraryManager = EntrypointTestHelpers.CreateLibraryManager(item);
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { MaxParallelism = 2 });
         var refresher = CreateRefresher(manager, libraryManager);
@@ -90,7 +104,7 @@ public sealed class TestMediaSegmentRefreshService
     }
 
     private static MediaSegmentRefreshService CreateRefresher(FakeMediaSegmentManager manager, ILibraryManager? libraryManager = null)
-        => new(manager, libraryManager ?? StubLibraryManager.Create(), NullLogger<MediaSegmentRefreshService>.Instance);
+        => new(manager, libraryManager ?? EntrypointTestHelpers.CreateLibraryManager(), NullLogger<MediaSegmentRefreshService>.Instance);
 
     private static Movie CreateMovie(Guid itemId)
     {
@@ -145,32 +159,5 @@ public sealed class TestMediaSegmentRefreshService
         public bool HasSegments(Guid itemId) => false;
 
         public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => [(Plugin.Instance!.Name, "intro-skipper")];
-    }
-
-    private class StubLibraryManager : DispatchProxy
-    {
-        private readonly Dictionary<Guid, BaseItem> _items = [];
-
-        public static ILibraryManager Create(params BaseItem[] items)
-        {
-            var proxy = Create<ILibraryManager, StubLibraryManager>();
-            var stub = (StubLibraryManager)(object)proxy;
-            foreach (var item in items)
-            {
-                stub._items[item.Id] = item;
-            }
-
-            return proxy;
-        }
-
-        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
-        {
-            if (targetMethod?.Name == nameof(ILibraryManager.GetItemById) && args is [Guid id])
-            {
-                return _items.TryGetValue(id, out var item) ? item : null;
-            }
-
-            throw new NotImplementedException(targetMethod?.Name);
-        }
     }
 }

--- a/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Manager;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.MediaSegments;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestMediaSegmentRefreshService
+{
+    [Fact]
+    public async Task RefreshAsync_AwaitsRunSegmentPluginProviders_BeforeCompleting()
+    {
+        var itemId = Guid.NewGuid();
+        var item = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            RunCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var refresher = CreateRefresher(manager);
+
+        var refreshTask = refresher.RefreshAsync(item, CancellationToken.None);
+
+        Assert.False(refreshTask.IsCompleted);
+
+        manager.RunCompletion.SetResult();
+        await refreshTask;
+
+        Assert.Equal(1, manager.RunCount);
+        Assert.Equal(itemId, manager.LastItemId);
+        Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
+    }
+
+    [Fact]
+    public async Task RefreshAsync_UsesExternalProvidersAndForceOverwrite()
+    {
+        var manager = new FakeMediaSegmentManager();
+        var refresher = CreateRefresher(manager);
+
+        await refresher.RefreshAsync(CreateMovie(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.NotNull(manager.LastLibraryOptions);
+        Assert.Contains("Chapter Segments Provider", manager.LastLibraryOptions!.DisabledMediaSegmentProviders);
+        Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
+    }
+
+    [Fact]
+    public async Task RefreshAsync_LogsAndReturnsAfterProviderFailure()
+    {
+        var itemId = Guid.NewGuid();
+        var manager = new FakeMediaSegmentManager
+        {
+            RunException = new InvalidOperationException("boom")
+        };
+        var refresher = CreateRefresher(manager);
+
+        await refresher.RefreshAsync(CreateMovie(itemId), CancellationToken.None);
+
+        Assert.Equal(1, manager.RunCount);
+        Assert.Equal(itemId, manager.LastItemId);
+        Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
+    }
+
+    private static MediaSegmentRefreshService CreateRefresher(FakeMediaSegmentManager manager)
+        => new(manager, NullLogger<MediaSegmentRefreshService>.Instance);
+
+    private static Movie CreateMovie(Guid itemId)
+    {
+        var item = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(item, "Id", itemId);
+        EntrypointTestHelpers.EnsureNonVirtual(item);
+        return item;
+    }
+
+    private sealed class FakeMediaSegmentManager : IMediaSegmentManager
+    {
+        public int RunCount { get; private set; }
+
+        public Guid LastItemId { get; private set; }
+
+        public bool? LastForceOverwrite { get; private set; }
+
+        public LibraryOptions? LastLibraryOptions { get; private set; }
+
+        public Exception? RunException { get; init; }
+
+        public TaskCompletionSource? RunCompletion { get; init; }
+
+        public Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken)
+        {
+            RunCount++;
+            LastItemId = baseItem.Id;
+            LastForceOverwrite = forceOverwrite;
+            LastLibraryOptions = libraryOptions;
+
+            if (RunException is not null)
+            {
+                throw RunException;
+            }
+
+            return RunCompletion?.Task ?? Task.CompletedTask;
+        }
+
+        public bool IsTypeSupported(BaseItem baseItem) => true;
+
+        public Task<MediaSegmentDto> CreateSegmentAsync(MediaSegmentDto mediaSegment, string segmentProviderId) => Task.FromResult(mediaSegment);
+
+        public Task DeleteSegmentAsync(Guid segmentId) => Task.CompletedTask;
+
+        public Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<IEnumerable<MediaSegmentDto>> GetSegmentsAsync(BaseItem item, IEnumerable<MediaSegmentType>? typeFilter, LibraryOptions libraryOptions, bool filterByProvider = true)
+        {
+            return Task.FromResult<IEnumerable<MediaSegmentDto>>(Array.Empty<MediaSegmentDto>());
+        }
+
+        public bool HasSegments(Guid itemId) => false;
+
+        public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => [(Plugin.Instance!.Name, "intro-skipper")];
+    }
+}

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
@@ -86,7 +85,7 @@ public sealed class TestSkipIntroController
         EntrypointTestHelpers.SetPropertyOrField(item, "Id", itemId);
         EntrypointTestHelpers.EnsureNonVirtual(item);
 
-        var libraryManager = LibraryManagerProxy.Create(item);
+        var libraryManager = EntrypointTestHelpers.CreateLibraryManager(item);
         var plugin = Plugin.Instance!;
         EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
@@ -125,28 +124,6 @@ public sealed class TestSkipIntroController
         public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
         {
             return Completion?.Task ?? Task.CompletedTask;
-        }
-    }
-
-    private class LibraryManagerProxy : DispatchProxy
-    {
-        private BaseItem? _item;
-
-        public static ILibraryManager Create(BaseItem item)
-        {
-            var proxy = Create<ILibraryManager, LibraryManagerProxy>();
-            ((LibraryManagerProxy)(object)proxy)._item = item;
-            return proxy;
-        }
-
-        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
-        {
-            if (targetMethod?.Name == nameof(ILibraryManager.GetItemById) && args is [{ } id] && id.Equals(_item!.Id))
-            {
-                return _item;
-            }
-
-            throw new NotImplementedException(targetMethod?.Name);
         }
     }
 }

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Controllers;
+using IntroSkipper.Data;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Db;
+using IntroSkipper.Manager;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestSkipIntroController
+{
+    [Fact]
+    public async Task UpdateTimestampsAsync_AwaitsDirectMediaSegmentRefresh_BeforeReturningNoContent()
+    {
+        var itemId = Guid.NewGuid();
+        var dbPath = CreateTempDbPath();
+        using var pluginScope = CreatePluginScope(dbPath, itemId, updateMediaSegments: true, out var item);
+        await EnsureDatabaseAsync(dbPath);
+        var refresher = new RecordingMediaSegmentRefresher
+        {
+            Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var controller = new SkipIntroController(refresher, new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+        var timestamps = new TimeStamps
+        {
+            Introduction = new Segment(itemId, new TimeRange(10, 20))
+        };
+
+        var actionTask = controller.UpdateTimestampsAsync(itemId, timestamps, CancellationToken.None);
+
+        Assert.False(actionTask.IsCompleted);
+        Assert.Equal(1, refresher.ItemCallCount);
+        Assert.Equal(item.Id, refresher.LastItemId);
+
+        refresher.Completion.SetResult();
+        var result = await actionTask;
+
+        Assert.IsType<NoContentResult>(result);
+        await using var db = new IntroSkipperDbContext(dbPath);
+        var segment = await db.DbSegment.SingleAsync();
+        Assert.Equal(itemId, segment.ItemId);
+        Assert.Equal(AnalysisMode.Introduction, segment.Type);
+        Assert.True(segment.IsUserProvided);
+    }
+
+    [Fact]
+    public async Task UpdateTimestampsAsync_DoesNotRefresh_WhenUpdateMediaSegmentsDisabled()
+    {
+        var itemId = Guid.NewGuid();
+        var dbPath = CreateTempDbPath();
+        using var pluginScope = CreatePluginScope(dbPath, itemId, updateMediaSegments: false, out _);
+        await EnsureDatabaseAsync(dbPath);
+        var refresher = new RecordingMediaSegmentRefresher
+        {
+            Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var controller = new SkipIntroController(refresher, new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+        var timestamps = new TimeStamps
+        {
+            Introduction = new Segment(itemId, new TimeRange(10, 20))
+        };
+
+        var result = await controller.UpdateTimestampsAsync(itemId, timestamps, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Equal(0, refresher.ItemCallCount);
+    }
+
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid itemId, bool updateMediaSegments, out Movie item)
+    {
+        var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        item = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(item, "Id", itemId);
+        EntrypointTestHelpers.EnsureNonVirtual(item);
+
+        var libraryManager = LibraryManagerProxy.Create(item);
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
+        EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+        return scope;
+    }
+
+    private static async Task EnsureDatabaseAsync(string dbPath)
+    {
+        await using var db = new IntroSkipperDbContext(dbPath);
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private static string CreateTempDbPath()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests", "skip-controller");
+        Directory.CreateDirectory(tempDir);
+        return Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+    }
+
+    private sealed class RecordingMediaSegmentRefresher : IMediaSegmentRefresher
+    {
+        public TaskCompletionSource? Completion { get; init; }
+
+        public int ItemCallCount { get; private set; }
+
+        public Guid LastItemId { get; private set; }
+
+        public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
+        {
+            ItemCallCount++;
+            LastItemId = item.Id;
+            return Completion?.Task ?? Task.CompletedTask;
+        }
+
+        public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+        {
+            return Completion?.Task ?? Task.CompletedTask;
+        }
+    }
+
+    private class LibraryManagerProxy : DispatchProxy
+    {
+        private BaseItem? _item;
+
+        public static ILibraryManager Create(BaseItem item)
+        {
+            var proxy = Create<ILibraryManager, LibraryManagerProxy>();
+            ((LibraryManagerProxy)(object)proxy)._item = item;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(ILibraryManager.GetItemById) && args is [{ } id] && id.Equals(_item!.Id))
+            {
+                return _item;
+            }
+
+            throw new NotImplementedException(targetMethod?.Name);
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Controllers;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Manager;
+using MediaBrowser.Controller.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestVisualizationController
+{
+    [Fact]
+    public async Task EraseSeasonAsync_AwaitsDirectMediaSegmentRefresh_BeforeReturningNoContent()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var dbPath = CreateTempDbPath();
+        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: true);
+        await SeedSeasonAsync(dbPath, seasonId, episodeIds);
+        var refresher = new RecordingMediaSegmentRefresher
+        {
+            Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+        var controller = CreateController(refresher, loggerFactory);
+
+        var actionTask = controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
+
+        Assert.False(actionTask.IsCompleted);
+        Assert.Equal(episodeIds.OrderBy(id => id), refresher.LastItemIds.OrderBy(id => id));
+
+        refresher.Completion.SetResult();
+        var result = await actionTask;
+
+        Assert.IsType<NoContentResult>(result);
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.False(await db.DbSegment.AnyAsync(s => episodeIds.Contains(s.ItemId)));
+        var seasonInfos = await db.DbSeasonInfo.Where(s => s.SeasonId == seasonId).ToListAsync();
+        Assert.All(seasonInfos, info => Assert.Empty(info.EpisodeIds));
+    }
+
+    [Fact]
+    public async Task EraseSeasonAsync_DoesNotRefresh_WhenUpdateMediaSegmentsDisabled()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var dbPath = CreateTempDbPath();
+        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: false);
+        await SeedSeasonAsync(dbPath, seasonId, episodeIds);
+        var refresher = new RecordingMediaSegmentRefresher
+        {
+            Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+        var controller = CreateController(refresher, loggerFactory);
+
+        var result = await controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Equal(0, refresher.CollectionCallCount);
+    }
+
+    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory)
+    {
+        return new VisualizationController(
+            NullLogger<VisualizationController>.Instance,
+            refresher,
+            libraryManager: null!,
+            providerManager: null!,
+            fileSystem: null!,
+            loggerFactory,
+            ffmpegService: null!,
+            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+    }
+
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
+    {
+        var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+        plugin.QueuedMediaItems[seasonId] =
+        [
+            new QueuedEpisode { SeriesId = seriesId, SeasonId = seasonId, EpisodeId = episodeIds[0], Name = "Episode 1" },
+            new QueuedEpisode { SeriesId = seriesId, SeasonId = seasonId, EpisodeId = episodeIds[1], Name = "Episode 2" }
+        ];
+        return scope;
+    }
+
+    private static async Task SeedSeasonAsync(string dbPath, Guid seasonId, IReadOnlyList<Guid> episodeIds)
+    {
+        await using var db = new IntroSkipperDbContext(dbPath);
+        await db.Database.EnsureCreatedAsync();
+        db.DbSegment.AddRange(
+            new DbSegment(new Segment(episodeIds[0], new TimeRange(10, 20)), AnalysisMode.Introduction),
+            new DbSegment(new Segment(episodeIds[1], new TimeRange(30, 40)), AnalysisMode.Introduction));
+        db.DbSeasonInfo.AddRange(
+            new DbSeasonInfo(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, episodeIds),
+            new DbSeasonInfo(seasonId, AnalysisMode.Credits, AnalyzerAction.Default, episodeIds));
+        await db.SaveChangesAsync();
+    }
+
+    private static string CreateTempDbPath()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests", "visualization-controller");
+        Directory.CreateDirectory(tempDir);
+        return Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+    }
+
+    private sealed class RecordingMediaSegmentRefresher : IMediaSegmentRefresher
+    {
+        public TaskCompletionSource? Completion { get; init; }
+
+        public int CollectionCallCount { get; private set; }
+
+        public IReadOnlyList<Guid> LastItemIds { get; private set; } = [];
+
+        public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
+        {
+            LastItemIds = [item.Id];
+            return Completion?.Task ?? Task.CompletedTask;
+        }
+
+        public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+        {
+            CollectionCallCount++;
+            LastItemIds = itemIds.ToArray();
+            return Completion?.Task ?? Task.CompletedTask;
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -140,7 +140,7 @@ public sealed class TestVisualizationController
         public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
         {
             CollectionCallCount++;
-            LastItemIds = itemIds.ToArray();
+            LastItemIds = [.. itemIds];
             return Completion?.Task ?? Task.CompletedTask;
         }
     }

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -23,17 +23,17 @@ namespace IntroSkipper.Controllers;
 /// <remarks>
 /// Initializes a new instance of the <see cref="SegmentEditorController"/> class.
 /// </remarks>
-/// <param name="mediaSegmentUpdateManager">MediaSegmentUpdateManager.</param>
+/// <param name="mediaSegmentEditorService">Media segment editor service.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("MediaSegmentsApi")]
-public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdateManager) : ControllerBase
+public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEditorService) : ControllerBase
 {
     // Maximum difference in seconds between two time values to be considered equal.
     private const double TimeComparisonToleranceSeconds = 0.01;
 
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly MediaSegmentEditorService _mediaSegmentEditorService = mediaSegmentEditorService;
 
     /// <summary>
     /// Plugin meta endpoint.
@@ -79,7 +79,7 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
 
         await Plugin.Instance!.UpdateTimestampAsync(seg, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        await _mediaSegmentUpdateManager.CreateOrReplaceSegmentAsync(item, segment, cancellationToken).ConfigureAwait(false);
+        await _mediaSegmentEditorService.CreateOrReplaceSegmentAsync(item, segment, cancellationToken).ConfigureAwait(false);
 
         return Ok();
     }
@@ -101,7 +101,7 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
         [FromQuery, Required] string type,
         CancellationToken cancellationToken = default)
     {
-        var existingSegment = await _mediaSegmentUpdateManager
+        var existingSegment = await _mediaSegmentEditorService
             .GetSegmentAsync(itemId, segmentId, cancellationToken)
             .ConfigureAwait(false);
 
@@ -146,7 +146,7 @@ public class SegmentEditorController(MediaSegmentUpdateManager mediaSegmentUpdat
 
         try
         {
-            await _mediaSegmentUpdateManager.DeleteSegmentAsync(segmentId).ConfigureAwait(false);
+            await _mediaSegmentEditorService.DeleteSegmentAsync(segmentId).ConfigureAwait(false);
         }
         catch
         {

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -26,9 +26,9 @@ namespace IntroSkipper.Controllers;
 [Authorize]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
-public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateManager, IDetectionCacheService cacheService) : ControllerBase
+public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, IDetectionCacheService cacheService) : ControllerBase
 {
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IDetectionCacheService _cacheService = cacheService;
 
     /// <summary>
@@ -76,13 +76,7 @@ public class SkipIntroController(MediaSegmentUpdateManager mediaSegmentUpdateMan
 
         if (Plugin.Instance.Configuration.UpdateMediaSegments)
         {
-            var episode = Plugin.Instance!.QueuedMediaItems[rawItem is Episode e ? e.SeasonId : rawItem.Id]
-                .FirstOrDefault(q => q.EpisodeId == rawItem.Id);
-
-            if (episode is not null)
-            {
-                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync([episode], cancellationToken).ConfigureAwait(false);
-            }
+            await _mediaSegmentRefresher.RefreshAsync(rawItem, cancellationToken).ConfigureAwait(false);
         }
 
         return NoContent();

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -29,7 +29,7 @@ namespace IntroSkipper.Controllers;
 /// Initializes a new instance of the <see cref="VisualizationController"/> class.
 /// </remarks>
 /// <param name="logger">Logger.</param>
-/// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
+/// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 /// <param name="libraryManager">libraryManager.</param>
 /// <param name="providerManager">providerManager.</param>
 /// <param name="fileSystem">fileSystem.</param>
@@ -40,10 +40,10 @@ namespace IntroSkipper.Controllers;
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("Intros")]
-public partial class VisualizationController(ILogger<VisualizationController> logger, MediaSegmentUpdateManager mediaSegmentUpdateManager, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem, ILoggerFactory loggerFactory, IFFmpegService ffmpegService, IDetectionCacheService cacheService) : ControllerBase
+public partial class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentRefresher mediaSegmentRefresher, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem, ILoggerFactory loggerFactory, IFFmpegService ffmpegService, IDetectionCacheService cacheService) : ControllerBase
 {
     private readonly ILogger<VisualizationController> _logger = logger;
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly IProviderManager _providerManager = providerManager;
     private readonly IFileSystem _fileSystem = fileSystem;
@@ -161,7 +161,7 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
             if (Plugin.Instance.Configuration.UpdateMediaSegments)
             {
-                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, cancellationToken).ConfigureAwait(false);
+                await _mediaSegmentRefresher.RefreshAsync(episodeIds, cancellationToken).ConfigureAwait(false);
             }
 
             return NoContent();
@@ -246,7 +246,7 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
                             _libraryManager,
                             _providerManager,
                             _fileSystem,
-                            _mediaSegmentUpdateManager,
+                            _mediaSegmentRefresher,
                             _ffmpegService,
                             _cacheService);
 

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -219,9 +219,26 @@ public class IntroSkipperDbContext : DbContext
         try
         {
             using var db = contextFactory();
-            segments = await db.DbSegment.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
-            segments = [.. segments.Where(s => s.ToSegment().Valid)];
-            seasonInfos = await db.DbSeasonInfo.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+            var connection = db.Database.GetDbConnection();
+            var wasOpen = connection.State == System.Data.ConnectionState.Open;
+            if (!wasOpen)
+            {
+                await db.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            try
+            {
+                segments = await db.DbSegment.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+                segments = [.. segments.Where(s => s.ToSegment().Valid)];
+                seasonInfos = await db.DbSeasonInfo.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (!wasOpen)
+                {
+                    await db.Database.CloseConnectionAsync().ConfigureAwait(false);
+                }
+            }
         }
         catch (OperationCanceledException)
         {

--- a/IntroSkipper/Manager/IMediaSegmentRefresher.cs
+++ b/IntroSkipper/Manager/IMediaSegmentRefresher.cs
@@ -1,0 +1,25 @@
+using MediaBrowser.Controller.Entities;
+
+namespace IntroSkipper.Manager;
+
+/// <summary>
+/// Refreshes Jellyfin media segments for library items.
+/// </summary>
+public interface IMediaSegmentRefresher
+{
+    /// <summary>
+    /// Refreshes media segments for an item.
+    /// </summary>
+    /// <param name="item">The item to refresh.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Refreshes media segments for item ids.
+    /// </summary>
+    /// <param name="itemIds">The item ids to refresh.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default);
+}

--- a/IntroSkipper/Manager/MediaSegmentEditorService.cs
+++ b/IntroSkipper/Manager/MediaSegmentEditorService.cs
@@ -1,7 +1,7 @@
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
-using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.MediaSegments;
 using Microsoft.Extensions.Logging;
 
@@ -14,17 +14,16 @@ namespace IntroSkipper.Manager;
 /// Initializes a new instance of the <see cref="MediaSegmentEditorService"/> class.
 /// </remarks>
 /// <param name="mediaSegmentManager">The Jellyfin <see cref="IMediaSegmentManager"/> used to edit segments.</param>
+/// <param name="libraryManager">The Jellyfin library manager used to resolve items by id.</param>
 /// <param name="logger">Application logger.</param>
 public partial class MediaSegmentEditorService(
     IMediaSegmentManager mediaSegmentManager,
+    ILibraryManager libraryManager,
     ILogger<MediaSegmentEditorService> logger)
 {
     private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
+    private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly ILogger<MediaSegmentEditorService> _logger = logger;
-    private readonly LibraryOptions _externalProviders = new()
-    {
-        DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
-    };
 
     // One semaphore per item id; serialises concurrent CreateOrReplaceSegmentAsync calls for
     // the same item so the get-then-create sequence is effectively atomic.
@@ -65,7 +64,7 @@ public partial class MediaSegmentEditorService(
             await lockEntry.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             acquired = true;
             var existingSegments = await _mediaSegmentManager
-                .GetSegmentsAsync(item, [segment.Type], _externalProviders, filterByProvider: false)
+                .GetSegmentsAsync(item, [segment.Type], MediaSegmentProviderDefaults.ExternalProviders, filterByProvider: false)
                 .ConfigureAwait(false);
 
             if (segment.Type == MediaSegmentType.Commercial)
@@ -140,7 +139,7 @@ public partial class MediaSegmentEditorService(
     /// <returns>The matching segment, or <c>null</c> if not found.</returns>
     public async Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
     {
-        var item = Plugin.Instance?.GetItem(itemId);
+        var item = itemId != Guid.Empty ? _libraryManager.GetItemById(itemId) : null;
         if (item is null)
         {
             LogItemNotFound(_logger, itemId);
@@ -148,7 +147,7 @@ public partial class MediaSegmentEditorService(
         }
 
         var segments = await _mediaSegmentManager
-            .GetSegmentsAsync(item, null, _externalProviders, filterByProvider: false)
+            .GetSegmentsAsync(item, null, MediaSegmentProviderDefaults.ExternalProviders, filterByProvider: false)
             .ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();

--- a/IntroSkipper/Manager/MediaSegmentEditorService.cs
+++ b/IntroSkipper/Manager/MediaSegmentEditorService.cs
@@ -1,9 +1,3 @@
-// SPDX-FileCopyrightText: 2024-2026 rlauuzo
-// SPDX-FileCopyrightText: 2024-2026 AbandonedCart
-// SPDX-FileCopyrightText: 2024-2026 Kilian von Pflugk
-// SPDX-License-Identifier: GPL-3.0-only
-
-using IntroSkipper.Data;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.MediaSegments;
@@ -14,16 +8,19 @@ using Microsoft.Extensions.Logging;
 namespace IntroSkipper.Manager;
 
 /// <summary>
-/// Initializes a new instance of the <see cref="MediaSegmentUpdateManager" /> class.
+/// Performs targeted Jellyfin media-segment editor operations.
 /// </summary>
-/// <param name="mediaSegmentManager">The Jellyfin <see cref="IMediaSegmentManager"/> used to update segments.</param>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MediaSegmentEditorService"/> class.
+/// </remarks>
+/// <param name="mediaSegmentManager">The Jellyfin <see cref="IMediaSegmentManager"/> used to edit segments.</param>
 /// <param name="logger">Application logger.</param>
-public partial class MediaSegmentUpdateManager(
+public partial class MediaSegmentEditorService(
     IMediaSegmentManager mediaSegmentManager,
-    ILogger<MediaSegmentUpdateManager> logger)
+    ILogger<MediaSegmentEditorService> logger)
 {
     private readonly IMediaSegmentManager _mediaSegmentManager = mediaSegmentManager;
-    private readonly ILogger<MediaSegmentUpdateManager> _logger = logger;
+    private readonly ILogger<MediaSegmentEditorService> _logger = logger;
     private readonly LibraryOptions _externalProviders = new()
     {
         DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
@@ -33,54 +30,8 @@ public partial class MediaSegmentUpdateManager(
     // the same item so the get-then-create sequence is effectively atomic.
     // RefCountedSemaphore tracks how many callers currently hold a reference so that entries
     // are pruned from the dictionary as soon as the last caller is done, preventing unbounded growth.
-    private static readonly Dictionary<Guid, RefCountedSemaphore> _itemLocks = new();
+    private static readonly Dictionary<Guid, RefCountedSemaphore> _itemLocks = [];
     private static readonly object _itemLocksLock = new();
-
-    /// <summary>
-    /// Updates all media items in a List.
-    /// </summary>
-    /// <param name="episodes">Queued media items.</param>
-    /// <param name="cancellationToken">CancellationToken.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task UpdateMediaSegmentsAsync(
-        IReadOnlyList<QueuedEpisode> episodes,
-        CancellationToken cancellationToken)
-    {
-        var maxParallelism = Plugin.Instance!.Configuration.MaxParallelism;
-        await Parallel.ForEachAsync(
-            episodes,
-            new ParallelOptions
-            {
-                CancellationToken = cancellationToken,
-                MaxDegreeOfParallelism = maxParallelism
-            },
-            async (episode, ct) =>
-            {
-                try
-                {
-                    // Retrieve the existing segments for the episode.
-                    var item = Plugin.Instance!.GetItem(episode.EpisodeId);
-                    if (item is null)
-                    {
-                        LogItemNotFound(_logger, episode.EpisodeId);
-                        return;
-                    }
-
-                    await _mediaSegmentManager.RunSegmentPluginProviders(item, _externalProviders, true, ct).ConfigureAwait(false);
-
-                    LogUpdatedSegments(_logger, episode.EpisodeId);
-                }
-                catch (OperationCanceledException)
-                {
-                    LogProcessingCanceled(_logger, episode.EpisodeId);
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    LogErrorProcessingEpisode(_logger, ex, episode.EpisodeId);
-                }
-            }).ConfigureAwait(false);
-    }
 
     /// <summary>
     /// Creates or replaces a Jellyfin media segment for the given item.
@@ -88,7 +39,7 @@ public partial class MediaSegmentUpdateManager(
     /// </summary>
     /// <remarks>
     /// Non-commercial segments are replaced: any existing Jellyfin segment of the same type
-    /// is deleted before the new one is created.  Commercial segments are deduplicated by
+    /// is deleted before the new one is created. Commercial segments are deduplicated by
     /// start/end ticks: the new segment is only created when no identical entry already exists.
     /// </remarks>
     /// <param name="item">The media item that owns the segment.</param>
@@ -243,17 +194,8 @@ public partial class MediaSegmentUpdateManager(
     [LoggerMessage(Level = LogLevel.Warning, Message = "Intro Skipper provider entry not found for item {ItemId}; Jellyfin segment will not be created")]
     private static partial void LogProviderNotFound(ILogger logger, Guid itemId);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Updated segments for episode {EpisodeId}")]
-    private static partial void LogUpdatedSegments(ILogger logger, Guid episodeId);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Processing for episode {EpisodeId} was canceled.")]
-    private static partial void LogProcessingCanceled(ILogger logger, Guid episodeId);
-
     [LoggerMessage(Level = LogLevel.Error, Message = "Error deleting segment {SegmentId}")]
     private static partial void LogErrorDeletingSegment(ILogger logger, Exception ex, Guid segmentId);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "Error processing episode {EpisodeId}")]
-    private static partial void LogErrorProcessingEpisode(ILogger logger, Exception ex, Guid episodeId);
 
     // Pairs a SemaphoreSlim with a caller reference count so that the dictionary entry can be
     // pruned and the semaphore disposed exactly when the last caller returns its reference.

--- a/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
+++ b/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
@@ -1,0 +1,20 @@
+using MediaBrowser.Model.Configuration;
+
+namespace IntroSkipper.Manager;
+
+/// <summary>
+/// Shared defaults for Intro Skipper media-segment provider operations.
+/// </summary>
+internal static class MediaSegmentProviderDefaults
+{
+    /// <summary>
+    /// Gets the <see cref="LibraryOptions"/> used when querying or running external media-segment
+    /// providers. The built-in "Chapter Segments Provider" is disabled so it is never re-run as part
+    /// of an Intro Skipper refresh or editor operation. The returned instance is shared and must be
+    /// treated as read-only.
+    /// </summary>
+    internal static LibraryOptions ExternalProviders { get; } = new()
+    {
+        DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
+    };
+}

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -1,0 +1,105 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Manager;
+
+/// <summary>
+/// Refreshes Jellyfin media segments by running media-segment providers directly.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MediaSegmentRefreshService"/> class.
+/// </remarks>
+/// <param name="mediaSegmentManager">The Jellyfin media segment manager.</param>
+/// <param name="logger">Application logger.</param>
+public sealed partial class MediaSegmentRefreshService(
+    IMediaSegmentManager mediaSegmentManager,
+    ILogger<MediaSegmentRefreshService> logger) : IMediaSegmentRefresher
+{
+    private static readonly LibraryOptions _externalProviders = new()
+    {
+        DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
+    };
+
+    /// <inheritdoc />
+    public async Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        try
+        {
+            await mediaSegmentManager.RunSegmentPluginProviders(item, _externalProviders, true, cancellationToken).ConfigureAwait(false);
+            LogUpdatedMediaSegments(logger, item.Id);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            LogMediaSegmentRefreshCanceled(logger, item.Id);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogErrorRefreshingMediaSegments(logger, ex, item.Id);
+        }
+    }
+
+    private async Task RefreshByIdAsync(Guid itemId, CancellationToken cancellationToken)
+    {
+        if (itemId == Guid.Empty)
+        {
+            return;
+        }
+
+        var item = Plugin.Instance!.GetItem(itemId);
+        if (item is null)
+        {
+            LogItemNotFoundForMediaSegmentRefresh(logger, itemId);
+            return;
+        }
+
+        await RefreshAsync(item, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(itemIds);
+
+        var ids = new HashSet<Guid>();
+        foreach (var itemId in itemIds)
+        {
+            if (itemId != Guid.Empty)
+            {
+                ids.Add(itemId);
+            }
+        }
+
+        if (ids.Count == 0)
+        {
+            return;
+        }
+
+        var options = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = Math.Max(1, Plugin.Instance!.Configuration.MaxParallelism),
+            CancellationToken = cancellationToken
+        };
+
+        await Parallel.ForEachAsync(ids, options, async (itemId, ct) =>
+        {
+            await RefreshByIdAsync(itemId, ct).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Updated media segments for item {ItemId}")]
+    private static partial void LogUpdatedMediaSegments(ILogger logger, Guid itemId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Media segment refresh for item {ItemId} was canceled.")]
+    private static partial void LogMediaSegmentRefreshCanceled(ILogger logger, Guid itemId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error refreshing media segments for item {ItemId}")]
+    private static partial void LogErrorRefreshingMediaSegments(ILogger logger, Exception ex, Guid itemId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Item not found for media segment refresh {ItemId}")]
+    private static partial void LogItemNotFoundForMediaSegmentRefresh(ILogger logger, Guid itemId);
+}

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -1,6 +1,6 @@
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
-using MediaBrowser.Model.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Manager;
@@ -12,16 +12,13 @@ namespace IntroSkipper.Manager;
 /// Initializes a new instance of the <see cref="MediaSegmentRefreshService"/> class.
 /// </remarks>
 /// <param name="mediaSegmentManager">The Jellyfin media segment manager.</param>
+/// <param name="libraryManager">The Jellyfin library manager used to resolve items by id.</param>
 /// <param name="logger">Application logger.</param>
 public sealed partial class MediaSegmentRefreshService(
     IMediaSegmentManager mediaSegmentManager,
+    ILibraryManager libraryManager,
     ILogger<MediaSegmentRefreshService> logger) : IMediaSegmentRefresher
 {
-    private static readonly LibraryOptions _externalProviders = new()
-    {
-        DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
-    };
-
     /// <inheritdoc />
     public async Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
     {
@@ -29,7 +26,7 @@ public sealed partial class MediaSegmentRefreshService(
 
         try
         {
-            await mediaSegmentManager.RunSegmentPluginProviders(item, _externalProviders, true, cancellationToken).ConfigureAwait(false);
+            await mediaSegmentManager.RunSegmentPluginProviders(item, MediaSegmentProviderDefaults.ExternalProviders, true, cancellationToken).ConfigureAwait(false);
             LogUpdatedMediaSegments(logger, item.Id);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -50,7 +47,7 @@ public sealed partial class MediaSegmentRefreshService(
             return;
         }
 
-        var item = Plugin.Instance!.GetItem(itemId);
+        var item = libraryManager.GetItemById(itemId);
         if (item is null)
         {
             LogItemNotFoundForMediaSegmentRefresh(logger, itemId);
@@ -65,14 +62,7 @@ public sealed partial class MediaSegmentRefreshService(
     {
         ArgumentNullException.ThrowIfNull(itemIds);
 
-        var ids = new HashSet<Guid>();
-        foreach (var itemId in itemIds)
-        {
-            if (itemId != Guid.Empty)
-            {
-                ids.Add(itemId);
-            }
-        }
+        var ids = itemIds.Where(itemId => itemId != Guid.Empty).ToHashSet();
 
         if (ids.Count == 0)
         {

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -36,6 +36,19 @@ public sealed partial class MediaSegmentRefreshService(
         }
         catch (Exception ex)
         {
+            // Do not swallow cancellation or critical exceptions.
+            if (ex is OperationCanceledException
+                || ex is OutOfMemoryException
+                || ex is StackOverflowException
+                || ex is ThreadAbortException
+                || ex is ThreadInterruptedException
+                || ex is AccessViolationException)
+            {
+                throw;
+            }
+
+            // Log and continue so that one item's provider failure does not
+            // abort the surrounding batch refresh.
             LogErrorRefreshingMediaSegments(logger, ex, item.Id);
         }
     }

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -28,7 +28,8 @@ namespace IntroSkipper
             serviceCollection.AddSingleton<IDetectionCacheService, DetectionCacheService>();
             serviceCollection.AddSingleton<IFFmpegService, FFmpegService>();
             serviceCollection.AddSingleton<IMediaSegmentProvider, SegmentProvider>();
-            serviceCollection.AddTransient<MediaSegmentUpdateManager>();
+            serviceCollection.AddSingleton<IMediaSegmentRefresher, MediaSegmentRefreshService>();
+            serviceCollection.AddTransient<MediaSegmentEditorService>();
             serviceCollection.AddSingleton<MediaSegmentsFirstEpisodeFilter>();
             serviceCollection.Configure<MvcOptions>(options =>
             {

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -29,7 +29,7 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="libraryManager">Library manager.</param>
 /// <param name="providerManager">Provider manager.</param>
 /// <param name="fileSystem">File system.</param>
-/// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
+/// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="cacheService">Detection cache service.</param>
 public partial class BaseItemAnalyzerTask(
@@ -38,7 +38,7 @@ public partial class BaseItemAnalyzerTask(
     ILibraryManager libraryManager,
     IProviderManager providerManager,
     IFileSystem fileSystem,
-    MediaSegmentUpdateManager mediaSegmentUpdateManager,
+    IMediaSegmentRefresher mediaSegmentRefresher,
     IFFmpegService ffmpegService,
     IDetectionCacheService cacheService)
 {
@@ -54,7 +54,7 @@ public partial class BaseItemAnalyzerTask(
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly IProviderManager _providerManager = providerManager;
     private readonly IFileSystem _fileSystem = fileSystem;
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
@@ -169,7 +169,7 @@ public partial class BaseItemAnalyzerTask(
 
             if (updateMediaSegments && _config.UpdateMediaSegments)
             {
-                await _mediaSegmentUpdateManager.UpdateMediaSegmentsAsync(episodes, ct).ConfigureAwait(false);
+                await _mediaSegmentRefresher.RefreshAsync(episodes.Select(e => e.EpisodeId), ct).ConfigureAwait(false);
             }
         }).ConfigureAwait(false);
 

--- a/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
+++ b/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
@@ -26,7 +26,7 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="providerManager">Provider manager.</param>
 /// <param name="fileSystem">File system.</param>
 /// <param name="logger">Logger.</param>
-/// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
+/// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="cacheService">Detection cache service.</param>
 public partial class DetectSegmentsTask(
@@ -35,7 +35,7 @@ public partial class DetectSegmentsTask(
     ILibraryManager libraryManager,
     IProviderManager providerManager,
     IFileSystem fileSystem,
-    MediaSegmentUpdateManager mediaSegmentUpdateManager,
+    IMediaSegmentRefresher mediaSegmentRefresher,
     IFFmpegService ffmpegService,
     IDetectionCacheService cacheService) : IScheduledTask
 {
@@ -44,7 +44,7 @@ public partial class DetectSegmentsTask(
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly IProviderManager _providerManager = providerManager;
     private readonly IFileSystem _fileSystem = fileSystem;
-    private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+    private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
 
@@ -98,7 +98,7 @@ public partial class DetectSegmentsTask(
                 _libraryManager,
                 _providerManager,
                 _fileSystem,
-                _mediaSegmentUpdateManager,
+                _mediaSegmentRefresher,
                 _ffmpegService,
                 _cacheService);
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -40,7 +40,7 @@ namespace IntroSkipper.Services
         private readonly IFFmpegService _ffmpegService;
         private readonly ILogger<Entrypoint> _logger;
         private readonly ILoggerFactory _loggerFactory;
-        private readonly MediaSegmentUpdateManager _mediaSegmentUpdateManager;
+        private readonly IMediaSegmentRefresher _mediaSegmentRefresher;
         private readonly HashSet<Guid> _seasonsToAnalyze = [];
         private readonly object _seasonsLock = new();
         private readonly Timer _queueTimer;
@@ -60,7 +60,7 @@ namespace IntroSkipper.Services
         /// <param name="ffmpegService">FFmpeg service.</param>
         /// <param name="logger">Logger.</param>
         /// <param name="loggerFactory">Logger factory.</param>
-        /// <param name="mediaSegmentUpdateManager">Media segment update manager.</param>
+        /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
         public Entrypoint(
             ILibraryManager libraryManager,
             IProviderManager providerManager,
@@ -70,7 +70,7 @@ namespace IntroSkipper.Services
             IFFmpegService ffmpegService,
             ILogger<Entrypoint> logger,
             ILoggerFactory loggerFactory,
-            MediaSegmentUpdateManager mediaSegmentUpdateManager)
+            IMediaSegmentRefresher mediaSegmentRefresher)
         {
             _libraryManager = libraryManager;
             _providerManager = providerManager;
@@ -80,7 +80,7 @@ namespace IntroSkipper.Services
             _ffmpegService = ffmpegService;
             _logger = logger;
             _loggerFactory = loggerFactory;
-            _mediaSegmentUpdateManager = mediaSegmentUpdateManager;
+            _mediaSegmentRefresher = mediaSegmentRefresher;
 
             _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
             _queueTimer = new Timer(
@@ -353,7 +353,7 @@ namespace IntroSkipper.Services
 
                         _analyzeAgain = false;
 
-                        var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentUpdateManager, _ffmpegService, _cacheService);
+                        var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentRefresher, _ffmpegService, _cacheService);
                         await analyzer.AnalyzeItemsAsync(new Progress<double>(), cts.Token, seasonIds).ConfigureAwait(false);
 
                         if (_analyzeAgain && !cts.IsCancellationRequested)


### PR DESCRIPTION
## Summary by Sourcery

Refactor media segment handling by splitting refresh responsibilities into a dedicated service and interface, updating controllers and scheduled tasks to depend on the new abstraction, and tightening DB connection handling.

Enhancements:
- Rename and narrow the media segment editor class to focus on targeted segment edits while removing bulk update responsibilities.
- Introduce IMediaSegmentRefresher and MediaSegmentRefreshService to run Jellyfin media-segment providers directly for items or collections of item IDs with parallel execution and logging.
- Refactor Entrypoint, controllers, and scheduled tasks to depend on IMediaSegmentRefresher instead of the old manager, improving separation of concerns and testability.
- Ensure database rebuild logic explicitly opens and closes EF Core connections around reads to avoid connection-state issues.

Tests:
- Add unit tests for SkipIntroController and VisualizationController ensuring they await media segment refresh operations and respect configuration flags when updating segments.
- Add unit tests for MediaSegmentRefreshService verifying it calls the Jellyfin media-segment manager with the correct options, handles exceptions, and honors cancellation.