### PR TITLE
feat: adaptive density threshold in BlackFrameAltAnalyzer

### DIFF
--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -234,6 +234,30 @@ public class TestBlackFrames
     }
 
     [Fact]
+    public void TestAdaptiveDensity_SentinelValuesExcluded_DoNotSkewMedian()
+    {
+        // ComputeSceneDensity returns -1 for scenes with no frames. If those sentinel
+        // values were included they would pull the median negative; they must be filtered out.
+        // Three valid scenes at ~0.30 density plus two empty-scene sentinels.
+        var densities = new List<double> { -1, 0.28, 0.30, 0.32, -1 };
+        var threshold = BlackFrameAltAnalyzer.ComputeAdaptiveDensityThreshold(densities);
+        // Valid densities: [0.28, 0.30, 0.32] — median = 0.30 → threshold = 0.30 * 0.6 = 0.18
+        Assert.True(threshold > 0, "Sentinel -1 values must not drive threshold negative");
+        Assert.Equal(0.30 * 0.6, threshold, precision: 10);
+    }
+
+    [Fact]
+    public void TestAdaptiveDensity_EvenCount_TrueMedianUsed()
+    {
+        // Four valid scenes: [0.20, 0.40, 0.60, 0.80]
+        // True median = (0.40 + 0.60) / 2 = 0.50; upper-middle (old bug) would give 0.60.
+        // threshold = min(0.50, 0.50 * 0.6) = 0.30
+        var densities = new List<double> { 0.20, 0.40, 0.60, 0.80 };
+        var threshold = BlackFrameAltAnalyzer.ComputeAdaptiveDensityThreshold(densities);
+        Assert.Equal(0.50 * 0.6, threshold, precision: 10);
+    }
+
+    [Fact]
     public void TestDetectCreditScenes_LowDensity_AdaptiveThresholdAllowsScenes()
     {
         // Simulate letterboxed content where credit scenes only reach ~30% density.

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -200,6 +200,104 @@ public class TestBlackFrames
         Assert.NotEmpty(scenes);
     }
 
+    // ── Adaptive density threshold tests ────────────────────────────────
+
+    [Fact]
+    public void TestAdaptiveDensity_FewScenes_ReturnsStaticThreshold()
+    {
+        // With fewer than 3 density measurements the distribution is too sparse to
+        // be meaningful, so the static MinimumBlackFrameDensity (0.50) is returned.
+        var densities = new List<double> { 0.3, 0.4 };
+        var threshold = BlackFrameAltAnalyzer.ComputeAdaptiveDensityThreshold(densities);
+        Assert.Equal(0.50, threshold);
+    }
+
+    [Fact]
+    public void TestAdaptiveDensity_LowDensityScenes_RelaxesThreshold()
+    {
+        // When all scenes have density ~0.30 the median is 0.30; adaptive threshold
+        // = min(0.50, 0.30 * 0.6) = min(0.50, 0.18) = 0.18, which allows them through.
+        var densities = new List<double> { 0.28, 0.30, 0.32 };
+        var threshold = BlackFrameAltAnalyzer.ComputeAdaptiveDensityThreshold(densities);
+        Assert.True(threshold < 0.50, "Threshold should be relaxed below the static 0.50 floor");
+        Assert.Equal(0.30 * 0.6, threshold, precision: 10);
+    }
+
+    [Fact]
+    public void TestAdaptiveDensity_HighDensityScenes_KeepsStaticThreshold()
+    {
+        // When all scenes have density >= 0.84, median * 0.6 >= 0.50, so the cap at
+        // the static threshold keeps the effective floor at 0.50.
+        var densities = new List<double> { 0.85, 0.90, 0.95 };
+        var threshold = BlackFrameAltAnalyzer.ComputeAdaptiveDensityThreshold(densities);
+        Assert.Equal(0.50, threshold);
+    }
+
+    [Fact]
+    public void TestDetectCreditScenes_LowDensity_AdaptiveThresholdAllowsScenes()
+    {
+        // Simulate letterboxed content where credit scenes only reach ~30% density.
+        // Static threshold (0.50) would reject them; adaptive threshold should allow them.
+        // Three clusters of 15 frames each, with about 30% black frames per cluster.
+        var frames = new List<BlackFrame>();
+
+        // Cluster 1: frames 0-14 at times 0-7.0s; 5 black (33% density)
+        for (var i = 0; i < 15; i++)
+        {
+            var percentage = (i % 3 == 0) ? 90 : 10; // every 3rd frame is black
+            frames.Add(new BlackFrame(percentage, i * 0.5, i));
+        }
+
+        // Non-black gap: frames 15-24 at times 7.5-12.0s
+        for (var i = 15; i < 25; i++)
+        {
+            frames.Add(new BlackFrame(10, i * 0.5, i));
+        }
+
+        // Cluster 2: frames 25-39 at times 12.5-19.5s; 5 black (33% density)
+        for (var i = 25; i < 40; i++)
+        {
+            var percentage = (i % 3 == 0) ? 90 : 10;
+            frames.Add(new BlackFrame(percentage, (i - 25) * 0.5 + 12.5, i));
+        }
+
+        // Non-black gap: frames 40-49 at times 20.0-24.5s
+        for (var i = 40; i < 50; i++)
+        {
+            frames.Add(new BlackFrame(10, (i - 40) * 0.5 + 20.0, i));
+        }
+
+        // Cluster 3: frames 50-64 at times 25.0-32.0s; 5 black (33% density)
+        for (var i = 50; i < 65; i++)
+        {
+            var percentage = (i % 3 == 0) ? 90 : 10;
+            frames.Add(new BlackFrame(percentage, (i - 50) * 0.5 + 25.0, i));
+        }
+
+        // minimum=85 means only 90%-black frames count; sceneChange=96 is unreachable here
+        var scenes = BlackFrameAltAnalyzer.DetectCreditScenes(frames, 85, 96);
+
+        // With adaptive density the three low-density clusters should survive gating.
+        // (Static 0.50 threshold would reject all of them since density ~33% < 50%.)
+        Assert.NotEmpty(scenes);
+    }
+
+    [Fact]
+    public void TestDetectCreditScenes_HighDensity_UnchangedBehavior()
+    {
+        // Standard high-density credits (80%+) must still be accepted — the adaptive
+        // threshold must never raise the floor above the static 0.50.
+        var frames = new List<BlackFrame>();
+        for (var i = 0; i < 100; i++)
+        {
+            var percentage = (i % 5 == 0) ? 30 : 90; // 80% of frames are black
+            frames.Add(new BlackFrame(percentage, i * 0.5, i));
+        }
+
+        var scenes = BlackFrameAltAnalyzer.DetectCreditScenes(frames, 85, 96);
+        Assert.NotEmpty(scenes);
+    }
+
     [Fact]
     public void TestRefineBoundary_NoPriorKeyframe_ReturnsOriginalStart()
     {

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -331,7 +331,8 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
     }
 
     /// <summary>
-    /// Checks whether a scene meets the minimum black-frame density threshold.
+    /// Computes the black-frame density for a scene: the fraction of frames within the scene
+    /// whose black percentage meets or exceeds <paramref name="minimum"/>.
     /// </summary>
     /// <remarks>
     /// <paramref name="searchStart"/> is an optimization index passed by reference. It tracks the
@@ -346,7 +347,12 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
     /// previous individual scene) must pass a fresh <c>searchStart = 0</c> to avoid skipping frames
     /// that fall within the merged range.</para>
     /// </remarks>
-    private static bool HasMinimumBlackFrameDensity(List<BlackFrame> frames, CreditScene scene, int minimum, ref int searchStart)
+    /// <param name="frames">All detected keyframes (time-sorted).</param>
+    /// <param name="scene">The scene to measure.</param>
+    /// <param name="minimum">Minimum black percentage for a frame to count as black.</param>
+    /// <param name="searchStart">Running scan index; advanced in-place.</param>
+    /// <returns>Black-frame density in [0, 1], or -1 if the scene contains no frames.</returns>
+    internal static double ComputeSceneDensity(List<BlackFrame> frames, CreditScene scene, int minimum, ref int searchStart)
     {
         var totalInScene = 0;
         var blackInScene = 0;
@@ -373,7 +379,54 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
             }
         }
 
-        return totalInScene > 0 && (double)blackInScene / totalInScene >= MinimumBlackFrameDensity;
+        return totalInScene > 0 ? (double)blackInScene / totalInScene : -1;
+    }
+
+    /// <summary>
+    /// Checks whether a scene meets the minimum black-frame density threshold.
+    /// </summary>
+    /// <param name="frames">All detected keyframes (time-sorted).</param>
+    /// <param name="scene">The scene to evaluate.</param>
+    /// <param name="minimum">Minimum black percentage for a frame to count as black.</param>
+    /// <param name="densityThreshold">The density ratio that the scene must meet or exceed.</param>
+    /// <param name="searchStart">Running scan index; advanced in-place.</param>
+    /// <returns><see langword="true"/> when the scene's black-frame density meets the threshold.</returns>
+    private static bool HasMinimumBlackFrameDensity(List<BlackFrame> frames, CreditScene scene, int minimum, double densityThreshold, ref int searchStart)
+    {
+        var density = ComputeSceneDensity(frames, scene, minimum, ref searchStart);
+        return density >= densityThreshold;
+    }
+
+    /// <summary>
+    /// Computes an adaptive density threshold from the measured densities of candidate scenes.
+    /// </summary>
+    /// <remarks>
+    /// When a video has letterboxing or slightly tinted frames the natural black density of
+    /// credit scenes sits below the static <see cref="MinimumBlackFrameDensity"/> floor, causing
+    /// legitimate credits to be rejected.  This method relaxes the floor when the video's own
+    /// distribution warrants it:
+    /// <list type="bullet">
+    ///   <item>With fewer than 3 scenes the distribution is too sparse to be meaningful, so
+    ///         the configured floor is returned unchanged.</item>
+    ///   <item>Otherwise the effective threshold is
+    ///         <c>min(configuredThreshold, median_density × 0.6)</c>.  Scaling the median
+    ///         downward by 40 % allows scenes that are somewhat less dense than the typical
+    ///         scene to pass while still rejecting clear noise.</item>
+    /// </list>
+    /// </remarks>
+    /// <param name="densities">Measured per-scene black-frame densities (in [0, 1]).</param>
+    /// <returns>Effective density threshold to apply during scene filtering.</returns>
+    internal static double ComputeAdaptiveDensityThreshold(IReadOnlyList<double> densities)
+    {
+        if (densities.Count < 3)
+        {
+            return MinimumBlackFrameDensity;
+        }
+
+        var sorted = new List<double>(densities);
+        sorted.Sort();
+        var median = sorted[sorted.Count / 2];
+        return Math.Min(MinimumBlackFrameDensity, median * 0.6);
     }
 
     internal static List<CreditScene> DetectCreditScenes(List<BlackFrame> frames, int minimum, int sceneChange)
@@ -423,15 +476,31 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
         // First filter individual scenes, then re-check merged spans so long non-black gaps do not
         // turn separate dense scenes into one mostly non-black segment.
         //
+        // Step 1 – measure density for every candidate scene.  The adaptive threshold is derived
+        // from these measurements, so we must compute them before filtering.
+        //
         // searchStart advances monotonically across this loop because scenes are time-sorted —
         // each scene starts at or after the previous one, so we never need to revisit earlier frames.
-        var densityFiltered = new List<CreditScene>(scenes.Count);
+        var sceneDensities = new List<double>(scenes.Count);
         var searchStart = 0;
         foreach (var scene in scenes)
         {
-            if (HasMinimumBlackFrameDensity(frames, scene, minimum, ref searchStart))
+            sceneDensities.Add(ComputeSceneDensity(frames, scene, minimum, ref searchStart));
+        }
+
+        // Step 2 – derive an adaptive density floor.
+        // On letterboxed or tinted content the credit scenes may have density well below the
+        // static 0.50 constant.  ComputeAdaptiveDensityThreshold relaxes the floor when the
+        // video's own distribution warrants it, without raising it above the static default.
+        var effectiveDensity = ComputeAdaptiveDensityThreshold(sceneDensities);
+
+        // Step 3 – filter scenes using the effective threshold.
+        var densityFiltered = new List<CreditScene>(scenes.Count);
+        for (var idx = 0; idx < scenes.Count; idx++)
+        {
+            if (sceneDensities[idx] >= effectiveDensity)
             {
-                densityFiltered.Add(scene);
+                densityFiltered.Add(scenes[idx]);
             }
         }
 
@@ -461,7 +530,7 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
                 // no frames in the merged range are skipped.
                 var mergeSearchStart = 0;
                 if (scene.StartTime - current.EndTime <= MaximumTimeSkip &&
-                    HasMinimumBlackFrameDensity(frames, mergedScene, minimum, ref mergeSearchStart))
+                    HasMinimumBlackFrameDensity(frames, mergedScene, minimum, effectiveDensity, ref mergeSearchStart))
                 {
                     current = mergedScene;
                 }

--- a/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs
@@ -414,18 +414,28 @@ public sealed partial class BlackFrameAltAnalyzer(ILogger<BlackFrameAltAnalyzer>
     ///         scene to pass while still rejecting clear noise.</item>
     /// </list>
     /// </remarks>
-    /// <param name="densities">Measured per-scene black-frame densities (in [0, 1]).</param>
+    /// <param name="densities">Measured per-scene black-frame densities.
+    /// Values less than zero are sentinel values from empty scenes (produced by
+    /// <see cref="ComputeSceneDensity"/> when no frames fall within a scene) and are
+    /// excluded before computing the distribution.</param>
     /// <returns>Effective density threshold to apply during scene filtering.</returns>
     internal static double ComputeAdaptiveDensityThreshold(IReadOnlyList<double> densities)
     {
-        if (densities.Count < 3)
+        // Exclude -1 sentinel values produced for empty scenes — including them would
+        // bias the median toward -1, potentially driving the threshold negative.
+        var valid = densities.Where(d => d >= 0).OrderBy(d => d).ToList();
+        if (valid.Count < 3)
         {
             return MinimumBlackFrameDensity;
         }
 
-        var sorted = new List<double>(densities);
-        sorted.Sort();
-        var median = sorted[sorted.Count / 2];
+        // True median: average the two middle elements for even counts rather than
+        // always taking the upper-middle element, which would bias the threshold upward.
+        var mid = valid.Count / 2;
+        var median = valid.Count % 2 == 0
+            ? (valid[mid - 1] + valid[mid]) / 2.0
+            : valid[mid];
+
         return Math.Min(MinimumBlackFrameDensity, median * 0.6);
     }
 


### PR DESCRIPTION
## Problem

`BlackFrameAltAnalyzer` uses a hardcoded `MinimumBlackFrameDensity = 0.50` constant to gate which detected black scenes are treated as valid credit sequences.  On **letterboxed content** (wide aspect-ratio video with black bars encoded into the frame) and **slightly tinted frames** (warm-tone grading, dark cinematography), legitimate credit scenes naturally sit below 50 % density — causing the analyzer to miss credits entirely.

## Solution

Replace the static gate with a **content-adaptive floor**.

After collecting all candidate scenes for an episode, the analyzer now:

1. Measures the black-frame density of every candidate scene.
2. Derives an *effective* threshold: `min(0.50, median_density × 0.6)`.
   - The `× 0.6` factor allows scenes that are somewhat less dense than the episode's typical scene to pass, while still rejecting clear noise.
   - The `min(…, 0.50)` cap ensures the threshold is **never raised** above the original static floor — standard high-contrast credits are unaffected.
3. With fewer than 3 candidate scenes the distribution is too sparse to be meaningful, so the static 0.50 floor is used unchanged.

The same adaptive threshold is applied during the merge-density re-check, keeping the two gating stages consistent.

## Affected content types

- Letterboxed 4:3-in-16:9 encodes
- Dark/cinematic shows where credit scenes average 25–40 % density
- Any video where the FFmpeg `blackframe` filter reports frames in the 70–85 % range rather than 95–100 %

## Changes

- `IntroSkipper/Analyzers/BlackFrameAltAnalyzer.cs`
  - Extracted density measurement into `ComputeSceneDensity` (returns the ratio; `internal static` for testing)
  - Added thin `HasMinimumBlackFrameDensity` wrapper that accepts an explicit threshold parameter
  - Added `ComputeAdaptiveDensityThreshold` (`internal static` for testing)
  - Updated `DetectCreditScenes` to measure densities first, compute adaptive threshold, then filter

- `IntroSkipper.Tests/TestBlackFrames.cs`
  - `TestAdaptiveDensity_FewScenes_ReturnsStaticThreshold` — fewer than 3 scenes → static 0.50
  - `TestAdaptiveDensity_LowDensityScenes_RelaxesThreshold` — median 0.30 → threshold 0.18
  - `TestAdaptiveDensity_HighDensityScenes_KeepsStaticThreshold` — median 0.90 → capped at 0.50
  - `TestDetectCreditScenes_LowDensity_AdaptiveThresholdAllowsScenes` — end-to-end: 3 clusters at ~33 % density survive gating
  - `TestDetectCreditScenes_HighDensity_UnchangedBehavior` — standard 80 % density credits still accepted

## Test plan

- [x] All 253 existing tests pass (`dotnet test --no-build -c Release`)
- [x] 5 new targeted unit tests added and passing
- [x] Build succeeds with 0 warnings (`TreatWarningsAsErrors=true`)
- [ ] Manual: run analyzer against a known-letterboxed episode and verify credits are detected where they previously were not
- [ ] Manual: run analyzer against a standard episode and verify no regression in credit detection timing

## Summary by Sourcery

Make BlackFrameAltAnalyzer use a content-adaptive black-frame density threshold so credit detection works on letterboxed and low-density content while preserving existing behavior on high-density credits.

New Features:
- Introduce an adaptive density threshold derived from per-scene black-frame densities for credit-scene detection.

Enhancements:
- Refactor black-frame density calculation into reusable helpers that compute per-scene density and derive an adaptive threshold.
- Apply the same effective density threshold consistently to both initial scene filtering and merged-scene rechecks.

Tests:
- Add unit tests covering adaptive threshold behavior across sparse, low-density, and high-density scenes, including end-to-end credit-scene detection cases.