### PR TITLE
Add structured exclusion lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ web/node_modules
 .idea/
 /.cursor
 .agents/
+.omo

--- a/IntroSkipper.Tests/TestExclusionPolicy.cs
+++ b/IntroSkipper.Tests/TestExclusionPolicy.cs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-FileCopyrightText: 2026 Kilian von Pflugk
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Helper;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestExclusionPolicy
+{
+    [Theory]
+    [InlineData("/mnt/rd/Series/Season 01/S01E01.mkv", "/mnt/rd", true)]
+    [InlineData("/mnt/rd", "/mnt/rd/", true)]
+    [InlineData("/mnt/rd-backup/Series/S01E01.mkv", "/mnt/rd", false)]
+    [InlineData("/mnt/RD/Series/S01E01.mkv", "/mnt/rd", true)]
+    [InlineData(@"C:\Media\Real-Debrid\Show\S01E01.mkv", @"C:\Media\Real-Debrid", true)]
+    [InlineData(@"C:\Media\Real-Debrid-Backup\Show\S01E01.mkv", @"C:\Media\Real-Debrid", false)]
+    [InlineData(@"\\server\share\Show\S01E01.mkv", @"\\server\share", true)]
+    [InlineData("/media/zurg/Movies/Film.mkv", "zurg", false)]
+    public void IsPathExcluded_MatchesExactPathOrChildrenOnly(string path, string fragment, bool expected)
+    {
+        var config = new PluginConfiguration
+        {
+            PathExclusions = { fragment }
+        };
+
+        var policy = ExclusionPolicy.FromConfiguration(config);
+
+        Assert.Equal(expected, policy.IsPathExcluded(path));
+    }
+
+    [Fact]
+    public void FromConfiguration_RejectsEmptyPathFragments()
+    {
+        var config = new PluginConfiguration
+        {
+            PathExclusions = { string.Empty, "   " }
+        };
+
+        var policy = ExclusionPolicy.FromConfiguration(config);
+
+        Assert.False(policy.IsPathExcluded("/mnt/rd/Show/S01E01.mkv"));
+    }
+
+    [Fact]
+    public void EvaluateSeries_UsesStructuredExclusions()
+    {
+        var config = new PluginConfiguration
+        {
+            SeriesExclusions = { "Structured Show" }
+        };
+
+        var policy = ExclusionPolicy.FromConfiguration(config);
+
+        Assert.True(policy.EvaluateSeries("structured show", Guid.NewGuid(), "/media/show.mkv").IsExcluded);
+        Assert.False(policy.EvaluateSeries("Other Show", Guid.NewGuid(), "/media/other.mkv").IsExcluded);
+    }
+
+    [Fact]
+    public void EvaluateMovie_UsesMovieExclusions()
+    {
+        var config = new PluginConfiguration
+        {
+            MovieExclusions = { "Excluded Movie" }
+        };
+
+        var policy = ExclusionPolicy.FromConfiguration(config);
+
+        Assert.True(policy.EvaluateMovie("excluded movie", Guid.NewGuid(), "/media/excluded.mkv").IsExcluded);
+        Assert.False(policy.EvaluateMovie("Other Movie", Guid.NewGuid(), "/media/other.mkv").IsExcluded);
+    }
+
+    [Fact]
+    public void EvaluateSeries_ExcludesByPathBeforeName()
+    {
+        var config = new PluginConfiguration
+        {
+            PathExclusions = { "/mnt/rd" }
+        };
+
+        var policy = ExclusionPolicy.FromConfiguration(config);
+        var decision = policy.EvaluateSeries("Any Show", Guid.NewGuid(), "/mnt/rd/Any Show/S01E01.mkv");
+
+        Assert.True(decision.IsExcluded);
+        Assert.Equal(ExclusionReason.Path, decision.Reason);
+        Assert.Equal("PathExclusions", decision.RuleLabel);
+    }
+}

--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -2,6 +2,10 @@
 // SPDX-FileCopyrightText: 2026 Kilian von Pflugk
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Xml.Serialization;
 using IntroSkipper.Configuration;
 using Xunit;
 
@@ -18,6 +22,98 @@ public class TestPluginConfiguration
         Assert.Equal(PluginConfiguration.DefaultAnalysisLengthLimit, config.AnalysisLengthLimit);
         Assert.Equal(PluginConfiguration.DefaultMinimumIntroDuration, config.MinimumIntroDuration);
         Assert.Equal(PluginConfiguration.DefaultSettledSeasonDelayHours, config.SettledSeasonDelayHours);
+        Assert.Equal(string.Empty, config.ExcludeSeries);
+        Assert.Empty(config.SeriesExclusions);
+        Assert.Empty(config.MovieExclusions);
+        Assert.Empty(config.PathExclusions);
+    }
+
+    [Fact]
+    public void ExclusionLists_AreMutableCollections()
+    {
+        var config = new PluginConfiguration();
+
+        config.SeriesExclusions.Add("The Office");
+        config.MovieExclusions.Add("The Matrix");
+        config.PathExclusions.Add("/mnt/remote");
+
+        Assert.Equal(["The Office"], config.SeriesExclusions);
+        Assert.Equal(["The Matrix"], config.MovieExclusions);
+        Assert.Equal(["/mnt/remote"], config.PathExclusions);
+    }
+
+    [Fact]
+    public void XmlSerialization_RoundTripsStructuredExclusionListsWithCommaValues()
+    {
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+        var config = new PluginConfiguration
+        {
+            ExcludeSeries = "Legacy Show",
+            SeriesExclusions = { "Show, With Comma", "The Office" },
+            MovieExclusions = { "Movie, Part 1" },
+            PathExclusions = { @"C:\Media, Remote" }
+        };
+
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, config);
+
+        var xml = writer.ToString();
+        Assert.Contains("<ExcludeSeries>Legacy Show</ExcludeSeries>", xml, StringComparison.Ordinal);
+        Assert.Contains("<string>Show, With Comma</string>", xml, StringComparison.Ordinal);
+        Assert.Contains("<string>Movie, Part 1</string>", xml, StringComparison.Ordinal);
+        Assert.Contains(@"<string>C:\Media, Remote</string>", xml, StringComparison.Ordinal);
+
+        using var reader = new StringReader(xml);
+        var roundTripped = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
+
+        Assert.Equal(config.ExcludeSeries, roundTripped.ExcludeSeries);
+        Assert.Equal(config.SeriesExclusions, roundTripped.SeriesExclusions);
+        Assert.Equal(config.MovieExclusions, roundTripped.MovieExclusions);
+        Assert.Equal(config.PathExclusions, roundTripped.PathExclusions);
+    }
+
+    [Fact]
+    public void JsonDeserialization_PopulatesStructuredExclusionLists()
+    {
+        var config = JsonSerializer.Deserialize<PluginConfiguration>(
+            """
+            {
+              "ExcludeSeries": "Legacy Show",
+              "SeriesExclusions": ["The Office", "Show, With Comma", null],
+              "MovieExclusions": ["The Matrix"],
+              "PathExclusions": ["/mnt/remote"]
+            }
+            """);
+
+        Assert.NotNull(config);
+        Assert.Equal("Legacy Show", config.ExcludeSeries);
+        Assert.Equal(["The Office", "Show, With Comma"], config.SeriesExclusions);
+        Assert.Equal(["The Matrix"], config.MovieExclusions);
+        Assert.Equal(["/mnt/remote"], config.PathExclusions);
+    }
+
+    [Fact]
+    public void JsonSerialization_WritesStructuredExclusionListsAsArrays()
+    {
+        var config = new PluginConfiguration
+        {
+            ExcludeSeries = "Legacy Show",
+            SeriesExclusions = { "The Office" },
+            MovieExclusions = { "The Matrix" },
+            PathExclusions = { "/mnt/remote" }
+        };
+
+        var json = JsonSerializer.Serialize(config);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal("Legacy Show", root.GetProperty("ExcludeSeries").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("SeriesExclusions").ValueKind);
+        Assert.Equal("The Office", root.GetProperty("SeriesExclusions")[0].GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("MovieExclusions").ValueKind);
+        Assert.Equal("The Matrix", root.GetProperty("MovieExclusions")[0].GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("PathExclusions").ValueKind);
+        Assert.Equal("/mnt/remote", root.GetProperty("PathExclusions")[0].GetString());
     }
 
     [Theory]

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -106,12 +106,12 @@ public sealed class TestSeasonReanalysisPlanner
     }
 
     [Fact]
-    public void IsSettledForReanalysis_ReturnsFalse_WhenExcluded()
+    public void IsSettledForReanalysis_IgnoresExcludedFlag_WhenQueueAlreadyFiltered()
     {
         var config = new PluginConfiguration { ReanalyzeSettledSeasons = true };
         var season = Season(SeasonReanalysisPlanner.MinimumEpisodes, SettledTime(), excluded: true);
 
-        Assert.False(SeasonReanalysisPlanner.IsSettledForReanalysis(season, config, Now));
+        Assert.True(SeasonReanalysisPlanner.IsSettledForReanalysis(season, config, Now));
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -75,6 +75,51 @@ public sealed class TestVisualizationController
         Assert.Equal(0, refresher.CollectionCallCount);
     }
 
+    [Fact]
+    public async Task ClearExcludedTimestampsAsync_RemovesOnlyCurrentlyExcludedState()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var excludedId = Guid.NewGuid();
+        var includedId = Guid.NewGuid();
+        var dbPath = CreateTempDbPath();
+        var config = new PluginConfiguration
+        {
+            UpdateMediaSegments = true,
+            SeriesExclusions = { "Excluded Show" }
+        };
+        using var pluginScope = CreatePluginScope(
+            dbPath,
+            seriesId,
+            seasonId,
+            [excludedId, includedId],
+            config);
+        await SeedSeasonAsync(dbPath, seasonId, [excludedId, includedId]);
+        await SeedCacheAsync(excludedId, includedId);
+        var refresher = new RecordingMediaSegmentRefresher();
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+        var controller = CreateController(refresher, loggerFactory);
+
+        var result = await controller.ClearExcludedTimestampsAsync(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ClearExcludedTimestampsResponse>(ok.Value);
+        Assert.Equal(1, response.AffectedItems);
+        Assert.Equal(1, response.RemovedSegments);
+        Assert.Equal(1, response.RemovedCacheEntries);
+        Assert.Equal([excludedId], refresher.LastItemIds);
+
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.False(await db.DbSegment.AnyAsync(s => s.ItemId == excludedId));
+        Assert.True(await db.DbSegment.AnyAsync(s => s.ItemId == includedId));
+        var seasonStates = await db.DbSeasonState.Where(s => s.SeasonId == seasonId).ToListAsync();
+        Assert.All(seasonStates, state => Assert.Equal([includedId], state.EpisodeIds));
+
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        Assert.False(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == excludedId));
+        Assert.True(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == includedId));
+    }
+
     private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory)
     {
         return new VisualizationController(
@@ -89,16 +134,24 @@ public sealed class TestVisualizationController
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
+        => CreatePluginScope(
+            dbPath,
+            seriesId,
+            seasonId,
+            episodeIds,
+            new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
+
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, PluginConfiguration config)
     {
         var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var plugin = Plugin.Instance!;
         EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
         plugin.QueuedMediaItems[seasonId] =
         [
-            new QueuedEpisode { SeriesId = seriesId, SeasonId = seasonId, EpisodeId = episodeIds[0], Name = "Episode 1" },
-            new QueuedEpisode { SeriesId = seriesId, SeasonId = seasonId, EpisodeId = episodeIds[1], Name = "Episode 2" }
+            new QueuedEpisode { SeriesId = seriesId, SeasonId = seasonId, EpisodeId = episodeIds[0], SeriesName = "Excluded Show", Name = "Episode 1" },
+            new QueuedEpisode { SeriesId = seriesId, SeasonId = seasonId, EpisodeId = episodeIds[1], SeriesName = "Included Show", Name = "Episode 2" }
         ];
         return scope;
     }
@@ -114,6 +167,15 @@ public sealed class TestVisualizationController
             new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, episodeIds),
             new DbSeasonState(seasonId, AnalysisMode.Credits, AnalyzerAction.Default, episodeIds));
         await db.SaveChangesAsync();
+    }
+
+    private static async Task SeedCacheAsync(Guid excludedId, Guid includedId)
+    {
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        cacheDb.DetectionCache.AddRange(
+            new DbDetectionCache(excludedId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray),
+            new DbDetectionCache(includedId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));
+        await cacheDb.SaveChangesAsync();
     }
 
     private static string CreateTempDbPath()

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -12,6 +12,7 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Xml.Serialization;
+using IntroSkipper.Data;
 using MediaBrowser.Model.Plugins;
 
 namespace IntroSkipper.Configuration;
@@ -72,6 +73,21 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the comma separated list of series names to exclude from analysis.
     /// </summary>
     public string ExcludeSeries { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the structured list of series names to exclude from analysis.
+    /// </summary>
+    public ExclusionList SeriesExclusions { get; init; } = [];
+
+    /// <summary>
+    /// Gets the structured list of movie names to exclude from analysis.
+    /// </summary>
+    public ExclusionList MovieExclusions { get; init; } = [];
+
+    /// <summary>
+    /// Gets the structured list of filesystem paths to exclude from analysis.
+    /// </summary>
+    public ExclusionList PathExclusions { get; init; } = [];
 
     /// <summary>
     /// Gets or sets a value indicating whether to automatically scan newly added items.

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -6,8 +6,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Net.Mime;
+using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
+using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
 using MediaBrowser.Common.Api;
@@ -178,6 +180,84 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     }
 
     /// <summary>
+    /// Clears timestamp, cache, and season-state data for media matched by the current exclusion policy.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Counts describing the cleared excluded timestamp state.</returns>
+    [HttpPost("ExcludedTimestamps/Clear")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<ClearExcludedTimestampsResponse>> ClearExcludedTimestampsAsync(CancellationToken cancellationToken = default)
+    {
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+
+        try
+        {
+            var excludedItems = await GetExcludedInventoryAsync(plugin, cancellationToken).ConfigureAwait(false);
+            var excludedIds = excludedItems.Select(e => e.EpisodeId).ToHashSet();
+            if (excludedIds.Count == 0)
+            {
+                return Ok(new ClearExcludedTimestampsResponse(0, 0, 0));
+            }
+
+            var excludedIdsBySeason = excludedItems
+                .GroupBy(e => e.SeasonId)
+                .ToDictionary(g => g.Key, g => g.Select(e => e.EpisodeId).ToHashSet());
+
+            int removedSegments;
+            using (var db = Plugin.CreateDbContext())
+            {
+                removedSegments = await db.DbSegment
+                    .Where(s => excludedIds.Contains(s.ItemId))
+                    .ExecuteDeleteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                var seasonIds = excludedIdsBySeason.Keys.ToHashSet();
+                var seasonStates = await db.DbSeasonState
+                    .Where(s => seasonIds.Contains(s.SeasonId))
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (var state in seasonStates)
+                {
+                    var currentIds = state.EpisodeIds.ToList();
+                    if (currentIds.RemoveAll(excludedIdsBySeason[state.SeasonId].Contains) > 0)
+                    {
+                        db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = currentIds;
+                    }
+                }
+
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            int removedCacheEntries;
+            using (var cacheDb = Plugin.CreateCacheDbContext())
+            {
+                removedCacheEntries = await cacheDb.DetectionCache
+                    .Where(e => excludedIds.Contains(e.ItemId))
+                    .ExecuteDeleteAsync(CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
+            if (plugin.Configuration.UpdateMediaSegments)
+            {
+                await _mediaSegmentRefresher.RefreshAsync(excludedIds, cancellationToken).ConfigureAwait(false);
+            }
+
+            return Ok(new ClearExcludedTimestampsResponse(excludedIds.Count, removedSegments, removedCacheEntries));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogFailedToClearExcludedTimestamps(_logger, ex);
+            return Problem("An unexpected error occurred while clearing excluded timestamp data.", statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    /// <summary>
     /// Updates the analyzer actions for the provided season.
     /// </summary>
     /// <param name="request">Update analyzer actions request.</param>
@@ -190,6 +270,34 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
         await Plugin.SetAnalyzerActionAsync(request.Id, request.AnalyzerActions, cancellationToken).ConfigureAwait(false);
 
         return NoContent();
+    }
+
+    private async Task<IReadOnlyList<QueuedEpisode>> GetExcludedInventoryAsync(Plugin plugin, CancellationToken cancellationToken)
+    {
+        if (_libraryManager is not null)
+        {
+            var queueManager = new QueueManager(
+                _loggerFactory.CreateLogger<QueueManager>(),
+                _libraryManager,
+                _providerManager,
+                _fileSystem,
+                _ffmpegService);
+            var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
+            return [.. queue.Values.SelectMany(static episodes => episodes).Where(static episode => episode.IsExcluded)];
+        }
+
+        var policy = ExclusionPolicy.FromConfiguration(plugin.Configuration);
+        return [.. plugin.QueuedMediaItems.Values
+            .SelectMany(static episodes => episodes)
+            .Where(episode => IsExcludedByPolicy(policy, episode))];
+    }
+
+    private static bool IsExcludedByPolicy(ExclusionPolicy policy, QueuedEpisode episode)
+    {
+        var decision = episode.Category == QueuedMediaCategory.Movie
+            ? policy.EvaluateMovie(episode.Name, episode.EpisodeId, episode.Path)
+            : policy.EvaluateSeries(episode.SeriesName, episode.SeriesId, episode.Path);
+        return decision.IsExcluded;
     }
 
     /// <summary>
@@ -273,6 +381,9 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to erase timestamps for series {SeriesId} season {SeasonId}")]
     private static partial void LogFailedToEraseTimestamps(ILogger logger, Exception ex, Guid seriesId, Guid seasonId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to clear excluded timestamp data")]
+    private static partial void LogFailedToClearExcludedTimestamps(ILogger logger, Exception ex);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Start (Re-) scan of season/movie {SeasonId}")]
     private static partial void LogStartRescan(ILogger logger, Guid seasonId);

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -233,6 +233,9 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
             int removedCacheEntries;
             using (var cacheDb = Plugin.CreateCacheDbContext())
             {
+                // Cache deletion must run to completion — the segment and season-state rows
+                // above are already deleted, so aborting here would leave orphaned cache
+                // entries out of sync with the database.
                 removedCacheEntries = await cacheDb.DetectionCache
                     .Where(e => excludedIds.Contains(e.ItemId))
                     .ExecuteDeleteAsync(CancellationToken.None)

--- a/IntroSkipper/Data/ClearExcludedTimestampsResponse.cs
+++ b/IntroSkipper/Data/ClearExcludedTimestampsResponse.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Response returned after clearing timestamp state for currently excluded media.
+/// </summary>
+/// <param name="AffectedItems">Number of excluded media items affected.</param>
+/// <param name="RemovedSegments">Number of timestamp rows removed.</param>
+/// <param name="RemovedCacheEntries">Number of detection cache rows removed.</param>
+public sealed record ClearExcludedTimestampsResponse(int AffectedItems, int RemovedSegments, int RemovedCacheEntries);

--- a/IntroSkipper/Data/ExclusionDecision.cs
+++ b/IntroSkipper/Data/ExclusionDecision.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Data;
+
+internal readonly record struct ExclusionDecision(bool IsExcluded, ExclusionReason Reason, string RuleLabel)
+{
+    public static ExclusionDecision Included { get; } = new(false, ExclusionReason.None, string.Empty);
+}

--- a/IntroSkipper/Data/ExclusionList.cs
+++ b/IntroSkipper/Data/ExclusionList.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+using IntroSkipper.Helper;
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Structured exclusion list that serializes entries without comma-separated value semantics.
+/// </summary>
+[JsonConverter(typeof(ExclusionListJsonConverter))]
+public sealed class ExclusionList : Collection<string>, IXmlSerializable
+{
+    /// <summary>
+    /// Gets the XML schema for this type.
+    /// </summary>
+    /// <returns>Always <see langword="null"/>; schema generation is not supported.</returns>
+    public XmlSchema? GetSchema() => null;
+
+    /// <summary>
+    /// Reads nested string elements.
+    /// </summary>
+    /// <param name="reader">XML reader positioned on the exclusion list element.</param>
+    public void ReadXml(XmlReader reader)
+    {
+        if (reader.IsEmptyElement)
+        {
+            reader.ReadStartElement();
+            return;
+        }
+
+        reader.ReadStartElement();
+        while (reader.NodeType != XmlNodeType.EndElement)
+        {
+            if (reader.NodeType == XmlNodeType.Element)
+            {
+                Add(reader.ReadElementContentAsString());
+            }
+            else
+            {
+                reader.Read();
+            }
+        }
+
+        reader.ReadEndElement();
+    }
+
+    /// <summary>
+    /// Writes list entries as nested string elements so values may contain commas.
+    /// </summary>
+    /// <param name="writer">XML writer positioned inside the exclusion list element.</param>
+    public void WriteXml(XmlWriter writer)
+    {
+        foreach (var item in this)
+        {
+            writer.WriteElementString("string", item);
+        }
+    }
+}

--- a/IntroSkipper/Data/ExclusionReason.cs
+++ b/IntroSkipper/Data/ExclusionReason.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Data;
+
+internal enum ExclusionReason
+{
+    None,
+    SeriesName,
+    MovieName,
+    Path
+}

--- a/IntroSkipper/Helper/ExclusionListJsonConverter.cs
+++ b/IntroSkipper/Helper/ExclusionListJsonConverter.cs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Helper;
+
+/// <summary>
+/// JSON converter that writes structured exclusion arrays and reads legacy string values for resilience.
+/// </summary>
+public sealed class ExclusionListJsonConverter : JsonConverter<ExclusionList>
+{
+    /// <inheritdoc />
+    public override ExclusionList Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var list = new ExclusionList();
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            AddLegacyItems(list, reader.GetString());
+            return list;
+        }
+
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException("Expected an exclusion list array or legacy comma-separated string.");
+        }
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                return list;
+            }
+
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                continue;
+            }
+
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException("Expected an exclusion list item string.");
+            }
+
+            list.Add(reader.GetString() ?? string.Empty);
+        }
+
+        throw new JsonException("Unexpected end of exclusion list array.");
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, ExclusionList value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var item in value)
+        {
+            writer.WriteStringValue(item);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void AddLegacyItems(ExclusionList list, string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        foreach (var item in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            list.Add(item);
+        }
+    }
+}

--- a/IntroSkipper/Helper/ExclusionPolicy.cs
+++ b/IntroSkipper/Helper/ExclusionPolicy.cs
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Helper;
+
+internal sealed class ExclusionPolicy
+{
+    private readonly HashSet<string> _seriesNames;
+    private readonly HashSet<string> _movieNames;
+    private readonly IReadOnlyList<string> _pathRoots;
+    private readonly int _broadPathRootCount;
+
+    private ExclusionPolicy(
+        HashSet<string> seriesNames,
+        HashSet<string> movieNames,
+        IReadOnlyList<string> pathRoots)
+    {
+        _seriesNames = seriesNames;
+        _movieNames = movieNames;
+        _pathRoots = pathRoots;
+        _broadPathRootCount = CountBroadPathRoots(pathRoots);
+    }
+
+    public static ExclusionPolicy Empty { get; } = new([], [], []);
+
+    public int BroadPathRootCount => _broadPathRootCount;
+
+    public static ExclusionPolicy FromConfiguration(PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return new ExclusionPolicy(
+            CreateNameSet(config.SeriesExclusions),
+            CreateNameSet(config.MovieExclusions),
+            CreatePathRoots(config.PathExclusions));
+    }
+
+    public ExclusionDecision EvaluateSeries(string seriesName, Guid seriesId, string? path)
+    {
+        _ = seriesId;
+
+        var pathDecision = EvaluatePath(path);
+        if (pathDecision.IsExcluded)
+        {
+            return pathDecision;
+        }
+
+        var name = seriesName.Trim();
+        if (name.Length == 0)
+        {
+            return ExclusionDecision.Included;
+        }
+
+        return _seriesNames.Contains(name)
+            ? new ExclusionDecision(true, ExclusionReason.SeriesName, name)
+            : ExclusionDecision.Included;
+    }
+
+    public ExclusionDecision EvaluateMovie(string movieName, Guid movieId, string? path)
+    {
+        _ = movieId;
+
+        var pathDecision = EvaluatePath(path);
+        if (pathDecision.IsExcluded)
+        {
+            return pathDecision;
+        }
+
+        var name = movieName.Trim();
+        return name.Length > 0 && _movieNames.Contains(name)
+            ? new ExclusionDecision(true, ExclusionReason.MovieName, name)
+            : ExclusionDecision.Included;
+    }
+
+    public bool IsPathExcluded(string? path)
+    {
+        var normalizedPath = NormalizePath(path);
+        if (normalizedPath.Length == 0 || _pathRoots.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var root in _pathRoots)
+        {
+            if (IsPathMatch(normalizedPath, root))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static HashSet<string> CreateNameSet(IEnumerable<string> entries)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+        {
+            var trimmed = entry.Trim();
+            if (trimmed.Length > 0)
+            {
+                names.Add(trimmed);
+            }
+        }
+
+        return names;
+    }
+
+    private static IReadOnlyList<string> CreatePathRoots(IEnumerable<string> entries)
+    {
+        var roots = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
+        {
+            var normalized = NormalizePath(entry);
+            if (normalized.Length > 0 && seen.Add(normalized))
+            {
+                roots.Add(normalized);
+            }
+        }
+
+        return roots;
+    }
+
+    private static int CountBroadPathRoots(IEnumerable<string> roots)
+    {
+        var count = 0;
+        foreach (var root in roots)
+        {
+            if (IsBroadPathRoot(root))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private ExclusionDecision EvaluatePath(string? path)
+        => IsPathExcluded(path)
+            ? new ExclusionDecision(true, ExclusionReason.Path, "PathExclusions")
+            : ExclusionDecision.Included;
+
+    private static bool IsPathMatch(string normalizedPath, string root)
+    {
+        if (string.Equals(normalizedPath, root, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (root == "/")
+        {
+            return normalizedPath.StartsWith('/');
+        }
+
+        return normalizedPath.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        var normalized = path.Trim().Replace('\\', '/');
+        while (normalized.Length > 1 &&
+               normalized.EndsWith('/') &&
+               !IsDriveRootWithSeparator(normalized))
+        {
+            normalized = normalized[..^1];
+        }
+
+        return IsDriveRootWithSeparator(normalized) ? normalized[..2] : normalized;
+    }
+
+    private static bool IsDriveRootWithSeparator(string path)
+        => path.Length == 3 &&
+           char.IsAsciiLetter(path[0]) &&
+           path[1] == ':' &&
+           path[2] == '/';
+
+    private static bool IsBroadPathRoot(string path)
+    {
+        if (path == "/" || IsDriveRoot(path))
+        {
+            return true;
+        }
+
+        return path.StartsWith("//", StringComparison.Ordinal) &&
+               path.Split('/', StringSplitOptions.RemoveEmptyEntries).Length == 2;
+    }
+
+    private static bool IsDriveRoot(string path)
+        => path.Length == 2 &&
+           char.IsAsciiLetter(path[0]) &&
+           path[1] == ':';
+}

--- a/IntroSkipper/Helper/ExclusionPolicy.cs
+++ b/IntroSkipper/Helper/ExclusionPolicy.cs
@@ -38,7 +38,7 @@ internal sealed class ExclusionPolicy
             CreatePathRoots(config.PathExclusions));
     }
 
-    public ExclusionDecision EvaluateSeries(string seriesName, Guid seriesId, string? path)
+    public ExclusionDecision EvaluateSeries(string? seriesName, Guid seriesId, string? path)
     {
         _ = seriesId;
 
@@ -48,7 +48,7 @@ internal sealed class ExclusionPolicy
             return pathDecision;
         }
 
-        var name = seriesName.Trim();
+        var name = seriesName?.Trim() ?? string.Empty;
         if (name.Length == 0)
         {
             return ExclusionDecision.Included;
@@ -59,7 +59,7 @@ internal sealed class ExclusionPolicy
             : ExclusionDecision.Included;
     }
 
-    public ExclusionDecision EvaluateMovie(string movieName, Guid movieId, string? path)
+    public ExclusionDecision EvaluateMovie(string? movieName, Guid movieId, string? path)
     {
         _ = movieId;
 
@@ -69,7 +69,7 @@ internal sealed class ExclusionPolicy
             return pathDecision;
         }
 
-        var name = movieName.Trim();
+        var name = movieName?.Trim() ?? string.Empty;
         return name.Length > 0 && _movieNames.Contains(name)
             ? new ExclusionDecision(true, ExclusionReason.MovieName, name)
             : ExclusionDecision.Included;

--- a/IntroSkipper/Helper/SeasonReanalysisPlanner.cs
+++ b/IntroSkipper/Helper/SeasonReanalysisPlanner.cs
@@ -39,8 +39,7 @@ internal static class SeasonReanalysisPlanner
 
         var first = seasonEpisodes[0];
 
-        // Only multi-episode TV seasons are comparative; movies and excluded items gain nothing.
-        if (first.IsExcluded || first.Category is QueuedMediaCategory.Movie)
+        if (first.Category is QueuedMediaCategory.Movie)
         {
             return false;
         }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -61,7 +61,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return _queuedEpisodes;
         }
 
-        plugin.TotalQueued = 0;
+        if (!includeExcluded)
+        {
+            plugin.TotalQueued = 0;
+        }
 
         LoadAnalysisSettings(plugin);
 
@@ -109,11 +112,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             LogRefreshedMetadata(_logger, _refreshedEpisodes.Count);
         }
 
-        plugin.TotalSeasons = _queuedEpisodes.Count;
-        plugin.QueuedMediaItems.Clear();
-        foreach (var kvp in _queuedEpisodes)
+        if (!includeExcluded)
         {
-            plugin.QueuedMediaItems.TryAdd(kvp.Key, kvp.Value);
+            plugin.TotalSeasons = _queuedEpisodes.Count;
+            plugin.QueuedMediaItems.Clear();
+            foreach (var kvp in _queuedEpisodes)
+            {
+                plugin.QueuedMediaItems.TryAdd(kvp.Key, kvp.Value);
+            }
         }
 
         return _queuedEpisodes;
@@ -268,7 +274,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             CreditsFingerprintEnd = creditsDuration,
         });
 
-        pluginInstance.TotalQueued++;
+        if (!includeExcluded)
+        {
+            pluginInstance.TotalQueued++;
+        }
+
         return true;
     }
 
@@ -333,7 +343,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             IsExcluded = decision.IsExcluded,
         });
 
-        pluginInstance.TotalQueued++;
+        if (!includeExcluded)
+        {
+            pluginInstance.TotalQueued++;
+        }
+
         return true;
     }
 

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -4,7 +4,6 @@
 // SPDX-FileCopyrightText: 2024-2026 Kilian von Pflugk
 // SPDX-License-Identifier: GPL-3.0-only
 
-using System.Text.RegularExpressions;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
@@ -43,14 +42,17 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private readonly Dictionary<Guid, List<QueuedEpisode>> _queuedEpisodes = [];
     private readonly HashSet<Guid> _refreshedEpisodes = [];
     private double _analysisPercent;
-    private List<string> _excludeSeries = [];
+    private ExclusionPolicy _exclusionPolicy = ExclusionPolicy.Empty;
 
     /// <summary>
     /// Gets all media items on the server.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
-    public async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
+    public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
+        => GetMediaItems(includeExcluded: false, cancellationToken);
+
+    internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
     {
         var plugin = Plugin.Instance;
         if (plugin is null)
@@ -90,7 +92,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
             try
             {
-                await QueueLibraryContents(folderId, cancellationToken).ConfigureAwait(false);
+                await QueueLibraryContents(folderId, includeExcluded, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -128,7 +130,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         // Store the analysis percent
         _analysisPercent = Convert.ToDouble(config.AnalysisPercent) / 100;
 
-        _excludeSeries = [.. config.ExcludeSeries.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+        _exclusionPolicy = ExclusionPolicy.FromConfiguration(config);
+        if (_exclusionPolicy.BroadPathRootCount > 0)
+        {
+            LogBroadPathRootExclusions(_logger, _exclusionPolicy.BroadPathRootCount);
+        }
 
         // If analysis settings have been changed from the default, log the modified settings.
         if (config.AnalysisLengthLimit != PluginConfiguration.DefaultAnalysisLengthLimit
@@ -139,7 +145,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
     }
 
-    private async Task QueueLibraryContents(Guid id, CancellationToken cancellationToken)
+    private async Task QueueLibraryContents(Guid id, bool includeExcluded, CancellationToken cancellationToken)
     {
         LogConstructingQuery(_logger);
 
@@ -166,24 +172,24 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
 
+        var queuedCount = 0;
         foreach (var item in items)
         {
             try
             {
                 if (item is Episode episode)
                 {
-                    if (!IsSeriesExcluded(episode.SeriesName))
+                    if (await QueueEpisode(episode, includeExcluded, cancellationToken).ConfigureAwait(false))
                     {
-                        await QueueEpisode(episode, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        LogSkippingExcludedSeries(_logger, episode.SeriesName);
+                        queuedCount++;
                     }
                 }
                 else if (item is Movie movie)
                 {
-                    await QueueMovieAsync(movie, cancellationToken).ConfigureAwait(false);
+                    if (await QueueMovieAsync(movie, includeExcluded, cancellationToken).ConfigureAwait(false))
+                    {
+                        queuedCount++;
+                    }
                 }
                 else
                 {
@@ -200,54 +206,24 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
         }
 
-        LogQueuedEpisodes(_logger, items.Count);
+        LogQueuedEpisodes(_logger, queuedCount);
     }
 
-    /// <summary>
-    /// Normalizes a series name by removing punctuation and converting to lowercase
-    /// to make comparisons more robust.
-    /// </summary>
-    /// <param name="name">The series name to normalize.</param>
-    /// <returns>Normalized series name.</returns>
-    private static string NormalizeSeriesName(string name)
-    {
-        if (string.IsNullOrEmpty(name))
-        {
-            return string.Empty;
-        }
-
-        // Remove all punctuation and convert to lowercase
-        return NormalizeSeriesNameRegex().Replace(name, string.Empty)
-            .ToLowerInvariant()
-            .Trim();
-    }
-
-    /// <summary>
-    /// Checks if a series is in the excluded list, using normalized name comparison
-    /// to handle differences in punctuation.
-    /// </summary>
-    /// <param name="seriesName">The series name to check.</param>
-    /// <returns>True if the series should be excluded, false otherwise.</returns>
-    private bool IsSeriesExcluded(string seriesName)
-    {
-        if (string.IsNullOrEmpty(seriesName))
-        {
-            return false;
-        }
-
-        // Then check normalized match
-        var normalizedName = NormalizeSeriesName(seriesName);
-        return _excludeSeries.Contains(normalizedName);
-    }
-
-    private async Task QueueEpisode(Episode episode, CancellationToken cancellationToken)
+    private async Task<bool> QueueEpisode(Episode episode, bool includeExcluded, CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
         if (string.IsNullOrEmpty(episode.Path))
         {
             LogNotQueuingEpisodeNoPath(_logger, episode.Name, episode.SeriesName, episode.Id);
-            return;
+            return false;
+        }
+
+        var decision = _exclusionPolicy.EvaluateSeries(episode.SeriesName, episode.SeriesId, episode.Path);
+        if (decision.IsExcluded && !includeExcluded)
+        {
+            LogSkippingExcludedItem(_logger, episode.Name, decision.RuleLabel);
+            return false;
         }
 
         // Allocate a new list for each new season
@@ -264,7 +240,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             duration >= 5 * 60 ? duration * _analysisPercent : duration,
             60 * pluginInstance.Configuration.AnalysisLengthLimit);
 
-        var creditsDuration = await ResolveCreditsFingerprintEndAsync(episode.Path, duration, cancellationToken).ConfigureAwait(false);
+        var creditsDuration = decision.IsExcluded
+            ? duration
+            : await ResolveCreditsFingerprintEndAsync(episode.Path, duration, cancellationToken).ConfigureAwait(false);
 
         var maxCreditsDuration = Math.Min(
             creditsDuration >= 5 * 60 ? creditsDuration * _analysisPercent : creditsDuration,
@@ -281,7 +259,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             EpisodeId = episode.Id,
             Name = episode.Name,
             Category = ResolveEpisodeCategory(episode, seasonEpisodes, pluginInstance),
-            IsExcluded = IsSeriesExcluded(episode.SeriesName),
+            IsExcluded = decision.IsExcluded,
             Path = episode.Path,
             Duration = duration,
             DateAdded = EpisodeAvailabilityDate(episode),
@@ -291,6 +269,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         });
 
         pluginInstance.TotalQueued++;
+        return true;
     }
 
     private static QueuedMediaCategory ResolveEpisodeCategory(Episode episode, IReadOnlyList<QueuedEpisode> seasonEpisodes, Plugin pluginInstance)
@@ -314,21 +293,30 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return episode.DateCreated != default ? episode.DateCreated : episode.DateLastSaved;
     }
 
-    private async Task QueueMovieAsync(Movie movie, CancellationToken cancellationToken)
+    private async Task<bool> QueueMovieAsync(Movie movie, bool includeExcluded, CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
         if (string.IsNullOrEmpty(movie.Path))
         {
             LogNotQueuingMovieNoPath(_logger, movie.Name, movie.Id);
-            return;
+            return false;
+        }
+
+        var decision = _exclusionPolicy.EvaluateMovie(movie.Name, movie.Id, movie.Path);
+        if (decision.IsExcluded && !includeExcluded)
+        {
+            LogSkippingExcludedItem(_logger, movie.Name, decision.RuleLabel);
+            return false;
         }
 
         // Allocate a new list for each movie.
         _queuedEpisodes.TryAdd(movie.Id, []);
 
         var duration = TimeSpan.FromTicks(movie.RunTimeTicks ?? 0).TotalSeconds;
-        var creditsDuration = await ResolveCreditsFingerprintEndAsync(movie.Path, duration, cancellationToken).ConfigureAwait(false);
+        var creditsDuration = decision.IsExcluded
+            ? duration
+            : await ResolveCreditsFingerprintEndAsync(movie.Path, duration, cancellationToken).ConfigureAwait(false);
 
         _queuedEpisodes[movie.Id].Add(new QueuedEpisode
         {
@@ -342,10 +330,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             CreditsFingerprintStart = Math.Max(0, creditsDuration - pluginInstance.Configuration.MaximumMovieCreditsDuration),
             CreditsFingerprintEnd = creditsDuration,
             Category = QueuedMediaCategory.Movie,
-            IsExcluded = IsSeriesExcluded(movie.Name),
+            IsExcluded = decision.IsExcluded,
         });
 
         pluginInstance.TotalQueued++;
+        return true;
     }
 
     private async Task<double> ResolveCreditsFingerprintEndAsync(string path, double duration, CancellationToken cancellationToken)
@@ -427,6 +416,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         var verified = new List<QueuedEpisode>(candidates.Count);
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+        var policy = ExclusionPolicy.FromConfiguration(plugin.Configuration);
         var snapshot = await Plugin.GetSeasonQueueSnapshotAsync(candidates[0].SeasonId, [.. candidates.Select(c => c.EpisodeId)], cancellationToken).ConfigureAwait(false);
 
         foreach (var candidate in candidates)
@@ -442,6 +432,16 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                     continue;
                 }
 
+                var decision = candidate.Category == QueuedMediaCategory.Movie
+                    ? policy.EvaluateMovie(candidate.Name, candidate.EpisodeId, path)
+                    : policy.EvaluateSeries(candidate.SeriesName, candidate.SeriesId, path);
+                if (decision.IsExcluded)
+                {
+                    LogSkippingExcludedItem(_logger, candidate.Name, decision.RuleLabel);
+                    continue;
+                }
+
+                candidate.Path = path;
                 verified.Add(candidate);
 
                 foreach (var mode in modes)
@@ -488,9 +488,6 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return verified;
     }
 
-    [GeneratedRegex(@"[^\w\s]")]
-    private static partial Regex NormalizeSeriesNameRegex();
-
     [LoggerMessage(Level = LogLevel.Error, Message = "Plugin instance is null in GetMediaItems()")]
     private static partial void LogPluginInstanceNull(ILogger logger);
 
@@ -521,8 +518,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Iterating through library items")]
     private static partial void LogIteratingLibraryItems(ILogger logger);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping excluded series: {Series}")]
-    private static partial void LogSkippingExcludedSeries(ILogger logger, string series);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping excluded item {Name}: matched {RuleLabel}")]
+    private static partial void LogSkippingExcludedItem(ILogger logger, string name, string ruleLabel);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Configured path exclusions include {Count} filesystem root or drive root entries")]
+    private static partial void LogBroadPathRootExclusions(ILogger logger, int count);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Item {Name} is not an episode or movie")]
     private static partial void LogItemNotEpisodeOrMovie(ILogger logger, string name);

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -111,6 +111,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             LogCacheDbInitializationError(_logger, ex);
         }
 
+        MigrateLegacyExcludeSeries();
+
         Configuration.FileTransformationPluginEnabled = _pluginManager
             .Plugins
             .Any(p => p.Id == Guid.Parse("5e87cc92-571a-4d8d-8d98-d2d4147f9f90")); // File Transformation plugin ID
@@ -742,6 +744,26 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             db.DbSegment.RemoveRange(entries);
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private void MigrateLegacyExcludeSeries()
+    {
+        var legacy = Configuration.ExcludeSeries;
+        if (string.IsNullOrWhiteSpace(legacy))
+        {
+            return;
+        }
+
+        if (Configuration.SeriesExclusions.Count == 0)
+        {
+            foreach (var item in legacy.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                Configuration.SeriesExclusions.Add(item);
+            }
+        }
+
+        Configuration.ExcludeSeries = string.Empty;
+        SaveConfiguration();
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -128,13 +128,6 @@ public partial class BaseItemAnalyzerTask(
             }
 
             var first = episodes[0];
-            if (first.IsExcluded)
-            {
-                Interlocked.Add(ref totalProcessed, episodes.Count * modes.Count);
-                progress.Report((double)totalProcessed / totalQueued * 100);
-                LogSkippingExcludedSeason(_logger, first.SeasonNumber, first.SeriesName);
-                return;
-            }
 
             // Run settled-season reanalysis from scratch after no new episodes have been added
             // for the configured delay so segments first derived from a partial season are
@@ -536,9 +529,6 @@ public partial class BaseItemAnalyzerTask(
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Skipping Chromaprint analysis! Chromaprint is not enabled in the current ffmpeg. If Jellyfin is running natively, install jellyfin-ffmpeg7. If Jellyfin is running in a container, upgrade to version 10.10.0 or newer.")]
     private static partial void LogSkippingChromaprint(ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Skipping excluded season {Season} of {Series}")]
-    private static partial void LogSkippingExcludedSeason(ILogger logger, int season, string series);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Re-analyzing settled season {Season} of {Series} ({Count} episodes)")]
     private static partial void LogReanalyzingSettledSeason(ILogger logger, int season, string series, int count);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -86,7 +86,7 @@ public partial class CleanCacheTask(
 
         // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders.
-        var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
+        var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
         var enabledLibraryEpisodes = queue.Values.SelectMany(static episodes => episodes).ToList();
 
         var enabledLibraryEpisodeIds = enabledLibraryEpisodes

--- a/web/src/components/exclusion-list-field.ts
+++ b/web/src/components/exclusion-list-field.ts
@@ -1,0 +1,217 @@
+import { configStore } from "../store/config-store.ts";
+import { el } from "./dom.ts";
+import { appendFieldMeta } from "./field-meta.ts";
+
+export type ExclusionListFieldId =
+    | "SeriesExclusions"
+    | "MovieExclusions"
+    | "PathExclusions";
+
+export type ExclusionListFieldOptions = {
+    id: ExclusionListFieldId;
+    label: string;
+    description?: string;
+    placeholder?: string;
+    suggestions?: () => Promise<string[]>;
+    confirmAdd?: (value: string) => Promise<boolean>;
+};
+
+function normalizeEntries(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    const entries: string[] = [];
+    for (const item of value) {
+        if (typeof item === "string") {
+            const trimmed = item.trim();
+            if (trimmed.length > 0) {
+                entries.push(trimmed);
+            }
+        }
+    }
+
+    return entries;
+}
+
+function hasEntry(entries: string[], value: string): boolean {
+    return entries.some((entry) => entry.toLocaleLowerCase() === value.toLocaleLowerCase());
+}
+
+function readValues(field: ExclusionListFieldId): string[] {
+    return normalizeEntries(configStore.get(field));
+}
+
+function changedField(value: unknown): string | null {
+    if (typeof value !== "object" || value === null) {
+        return null;
+    }
+
+    const field = Reflect.get(value, "field");
+    return typeof field === "string" ? field : null;
+}
+
+function setDescribedBy(input: HTMLInputElement, ids: string[]): void {
+    if (ids.length > 0) {
+        input.setAttribute("aria-describedby", ids.join(" "));
+    }
+}
+
+export function exclusionListField(opts: ExclusionListFieldOptions): HTMLElement {
+    const container = el("div", { className: "input-container exclusion-list-field" });
+    const inputId = "field-" + opts.id;
+    const suggestionsId = inputId + "-suggestions";
+
+    const label = el("label", { className: "input-label", for: inputId }, opts.label);
+    const input = document.createElement("input");
+    input.type = "text";
+    input.id = inputId;
+    input.name = opts.id;
+    input.autocomplete = "off";
+    if (opts.placeholder) {
+        input.placeholder = opts.placeholder;
+    }
+
+    const addButton = el(
+        "button",
+        { className: "exclusion-add-button", type: "button" },
+        "Add",
+    );
+    const inputRow = el("div", { className: "exclusion-input-row" });
+    inputRow.append(input, addButton);
+
+    const errorDiv = el("div", {
+        className: "field-error",
+        id: inputId + "-error",
+        role: "status",
+        "aria-live": "polite",
+        "aria-atomic": "true",
+    });
+
+    const list = el("ul", { className: "exclusion-list-values" });
+    const empty = el("div", { className: "exclusion-list-empty" }, "No entries");
+    const describedByIds = [errorDiv.id];
+
+    container.append(label, inputRow, errorDiv);
+    describedByIds.push(...appendFieldMeta(container, { ...opts, idBase: inputId }));
+    container.append(list, empty);
+    setDescribedBy(input, describedByIds);
+
+    const datalist = opts.suggestions ? el("datalist", { id: suggestionsId }) : null;
+    if (datalist) {
+        input.setAttribute("list", suggestionsId);
+        container.append(datalist);
+    }
+
+    function showError(message: string | null): void {
+        errorDiv.textContent = message ?? "";
+        errorDiv.style.display = message ? "" : "none";
+        input.classList.toggle("field-error-active", Boolean(message));
+        if (message) {
+            input.setAttribute("aria-invalid", "true");
+        } else {
+            input.removeAttribute("aria-invalid");
+        }
+    }
+
+    function render(): void {
+        const values = readValues(opts.id);
+        list.replaceChildren();
+        empty.style.display = values.length === 0 ? "" : "none";
+
+        for (const value of values) {
+            const item = el("li", { className: "exclusion-list-item" });
+            const text = el("span", { className: "exclusion-list-value" }, value);
+            const removeButton = el(
+                "button",
+                {
+                    className: "exclusion-remove-button",
+                    type: "button",
+                    "aria-label": "Remove " + value,
+                },
+                "x",
+            );
+            removeButton.addEventListener("click", () => {
+                configStore.set(
+                    opts.id,
+                    readValues(opts.id).filter((entry) => entry !== value),
+                );
+                showError(null);
+            });
+            item.append(text, removeButton);
+            list.append(item);
+        }
+    }
+
+    async function addCurrentValue(): Promise<void> {
+        const value = input.value.trim();
+        if (value.length === 0) {
+            showError("Enter a value before adding it.");
+            return;
+        }
+
+        const values = readValues(opts.id);
+        if (hasEntry(values, value)) {
+            showError("This entry is already listed.");
+            return;
+        }
+
+        if (opts.confirmAdd && !(await opts.confirmAdd(value))) {
+            return;
+        }
+
+        configStore.set(opts.id, [...values, value]);
+        input.value = "";
+        showError(null);
+        input.focus();
+    }
+
+    addButton.addEventListener("click", () => {
+        addCurrentValue().catch((error: unknown) => {
+            console.error("Failed to add exclusion entry", error);
+            showError("Failed to add entry.");
+        });
+    });
+    input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+            event.preventDefault();
+            addCurrentValue().catch((error: unknown) => {
+                console.error("Failed to add exclusion entry", error);
+                showError("Failed to add entry.");
+            });
+        }
+    });
+
+    configStore.subscribe("loaded", render);
+    configStore.subscribe("changed", (...args: unknown[]) => {
+        if (changedField(args[0]) === opts.id) {
+            render();
+        }
+    });
+
+    if (configStore.isLoaded()) {
+        render();
+    }
+
+    if (opts.suggestions && datalist) {
+        opts
+            .suggestions()
+            .then((values) => {
+                const seen = new Set<string>();
+                for (const value of normalizeEntries(values)) {
+                    const key = value.toLocaleLowerCase();
+                    if (seen.has(key)) {
+                        continue;
+                    }
+
+                    seen.add(key);
+                    datalist.append(el("option", { value }));
+                }
+            })
+            .catch((error: unknown) => {
+                console.error("Failed to load exclusion suggestions", error);
+            });
+    }
+
+    return container;
+}

--- a/web/src/store/api.ts
+++ b/web/src/store/api.ts
@@ -7,6 +7,7 @@ import type {
     PluginInfo,
     LibraryStorage,
     SystemStorageInfo,
+    ClearExcludedTimestampsResponse,
 } from "../types.ts";
 
 const PLUGIN_ID = "c83d86bb-a1e0-4c35-a113-e2101cf4ee6b";
@@ -104,6 +105,58 @@ export function eraseTimestamps(mode: string, eraseCache: boolean): Promise<Resp
 
 export function eraseItemTimestamps(urlPath: string, eraseCache: boolean): Promise<Response> {
     return fetchWithAuth(`${urlPath}?eraseCache=${eraseCache}`, "DELETE");
+}
+
+function hasNumberProperty(target: object, property: keyof ClearExcludedTimestampsResponse): boolean {
+    return typeof Reflect.get(target, property) === "number";
+}
+
+function isClearExcludedTimestampsResponse(
+    value: unknown,
+): value is ClearExcludedTimestampsResponse {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        hasNumberProperty(value, "AffectedItems") &&
+        hasNumberProperty(value, "RemovedSegments") &&
+        hasNumberProperty(value, "RemovedCacheEntries")
+    );
+}
+
+export async function clearExcludedTimestamps(): Promise<
+    ApiResult<ClearExcludedTimestampsResponse>
+> {
+    try {
+        const response = await fetchWithAuth("Intros/ExcludedTimestamps/Clear", "POST");
+        if (!response.ok) {
+            return {
+                ok: false,
+                status: response.status,
+                error: "Server returned " + response.status,
+            };
+        }
+
+        const data: unknown = await response.json();
+        if (!isClearExcludedTimestampsResponse(data)) {
+            return {
+                ok: false,
+                status: response.status,
+                error: "Unexpected clear response shape",
+            };
+        }
+
+        return {
+            ok: true,
+            status: response.status,
+            data,
+        };
+    } catch (err: unknown) {
+        return {
+            ok: false,
+            status: null,
+            error: err instanceof Error ? err.message : "Network error",
+        };
+    }
 }
 
 // Support and storage tools.

--- a/web/src/store/config-store.ts
+++ b/web/src/store/config-store.ts
@@ -14,6 +14,17 @@ const listeners = new Map<StoreEvent, Set<(...args: unknown[]) => void>>();
 let scopedListeners: Array<{ event: StoreEvent; callback: (...args: unknown[]) => void }> = [];
 let trackingScope = false;
 
+function normalizeStringList(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
+}
+
+function normalizePluginConfig(loadedConfig: PluginConfig): PluginConfig {
+    loadedConfig.SeriesExclusions = normalizeStringList(loadedConfig.SeriesExclusions);
+    loadedConfig.MovieExclusions = normalizeStringList(loadedConfig.MovieExclusions);
+    loadedConfig.PathExclusions = normalizeStringList(loadedConfig.PathExclusions);
+    return loadedConfig;
+}
+
 export const configStore = {
     subscribe(event: StoreEvent, callback: (...args: unknown[]) => void): void {
         if (!listeners.has(event)) {
@@ -55,7 +66,7 @@ export const configStore = {
 
     async load(): Promise<void> {
         try {
-            config = await loadPluginConfig();
+            config = normalizePluginConfig(await loadPluginConfig());
             snapshot = JSON.parse(JSON.stringify(config)) as PluginConfig;
             this.emit("loaded");
         } catch (err) {
@@ -126,9 +137,6 @@ export const configStore = {
 
     isDirty(): boolean {
         if (!config || !snapshot) return false;
-        for (const key of Object.keys(config) as Array<keyof PluginConfig>) {
-            if (config[key] !== snapshot[key]) return true;
-        }
-        return false;
+        return JSON.stringify(config) !== JSON.stringify(snapshot);
     },
 };

--- a/web/src/styles/forms.css
+++ b/web/src/styles/forms.css
@@ -155,6 +155,84 @@ select:focus:not(:focus-visible) {
     outline: none;
 }
 
+.exclusion-input-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+}
+
+.exclusion-input-row input[type="text"] {
+    flex: 1;
+    min-width: 0;
+}
+
+.exclusion-add-button,
+.exclusion-remove-button {
+    border-radius: 4px;
+    border: 1px solid var(--is-input-border);
+    background: var(--is-input-bg);
+    color: var(--is-text);
+    cursor: pointer;
+    font: inherit;
+}
+
+.exclusion-add-button {
+    padding: 8px 14px;
+}
+
+.exclusion-add-button:hover,
+.exclusion-remove-button:hover {
+    background: var(--is-hover-strong);
+}
+
+.exclusion-add-button:focus-visible,
+.exclusion-remove-button:focus-visible {
+    outline: 2px solid var(--is-accent);
+    outline-offset: 2px;
+}
+
+.exclusion-list-values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+}
+
+.exclusion-list-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    min-width: 0;
+    padding: 4px 6px 4px 8px;
+    border: 1px solid var(--is-border);
+    border-radius: 4px;
+    background: var(--is-hover);
+}
+
+.exclusion-list-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.exclusion-remove-button {
+    flex: 0 0 auto;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    line-height: 1;
+}
+
+.exclusion-list-empty {
+    margin-top: 8px;
+    color: var(--is-text-muted);
+    font-size: 0.85em;
+}
+
 fieldset {
     border: 1px solid var(--is-border);
     border-radius: 4px;

--- a/web/src/tabs/general.ts
+++ b/web/src/tabs/general.ts
@@ -1,16 +1,75 @@
 import type { Tab } from "../types.ts";
 import { MAXIMUM_SETTLED_SEASON_DELAY_HOURS } from "../config-limits.ts";
 import { configStore } from "../store/config-store.ts";
-import { injectSkipButtonCss } from "../store/api.ts";
+import {
+    clearExcludedTimestamps,
+    getStorageUsage,
+    injectSkipButtonCss,
+} from "../store/api.ts";
 import { el, htmlEl } from "../components/dom.ts";
 import { bindVisibility } from "../components/field-bind.ts";
 import { appendTabContent } from "../components/tab-layout.ts";
 import { checkboxField } from "../components/checkbox-field.ts";
-import { textField } from "../components/text-field.ts";
 import { numberField } from "../components/number-field.ts";
 import { inlineCheckboxGroup } from "../components/inline-checkbox-group.ts";
 import { actionButton } from "../components/action-button.ts";
 import { createStatusMessage } from "../components/async-feedback.ts";
+import { exclusionListField } from "../components/exclusion-list-field.ts";
+import { confirmDialog } from "../components/confirm-dialog.ts";
+
+function normalizePathCandidate(value: string): string {
+    let normalized = value.trim().replace(/\\/g, "/");
+    while (normalized.length > 1 && normalized.endsWith("/")) {
+        normalized = normalized.slice(0, -1);
+    }
+
+    return normalized;
+}
+
+function isBroadPathRoot(value: string): boolean {
+    const normalized = normalizePathCandidate(value);
+    if (normalized === "/" || /^[A-Za-z]:$/.test(normalized)) {
+        return true;
+    }
+
+    return normalized.startsWith("//") && normalized.split("/").filter(Boolean).length === 2;
+}
+
+function confirmDashboard(body: string, title: string): Promise<boolean> {
+    return new Promise((resolve) => {
+        window.Dashboard.confirm(body, title, resolve);
+    });
+}
+
+async function confirmPathExclusion(value: string): Promise<boolean> {
+    if (!isBroadPathRoot(value)) {
+        return true;
+    }
+
+    return confirmDashboard(
+        "This path appears to be a filesystem root or drive root. Excluding it can skip a large part of the library.",
+        "Confirm Path Exclusion",
+    );
+}
+
+async function loadStoragePathSuggestions(): Promise<string[]> {
+    const libraries = await getStorageUsage();
+    const paths: string[] = [];
+    for (const library of libraries) {
+        for (const folder of library.Folders) {
+            const path = folder.Path.trim();
+            if (path.length > 0) {
+                paths.push(path);
+            }
+        }
+    }
+
+    return paths;
+}
+
+function countLabel(count: number, singular: string, plural: string): string {
+    return `${String(count)} ${count === 1 ? singular : plural}`;
+}
 
 export const generalTab: Tab = {
     id: "general",
@@ -63,6 +122,44 @@ export const generalTab: Tab = {
         );
         bindVisibility(ftWarning, () => !configStore.get("FileTransformationPluginEnabled"));
 
+        const clearExcludedSection = el("div", { className: "input-container" });
+        clearExcludedSection.append(
+            el("h3", { className: "checkbox-list-label" }, "Clear Excluded Timestamps"),
+            el(
+                "div",
+                { className: "field-description" },
+                "Remove timestamp, cache, and season-state rows for media currently matched by the exclusion lists.",
+            ),
+        );
+
+        const clearStatus = createStatusMessage({ display: "block" });
+        clearExcludedSection.append(
+            actionButton("Clear excluded timestamp data", async () => {
+                const result = await confirmDialog({
+                    title: "Clear Excluded Timestamps",
+                    body: "Remove timestamp data for media currently matched by the exclusion lists. Included media in the same seasons will be kept.",
+                    confirmLabel: "Clear",
+                });
+                if (!result) return;
+
+                clearStatus.show("Clearing excluded timestamp data...", "var(--is-accent)");
+                const response = await clearExcludedTimestamps();
+                if (!response.ok || !response.data) {
+                    clearStatus.show(
+                        response.error ?? "Failed to clear excluded timestamp data.",
+                        "var(--is-error)",
+                    );
+                    return;
+                }
+
+                clearStatus.show(
+                    `Cleared ${countLabel(response.data.RemovedSegments, "timestamp row", "timestamp rows")} and ${countLabel(response.data.RemovedCacheEntries, "cache row", "cache rows")} for ${countLabel(response.data.AffectedItems, "excluded item", "excluded items")}.`,
+                    "var(--is-success)",
+                );
+            }),
+            clearStatus.element,
+        );
+
         appendTabContent(
             container,
             checkboxField({
@@ -93,12 +190,29 @@ export const generalTab: Tab = {
                 description:
                     "Enable this option to update media segments for any uncached media during a library scan.<br/>This includes recently added, modified, or previously skipped (but not ignored) files.<br/><b>Warning:</b> This should be disabled if you're using media segment providers other than Intro Skipper.",
             }),
-            textField({
-                id: "ExcludeSeries",
-                label: "Exclude series",
+            exclusionListField({
+                id: "SeriesExclusions",
+                label: "Excluded series",
+                placeholder: "Series name",
                 description:
-                    "Exclude series from analysis. Enter a comma-separated list of series names to exclude.",
+                    "Series names matched exactly, case-insensitively.",
             }),
+            exclusionListField({
+                id: "MovieExclusions",
+                label: "Excluded movies",
+                placeholder: "Movie name",
+                description: "Movie names matched exactly, case-insensitively.",
+            }),
+            exclusionListField({
+                id: "PathExclusions",
+                label: "Excluded paths",
+                placeholder: "/media/library",
+                description:
+                    "Exact paths or child paths under a listed root. Storage folders are available as suggestions when the server reports them.",
+                suggestions: loadStoragePathSuggestions,
+                confirmAdd: confirmPathExclusion,
+            }),
+            clearExcludedSection,
             inlineCheckboxGroup("Analyze for:", [
                 { id: "ScanIntroduction", label: "Introduction" },
                 { id: "ScanCredits", label: "Credits" },

--- a/web/src/tabs/general.ts
+++ b/web/src/tabs/general.ts
@@ -6,6 +6,7 @@ import {
     getStorageUsage,
     injectSkipButtonCss,
 } from "../store/api.ts";
+import { getLibraries, getShowsInLibrary } from "../store/jellyfin-client.ts";
 import { el, htmlEl } from "../components/dom.ts";
 import { bindVisibility } from "../components/field-bind.ts";
 import { appendTabContent } from "../components/tab-layout.ts";
@@ -50,6 +51,19 @@ async function confirmPathExclusion(value: string): Promise<boolean> {
         "This path appears to be a filesystem root or drive root. Excluding it can skip a large part of the library.",
         "Confirm Path Exclusion",
     );
+}
+
+async function loadMediaNameSuggestions(type: "Series" | "Movie"): Promise<string[]> {
+    const libraries = await getLibraries();
+    const groups = await Promise.all(
+        libraries.map((library) => getShowsInLibrary(library.Id, library.Name)),
+    );
+
+    return groups
+        .flat()
+        .filter((item) => item.Type === type)
+        .map((item) => item.Name)
+        .sort((a, b) => a.localeCompare(b));
 }
 
 async function loadStoragePathSuggestions(): Promise<string[]> {
@@ -195,13 +209,16 @@ export const generalTab: Tab = {
                 label: "Excluded series",
                 placeholder: "Series name",
                 description:
-                    "Series names matched exactly, case-insensitively.",
+                    "Series names matched exactly, case-insensitively. Start typing to pick from your libraries.",
+                suggestions: () => loadMediaNameSuggestions("Series"),
             }),
             exclusionListField({
                 id: "MovieExclusions",
                 label: "Excluded movies",
                 placeholder: "Movie name",
-                description: "Movie names matched exactly, case-insensitively.",
+                description:
+                    "Movie names matched exactly, case-insensitively. Start typing to pick from your libraries.",
+                suggestions: () => loadMediaNameSuggestions("Movie"),
             }),
             exclusionListField({
                 id: "PathExclusions",

--- a/web/src/tabs/general.ts
+++ b/web/src/tabs/general.ts
@@ -149,6 +149,14 @@ export const generalTab: Tab = {
         const clearStatus = createStatusMessage({ display: "block" });
         clearExcludedSection.append(
             actionButton("Clear excluded timestamp data", async () => {
+                if (configStore.isDirty()) {
+                    clearStatus.show(
+                        "Save configuration changes before clearing timestamp data.",
+                        "var(--is-error)",
+                    );
+                    return;
+                }
+
                 const result = await confirmDialog({
                     title: "Clear Excluded Timestamps",
                     body: "Remove timestamp data for media currently matched by the exclusion lists. Included media in the same seasons will be kept.",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -37,6 +37,9 @@ export interface PluginConfig {
     ChapterAnalyzerRecapPattern: string;
     ChapterAnalyzerCommercialPattern: string;
     ExcludeSeries: string;
+    SeriesExclusions: string[];
+    MovieExclusions: string[];
+    PathExclusions: string[];
 
     // Feature toggles persisted in the plugin configuration.
     AutoDetectIntros: boolean;
@@ -116,6 +119,12 @@ export type LibraryStorage = {
 
 export type SystemStorageInfo = {
     Libraries: LibraryStorage[];
+};
+
+export type ClearExcludedTimestampsResponse = {
+    AffectedItems: number;
+    RemovedSegments: number;
+    RemovedCacheEntries: number;
 };
 
 // Raw Jellyfin API response shapes (only the fields we actually read).


### PR DESCRIPTION
Supersede #788

## Summary by Sourcery

Introduce structured exclusion policies for series, movies, and paths, apply them consistently across queueing, analysis, and cleanup, and expose corresponding configuration and management UI and APIs.

New Features:
- Add structured series, movie, and path exclusion lists to plugin configuration and apply them via a centralized exclusion policy, including path-root safety checks.
- Expose a server API and dashboard control to clear timestamp and cache data for media currently matched by the exclusion lists, with optional media segment refresh.
- Provide a dashboard UI for managing exclusion lists with suggestions from library storage paths and client-side validation.

Enhancements:
- Refine queueing, verification, and reanalysis logic to respect the new exclusion policy while still analyzing excluded items' durations without generating fingerprints.
- Migrate legacy comma-separated series exclusions into the new structured lists and ensure backward-compatible XML/JSON serialization and config loading.
- Adjust cache cleaning to consider excluded items and improve configuration change detection in the web UI.

Tests:
- Add unit tests for exclusion policy behavior, configuration serialization/deserialization of exclusion lists, exclusion-aware cache clearing, and updated season reanalysis rules.