### PR TITLE
Add options for localized regex patterns to be selectively enabled

### DIFF
--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -116,6 +116,7 @@ public class TestChapterAnalyzer
     [InlineData("Recap")]
     [InlineData("Previously")]
     [InlineData("前回のあらすじ")]
+    [InlineData("[1] 前回のあらすじ:")]
     public void TestRecapExpression(string chapterName)
     {
         var recapChapter = FindChapter(chapterName, AnalysisMode.Recap);

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -24,6 +24,7 @@ public class TestChapterAnalyzer
     [InlineData("Intro:")]
     [InlineData("Intro Start")]
     [InlineData("Introduction")]
+    [InlineData("オープニング")]
     public void TestIntroductionExpression(string chapterName)
     {
         var introChapter = FindChapter(chapterName, AnalysisMode.Introduction);
@@ -40,6 +41,9 @@ public class TestChapterAnalyzer
     [InlineData("Closing Credits")]
     [InlineData("Credits")]
     [InlineData("Credits:")]
+    [InlineData("エンディング")]
+    [InlineData("Générique")]
+    [InlineData("Abspann")]
     public void TestEndCreditsExpression(string chapterName)
     {
         var creditsChapter = FindChapter(chapterName, AnalysisMode.Credits);
@@ -98,6 +102,7 @@ public class TestChapterAnalyzer
     [Theory]
     [InlineData("Preview")]
     [InlineData("Trailer")]
+    [InlineData("予告")]
     public void TestPreviewExpression(string chapterName)
     {
         var previewChapter = FindChapter(chapterName, AnalysisMode.Preview);
@@ -110,6 +115,7 @@ public class TestChapterAnalyzer
     [Theory]
     [InlineData("Recap")]
     [InlineData("Previously")]
+    [InlineData("前回のあらすじ")]
     public void TestRecapExpression(string chapterName)
     {
         var recapChapter = FindChapter(chapterName, AnalysisMode.Recap);

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -10,7 +10,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Helper;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -232,16 +234,16 @@ public class TestChapterAnalyzer
     }
 
     [Theory]
-    [InlineData("オープニング", AnalysisMode.Introduction)]
-    [InlineData("エンディング", AnalysisMode.Credits)]
-    [InlineData("Générique", AnalysisMode.Credits)]
-    [InlineData("Abspann", AnalysisMode.Credits)]
-    [InlineData("予告", AnalysisMode.Preview)]
-    [InlineData("前回のあらすじ", AnalysisMode.Recap)]
-    [InlineData("[1] 前回のあらすじ:", AnalysisMode.Recap)]
-    public void TestInternationalPatternsWhenEnabled(string chapterName, AnalysisMode mode)
+    [InlineData("オープニング", AnalysisMode.Introduction, "Japanese")]
+    [InlineData("エンディング", AnalysisMode.Credits, "Japanese")]
+    [InlineData("予告", AnalysisMode.Preview, "Japanese")]
+    [InlineData("前回のあらすじ", AnalysisMode.Recap, "Japanese")]
+    [InlineData("[1] 前回のあらすじ:", AnalysisMode.Recap, "Japanese")]
+    [InlineData("Générique", AnalysisMode.Credits, "French")]
+    [InlineData("Abspann", AnalysisMode.Credits, "German")]
+    public void TestLocalizedPatternsWhenLanguageEnabled(string chapterName, AnalysisMode mode, string language)
     {
-        var chapter = FindChapter(chapterName, mode, enableInternationalPatterns: true);
+        var chapter = FindChapter(chapterName, mode, enabledLanguage: language);
 
         Assert.NotNull(chapter);
     }
@@ -253,11 +255,60 @@ public class TestChapterAnalyzer
     [InlineData("Abspann", AnalysisMode.Credits)]
     [InlineData("予告", AnalysisMode.Preview)]
     [InlineData("前回のあらすじ", AnalysisMode.Recap)]
-    public void TestInternationalPatternsNotMatchedWhenDisabled(string chapterName, AnalysisMode mode)
+    public void TestLocalizedPatternsNotMatchedWhenDisabled(string chapterName, AnalysisMode mode)
     {
-        var chapter = FindChapter(chapterName, mode, enableInternationalPatterns: false);
+        var chapter = FindChapter(chapterName, mode);
 
         Assert.Null(chapter);
+    }
+
+    [Theory]
+    [InlineData("エンディング", "French")]
+    [InlineData("エンディング", "German")]
+    [InlineData("Générique", "Japanese")]
+    [InlineData("Générique", "German")]
+    [InlineData("Abspann", "Japanese")]
+    [InlineData("Abspann", "French")]
+    public void TestLocalizedPatternNotMatchedWhenDifferentLanguageEnabled(string chapterName, string enabledLanguage)
+    {
+        var chapter = FindChapter(chapterName, AnalysisMode.Credits, enabledLanguage: enabledLanguage);
+
+        Assert.Null(chapter);
+    }
+
+    [Theory]
+    [InlineData("Japanese", AnalysisMode.Introduction)]
+    [InlineData("Japanese", AnalysisMode.Credits)]
+    [InlineData("Japanese", AnalysisMode.Preview)]
+    [InlineData("Japanese", AnalysisMode.Recap)]
+    [InlineData("French", AnalysisMode.Credits)]
+    [InlineData("German", AnalysisMode.Credits)]
+    public void TestLocalizedPatternSettingChangesRelevantAnalysisHash(string language, AnalysisMode mode)
+    {
+        var disabled = new PluginConfiguration();
+        var enabled = new PluginConfiguration();
+        EnableLanguage(enabled, language);
+
+        var disabledHash = ConfigHasher.Analysis(disabled, mode, AnalyzerAction.Default);
+        var enabledHash = ConfigHasher.Analysis(enabled, mode, AnalyzerAction.Default);
+
+        Assert.NotEqual(disabledHash, enabledHash);
+    }
+
+    [Theory]
+    [InlineData("Japanese", AnalysisMode.Commercial)]
+    [InlineData("French", AnalysisMode.Introduction)]
+    [InlineData("German", AnalysisMode.Preview)]
+    public void TestLocalizedPatternSettingDoesNotChangeUnrelatedAnalysisHash(string language, AnalysisMode mode)
+    {
+        var disabled = new PluginConfiguration();
+        var enabled = new PluginConfiguration();
+        EnableLanguage(enabled, language);
+
+        var disabledHash = ConfigHasher.Analysis(disabled, mode, AnalyzerAction.Default);
+        var enabledHash = ConfigHasher.Analysis(enabled, mode, AnalyzerAction.Default);
+
+        Assert.Equal(disabledHash, enabledHash);
     }
 
     private Segment? FindChapter(
@@ -265,40 +316,18 @@ public class TestChapterAnalyzer
         AnalysisMode mode,
         string? expressionOverride = null,
         bool enableSponsorBlockChapterDetection = true,
-        bool enableInternationalPatterns = false)
+        string? enabledLanguage = null)
     {
         var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, null!);
         var chapters = CreateChapters(chapterName, mode);
 
-        var config = new Configuration.PluginConfiguration();
-        var expression = mode switch
+        var config = new PluginConfiguration();
+        if (enabledLanguage is not null)
         {
-            AnalysisMode.Introduction => config.ChapterAnalyzerIntroductionPattern,
-            AnalysisMode.Credits => config.ChapterAnalyzerEndCreditsPattern,
-            AnalysisMode.Preview => config.ChapterAnalyzerPreviewPattern,
-            AnalysisMode.Recap => config.ChapterAnalyzerRecapPattern,
-            AnalysisMode.Commercial => config.ChapterAnalyzerCommercialPattern,
-            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
-        };
-
-        if (enableInternationalPatterns)
-        {
-            var intlPattern = mode switch
-            {
-                AnalysisMode.Introduction => @"(^|\s)(オープニング)(\s|:|$)",
-                AnalysisMode.Credits => @"(^|\s)(エンディング|Générique|Abspann)(\s|:|$)",
-                AnalysisMode.Preview => @"(^|\s)(予告)(\s|:|$)",
-                AnalysisMode.Recap => @"(^|\s)(前回のあらすじ)(\s|:|$)",
-                _ => string.Empty
-            };
-
-            if (!string.IsNullOrEmpty(intlPattern))
-            {
-                expression = string.IsNullOrWhiteSpace(expression)
-                    ? intlPattern
-                    : expression + "|" + intlPattern;
-            }
+            EnableLanguage(config, enabledLanguage);
         }
+
+        var expression = ChapterAnalyzer.GetChapterPattern(config, mode);
 
         return analyzer.FindMatchingChapter(
             new() { Duration = 2000 },
@@ -306,6 +335,24 @@ public class TestChapterAnalyzer
             expressionOverride ?? expression,
             mode,
             enableSponsorBlockChapterDetection);
+    }
+
+    private static void EnableLanguage(PluginConfiguration config, string language)
+    {
+        switch (language)
+        {
+            case "Japanese":
+                config.EnableJapaneseChapterPatterns = true;
+                break;
+            case "French":
+                config.EnableFrenchChapterPatterns = true;
+                break;
+            case "German":
+                config.EnableGermanChapterPatterns = true;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(language), language, null);
+        }
     }
 
     private Collection<ChapterInfo> CreateChapters(string name, AnalysisMode mode)

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -24,7 +24,6 @@ public class TestChapterAnalyzer
     [InlineData("Intro:")]
     [InlineData("Intro Start")]
     [InlineData("Introduction")]
-    [InlineData("オープニング")]
     public void TestIntroductionExpression(string chapterName)
     {
         var introChapter = FindChapter(chapterName, AnalysisMode.Introduction);
@@ -41,9 +40,6 @@ public class TestChapterAnalyzer
     [InlineData("Closing Credits")]
     [InlineData("Credits")]
     [InlineData("Credits:")]
-    [InlineData("エンディング")]
-    [InlineData("Générique")]
-    [InlineData("Abspann")]
     public void TestEndCreditsExpression(string chapterName)
     {
         var creditsChapter = FindChapter(chapterName, AnalysisMode.Credits);
@@ -102,7 +98,6 @@ public class TestChapterAnalyzer
     [Theory]
     [InlineData("Preview")]
     [InlineData("Trailer")]
-    [InlineData("予告")]
     public void TestPreviewExpression(string chapterName)
     {
         var previewChapter = FindChapter(chapterName, AnalysisMode.Preview);
@@ -115,8 +110,6 @@ public class TestChapterAnalyzer
     [Theory]
     [InlineData("Recap")]
     [InlineData("Previously")]
-    [InlineData("前回のあらすじ")]
-    [InlineData("[1] 前回のあらすじ:")]
     public void TestRecapExpression(string chapterName)
     {
         var recapChapter = FindChapter(chapterName, AnalysisMode.Recap);
@@ -238,11 +231,41 @@ public class TestChapterAnalyzer
         Assert.Equal(90, introChapter.End);
     }
 
+    [Theory]
+    [InlineData("オープニング", AnalysisMode.Introduction)]
+    [InlineData("エンディング", AnalysisMode.Credits)]
+    [InlineData("Générique", AnalysisMode.Credits)]
+    [InlineData("Abspann", AnalysisMode.Credits)]
+    [InlineData("予告", AnalysisMode.Preview)]
+    [InlineData("前回のあらすじ", AnalysisMode.Recap)]
+    [InlineData("[1] 前回のあらすじ:", AnalysisMode.Recap)]
+    public void TestInternationalPatternsWhenEnabled(string chapterName, AnalysisMode mode)
+    {
+        var chapter = FindChapter(chapterName, mode, enableInternationalPatterns: true);
+
+        Assert.NotNull(chapter);
+    }
+
+    [Theory]
+    [InlineData("オープニング", AnalysisMode.Introduction)]
+    [InlineData("エンディング", AnalysisMode.Credits)]
+    [InlineData("Générique", AnalysisMode.Credits)]
+    [InlineData("Abspann", AnalysisMode.Credits)]
+    [InlineData("予告", AnalysisMode.Preview)]
+    [InlineData("前回のあらすじ", AnalysisMode.Recap)]
+    public void TestInternationalPatternsNotMatchedWhenDisabled(string chapterName, AnalysisMode mode)
+    {
+        var chapter = FindChapter(chapterName, mode, enableInternationalPatterns: false);
+
+        Assert.Null(chapter);
+    }
+
     private Segment? FindChapter(
         string chapterName,
         AnalysisMode mode,
         string? expressionOverride = null,
-        bool enableSponsorBlockChapterDetection = true)
+        bool enableSponsorBlockChapterDetection = true,
+        bool enableInternationalPatterns = false)
     {
         var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, null!);
         var chapters = CreateChapters(chapterName, mode);
@@ -257,6 +280,25 @@ public class TestChapterAnalyzer
             AnalysisMode.Commercial => config.ChapterAnalyzerCommercialPattern,
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
+
+        if (enableInternationalPatterns)
+        {
+            var intlPattern = mode switch
+            {
+                AnalysisMode.Introduction => @"(^|\s)(オープニング)(\s|:|$)",
+                AnalysisMode.Credits => @"(^|\s)(エンディング|Générique|Abspann)(\s|:|$)",
+                AnalysisMode.Preview => @"(^|\s)(予告)(\s|:|$)",
+                AnalysisMode.Recap => @"(^|\s)(前回のあらすじ)(\s|:|$)",
+                _ => string.Empty
+            };
+
+            if (!string.IsNullOrEmpty(intlPattern))
+            {
+                expression = string.IsNullOrWhiteSpace(expression)
+                    ? intlPattern
+                    : expression + "|" + intlPattern;
+            }
+        }
 
         return analyzer.FindMatchingChapter(
             new() { Duration = 2000 },

--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -29,6 +29,9 @@ public class TestPluginConfiguration
         Assert.Empty(config.SeriesExclusions);
         Assert.Empty(config.MovieExclusions);
         Assert.Empty(config.PathExclusions);
+        Assert.False(config.EnableJapaneseChapterPatterns);
+        Assert.False(config.EnableFrenchChapterPatterns);
+        Assert.False(config.EnableGermanChapterPatterns);
     }
 
     [Fact]

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -87,6 +87,25 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
             _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Unexpected analysis mode: {mode}")
         };
 
+        if (_config.EnableInternationalChapterPatterns)
+        {
+            var intlPattern = mode switch
+            {
+                AnalysisMode.Introduction => @"(^|\s)(オープニング)(\s|:|$)",
+                AnalysisMode.Credits => @"(^|\s)(エンディング|Générique|Abspann)(\s|:|$)",
+                AnalysisMode.Preview => @"(^|\s)(予告)(\s|:|$)",
+                AnalysisMode.Recap => @"(^|\s)(前回のあらすじ)(\s|:|$)",
+                _ => string.Empty
+            };
+
+            if (!string.IsNullOrEmpty(intlPattern))
+            {
+                expression = string.IsNullOrWhiteSpace(expression)
+                    ? intlPattern
+                    : expression + "|" + intlPattern;
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(expression) && !_config.EnableSponsorBlockChapterDetection && !enableRecapBlackFrameFallback)
         {
             return analysisQueue;

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -77,34 +77,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
         CancellationToken cancellationToken)
     {
         var enableRecapBlackFrameFallback = mode == AnalysisMode.Recap && _config.DetectRecapUsingBlackFrames;
-        var expression = mode switch
-        {
-            AnalysisMode.Introduction => _config.ChapterAnalyzerIntroductionPattern,
-            AnalysisMode.Credits => _config.ChapterAnalyzerEndCreditsPattern,
-            AnalysisMode.Recap => _config.ChapterAnalyzerRecapPattern,
-            AnalysisMode.Preview => _config.ChapterAnalyzerPreviewPattern,
-            AnalysisMode.Commercial => _config.ChapterAnalyzerCommercialPattern,
-            _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Unexpected analysis mode: {mode}")
-        };
-
-        if (_config.EnableInternationalChapterPatterns)
-        {
-            var intlPattern = mode switch
-            {
-                AnalysisMode.Introduction => @"(^|\s)(オープニング)(\s|:|$)",
-                AnalysisMode.Credits => @"(^|\s)(エンディング|Générique|Abspann)(\s|:|$)",
-                AnalysisMode.Preview => @"(^|\s)(予告)(\s|:|$)",
-                AnalysisMode.Recap => @"(^|\s)(前回のあらすじ)(\s|:|$)",
-                _ => string.Empty
-            };
-
-            if (!string.IsNullOrEmpty(intlPattern))
-            {
-                expression = string.IsNullOrWhiteSpace(expression)
-                    ? intlPattern
-                    : expression + "|" + intlPattern;
-            }
-        }
+        var expression = GetChapterPattern(_config, mode);
 
         if (string.IsNullOrWhiteSpace(expression) && !_config.EnableSponsorBlockChapterDetection && !enableRecapBlackFrameFallback)
         {
@@ -146,6 +119,63 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
         }
 
         return analysisQueue;
+    }
+
+    /// <summary>
+    /// Gets the configured chapter pattern with each enabled language pattern appended.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <returns>The effective regular expression.</returns>
+    internal static string GetChapterPattern(PluginConfiguration config, AnalysisMode mode)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var expression = mode switch
+        {
+            AnalysisMode.Introduction => config.ChapterAnalyzerIntroductionPattern,
+            AnalysisMode.Credits => config.ChapterAnalyzerEndCreditsPattern,
+            AnalysisMode.Recap => config.ChapterAnalyzerRecapPattern,
+            AnalysisMode.Preview => config.ChapterAnalyzerPreviewPattern,
+            AnalysisMode.Commercial => config.ChapterAnalyzerCommercialPattern,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), $"Unexpected analysis mode: {mode}")
+        };
+
+        if (config.EnableJapaneseChapterPatterns)
+        {
+            expression = AppendPattern(expression, mode switch
+            {
+                AnalysisMode.Introduction => @"(^|\s)(オープニング)(\s|:|$)",
+                AnalysisMode.Credits => @"(^|\s)(エンディング)(\s|:|$)",
+                AnalysisMode.Preview => @"(^|\s)(予告)(\s|:|$)",
+                AnalysisMode.Recap => @"(^|\s)(前回のあらすじ)(\s|:|$)",
+                _ => string.Empty
+            });
+        }
+
+        if (config.EnableFrenchChapterPatterns && mode == AnalysisMode.Credits)
+        {
+            expression = AppendPattern(expression, @"(^|\s)(Générique)(\s|:|$)");
+        }
+
+        if (config.EnableGermanChapterPatterns && mode == AnalysisMode.Credits)
+        {
+            expression = AppendPattern(expression, @"(^|\s)(Abspann)(\s|:|$)");
+        }
+
+        return expression;
+    }
+
+    private static string AppendPattern(string expression, string additionalPattern)
+    {
+        if (string.IsNullOrEmpty(additionalPattern))
+        {
+            return expression;
+        }
+
+        return string.IsNullOrWhiteSpace(expression)
+            ? additionalPattern
+            : expression + "|" + additionalPattern;
     }
 
     /// <summary>

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -349,31 +349,37 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the regular expression used to detect introduction chapters.
     /// </summary>
     public string ChapterAnalyzerIntroductionPattern { get; set; } =
-        @"(^|\s)(Intro|Introduction|OP|Opening|オープニング)(?![\s:]+End)(\s|:|$)";
+        @"(^|\s)(Intro|Introduction|OP|Opening)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect ending credit chapters.
     /// </summary>
     public string ChapterAnalyzerEndCreditsPattern { get; set; } =
-        @"(^|\s)(Credits?|ED|Ending|Outro|エンディング|Générique|Abspann)(?![\s:]+End)(\s|:|$)";
+        @"(^|\s)(Credits?|ED|Ending|Outro)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect Preview chapters.
     /// </summary>
     public string ChapterAnalyzerPreviewPattern { get; set; } =
-        @"(^|\s)(Preview|PV|Sneak\s?Peek|Coming\s?(Up|Soon)|Next\s+(time|on|episode)|Extra|Teaser|Trailer|予告)(?![\s:]+End)(\s|:|$)";
+        @"(^|\s)(Preview|PV|Sneak\s?Peek|Coming\s?(Up|Soon)|Next\s+(time|on|episode)|Extra|Teaser|Trailer)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect Recap chapters.
     /// </summary>
     public string ChapterAnalyzerRecapPattern { get; set; } =
-        @"(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?![\s:]+End)(\s|:|$)|(^|\s)前回のあらすじ(\s|:|$)";
+        @"(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect Commercial chapters.
     /// </summary>
     public string ChapterAnalyzerCommercialPattern { get; set; } =
         @"(^|\s)(Ad(vert(isement)?)?|Commercial|Intermission)(?![\s:]+End)(\s|:|$)";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include international chapter title terms
+    /// (Japanese, French, German) in the chapter analyzer patterns in addition to the default English terms.
+    /// </summary>
+    public bool EnableInternationalChapterPatterns { get; set; } = false;
 
     // ===== Playback settings =====
 

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -367,7 +367,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the regular expression used to detect Recap chapters.
     /// </summary>
     public string ChapterAnalyzerRecapPattern { get; set; } =
-        @"(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?![\s:]+End)(\s|:|$)|^前回のあらすじ$";
+        @"(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?![\s:]+End)(\s|:|$)|(^|\s)前回のあらすじ(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect Commercial chapters.

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -349,25 +349,25 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the regular expression used to detect introduction chapters.
     /// </summary>
     public string ChapterAnalyzerIntroductionPattern { get; set; } =
-        @"(^|\s)(Intro|Introduction|OP|Opening)(?![\s:]+End)(\s|:|$)";
+        @"(^|\s)(Intro|Introduction|OP|Opening|オープニング)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect ending credit chapters.
     /// </summary>
     public string ChapterAnalyzerEndCreditsPattern { get; set; } =
-        @"(^|\s)(Credits?|ED|Ending|Outro)(?![\s:]+End)(\s|:|$)";
+        @"(^|\s)(Credits?|ED|Ending|Outro|エンディング|Générique|Abspann)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect Preview chapters.
     /// </summary>
     public string ChapterAnalyzerPreviewPattern { get; set; } =
-        @"(^|\s)(Preview|PV|Sneak\s?Peek|Coming\s?(Up|Soon)|Next\s+(time|on|episode)|Extra|Teaser|Trailer)(?![\s:]+End)(\s|:|$)";
+        @"(^|\s)(Preview|PV|Sneak\s?Peek|Coming\s?(Up|Soon)|Next\s+(time|on|episode)|Extra|Teaser|Trailer|予告)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect Recap chapters.
     /// </summary>
     public string ChapterAnalyzerRecapPattern { get; set; } =
-        @"(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?![\s:]+End)(\s|:|$)";
+        @"(^|\s)(Re?cap|Sum{1,2}ary|Prev(ious(ly)?)?|(Last|Earlier)(\s\w+)?|Catch[ -]up)(?![\s:]+End)(\s|:|$)|^前回のあらすじ$";
 
     /// <summary>
     /// Gets or sets the regular expression used to detect Commercial chapters.

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -376,10 +376,19 @@ public class PluginConfiguration : BasePluginConfiguration
         @"(^|\s)(Ad(vert(isement)?)?|Commercial|Intermission)(?![\s:]+End)(\s|:|$)";
 
     /// <summary>
-    /// Gets or sets a value indicating whether to include international chapter title terms
-    /// (Japanese, French, German) in the chapter analyzer patterns in addition to the default English terms.
+    /// Gets or sets a value indicating whether to include Japanese chapter title terms.
     /// </summary>
-    public bool EnableInternationalChapterPatterns { get; set; } = false;
+    public bool EnableJapaneseChapterPatterns { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include French chapter title terms.
+    /// </summary>
+    public bool EnableFrenchChapterPatterns { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include German chapter title terms.
+    /// </summary>
+    public bool EnableGermanChapterPatterns { get; set; }
 
     // ===== Playback settings =====
 

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -27,13 +27,13 @@ public static class ConfigHasher
         var input = mode switch
         {
             AnalysisMode.Introduction => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerIntroductionPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerIntroductionPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|min={config.MinimumIntroDuration}|max={config.MaximumIntroDuration}",
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}",
@@ -42,14 +42,14 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Recap => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
+                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
                 $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Preview => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"analysis|v1|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Commercial => Invariant(

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -27,13 +27,13 @@ public static class ConfigHasher
         var input = mode switch
         {
             AnalysisMode.Introduction => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerIntroductionPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}",
+                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerIntroductionPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|jpchap={config.EnableJapaneseChapterPatterns}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|min={config.MinimumIntroDuration}|max={config.MaximumIntroDuration}",
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}",
+                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|jpchap={config.EnableJapaneseChapterPatterns}|frchap={config.EnableFrenchChapterPatterns}|dechap={config.EnableGermanChapterPatterns}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}",
@@ -42,14 +42,14 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Recap => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
+                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|jpchap={config.EnableJapaneseChapterPatterns}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
                 $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Preview => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|intl={config.EnableInternationalChapterPatterns}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"analysis|v1|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|jpchap={config.EnableJapaneseChapterPatterns}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Commercial => Invariant(

--- a/web/src/tabs/chapters.ts
+++ b/web/src/tabs/chapters.ts
@@ -4,6 +4,7 @@ import { el } from "../components/dom.ts";
 import { appendTabContent } from "../components/tab-layout.ts";
 import { textField } from "../components/text-field.ts";
 import { checkboxField } from "../components/checkbox-field.ts";
+import { fieldGroup } from "../components/field-group.ts";
 
 const DEFAULTS: Record<string, string> = {
     ChapterAnalyzerIntroductionPattern: "(^|\\s)(Intro|Introduction|OP|Opening)(?![\\s:]+End)(\\s|:|$)",
@@ -57,6 +58,27 @@ export const chaptersTab: Tab = {
             patternField("ChapterAnalyzerPreviewPattern", "Preview", "preview"),
             patternField("ChapterAnalyzerRecapPattern", "Recaps", "recap"),
             patternField("ChapterAnalyzerCommercialPattern", "Commercials", "commercial"),
+            fieldGroup(
+                "Additional chapter languages",
+                checkboxField({
+                    id: "EnableJapaneseChapterPatterns",
+                    label: "Japanese (日本語)",
+                    description:
+                        "Append built-in Japanese chapter-title patterns to the expressions above.",
+                }),
+                checkboxField({
+                    id: "EnableFrenchChapterPatterns",
+                    label: "French (français)",
+                    description:
+                        "Append built-in French chapter-title patterns to the expressions above.",
+                }),
+                checkboxField({
+                    id: "EnableGermanChapterPatterns",
+                    label: "German (Deutsch)",
+                    description:
+                        "Append built-in German chapter-title patterns to the expressions above.",
+                }),
+            ),
             checkboxField({
                 id: "EnableSponsorBlockChapterDetection",
                 label: "Enable SponsorBlock chapter detection",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -53,6 +53,9 @@ export interface PluginConfig {
     UseChapterMarkersBlackFrame: boolean;
     FullLengthChapters: boolean;
     EnableSponsorBlockChapterDetection: boolean;
+    EnableJapaneseChapterPatterns: boolean;
+    EnableFrenchChapterPatterns: boolean;
+    EnableGermanChapterPatterns: boolean;
     SkipFirstEpisode: boolean;
     SkipFirstEpisodeAnime: boolean;
     AnimePreviewFromCreditsEnd: boolean;


### PR DESCRIPTION
Continuation of the discarded PR https://github.com/intro-skipper/intro-skipper/pull/789

## Summary by Sourcery

Add an option to enable international chapter title regex patterns and apply it in chapter analysis.

New Features:
- Introduce a configuration flag to include international (Japanese, French, German) chapter title patterns alongside existing English patterns in the chapter analyzer.

Enhancements:
- Update chapter analysis logic and config hashing to respect the international chapter pattern flag and combine localized patterns with existing expressions when enabled.

Tests:
- Add unit tests verifying that international chapter patterns are only matched when the new configuration option is enabled.