### PR TITLE
feat(fingerprint): add confidence scoring to fingerprint matches

### DIFF
--- a/IntroSkipper.Tests/TestAudioFingerprinting.cs
+++ b/IntroSkipper.Tests/TestAudioFingerprinting.cs
@@ -97,6 +97,40 @@ public class TestAudioFingerprinting
         Assert.Equal(expected, actual);
     }
 
+    /// <summary>
+    /// Verify that CompareEpisodes populates a non-trivial Confidence value on the returned segments.
+    /// Two identical 200-point fingerprints share every point, so a contiguous match is guaranteed.
+    /// With the neutral bit-error proxy the confidence factor from bit-quality is 0.5, so the
+    /// resulting Confidence must be strictly between 0.0 and 1.0.
+    /// </summary>
+    [Fact]
+    public void TestCompareEpisodesPopulatesConfidence()
+    {
+        // Build two identical fingerprints with enough points to exceed MinimumIntroDuration.
+        // SampleDuration ≈ 0.1238 s, so 200 points → ~24.8 s > default MinimumIntroDuration (15 s).
+        var fingerprint = new uint[200];
+        for (var i = 0; i < fingerprint.Length; i++)
+        {
+            fingerprint[i] = (uint)(i + 1); // distinct non-zero values to populate the inverted index
+        }
+
+        var lhsId = Guid.NewGuid();
+        var rhsId = Guid.NewGuid();
+
+        var analyzer = CreateChromaprintAnalyzer();
+        var (lhs, rhs) = analyzer.CompareEpisodes(lhsId, fingerprint, rhsId, fingerprint);
+
+        // The segments must be valid (a match was found).
+        Assert.True(lhs.Valid, "Expected LHS segment to be valid");
+        Assert.True(rhs.Valid, "Expected RHS segment to be valid");
+
+        // Confidence must be strictly between 0.0 and 1.0 — not the default 1.0 and not zero.
+        Assert.True(lhs.Confidence > 0.0, $"LHS Confidence should be > 0 but was {lhs.Confidence}");
+        Assert.True(lhs.Confidence < 1.0, $"LHS Confidence should be < 1 but was {lhs.Confidence}");
+        Assert.True(rhs.Confidence > 0.0, $"RHS Confidence should be > 0 but was {rhs.Confidence}");
+        Assert.True(rhs.Confidence < 1.0, $"RHS Confidence should be < 1 but was {rhs.Confidence}");
+    }
+
     [FactSkipFFmpegTests]
     public async Task TestIntroDetection()
     {

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -150,6 +150,14 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             // If an intro is found for this episode, adjust its times and save it else add it to the list of episodes without intros.
             if (seasonIntros.TryGetValue(currentEpisode.EpisodeId, out var intro))
             {
+                // Skip segments whose fingerprint confidence falls below the minimum threshold.
+                const double MinimumConfidence = 0.3;
+                if (intro.Confidence < MinimumConfidence)
+                {
+                    LogLowConfidenceSegmentSkipped(intro.EpisodeId, intro.Confidence, MinimumConfidence);
+                    continue;
+                }
+
                 var adjustedIntro = await timeAdjustmentHelper.AdjustIntroTimesAsync(currentEpisode, intro, cancellationToken: cancellationToken).ConfigureAwait(false);
                 currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
                 await Plugin.Instance!.UpdateTimestampAsync(adjustedIntro, mode, configHash: currentEpisode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -181,7 +189,33 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
         {
             LogIndexSearchSuccessful();
 
-            return GetLongestTimeRange(lhsId, lhsRanges, rhsId, rhsRanges);
+            var (lhsSegment, rhsSegment) = GetLongestTimeRange(lhsId, lhsRanges, rhsId, rhsRanges);
+
+            // Compute fingerprint match confidence.
+            // We use MaximumFingerprintPointDifferences / 2.0 as a neutral average bit-error proxy
+            // because per-point Hamming distances are not surfaced through the current inverted-index
+            // path; only points that pass the threshold are recorded, so the true average is
+            // somewhere between 0 and MaximumFingerprintPointDifferences.
+            var maxDur = _analysisMode == AnalysisMode.Introduction
+                ? (double)_config.MaximumIntroDuration
+                : (double)_config.MaximumCreditsDuration;
+            var avgBitErrorProxy = _config.MaximumFingerprintPointDifferences / 2.0;
+            var maxBitErrors = (double)_config.MaximumFingerprintPointDifferences;
+
+            lhsSegment.Confidence = Math.Clamp(
+                (lhsSegment.Duration / maxDur) * (1.0 - (avgBitErrorProxy / maxBitErrors)),
+                0.0,
+                1.0);
+
+            rhsSegment.Confidence = Math.Clamp(
+                (rhsSegment.Duration / maxDur) * (1.0 - (avgBitErrorProxy / maxBitErrors)),
+                0.0,
+                1.0);
+
+            LogSegmentConfidence(lhsSegment.EpisodeId, lhsSegment.Start, lhsSegment.End, lhsSegment.Confidence);
+            LogSegmentConfidence(rhsSegment.EpisodeId, rhsSegment.Start, rhsSegment.End, rhsSegment.Confidence);
+
+            return (lhsSegment, rhsSegment);
         }
 
         LogSharedIntroNotFound(lhsId, rhsId);
@@ -393,4 +427,10 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Unable to find a shared introduction sequence between {LHS} and {RHS}")]
     private partial void LogSharedIntroNotFound(Guid lhs, Guid rhs);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Segment {EpisodeId} [{Start:F3}s – {End:F3}s] confidence {Confidence:F4}")]
+    private partial void LogSegmentConfidence(Guid episodeId, double start, double end, double confidence);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping low-confidence segment for {EpisodeId}: confidence {Confidence:F4} is below threshold {Threshold:F4}")]
+    private partial void LogLowConfidenceSegmentSkipped(Guid episodeId, double confidence, double threshold);
 }

--- a/IntroSkipper/Data/Segment.cs
+++ b/IntroSkipper/Data/Segment.cs
@@ -48,6 +48,7 @@ public class Segment
         EpisodeId = segment.EpisodeId;
         Start = segment.Start;
         End = segment.End;
+        Confidence = segment.Confidence;
     }
 
     /// <summary>
@@ -74,6 +75,14 @@ public class Segment
     /// </summary>
     [DataMember]
     public double End { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fingerprint match confidence for this segment.
+    /// A value of 1.0 indicates the highest possible confidence; 0.0 the lowest.
+    /// Segments produced by non-fingerprint analyzers (chapter, black-frame) default to 1.0.
+    /// </summary>
+    [DataMember]
+    public double Confidence { get; set; } = 1.0;
 
     /// <summary>
     /// Gets a value indicating whether this segment is valid or not.


### PR DESCRIPTION
## Summary
- Add a `Confidence` property (range 0.0–1.0, default 1.0) to `Segment` so fingerprint match quality can be communicated to callers
- In `ChromaprintAnalyzer`, compute confidence as `clamp((match_length / MaximumIntroDuration) * (1.0 - avg_bit_error / max_bit_errors), 0.0, 1.0)` — the average bit-error is approximated as `MaximumFingerprintPointDifferences / 2` since only passing points are tracked in the inverted index
- Segments with `Confidence < 0.3` are silently skipped before time-adjustment and persistence, preventing very weak matches from overwriting better results from a different episode pair
- Segments from non-fingerprint analyzers (ChapterAnalyzer, BlackFrameAnalyzer) keep the default `Confidence = 1.0` and are never filtered
- New unit test verifies that `CompareEpisodes` populates a non-trivial confidence (> 0.0 and < 1.0) for a perfect-match fingerprint pair

## Motivation
All fingerprint matches were treated with equal weight regardless of match length or bit similarity, causing weak coincidental matches to persist in the database and degrade user experience.

## Test plan
- [x] Unit test added (`TestCompareEpisodesPopulatesConfidence` in `TestAudioFingerprinting.cs`)
- [x] `dotnet build` passes with no warnings
- [ ] Manual: check Jellyfin admin dashboard after plugin reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add confidence scoring to fingerprint-based intro segments and filter out low-confidence matches before persisting results.

New Features:
- Introduce a Confidence field on segments to represent fingerprint match quality between 0.0 and 1.0.

Bug Fixes:
- Prevent weak fingerprint matches from overwriting stronger intro detections by ignoring low-confidence segments.

Enhancements:
- Compute and log confidence values for the longest matching fingerprint segments when comparing episodes.
- Extend segment copy construction to preserve the computed confidence value.

Tests:
- Add a unit test ensuring CompareEpisodes populates non-trivial confidence values for matching fingerprints.