### PR TITLE
feat(chromaprint): replace fixed AnalysisPercent window with duration-adaptive range

### DIFF
--- a/IntroSkipper.Tests/TestDynamicAnalysisRange.cs
+++ b/IntroSkipper.Tests/TestDynamicAnalysisRange.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Configuration;
+using IntroSkipper.Manager;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+/// <summary>
+/// Tests for the duration-scaled Chromaprint analysis range introduced in
+/// <see cref="QueueManager.ComputeDynamicFingerprintDuration"/>.
+/// </summary>
+public class TestDynamicAnalysisRange
+{
+    // Short episodes (< 15 min / 900 s): 50 % up to 360 s
+
+    [Theory]
+    [InlineData(600, 300)]
+    [InlineData(660, 330)]
+    [InlineData(899, 360)]
+    public void ShortEpisode_Returns50PercentUpTo360Seconds(double duration, double expected)
+    {
+        var result = QueueManager.ComputeDynamicFingerprintDuration(duration, PluginConfiguration.DefaultAnalysisLengthLimit);
+
+        Assert.Equal(expected, result, 1);
+    }
+
+    // Medium episodes (15-30 min): 35 % up to 480 s
+
+    [Theory]
+    [InlineData(900, 315)]
+    [InlineData(1200, 420)]
+    [InlineData(1799, 480)]
+    public void MediumEpisode_Returns35PercentUpTo480Seconds(double duration, double expected)
+    {
+        var result = QueueManager.ComputeDynamicFingerprintDuration(duration, PluginConfiguration.DefaultAnalysisLengthLimit);
+
+        Assert.Equal(expected, result, 1);
+    }
+
+    // Long episodes (>= 30 min): 15 % up to 600 s
+
+    [Theory]
+    [InlineData(1800, 270)]
+    [InlineData(2700, 405)]
+    [InlineData(4800, 600)]
+    public void LongEpisode_Returns15PercentUpTo600Seconds(double duration, double expected)
+    {
+        var result = QueueManager.ComputeDynamicFingerprintDuration(duration, PluginConfiguration.DefaultAnalysisLengthLimit);
+
+        Assert.Equal(expected, result, 1);
+    }
+
+    // AnalysisLengthLimit acts as an absolute cap
+
+    [Fact]
+    public void AnalysisLengthLimit_CapsResultBelowTierMaximum()
+    {
+        // 45-min episode with tier cap 600 s, but admin lowered limit to 5 min (300 s)
+        const double duration = 2700;
+        const int limitMinutes = 5;
+
+        var result = QueueManager.ComputeDynamicFingerprintDuration(duration, limitMinutes);
+
+        Assert.Equal(300, result, 1);
+    }
+
+    // UseDynamicAnalysisRange flag: enabled by default
+
+    [Fact]
+    public void UseDynamicAnalysisRange_IsTrueByDefault()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.True(config.UseDynamicAnalysisRange);
+    }
+}

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -178,6 +178,16 @@ public class PluginConfiguration : BasePluginConfiguration
     public int AnalysisLengthLimit { get; set; } = DefaultAnalysisLengthLimit;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to use duration-scaled analysis ranges instead of
+    /// the fixed <see cref="AnalysisPercent"/> percentage when computing how much of each episode
+    /// to fingerprint. When enabled, short episodes are given a higher relative share so that
+    /// intros near the 50 % mark are not missed, while long episodes are capped earlier to avoid
+    /// wasting CPU time on content that cannot possibly be an intro.
+    /// The absolute cap from <see cref="AnalysisLengthLimit"/> is still respected.
+    /// </summary>
+    public bool UseDynamicAnalysisRange { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to use the minimum and maximum duration for chapters.
     /// </summary>
     public bool FullLengthChapters { get; set; } = false;

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -260,9 +260,12 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
 
         var duration = TimeSpan.FromTicks(episode.RunTimeTicks ?? 0).TotalSeconds;
-        var fingerprintDuration = Math.Min(
-            duration >= 5 * 60 ? duration * _analysisPercent : duration,
-            60 * pluginInstance.Configuration.AnalysisLengthLimit);
+        var config = pluginInstance.Configuration;
+        var fingerprintDuration = config.UseDynamicAnalysisRange
+            ? ComputeDynamicFingerprintDuration(duration, config.AnalysisLengthLimit)
+            : Math.Min(
+                duration >= 5 * 60 ? duration * _analysisPercent : duration,
+                60 * config.AnalysisLengthLimit);
 
         var creditsDuration = await ResolveCreditsFingerprintEndAsync(episode.Path, duration, cancellationToken).ConfigureAwait(false);
 
@@ -486,6 +489,44 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
 
         return verified;
+    }
+
+    /// <summary>
+    /// Computes the intro fingerprint window (in seconds) for an episode using duration-scaled
+    /// thresholds. The resulting value is always capped by <paramref name="analysisLengthLimitMinutes"/>.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    ///   <item>Episodes shorter than 15 minutes: up to 50 % of duration, capped at 360 s (6 min).</item>
+    ///   <item>Episodes shorter than 30 minutes: up to 35 % of duration, capped at 480 s (8 min).</item>
+    ///   <item>Episodes 30 minutes or longer: up to 15 % of duration, capped at 600 s (10 min).</item>
+    /// </list>
+    /// The absolute cap from the plugin's <c>AnalysisLengthLimit</c> setting (converted to seconds)
+    /// is applied on top of the tier cap so administrators can still reduce the limit further.
+    /// </remarks>
+    /// <param name="duration">Total episode duration in seconds.</param>
+    /// <param name="analysisLengthLimitMinutes">The configured <c>AnalysisLengthLimit</c> (in minutes).</param>
+    /// <returns>Number of seconds to fingerprint.</returns>
+    internal static double ComputeDynamicFingerprintDuration(double duration, int analysisLengthLimitMinutes)
+    {
+        double tierResult;
+        if (duration < 900)
+        {
+            // < 15 min: 50 % up to 6 min
+            tierResult = Math.Min(duration * 0.50, 360);
+        }
+        else if (duration < 1800)
+        {
+            // 15-30 min: 35 % up to 8 min
+            tierResult = Math.Min(duration * 0.35, 480);
+        }
+        else
+        {
+            // >= 30 min: 15 % up to 10 min
+            tierResult = Math.Min(duration * 0.15, 600);
+        }
+
+        return Math.Min(tierResult, 60.0 * analysisLengthLimitMinutes);
     }
 
     [GeneratedRegex(@"[^\w\s]")]


### PR DESCRIPTION
## Summary
- Replace the single `AnalysisPercent`-based fingerprint window with a three-tier duration-adaptive range via `QueueManager.ComputeDynamicFingerprintDuration()`
- Short episodes (< 15 min): 50% of duration, capped at 360 s — ensures OPs near the 50% mark are captured for anime shorts
- Medium episodes (15–30 min): 35% of duration, capped at 480 s
- Long episodes (≥ 30 min): 15% of duration, capped at 600 s — avoids wasting CPU on content that can't be an intro
- The per-admin `AnalysisLengthLimit` cap is still applied on top of the tier cap
- New `UseDynamicAnalysisRange` config flag (default: `true`) lets admins opt back to the old fixed-percentage path
- Full unit test coverage across all three tiers and the admin cap edge case

## Motivation
The old fixed `AnalysisPercent` (default 25%) under-analyzes short content (e.g. 10-minute anime shorts where the OP sits at 45% of the episode) while over-analyzing feature-length episodes.

## Test plan
- [x] Unit tests added for all three duration tiers and the `AnalysisLengthLimit` cap override (`TestDynamicAnalysisRange.cs`)
- [x] `dotnet build` passes with no warnings
- [ ] Manual: check Jellyfin admin dashboard after plugin reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a duration-adaptive Chromaprint fingerprint window with a configurable opt-out, improving analysis coverage for short episodes while reducing unnecessary processing for long ones.

New Features:
- Add a dynamic fingerprint duration calculation that scales the analysis window based on episode length with tiered percentage and cap rules.
- Introduce a UseDynamicAnalysisRange configuration flag to toggle between the new dynamic behavior and the legacy fixed-percentage analysis.

Enhancements:
- Ensure the global AnalysisLengthLimit setting is applied as an absolute cap on the dynamically computed fingerprint duration.

Tests:
- Add unit tests covering all duration tiers, the AnalysisLengthLimit cap behavior, and the default value of the UseDynamicAnalysisRange flag.