### PR TITLE
[Recap RFC A] Subtitle phrase detection

### DIFF
--- a/IntroSkipper.Tests/TestSubtitleRecapDetection.cs
+++ b/IntroSkipper.Tests/TestSubtitleRecapDetection.cs
@@ -1,0 +1,453 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System.Collections.Generic;
+using System.Linq;
+using IntroSkipper.Subtitles;
+using Xunit;
+
+/// <summary>
+/// Unit tests for the subtitle-driven recap detection prototype. These exercise the full pure
+/// pipeline (parse -> match -> build) with no media files, plus the codec classifier and the
+/// ffprobe JSON parser used to scope which streams are eligible.
+/// </summary>
+public class TestSubtitleRecapDetection
+{
+    // ───────────────────────── Parser: SubRip ─────────────────────────
+
+    [Fact]
+    public void ParseSubRip_ParsesCuesWithCommaMilliseconds()
+    {
+        const string srt = """
+            1
+            00:00:02,000 --> 00:00:05,000
+            Previously on Test Show...
+
+            2
+            00:00:05,500 --> 00:00:09,000
+            ...the hero lost everything.
+            """;
+
+        var cues = SubtitleParser.ParseSubRip(srt);
+
+        Assert.Equal(2, cues.Count);
+        Assert.Equal(2.0, cues[0].Start);
+        Assert.Equal(5.0, cues[0].End);
+        Assert.Equal("Previously on Test Show...", cues[0].Text);
+        Assert.Equal(5.5, cues[1].Start);
+    }
+
+    [Fact]
+    public void ParseSubRip_JoinsMultiLineCuesAndStripsMarkup_ViaMatcher()
+    {
+        const string srt = """
+            1
+            00:00:01,000 --> 00:00:04,000
+            <i>Previously</i>
+            on the show
+
+            """;
+
+        var cues = SubtitleParser.ParseSubRip(srt);
+
+        Assert.Single(cues);
+        Assert.Equal("<i>Previously</i> on the show", cues[0].Text);
+        // Markup is stripped during normalization, not parsing.
+        Assert.Equal("previously on the show", RecapPhraseMatcher.Normalize(cues[0].Text));
+    }
+
+    [Fact]
+    public void ParseSubRip_ToleratesBomCrlfAndMissingIndex()
+    {
+        const string srt = "\uFEFF00:00:02,000 --> 00:00:05,000\r\nPreviously on\r\n\r\n";
+
+        var cues = SubtitleParser.ParseSubRip(srt);
+
+        Assert.Single(cues);
+        Assert.Equal(2.0, cues[0].Start);
+        Assert.Equal("Previously on", cues[0].Text);
+    }
+
+    // ───────────────────────── Parser: WebVTT ─────────────────────────
+
+    [Fact]
+    public void ParseWebVtt_HandlesDotMillisecondsCueSettingsAndShortTimestamps()
+    {
+        const string vtt = """
+            WEBVTT
+
+            NOTE this is a comment
+
+            intro-1
+            00:02.000 --> 00:05.000 align:start position:50%
+            Previously on Test Show
+
+            00:00:30.000 --> 00:00:33.000
+            Welcome back.
+            """;
+
+        var cues = SubtitleParser.Parse(vtt);
+
+        Assert.Equal(SubtitleFormat.WebVtt, SubtitleParser.DetectFormat(vtt));
+        Assert.Equal(2, cues.Count);
+        Assert.Equal(2.0, cues[0].Start);
+        Assert.Equal(5.0, cues[0].End);
+        Assert.Equal("Previously on Test Show", cues[0].Text);
+        Assert.Equal(30.0, cues[1].Start);
+    }
+
+    // ───────────────────────── Parser: ASS ─────────────────────────
+
+    [Fact]
+    public void ParseAss_ParsesDialogueLinesAndTextCommas()
+    {
+        const string ass = """
+            [Script Info]
+            ScriptType: v4.00+
+
+            [Events]
+            Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+            Dialogue: 0,0:00:02.00,0:00:05.00,Default,,0,0,0,,{\an8}Previously on, the show
+            Dialogue: 0,0:00:06.00,0:00:09.00,Default,,0,0,0,,Second line\Nwith a break
+            """;
+
+        var cues = SubtitleParser.Parse(ass);
+
+        Assert.Equal(SubtitleFormat.Ass, SubtitleParser.DetectFormat(ass));
+        Assert.Equal(2, cues.Count);
+        Assert.Equal(2.0, cues[0].Start);
+        Assert.Equal(5.0, cues[0].End);
+        // Text field keeps its internal comma; the ASS override block survives until normalization.
+        Assert.Equal("{\\an8}Previously on, the show", cues[0].Text);
+        Assert.Equal("Second line with a break", cues[1].Text);
+    }
+
+    [Theory]
+    [InlineData("00:00:02,000", 2.0)]
+    [InlineData("00:00:02.500", 2.5)]
+    [InlineData("01:02:03,250", 3723.25)]
+    [InlineData("00:05.250", 5.25)]
+    [InlineData("00:00:00,5", 0.5)]
+    public void TryParseTimestamp_ParsesSupportedForms(string token, double expected)
+    {
+        Assert.True(SubtitleParser.TryParseTimestamp(token, out var seconds));
+        Assert.Equal(expected, seconds, precision: 3);
+    }
+
+    [Theory]
+    [InlineData("not a time")]
+    [InlineData("12345")]
+    public void TryParseTimestamp_RejectsGarbage(string token)
+    {
+        Assert.False(SubtitleParser.TryParseTimestamp(token, out _));
+    }
+
+    // ───────────────────────── Phrase matcher ─────────────────────────
+
+    [Theory]
+    [InlineData("Previously on Breaking Bad")]
+    [InlineData("PREVIOUSLY ON THE WIRE")]
+    [InlineData("Previously, on Lost")]
+    [InlineData("Last time on The Expanse")]
+    [InlineData("Last week on...")]
+    [InlineData("[NARRATOR] Previously on the show")] // short leading speaker label tolerated
+    [InlineData("- Previously on the show")]
+    public void Matcher_MatchesEnglishOpenings(string text)
+    {
+        Assert.True(RecapPhraseMatcher.Default.IsRecapOpening(text));
+    }
+
+    [Theory]
+    [InlineData("Précédemment dans...")]      // French, with diacritics
+    [InlineData("Anteriormente en...")]       // Spanish
+    [InlineData("Was bisher geschah")]        // German
+    [InlineData("Negli episodi precedenti")]  // Italian
+    [InlineData("前回のあらすじ")]              // Japanese (前回 …)
+    public void Matcher_MatchesMultilingualOpenings(string text)
+    {
+        Assert.True(RecapPhraseMatcher.Default.IsRecapOpening(text));
+    }
+
+    [Theory]
+    [InlineData("I told you previously on Tuesday that we should leave")] // mid-line, beyond anchor
+    [InlineData("Welcome back. Let's begin.")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Matcher_RejectsNonOpenings(string text)
+    {
+        Assert.False(RecapPhraseMatcher.Default.IsRecapOpening(text));
+    }
+
+    [Fact]
+    public void Matcher_IsConfigurable()
+    {
+        var matcher = new RecapPhraseMatcher(["catch up on the story"]);
+
+        Assert.True(matcher.IsRecapOpening("Catch up on the story so far"));
+        Assert.False(matcher.IsRecapOpening("Previously on the show"));
+        Assert.Equal(1, matcher.PhraseCount);
+    }
+
+    [Fact]
+    public void Normalize_StripsDiacriticsMarkupAndPunctuation()
+    {
+        Assert.Equal("previously on the show", RecapPhraseMatcher.Normalize("<i>Previously</i>, on the show!"));
+        Assert.Equal("precedemment dans", RecapPhraseMatcher.Normalize("Précédemment, dans"));
+    }
+
+    // ───────────────────────── Segment builder ─────────────────────────
+
+    private static readonly SubtitleRecapOptions DefaultOptions = new();
+
+    [Fact]
+    public void Build_AnchorsAtPhraseStart_NotForcedToZero()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(2.0, 5.0, "Previously on Test Show"),
+            new(5.5, 9.0, "...the hero lost everything."),
+            new(30.0, 33.0, "Welcome back."),
+        };
+
+        var result = SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, DefaultOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(2.0, result!.Start); // start is the matched cue, NOT 0
+        Assert.Equal(9.0, result.End);    // cluster ends before the 30s gap
+        Assert.Equal(2, result.CueCount);
+        Assert.False(result.SnappedToBlackFrame);
+    }
+
+    [Fact]
+    public void Build_SnapsEndToNearbyBlackFrame()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(2.0, 5.0, "Previously on Test Show"),
+            new(5.5, 9.0, "...the hero lost everything."),
+            new(30.0, 33.0, "Welcome back."),
+        };
+
+        // Fade-to-black occurs at 10.0s, 1.0s after the last recap cue.
+        var blackFrames = new List<double> { 10.0, 10.2, 10.4 };
+
+        var result = SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, DefaultOptions, blackFrames);
+
+        Assert.NotNull(result);
+        Assert.Equal(2.0, result!.Start);
+        Assert.Equal(10.0, result.End);
+        Assert.True(result.SnappedToBlackFrame);
+    }
+
+    [Fact]
+    public void Build_IgnoresDistantBlackFrames()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(2.0, 5.0, "Previously on Test Show"),
+            new(5.5, 9.0, "...the hero lost everything."),
+        };
+
+        // Black frame is 20s away — well beyond BlackFrameSnapSeconds (6s default).
+        var result = SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, DefaultOptions, [29.0]);
+
+        Assert.NotNull(result);
+        Assert.Equal(9.0, result!.End);
+        Assert.False(result.SnappedToBlackFrame);
+    }
+
+    [Fact]
+    public void Build_StopsClusterAtLargeGap()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(2.0, 5.0, "Previously on Test Show"),
+            new(6.0, 9.0, "Recap line two"),
+            new(10.0, 13.0, "Recap line three"),
+            // 20s gap -> cold open begins; must not be absorbed.
+            new(33.0, 36.0, "Cold open dialogue"),
+            new(37.0, 40.0, "More dialogue"),
+        };
+
+        var result = SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, DefaultOptions);
+
+        Assert.NotNull(result);
+        Assert.Equal(2.0, result!.Start);
+        Assert.Equal(13.0, result.End);
+        Assert.Equal(3, result.CueCount);
+    }
+
+    [Fact]
+    public void Build_ReturnsNull_WhenNoRecapPhrase()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(2.0, 5.0, "Hello there."),
+            new(6.0, 9.0, "General Kenobi."),
+        };
+
+        Assert.Null(SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, DefaultOptions));
+    }
+
+    [Fact]
+    public void Build_ReturnsNull_WhenPhraseIsBeyondMaxWindow()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(900.0, 903.0, "Previously on Test Show"), // 15 min in -> not a recap
+        };
+
+        var result = SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, DefaultOptions);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Build_ReturnsNull_WhenTooShort()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(2.0, 4.0, "Previously on Test Show"), // 2s < MinDurationSeconds (5s)
+            new(30.0, 33.0, "Welcome back."),
+        };
+
+        Assert.Null(SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, DefaultOptions));
+    }
+
+    [Fact]
+    public void Build_ClampsToMaxDuration()
+    {
+        var cues = new List<SubtitleCue>();
+        // A continuous wall of cues 5s apart for 5 minutes, all anchored by the opener.
+        cues.Add(new SubtitleCue(2.0, 5.0, "Previously on Test Show"));
+        for (var t = 6.0; t < 320.0; t += 5.0)
+        {
+            cues.Add(new SubtitleCue(t, t + 3.0, "recap continues"));
+        }
+
+        var options = new SubtitleRecapOptions { MaxWindowSeconds = 600, MaxDurationSeconds = 90 };
+        var result = SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, options);
+
+        Assert.NotNull(result);
+        Assert.Equal(2.0, result!.Start);
+        Assert.Equal(92.0, result.End); // start + MaxDurationSeconds
+    }
+
+    [Fact]
+    public void Build_SnapStartToZero_IsOptInAndBounded()
+    {
+        var cues = new List<SubtitleCue>
+        {
+            new(1.5, 5.0, "Previously on Test Show"),
+            new(5.5, 9.0, "...the hero lost everything."),
+        };
+
+        var off = SubtitleRecapSegmentBuilder.Build(cues, RecapPhraseMatcher.Default, new SubtitleRecapOptions());
+        Assert.Equal(1.5, off!.Start);
+
+        var on = SubtitleRecapSegmentBuilder.Build(
+            cues,
+            RecapPhraseMatcher.Default,
+            new SubtitleRecapOptions { SnapStartToZero = true, StartSnapSeconds = 2.0 });
+        Assert.Equal(0.0, on!.Start);
+    }
+
+    [Fact]
+    public void Build_ReturnsNull_ForEmptyInput()
+    {
+        Assert.Null(SubtitleRecapSegmentBuilder.Build([], RecapPhraseMatcher.Default, DefaultOptions));
+    }
+
+    // ───────────────────────── Codec classification ─────────────────────────
+
+    [Theory]
+    [InlineData("subrip")]
+    [InlineData("srt")]
+    [InlineData("mov_text")]
+    [InlineData("webvtt")]
+    [InlineData("ass")]
+    [InlineData("ssa")]
+    [InlineData("SUBRIP")] // case-insensitive
+    public void Codec_RecognizesTextCodecs(string codec)
+    {
+        Assert.True(SubtitleCodec.IsTextBased(codec));
+        Assert.False(SubtitleCodec.IsImageBased(codec));
+    }
+
+    [Theory]
+    [InlineData("hdmv_pgs_subtitle")]
+    [InlineData("dvd_subtitle")]
+    [InlineData("dvb_subtitle")]
+    [InlineData("xsub")]
+    public void Codec_RecognizesImageCodecs(string codec)
+    {
+        Assert.False(SubtitleCodec.IsTextBased(codec));
+        Assert.True(SubtitleCodec.IsImageBased(codec));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("some_future_codec")]
+    public void Codec_TreatsUnknownAsNonText(string? codec)
+    {
+        Assert.False(SubtitleCodec.IsTextBased(codec));
+    }
+
+    // ───────────────────────── ffprobe JSON parsing ─────────────────────────
+
+    [Fact]
+    public void Probe_ParsesMixedTextAndImageStreams()
+    {
+        // Shape mirrors: ffprobe -select_streams s -show_entries
+        //   stream=index,codec_name,codec_type,disposition:stream_tags=language -of json
+        const string json = """
+            {
+              "streams": [
+                {
+                  "index": 2,
+                  "codec_name": "subrip",
+                  "codec_type": "subtitle",
+                  "disposition": { "forced": 0 },
+                  "tags": { "language": "eng" }
+                },
+                {
+                  "index": 3,
+                  "codec_name": "hdmv_pgs_subtitle",
+                  "codec_type": "subtitle",
+                  "disposition": { "forced": 1 },
+                  "tags": { "language": "jpn" }
+                }
+              ]
+            }
+            """;
+
+        var streams = SubtitleProbe.Parse(json);
+
+        Assert.Equal(2, streams.Count);
+
+        Assert.Equal(2, streams[0].Index);
+        Assert.Equal("subrip", streams[0].Codec);
+        Assert.Equal("eng", streams[0].Language);
+        Assert.True(streams[0].IsTextBased);
+        Assert.False(streams[0].IsForced);
+
+        Assert.Equal("hdmv_pgs_subtitle", streams[1].Codec);
+        Assert.False(streams[1].IsTextBased);
+        Assert.True(streams[1].IsForced);
+
+        // Only the text stream is eligible for phrase detection.
+        Assert.Single(streams, s => s.IsTextBased);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{\"streams\": []}")]
+    public void Probe_ReturnsEmptyForMissingOrInvalid(string json)
+    {
+        Assert.Empty(SubtitleProbe.Parse(json));
+    }
+}

--- a/IntroSkipper.Tests/TestSubtitleRecapSpike.cs
+++ b/IntroSkipper.Tests/TestSubtitleRecapSpike.cs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+/* End-to-end spike for subtitle-driven recap detection (RFC A).
+ *
+ * Unlike the pure tests in TestSubtitleRecapDetection, this test exercises the real ffmpeg
+ * extraction path: it muxes a synthetic clip with an embedded TEXT subtitle stream plus a
+ * fade-to-black, then runs the exact production code (SubtitleProbe -> SubtitleParser ->
+ * FFmpegOutputParser -> SubtitleRecapSegmentBuilder) over genuine ffmpeg output.
+ *
+ * Gated by FactSkipFFmpegTests so it runs where ffmpeg is on PATH and is skipped otherwise.
+ */
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Subtitles;
+using Xunit;
+
+public class TestSubtitleRecapSpike
+{
+    [FactSkipFFmpegTests]
+    public async Task EndToEnd_ExtractsSubtitlesAndBuildsRecapSegment()
+    {
+        var work = Path.Combine(Path.GetTempPath(), "is-recap-spike-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(work);
+
+        try
+        {
+            var srtPath = Path.Combine(work, "recap.srt");
+            var videoPath = Path.Combine(work, "video.mp4");
+            var episodePath = Path.Combine(work, "episode.mkv");
+
+            await File.WriteAllTextAsync(
+                srtPath,
+                "1\n00:00:02,000 --> 00:00:05,000\nPreviously on Test Show...\n\n"
+                + "2\n00:00:05,500 --> 00:00:09,000\n...the hero lost everything.\n\n"
+                + "3\n00:00:30,000 --> 00:00:33,000\nWelcome back. Let's begin.\n");
+
+            // 1) Synthesize a 40s clip with full-black frames in [10,11] (the recap fade-out).
+            //    Commas in the enable() expression are backslash-escaped (no shell involved).
+            await RunAsync("ffmpeg", new[]
+            {
+                "-hide_banner", "-loglevel", "error",
+                "-f", "lavfi", "-i", "testsrc=size=320x240:rate=5:duration=40",
+                "-vf", @"drawbox=x=0:y=0:w=in_w:h=in_h:color=black:t=fill:enable=between(t\,10\,11)",
+                "-pix_fmt", "yuv420p", videoPath,
+            });
+
+            // 1b) Mux the .srt as an embedded TEXT subtitle stream tagged eng.
+            await RunAsync("ffmpeg", new[]
+            {
+                "-hide_banner", "-loglevel", "error",
+                "-i", videoPath, "-i", srtPath,
+                "-c:v", "copy", "-c:s", "srt", "-metadata:s:s:0", "language=eng",
+                episodePath,
+            });
+
+            Assert.True(File.Exists(episodePath), "ffmpeg failed to produce the muxed sample");
+
+            // 2) Enumerate subtitle streams with ffprobe and classify via production code.
+            var probeJson = await RunAsync("ffprobe", new[]
+            {
+                "-v", "error", "-select_streams", "s",
+                "-show_entries", "stream=index,codec_name,codec_type,disposition:stream_tags=language",
+                "-of", "json", episodePath,
+            });
+
+            var streams = SubtitleProbe.Parse(probeJson.StdOut);
+            var textStream = Assert.Single(streams, s => s.IsTextBased);
+            Assert.Equal("subrip", textStream.Codec);
+            Assert.Equal("eng", textStream.Language);
+
+            // 3) Extract ONLY the opening 15s as SubRip to stdout, then parse with production code.
+            var extract = await RunAsync("ffmpeg", new[]
+            {
+                "-hide_banner", "-loglevel", "error",
+                "-i", episodePath, "-to", "15",
+                "-map", "0:s:" + (streams.Count == 1 ? "0" : textStream.Index.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                "-f", "srt", "-",
+            });
+
+            var cues = SubtitleParser.ParseSubRip(extract.StdOut);
+            Assert.Equal(2, cues.Count); // the 30s cue is correctly excluded by the 15s window
+            Assert.True(RecapPhraseMatcher.Default.IsRecapOpening(cues[0].Text));
+
+            // 4) Detect black frames with the SAME filter/parser the plugin uses.
+            var black = await RunAsync("ffmpeg", new[]
+            {
+                "-hide_banner", "-loglevel", "info",
+                "-ss", "0", "-i", episodePath, "-to", "20",
+                "-an", "-dn", "-sn",
+                "-vf", "blackframe=amount=50:threshold=28",
+                "-f", "null", "-",
+            });
+
+            var blackFrames = FFmpegOutputParser.ParseBlackFrames(black.StdErr);
+            Assert.NotEmpty(blackFrames);
+            var blackTimes = blackFrames.Select(static f => f.Time).ToList();
+            Assert.Contains(blackTimes, t => Math.Abs(t - 10.0) < 0.25);
+
+            // 5) Run the real builder over genuinely extracted cues + black frames.
+            var result = SubtitleRecapSegmentBuilder.Build(
+                cues,
+                RecapPhraseMatcher.Default,
+                new SubtitleRecapOptions(),
+                blackTimes);
+
+            Assert.NotNull(result);
+            Assert.InRange(result!.Start, 1.9, 2.1);   // anchored to the matched cue, NOT 0
+            Assert.InRange(result.End, 9.9, 10.1);      // snapped to the 10s fade-to-black
+            Assert.True(result.SnappedToBlackFrame);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(work, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    private static async Task<(string StdOut, string StdErr)> RunAsync(string fileName, string[] args)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var arg in args)
+        {
+            info.ArgumentList.Add(arg);
+        }
+
+        using var process = Process.Start(info) ?? throw new InvalidOperationException($"could not start {fileName}");
+
+        // Read both streams concurrently to avoid pipe-buffer deadlock.
+        var stdOutTask = process.StandardOutput.ReadToEndAsync();
+        var stdErrTask = process.StandardError.ReadToEndAsync();
+        var stdOut = await stdOutTask;
+        var stdErr = await stdErrTask;
+        await process.WaitForExitAsync();
+
+        return (stdOut, stdErr);
+    }
+}

--- a/IntroSkipper/Subtitles/RecapPhraseMatcher.cs
+++ b/IntroSkipper/Subtitles/RecapPhraseMatcher.cs
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Matches recap-opening phrases (e.g. "Previously on…") against subtitle cue text.
+/// Matching is "anchored": structured leading noise (speaker labels, bracketed sound cues, dashes,
+/// markup) is stripped first, then the cue must <em>begin</em> with a recap phrase on a normalized
+/// form (lower-cased, diacritics removed, punctuation collapsed). This rejects an incidental
+/// "…previously on…" buried inside a line of dialogue while still catching real openers preceded by
+/// a short label such as "[NARRATOR] Previously on…".
+/// </summary>
+public sealed partial class RecapPhraseMatcher
+{
+    /// <summary>
+    /// Default maximum residual character offset at which an anchored phrase may begin after leading
+    /// noise has been stripped. Kept small: real recap openers begin the cue, so the structured strip
+    /// (not a wide tolerance) is what absorbs labels.
+    /// </summary>
+    public const int DefaultAnchorTolerance = 2;
+
+    private readonly string[] _normalizedPhrases;
+    private readonly int _anchorTolerance;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RecapPhraseMatcher"/> class.
+    /// </summary>
+    /// <param name="phrases">Recap-opening phrases to match (raw, in any casing/diacritics; each is normalized once here).</param>
+    /// <param name="anchorTolerance">Maximum residual character offset at which a matched phrase may begin within the normalized, noise-stripped cue.</param>
+    public RecapPhraseMatcher(IEnumerable<string> phrases, int anchorTolerance = DefaultAnchorTolerance)
+    {
+        ArgumentNullException.ThrowIfNull(phrases);
+
+        _normalizedPhrases = phrases
+            .Select(Normalize)
+            .Where(static p => p.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        _anchorTolerance = Math.Max(0, anchorTolerance);
+    }
+
+    /// <summary>
+    /// Gets the curated default list of recap-opening phrases across several major languages.
+    /// This is the seed for the configurable plugin setting; it is deliberately biased toward
+    /// precision (multi-word forms) over recall.
+    /// </summary>
+    public static IReadOnlyList<string> DefaultPhrases { get; } =
+    [
+        // English
+        "previously on",
+        "last time on",
+        "last week on",
+        "last season on",
+        "earlier this season",
+        // Spanish
+        "anteriormente en",
+        "en episodios anteriores",
+        // Portuguese
+        "anteriormente em",
+        // French ("précédemment" -> "precedemment" after diacritics removal)
+        "precedemment dans",
+        "precedemment sur",
+        // German
+        "was bisher geschah",
+        "was bisher passierte",
+        "bisher bei",
+        // Italian
+        "negli episodi precedenti",
+        "nelle puntate precedenti",
+        // Dutch
+        "wat voorafging",
+        // Japanese (前回 / これまでの…)
+        "前回",
+        "これまでの",
+        // Korean
+        "지난 이야기",
+    ];
+
+    /// <summary>
+    /// Gets a matcher built from <see cref="DefaultPhrases"/>.
+    /// </summary>
+    public static RecapPhraseMatcher Default { get; } = new(DefaultPhrases);
+
+    /// <summary>
+    /// Gets the number of normalized phrases this matcher will test against.
+    /// </summary>
+    public int PhraseCount => _normalizedPhrases.Length;
+
+    /// <summary>
+    /// Determines whether the supplied cue text begins (after leading-noise stripping) with a recap-opening phrase.
+    /// </summary>
+    /// <param name="cueText">Raw cue text.</param>
+    /// <returns><see langword="true"/> when a recap-opening phrase is found at/near the cue start.</returns>
+    public bool IsRecapOpening(string? cueText) => TryMatch(cueText, out _);
+
+    /// <summary>
+    /// Attempts to match a recap-opening phrase against the supplied cue text.
+    /// </summary>
+    /// <param name="cueText">Raw cue text.</param>
+    /// <param name="matchedPhrase">The normalized phrase that matched, when successful.</param>
+    /// <returns><see langword="true"/> when a recap-opening phrase is found at/near the cue start.</returns>
+    public bool TryMatch(string? cueText, out string matchedPhrase)
+    {
+        matchedPhrase = string.Empty;
+        if (string.IsNullOrWhiteSpace(cueText))
+        {
+            return false;
+        }
+
+        var normalized = Normalize(StripLeadingNoise(cueText));
+        if (normalized.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var phrase in _normalizedPhrases)
+        {
+            var index = normalized.IndexOf(phrase, StringComparison.Ordinal);
+            if (index >= 0 && index <= _anchorTolerance)
+            {
+                matchedPhrase = phrase;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Normalizes subtitle text for robust, locale-insensitive matching: strips HTML/VTT/ASS markup,
+    /// removes diacritics, lower-cases, maps punctuation to spaces, and collapses whitespace.
+    /// </summary>
+    /// <param name="text">Raw text.</param>
+    /// <returns>The normalized text.</returns>
+    public static string Normalize(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        // Remove HTML/VTT tags (<i>, <c.classname>, <font …>) and ASS override blocks ({\an8}).
+        var stripped = MarkupRegex().Replace(text, " ");
+
+        // Decompose so diacritics become combining marks we can drop (Précédemment -> precedemment).
+        var decomposed = stripped.Normalize(NormalizationForm.FormD);
+        var builder = new StringBuilder(decomposed.Length);
+        foreach (var ch in decomposed)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
+            {
+                continue;
+            }
+
+            if (char.IsLetterOrDigit(ch) || char.IsWhiteSpace(ch))
+            {
+                builder.Append(ch);
+            }
+            else
+            {
+                // Punctuation/symbols become separators so "previously," matches "previously".
+                builder.Append(' ');
+            }
+        }
+
+        var collapsed = WhitespaceRegex().Replace(builder.ToString(), " ").Trim();
+        return collapsed.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Strips structured leading noise from raw cue text: markup tags, leading bracketed/parenthetical
+    /// sound cues, a single leading speaker label ("NAME:"), and dialogue dashes/quote glyphs. This is
+    /// what makes "[NARRATOR] Previously on…" anchor while "I told you previously on Tuesday" does not.
+    /// </summary>
+    /// <param name="text">Raw cue text.</param>
+    /// <returns>The text with leading noise removed.</returns>
+    internal static string StripLeadingNoise(string text)
+    {
+        var current = text;
+        var changed = true;
+        while (changed)
+        {
+            changed = false;
+            var trimmed = current.TrimStart(' ', '\t', '-', '\u2010', '\u2013', '\u2014', '*', '>', '"', '\'', '\u201C', '\u201D', '\u2018', '\u2019', '\u266A', '\u266B', '\u2669');
+            if (!string.Equals(trimmed, current, StringComparison.Ordinal))
+            {
+                current = trimmed;
+                changed = true;
+            }
+
+            var bracket = LeadingBracketRegex().Match(current);
+            if (bracket.Success && bracket.Length > 0)
+            {
+                current = current[bracket.Length..];
+                changed = true;
+                continue;
+            }
+
+            var speaker = LeadingSpeakerRegex().Match(current);
+            if (speaker.Success && speaker.Length > 0)
+            {
+                current = current[speaker.Length..];
+                changed = true;
+            }
+        }
+
+        return current;
+    }
+
+    [GeneratedRegex(@"<[^>]+>|\{[^}]*\}")]
+    private static partial Regex MarkupRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+
+    // A leading bracketed/parenthetical/markup group: "[NARRATOR]", "(theme music)", "<i>".
+    [GeneratedRegex(@"^\s*(?:\[[^\]]*\]|\([^)]*\)|<[^>]*>)\s*")]
+    private static partial Regex LeadingBracketRegex();
+
+    // A single short leading speaker label ending in a colon, e.g. "JOHN:" or "Narrator:".
+    // Excludes commas/semicolons so a real sentence is never mistaken for a label.
+    [GeneratedRegex(@"^\s*[\p{L}0-9][\p{L}0-9 .'\-]{0,24}:\s+")]
+    private static partial Regex LeadingSpeakerRegex();
+}

--- a/IntroSkipper/Subtitles/SubtitleCodec.cs
+++ b/IntroSkipper/Subtitles/SubtitleCodec.cs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Frozen;
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Classifies subtitle codecs as text-based (cheaply extractable to plain text by ffmpeg)
+/// or image-based (require OCR and are therefore out of scope for phrase detection).
+/// </summary>
+/// <remarks>
+/// The codec strings are the <c>codec_name</c> values reported by <c>ffprobe -show_streams</c>.
+/// They were verified against the local ffmpeg decoder list (see docs/recap-research/A-subtitles.md).
+/// </remarks>
+public static class SubtitleCodec
+{
+    // ffprobe codec_name values for text subtitle streams that ffmpeg can transcode to SubRip/WebVTT.
+    private static readonly FrozenSet<string> _textCodecs = new[]
+    {
+        "subrip",
+        "srt",
+        "text",
+        "ssa",
+        "ass",
+        "webvtt",
+        "mov_text",
+        "subviewer",
+        "subviewer1",
+        "sami",
+        "microdvd",
+        "mpl2",
+        "jacosub",
+        "pjs",
+        "realtext",
+        "vplayer",
+        "stl",
+        "eia_608",
+        "cc_dec",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    // ffprobe codec_name values for bitmap subtitle streams. Listed for explicit, testable rejection.
+    private static readonly FrozenSet<string> _imageCodecs = new[]
+    {
+        "hdmv_pgs_subtitle",
+        "dvd_subtitle",
+        "dvb_subtitle",
+        "dvbsub",
+        "xsub",
+        "dvb_teletext",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether the given ffprobe <c>codec_name</c> identifies a text subtitle stream
+    /// that can be extracted to plain text without OCR.
+    /// </summary>
+    /// <param name="codecName">The ffprobe <c>codec_name</c> value (e.g. <c>subrip</c>, <c>hdmv_pgs_subtitle</c>).</param>
+    /// <returns><see langword="true"/> for a known text codec; otherwise <see langword="false"/> (including unknown codecs, which are treated as non-text to stay conservative).</returns>
+    public static bool IsTextBased(string? codecName)
+    {
+        if (string.IsNullOrWhiteSpace(codecName))
+        {
+            return false;
+        }
+
+        return _textCodecs.Contains(codecName);
+    }
+
+    /// <summary>
+    /// Determines whether the given ffprobe <c>codec_name</c> identifies a known bitmap subtitle
+    /// stream that would require OCR.
+    /// </summary>
+    /// <param name="codecName">The ffprobe <c>codec_name</c> value.</param>
+    /// <returns><see langword="true"/> for a known image codec; otherwise <see langword="false"/>.</returns>
+    public static bool IsImageBased(string? codecName)
+    {
+        if (string.IsNullOrWhiteSpace(codecName))
+        {
+            return false;
+        }
+
+        return _imageCodecs.Contains(codecName);
+    }
+}

--- a/IntroSkipper/Subtitles/SubtitleCue.cs
+++ b/IntroSkipper/Subtitles/SubtitleCue.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// A single timed subtitle cue parsed from a text subtitle stream or sidecar file.
+/// All times are measured in seconds relative to the beginning of the media file.
+/// </summary>
+/// <param name="Start">Cue start time (in seconds).</param>
+/// <param name="End">Cue end time (in seconds).</param>
+/// <param name="Text">Plain cue text with line breaks normalized to spaces. Markup is preserved as-is.</param>
+public record SubtitleCue(double Start, double End, string Text);

--- a/IntroSkipper/Subtitles/SubtitleFormat.cs
+++ b/IntroSkipper/Subtitles/SubtitleFormat.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Text subtitle container format understood by <see cref="SubtitleParser"/>.
+/// </summary>
+public enum SubtitleFormat
+{
+    /// <summary>
+    /// Format could not be determined.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// SubRip (.srt). Also the format Intro Skipper requests from ffmpeg (<c>-f srt</c>).
+    /// </summary>
+    SubRip = 1,
+
+    /// <summary>
+    /// WebVTT (.vtt).
+    /// </summary>
+    WebVtt = 2,
+
+    /// <summary>
+    /// Advanced SubStation Alpha (.ass/.ssa).
+    /// </summary>
+    Ass = 3,
+}

--- a/IntroSkipper/Subtitles/SubtitleParser.cs
+++ b/IntroSkipper/Subtitles/SubtitleParser.cs
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Parses text subtitle payloads (SubRip, WebVTT, and ASS/SSA) into a flat list of timed
+/// <see cref="SubtitleCue"/> values. The parser is intentionally lenient: it scans for cue
+/// timing lines and tolerates missing indices, BOMs, CRLF line endings, and cue settings.
+/// </summary>
+/// <remarks>
+/// Intro Skipper extracts subtitles with <c>ffmpeg -f srt</c>, so <see cref="ParseSubRip"/> is the
+/// hot path; the WebVTT and ASS parsers exist for reading external sidecar files without a second
+/// ffmpeg invocation.
+/// </remarks>
+public static partial class SubtitleParser
+{
+    /// <summary>
+    /// Detects the subtitle format from a payload's header/structure and parses it.
+    /// </summary>
+    /// <param name="payload">Raw subtitle text.</param>
+    /// <returns>Parsed cues in document order. Empty when nothing could be parsed.</returns>
+    public static IReadOnlyList<SubtitleCue> Parse(string? payload)
+    {
+        return Parse(payload, DetectFormat(payload));
+    }
+
+    /// <summary>
+    /// Parses a subtitle payload using the supplied format.
+    /// </summary>
+    /// <param name="payload">Raw subtitle text.</param>
+    /// <param name="format">The format to parse as.</param>
+    /// <returns>Parsed cues in document order. Empty when nothing could be parsed.</returns>
+    public static IReadOnlyList<SubtitleCue> Parse(string? payload, SubtitleFormat format)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return [];
+        }
+
+        return format switch
+        {
+            SubtitleFormat.Ass => ParseAss(payload),
+            // SubRip and WebVTT share a cue grammar ("start --> end" + text lines); the timestamp
+            // tokenizer accepts both ',' and '.' millisecond separators, so one routine handles both.
+            _ => ParseTimedBlocks(payload),
+        };
+    }
+
+    /// <summary>
+    /// Parses a SubRip (.srt) payload.
+    /// </summary>
+    /// <param name="payload">Raw SubRip text.</param>
+    /// <returns>Parsed cues in document order.</returns>
+    public static IReadOnlyList<SubtitleCue> ParseSubRip(string payload) => ParseTimedBlocks(payload);
+
+    /// <summary>
+    /// Parses a WebVTT (.vtt) payload.
+    /// </summary>
+    /// <param name="payload">Raw WebVTT text.</param>
+    /// <returns>Parsed cues in document order.</returns>
+    public static IReadOnlyList<SubtitleCue> ParseWebVtt(string payload) => ParseTimedBlocks(payload);
+
+    /// <summary>
+    /// Detects the subtitle format from a payload's leading bytes/structure.
+    /// </summary>
+    /// <param name="payload">Raw subtitle text.</param>
+    /// <returns>The detected format, or <see cref="SubtitleFormat.Unknown"/>.</returns>
+    public static SubtitleFormat DetectFormat(string? payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            return SubtitleFormat.Unknown;
+        }
+
+        var trimmed = payload.TrimStart('\uFEFF', ' ', '\r', '\n', '\t');
+
+        if (trimmed.StartsWith("WEBVTT", StringComparison.Ordinal))
+        {
+            return SubtitleFormat.WebVtt;
+        }
+
+        if (trimmed.StartsWith("[Script Info]", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Contains("[Events]", StringComparison.OrdinalIgnoreCase))
+        {
+            return SubtitleFormat.Ass;
+        }
+
+        if (TimeLineRegex().IsMatch(trimmed))
+        {
+            return SubtitleFormat.SubRip;
+        }
+
+        return SubtitleFormat.Unknown;
+    }
+
+    private static IReadOnlyList<SubtitleCue> ParseTimedBlocks(string payload)
+    {
+        var cues = new List<SubtitleCue>();
+        var lines = SplitLines(payload);
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var match = TimeLineRegex().Match(lines[i]);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            if (!TryParseTimestamp(match.Groups["start"].Value, out var start) ||
+                !TryParseTimestamp(match.Groups["end"].Value, out var end))
+            {
+                continue;
+            }
+
+            // Collect text lines until the next blank line.
+            var builder = new StringBuilder();
+            var j = i + 1;
+            for (; j < lines.Length && lines[j].Trim().Length > 0; j++)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append(lines[j].Trim());
+            }
+
+            i = j;
+
+            var text = builder.ToString().Trim();
+            if (text.Length > 0 && end > start)
+            {
+                cues.Add(new SubtitleCue(start, end, text));
+            }
+        }
+
+        return cues;
+    }
+
+    private static IReadOnlyList<SubtitleCue> ParseAss(string payload)
+    {
+        var cues = new List<SubtitleCue>();
+
+        foreach (var rawLine in SplitLines(payload))
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith("Dialogue:", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // ASS Dialogue: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
+            // Split on the first 9 commas only; the 10th field (Text) may itself contain commas.
+            var body = line["Dialogue:".Length..].TrimStart();
+            var fields = body.Split(',', 10);
+            if (fields.Length < 10)
+            {
+                continue;
+            }
+
+            if (!TryParseTimestamp(fields[1].Trim(), out var start) ||
+                !TryParseTimestamp(fields[2].Trim(), out var end))
+            {
+                continue;
+            }
+
+            // ASS uses "\N" for hard line breaks; normalize to spaces.
+            var text = fields[9].Replace("\\N", " ", StringComparison.Ordinal).Replace("\\n", " ", StringComparison.Ordinal).Trim();
+            if (text.Length > 0 && end > start)
+            {
+                cues.Add(new SubtitleCue(start, end, text));
+            }
+        }
+
+        return cues;
+    }
+
+    private static string[] SplitLines(string payload)
+        => payload.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n').Split('\n');
+
+    /// <summary>
+    /// Parses a subtitle timestamp of the form <c>HH:MM:SS,mmm</c>, <c>HH:MM:SS.mmm</c>, or
+    /// <c>MM:SS.mmm</c> into seconds.
+    /// </summary>
+    /// <param name="value">The timestamp token.</param>
+    /// <param name="seconds">The parsed time in seconds when successful.</param>
+    /// <returns><see langword="true"/> when the token was a valid timestamp.</returns>
+    internal static bool TryParseTimestamp(string value, out double seconds)
+    {
+        seconds = 0;
+        var match = TimestampRegex().Match(value.Trim());
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var hours = match.Groups["h"].Success
+            ? int.Parse(match.Groups["h"].Value, CultureInfo.InvariantCulture)
+            : 0;
+        var minutes = int.Parse(match.Groups["m"].Value, CultureInfo.InvariantCulture);
+        var secs = int.Parse(match.Groups["s"].Value, CultureInfo.InvariantCulture);
+        var millis = match.Groups["ms"].Success
+            ? int.Parse(match.Groups["ms"].Value.PadRight(3, '0')[..3], CultureInfo.InvariantCulture)
+            : 0;
+
+        seconds = (hours * 3600) + (minutes * 60) + secs + (millis / 1000.0);
+        return true;
+    }
+
+    // Matches a cue timing line, capturing the two endpoints. Cue settings after the end timestamp
+    // (WebVTT, e.g. "align:start position:50%") are ignored.
+    [GeneratedRegex(@"(?<start>\d{1,2}:\d{2}(?::\d{2})?[.,]\d{1,3})\s*-->\s*(?<end>\d{1,2}:\d{2}(?::\d{2})?[.,]\d{1,3})")]
+    private static partial Regex TimeLineRegex();
+
+    // Matches a single timestamp; hours are optional (WebVTT allows MM:SS.mmm).
+    [GeneratedRegex(@"^(?:(?<h>\d{1,2}):)?(?<m>\d{2}):(?<s>\d{2})[.,](?<ms>\d{1,3})$")]
+    private static partial Regex TimestampRegex();
+}

--- a/IntroSkipper/Subtitles/SubtitleProbe.cs
+++ b/IntroSkipper/Subtitles/SubtitleProbe.cs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Text.Json;
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Parses <c>ffprobe -show_streams</c> JSON output into <see cref="SubtitleStreamInfo"/> values and
+/// applies the text/image codec classification used to scope phrase detection.
+/// </summary>
+/// <remarks>
+/// Expected invocation:
+/// <c>ffprobe -v error -select_streams s -show_entries stream=index,codec_name,codec_type,disposition:stream_tags=language -of json &lt;path&gt;</c>.
+/// </remarks>
+public static class SubtitleProbe
+{
+    /// <summary>
+    /// Parses ffprobe JSON into subtitle stream descriptors. Non-subtitle streams are ignored.
+    /// </summary>
+    /// <param name="ffprobeJson">The raw JSON emitted by ffprobe.</param>
+    /// <returns>Subtitle streams in document order. Empty when none are present or parsing fails.</returns>
+    public static IReadOnlyList<SubtitleStreamInfo> Parse(string? ffprobeJson)
+    {
+        if (string.IsNullOrWhiteSpace(ffprobeJson))
+        {
+            return [];
+        }
+
+        var streams = new List<SubtitleStreamInfo>();
+
+        try
+        {
+            using var document = JsonDocument.Parse(ffprobeJson);
+            if (!document.RootElement.TryGetProperty("streams", out var streamsElement) ||
+                streamsElement.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            foreach (var stream in streamsElement.EnumerateArray())
+            {
+                if (!TryGetString(stream, "codec_type", out var codecType) ||
+                    !string.Equals(codecType, "subtitle", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var index = stream.TryGetProperty("index", out var indexElement) &&
+                            indexElement.TryGetInt32(out var parsedIndex)
+                    ? parsedIndex
+                    : -1;
+
+                TryGetString(stream, "codec_name", out var codec);
+                codec ??= string.Empty;
+
+                string? language = null;
+                if (stream.TryGetProperty("tags", out var tags) && tags.ValueKind == JsonValueKind.Object)
+                {
+                    TryGetString(tags, "language", out language);
+                }
+
+                var forced = false;
+                if (stream.TryGetProperty("disposition", out var disposition) &&
+                    disposition.ValueKind == JsonValueKind.Object &&
+                    disposition.TryGetProperty("forced", out var forcedElement) &&
+                    forcedElement.TryGetInt32(out var forcedValue))
+                {
+                    forced = forcedValue != 0;
+                }
+
+                streams.Add(new SubtitleStreamInfo(
+                    index,
+                    codec,
+                    language,
+                    SubtitleCodec.IsTextBased(codec),
+                    forced));
+            }
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+
+        return streams;
+    }
+
+    private static bool TryGetString(JsonElement element, string property, out string? value)
+    {
+        value = null;
+        if (element.TryGetProperty(property, out var child) && child.ValueKind == JsonValueKind.String)
+        {
+            value = child.GetString();
+            return value is not null;
+        }
+
+        return false;
+    }
+}

--- a/IntroSkipper/Subtitles/SubtitleRecapOptions.cs
+++ b/IntroSkipper/Subtitles/SubtitleRecapOptions.cs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Tunables for <see cref="SubtitleRecapSegmentBuilder"/>.
+/// </summary>
+public sealed record SubtitleRecapOptions
+{
+    /// <summary>
+    /// Gets the latest cue start (in seconds) that may anchor a recap. Cues beyond this are ignored,
+    /// which keeps an incidental "previously on" mid-episode from being treated as a recap.
+    /// </summary>
+    public double MaxWindowSeconds { get; init; } = 150;
+
+    /// <summary>
+    /// Gets the maximum gap (in seconds) allowed between consecutive cues while growing the recap
+    /// cluster. A larger gap ends the cluster (e.g. the transition into the cold open).
+    /// </summary>
+    public double MaxClusterGapSeconds { get; init; } = 12;
+
+    /// <summary>
+    /// Gets the minimum acceptable recap duration (in seconds). Shorter results are rejected.
+    /// </summary>
+    public double MinDurationSeconds { get; init; } = 5;
+
+    /// <summary>
+    /// Gets the maximum acceptable recap duration (in seconds). The end is clamped to this.
+    /// </summary>
+    public double MaxDurationSeconds { get; init; } = 120;
+
+    /// <summary>
+    /// Gets the forward window (in seconds) within which the cluster end is snapped to a black frame
+    /// (the fade-out that typically ends a recap montage). Set to 0 to disable black-frame snapping.
+    /// </summary>
+    public double BlackFrameSnapSeconds { get; init; } = 6;
+
+    /// <summary>
+    /// Gets a value indicating whether the start may be snapped back to 0 when the anchor cue begins
+    /// within <see cref="StartSnapSeconds"/> of the file start. Recaps frequently open the episode,
+    /// but unlike the current implementation this is opt-in rather than forced.
+    /// </summary>
+    public bool SnapStartToZero { get; init; }
+
+    /// <summary>
+    /// Gets the threshold (in seconds) used by <see cref="SnapStartToZero"/>.
+    /// </summary>
+    public double StartSnapSeconds { get; init; } = 2.0;
+}

--- a/IntroSkipper/Subtitles/SubtitleRecapResult.cs
+++ b/IntroSkipper/Subtitles/SubtitleRecapResult.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// The result of building a recap segment from subtitle cues.
+/// </summary>
+/// <param name="Start">Recap start time (in seconds).</param>
+/// <param name="End">Recap end time (in seconds).</param>
+/// <param name="MatchedPhrase">The normalized recap-opening phrase that anchored the segment.</param>
+/// <param name="AnchorCueText">The raw text of the cue that anchored the segment.</param>
+/// <param name="CueCount">Number of cues absorbed into the recap cluster.</param>
+/// <param name="SnappedToBlackFrame">Whether <see cref="End"/> was snapped to a black frame.</param>
+public record SubtitleRecapResult(
+    double Start,
+    double End,
+    string MatchedPhrase,
+    string AnchorCueText,
+    int CueCount,
+    bool SnappedToBlackFrame)
+{
+    /// <summary>
+    /// Gets the recap duration (in seconds).
+    /// </summary>
+    public double Duration => End - Start;
+}

--- a/IntroSkipper/Subtitles/SubtitleRecapSegmentBuilder.cs
+++ b/IntroSkipper/Subtitles/SubtitleRecapSegmentBuilder.cs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Builds a recap <see cref="SubtitleRecapResult"/> from parsed subtitle cues by locating a
+/// recap-opening phrase, growing a dense cue cluster, and optionally snapping the end to a black
+/// frame. This is a pure function of its inputs and carries no I/O, so it is fully unit-testable
+/// without media.
+/// </summary>
+public static class SubtitleRecapSegmentBuilder
+{
+    /// <summary>
+    /// Builds a recap segment from subtitle cues.
+    /// </summary>
+    /// <param name="cues">Parsed subtitle cues (any order; sorted internally by start time).</param>
+    /// <param name="matcher">The recap-opening phrase matcher.</param>
+    /// <param name="options">Builder tunables.</param>
+    /// <param name="blackFrameTimes">
+    /// Optional black-frame timestamps (in seconds) from the existing ffmpeg black-frame pass, used to
+    /// snap the recap end to the fade-out. Pass <see langword="null"/> or empty to skip snapping.
+    /// </param>
+    /// <returns>The recap segment, or <see langword="null"/> when no recap was found or it failed validation.</returns>
+    public static SubtitleRecapResult? Build(
+        IReadOnlyList<SubtitleCue> cues,
+        RecapPhraseMatcher matcher,
+        SubtitleRecapOptions options,
+        IReadOnlyList<double>? blackFrameTimes = null)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (cues is null || cues.Count == 0)
+        {
+            return null;
+        }
+
+        var ordered = cues.OrderBy(static c => c.Start).ThenBy(static c => c.End).ToList();
+
+        // 1) Anchor: the first cue inside the opening window whose text is a recap opening.
+        var anchorIndex = -1;
+        var matchedPhrase = string.Empty;
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            if (ordered[i].Start > options.MaxWindowSeconds)
+            {
+                break;
+            }
+
+            if (matcher.TryMatch(ordered[i].Text, out matchedPhrase))
+            {
+                anchorIndex = i;
+                break;
+            }
+        }
+
+        if (anchorIndex < 0)
+        {
+            return null;
+        }
+
+        var anchor = ordered[anchorIndex];
+        var start = anchor.Start;
+        var end = anchor.End;
+        var cueCount = 1;
+
+        // 2) Grow the dense cluster forward while consecutive cues stay within the gap limit.
+        for (var i = anchorIndex + 1; i < ordered.Count; i++)
+        {
+            var cue = ordered[i];
+            if (cue.Start - end > options.MaxClusterGapSeconds)
+            {
+                break;
+            }
+
+            if (cue.End > end)
+            {
+                end = cue.End;
+            }
+
+            cueCount++;
+        }
+
+        // 3) Snap the end forward to a black frame (the montage fade-out), if one is close enough.
+        var snapped = false;
+        if (options.BlackFrameSnapSeconds > 0 && blackFrameTimes is { Count: > 0 })
+        {
+            var snapEnd = end;
+            var bestDelta = double.MaxValue;
+            foreach (var time in blackFrameTimes)
+            {
+                var delta = time - end;
+
+                // Accept a small backward tolerance (cluster end may overshoot the fade by <1s)
+                // and a forward window up to BlackFrameSnapSeconds.
+                if (delta >= -1.0 && delta <= options.BlackFrameSnapSeconds && Math.Abs(delta) < bestDelta)
+                {
+                    bestDelta = Math.Abs(delta);
+                    snapEnd = time;
+                }
+            }
+
+            if (snapEnd != end)
+            {
+                end = snapEnd;
+                snapped = true;
+            }
+        }
+
+        // 4) Optional start-to-zero snap (opt-in, unlike the current forced behavior).
+        if (options.SnapStartToZero && start <= options.StartSnapSeconds)
+        {
+            start = 0;
+        }
+
+        // 5) Clamp the duration and validate.
+        if (end - start > options.MaxDurationSeconds)
+        {
+            end = start + options.MaxDurationSeconds;
+        }
+
+        if (end - start < options.MinDurationSeconds)
+        {
+            return null;
+        }
+
+        return new SubtitleRecapResult(start, end, matchedPhrase, anchor.Text, cueCount, snapped);
+    }
+}

--- a/IntroSkipper/Subtitles/SubtitleStreamInfo.cs
+++ b/IntroSkipper/Subtitles/SubtitleStreamInfo.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Subtitles;
+
+/// <summary>
+/// Describes a single subtitle stream discovered in a media container via <c>ffprobe</c>.
+/// </summary>
+/// <param name="Index">The absolute stream index inside the container (ffprobe <c>stream.index</c>).</param>
+/// <param name="Codec">The ffprobe <c>codec_name</c> (e.g. <c>subrip</c>, <c>hdmv_pgs_subtitle</c>).</param>
+/// <param name="Language">The BCP-47/ISO-639 language tag from <c>stream_tags.language</c>, or <see langword="null"/> when untagged.</param>
+/// <param name="IsTextBased">Whether <see cref="Codec"/> is a text codec extractable without OCR.</param>
+/// <param name="IsForced">Whether the stream carries the <c>forced</c> disposition (often used for on-screen text such as recap cards).</param>
+public record SubtitleStreamInfo(
+    int Index,
+    string Codec,
+    string? Language,
+    bool IsTextBased,
+    bool IsForced);

--- a/docs/recap-research/A-subtitles.md
+++ b/docs/recap-research/A-subtitles.md
@@ -1,0 +1,547 @@
+# RFC A — Subtitle / caption phrase detection for Recap segments
+
+**Status:** Research + design spike. **Not** a mergeable feature. No analyzer is wired into the
+runtime chain; this RFC ships a unit-tested pure core plus an ffmpeg-gated end-to-end spike that
+proves the extraction mechanism, and a design for how it would integrate.
+
+**Author:** recap research spike • **Target:** `intro-skipper/intro-skipper` branch `10.11`
+**ffmpeg verified against:** `ffmpeg 6.1.1` (Ubuntu) — `subrip`/`mov_text`/`webvtt`/`ass` encoders + `ffprobe` present.
+
+---
+
+## TL;DR verdict
+
+Subtitle phrase detection is the **highest-precision, cheapest** recap cue available, and it fixes
+the two structural mistakes in the current recap code: (1) it can find recaps that **don't start at
+0** (after a cold open / after the intro), which the current code structurally cannot, and (2) it
+needs **no cross-episode comparison**, so it works on a single episode, season 1 episode 1, and
+shows with no shared "Previously on" sting.
+
+It is **not** a universal solution: it only works when a **text** subtitle stream (or sidecar) exists
+and actually transcribes the recap voiceover/cards. Image subs (PGS/VOBSUB/DVBSUB) and
+no-subtitle content fall through to the existing audio/black-frame signals. So the honest framing is
+**"a new high-precision first pass in the Recap chain, with the current detectors as fallback"** —
+not a replacement.
+
+What is **proven** in this spike (real ffmpeg, see [§0](#0-what-was-actually-built-and-verified)) vs
+**asserted** (design only) is called out explicitly throughout.
+
+---
+
+## 0. What was actually built and verified
+
+### Prototype (committed, compiles under the repo's strict analyzers, unit-tested)
+
+Pure, I/O-free core under `IntroSkipper/Subtitles/`:
+
+| File | Responsibility |
+|---|---|
+| `IntroSkipper/Subtitles/SubtitleCue.cs` | `record SubtitleCue(double Start, double End, string Text)` |
+| `IntroSkipper/Subtitles/SubtitleParser.cs` | Parse SubRip / WebVTT / ASS payloads → cues (lenient; BOM/CRLF/cue-settings tolerant) |
+| `IntroSkipper/Subtitles/RecapPhraseMatcher.cs` | Normalize (case/diacritics/markup/punct) + **anchored** multilingual phrase match |
+| `IntroSkipper/Subtitles/SubtitleRecapSegmentBuilder.cs` | **The core**: cues + matcher + options + black frames → `SubtitleRecapResult?` |
+| `IntroSkipper/Subtitles/SubtitleRecapOptions.cs` / `SubtitleRecapResult.cs` | Tunables / result record |
+| `IntroSkipper/Subtitles/SubtitleCodec.cs` | TEXT vs IMAGE `codec_name` classification (grounded in real ffmpeg codec strings) |
+| `IntroSkipper/Subtitles/SubtitleStreamInfo.cs` / `SubtitleProbe.cs` | `ffprobe -show_streams` JSON → typed stream list + classification |
+
+Tests:
+
+- `IntroSkipper.Tests/TestSubtitleRecapDetection.cs` — **58 pure unit tests**, no media: parser
+  (SRT/VTT/ASS, BOM, CRLF, multi-line, cue settings, short timestamps), matcher (English +
+  ES/PT/FR/DE/IT/JA, diacritics, anchoring, **false-positive rejection**), builder (anchor, cluster
+  growth, gap stop, black-frame snap, min/max clamp, window guard, opt-in start-to-0), codec
+  classification, ffprobe JSON parsing.
+- `IntroSkipper.Tests/TestSubtitleRecapSpike.cs` — **1 ffmpeg-gated end-to-end test**
+  (`[FactSkipFFmpegTests]`): muxes a synthetic clip → enumerates streams with ffprobe → extracts the
+  opening window as SRT → detects the black frame → runs the **real** builder. Asserts
+  `Start≈2.0` (not 0) and `End≈10.0` (snapped to the fade-to-black).
+
+Test result on this environment: **374 passed, 1 failed, 0 skipped**. The single failure
+(`TestAudioFingerprinting.TestSilenceDetection`) is **pre-existing and environmental** — an ffmpeg
+`silencedetect` floating-point rounding difference (`44.631042` expected vs `44.631` actual) present
+on the pristine `10.11` checkout, unrelated to this work. My 59 added tests all pass.
+
+### End-to-end ffmpeg proof (`docs/recap-research/spike/extract_spike.sh`)
+
+The committable script (run with `bash docs/recap-research/spike/extract_spike.sh`) muxes a 40 s
+synthetic clip with an embedded `subrip` track ("Previously on…") plus a fade-to-black in `[10,11] s`,
+then proves each pipeline step. **Verbatim observed output:**
+
+```
+==> (2) ffprobe: enumerate subtitle streams (index, codec, language)
+{ "streams": [ { "index": 1, "codec_name": "subrip", "codec_type": "subtitle",
+                 "tags": { "language": "eng" } } ] }
+
+==> (3) extract ONLY the opening 15s as SubRip to stdout (mkv/subrip)
+1
+00:00:02,000 --> 00:00:05,000
+Previously on Test Show...
+
+2
+00:00:05,500 --> 00:00:09,000
+...the hero lost everything.
+            (cue #3 at 00:00:30 is correctly excluded by the 15s window)
+
+==> (4) black-frame detection in [0,20] (plugin filter: blackframe=amount=50:threshold=28)
+[Parsed_blackframe_0 @ ...] frame:50 pblack:100 pts:10000 t:10.000000 ...
+[Parsed_blackframe_0 @ ...] frame:51 pblack:100 pts:10200 t:10.200000 ...
+```
+
+This de-risks the entire mechanism: **mux → probe (codec+lang) → cheap windowed text extraction →
+black-frame boundary** all work with stock ffmpeg 6.1.1 and feed the production parser/builder.
+
+**Verified vs assumed** is tabulated in [§11](#11-verified-vs-assumed).
+
+---
+
+## 1. Subtitle sources
+
+### 1.1 Text vs image streams
+
+Only **text** subtitle codecs can be transcribed cheaply; image (bitmap) subs require OCR and are
+**out of scope** for phrase detection. The classifier (`SubtitleCodec.cs`) uses the exact
+`codec_name` strings ffprobe reports, taken from the local ffmpeg decoder list:
+
+- **TEXT (in scope):** `subrip`, `srt`, `mov_text`, `webvtt`, `ass`, `ssa`, `text`, `subviewer`,
+  `sami`, `microdvd`, `mpl2`, `jacosub`, `pjs`, `realtext`, `vplayer`, `stl`, `eia_608`/`cc_dec`
+  (CEA-608 closed captions).
+- **IMAGE (skip — need OCR):** `hdmv_pgs_subtitle` (PGS), `dvd_subtitle` (VOBSUB/DVDSUB),
+  `dvb_subtitle`/`dvbsub` (DVBSUB), `xsub`, `dvb_teletext`.
+
+Unknown/future codecs are treated as **non-text** (conservative: we never feed garbage to the
+matcher). Sidecar files are classified by extension → `.srt`/`.vtt`/`.ass`/`.ssa` are text and parsed
+directly (no ffmpeg call); `.sup`/`.idx`+`.sub` are image and skipped.
+
+### 1.2 Enumerating streams (ffprobe)
+
+The plugin **already shells out to ffprobe** — see `FFmpegService.ProbeAudioDurationAsync`
+(`IntroSkipper/FFmpeg/FFmpegService.cs:322-368`) and ffprobe-path resolution
+`GetFFprobePath` (`IntroSkipper/FFmpeg/FFmpegService.cs:490-502`). Subtitle enumeration reuses
+exactly that pattern:
+
+```
+ffprobe -v error -select_streams s \
+  -show_entries stream=index,codec_name,codec_type,disposition:stream_tags=language \
+  -of json <path>
+```
+
+`SubtitleProbe.Parse` turns that JSON into `SubtitleStreamInfo { Index, Codec, Language, IsTextBased,
+IsForced }`. `IsForced` is useful because **forced** subtitle tracks often carry the on-screen
+"Previously on" card text even when the main dialogue track is image-based.
+
+### 1.3 Extracting just the opening window (ffmpeg)
+
+We never extract the whole file. We map a single subtitle stream and bound it with `-to`:
+
+```
+ffmpeg -hide_banner -loglevel error -i <path> -to <window> -map 0:s:<idx> -f srt -
+```
+
+- `-map 0:s:<idx>` selects **only** the subtitle stream → video/audio are not decoded.
+- `-to <window>` (e.g. 150 s) reads only the opening of the container.
+- `-f srt` normalizes every text codec (`mov_text`, `webvtt`, `ass`, …) into one grammar, so the hot
+  path is a single SubRip parser. **Verified** for both `subrip` (MKV) and `mov_text` (MP4) in §0.
+
+External sidecars are read off disk and parsed directly by `SubtitleParser` (no ffmpeg), with
+`SubtitleParser.DetectFormat` choosing the SRT/VTT/ASS branch.
+
+### 1.4 Jellyfin context
+
+"Jellyfin extracts subtitles on demand, not during indexing," so the plugin must do its own
+extraction — which is exactly what §1.2/§1.3 do via the existing `FFmpegService`/`FFmpegProcess`
+plumbing (`IntroSkipper/FFmpeg/FFmpegProcess.cs:42-118`). Optionally, if
+`jellyfin-plugin-subtitleextract` has already written a sidecar, we can prefer that file and skip the
+ffmpeg call entirely.
+
+---
+
+## 2. Phrase matching
+
+### 2.1 Normalization (`RecapPhraseMatcher.Normalize`)
+
+Cue text is normalized before comparison so casing, diacritics, and markup never block a match:
+
+1. strip HTML/VTT tags and ASS override blocks (`<i>`, `<c.x>`, `{\an8}`);
+2. Unicode **NFD decompose** and drop combining marks → `Précédemment` → `precedemment`;
+3. map punctuation/symbols to spaces (so `previously,` ≈ `previously`);
+4. collapse whitespace; lower-case (`ToLowerInvariant`).
+
+### 2.2 Anchoring (the precision lever — and a finding)
+
+Naïve "phrase appears anywhere in the cue" is too loose. My **first** implementation used a
+character-offset tolerance (allow the phrase to start within N chars). A unit test immediately
+falsified it: `"I told you previously on Tuesday that we should leave"` has `"previously on"` at
+char 11, indistinguishable by offset from a legitimate `"[NARRATOR] Previously on…"`.
+
+The fix (kept) strips **structured** leading noise on the raw text before matching
+(`RecapPhraseMatcher.StripLeadingNoise`): a single leading bracketed/parenthetical sound cue
+(`[NARRATOR]`, `(theme music)`), one `NAME:` speaker label, dialogue dashes, and quote/♪ glyphs —
+then requires the phrase at the **start** (tolerance 2). Result:
+
+- ✅ `"[NARRATOR] Previously on the show"`, `"- Previously on…"`, `"JOHN: Previously on…"` → match
+- ❌ `"I told you previously on Tuesday…"` → **rejected** (no strippable prefix; doesn't start with the phrase)
+
+This is exactly the kind of edge that a "matches 'previously on' in subtitles" one-liner gets wrong;
+the prototype encodes the precise rule and tests it.
+
+### 2.3 Default phrase list (multilingual, precision-biased)
+
+`RecapPhraseMatcher.DefaultPhrases` (configurable seed):
+
+| Lang | Phrases |
+|---|---|
+| English | `previously on`, `last time on`, `last week on`, `last season on`, `earlier this season` |
+| Spanish | `anteriormente en`, `en episodios anteriores` |
+| Portuguese | `anteriormente em` |
+| French | `précédemment dans`, `précédemment sur` |
+| German | `was bisher geschah`, `was bisher passierte`, `bisher bei` |
+| Italian | `negli episodi precedenti`, `nelle puntate precedenti` |
+| Dutch | `wat voorafging` |
+| Japanese | `前回`, `これまでの` |
+| Korean | `지난 이야기` |
+
+Deliberately **multi-word** for English (`previously on`, not bare `previously`) to avoid matching
+`"Previously unseen footage…"`. This is a recall/precision trade documented in [§7](#7-limits-failure-modes-and-where-it-breaks).
+Prior art (`Hellowlol/bw_plex`) matches `previously on` / `last season` / `last episode`; this list
+is a superset with stricter anchoring.
+
+### 2.4 End cue
+
+End cues are rare in subtitles (a recap montage just stops). The primary end mechanism is the
+**dense-cluster + black-frame snap** in §3, not a phrase. The builder is structured so an optional
+end-phrase list could short-circuit cluster growth later, but it is intentionally not relied upon.
+
+---
+
+## 3. Boundary construction (`SubtitleRecapSegmentBuilder.Build`)
+
+Given parsed `cues`, a `matcher`, `SubtitleRecapOptions`, and optional `blackFrameTimes`:
+
+1. **Anchor.** First cue (by start) with `Start ≤ MaxWindowSeconds` whose text matches a recap
+   opening. `Start = anchorCue.Start` — **not forced to 0**. No match → `null`.
+2. **Grow cluster.** Absorb subsequent cues while `nextCue.Start − end ≤ MaxClusterGapSeconds`
+   (default 12 s). `End = last absorbed cue.End`. The first large gap (cold open / dialogue) ends it.
+3. **Black-frame snap.** If black-frame times are supplied, snap `End` to the nearest one in
+   `[end − 1 s, end + BlackFrameSnapSeconds]` (default forward window 6 s) — the montage fade-out.
+4. **Optional start-to-0 snap.** Only if `SnapStartToZero` (opt-in) **and** `Start ≤ StartSnapSeconds`.
+5. **Clamp & validate.** Clamp duration to `MaxDurationSeconds`; reject if `< MinDurationSeconds`.
+
+Returns `SubtitleRecapResult { Start, End, MatchedPhrase, AnchorCueText, CueCount,
+SnappedToBlackFrame }`.
+
+### On-screen card vs subtitle
+
+- If the "Previously on" text is a **subtitle cue** (incl. forced track) → handled directly.
+- If it's a **burned-in on-screen card** with no cue → there is no text to match; this case falls
+  through to the existing chromaprint/black-frame detectors. The forced-track path (§1.2) recovers
+  many of these because studios frequently ship the card as a forced subtitle.
+
+### Why End uses the existing black-frame pass
+
+Reusing `FFmpegService.DetectBlackFramesAsync` (`IntroSkipper/FFmpeg/FFmpegService.cs:166-199`) +
+`FFmpegOutputParser.ParseBlackFrames` (`IntroSkipper/FFmpeg/FFmpegOutputParser.cs:76-101`) means the
+end boundary is **frame-accurate at the fade**, and the subtitle layer only has to get the
+*neighborhood* right. The spike test exercises this exact parser on real ffmpeg output.
+
+---
+
+## 4. Integration into this codebase
+
+### 4.1 New analyzer in the Recap chain
+
+Add `SubtitleRecapAnalyzer : IMediaFileAnalyzer` (`IntroSkipper/Analyzers/IMediaFileAnalyzer.cs:14-27`).
+Per-episode (no cross-episode comparison): enumerate streams → pick best text stream (prefer
+`Language` ∈ configured filter, prefer `forced`) → extract opening window → parse → `Build(...)` with
+black frames from `DetectBlackFramesAsync` → on success, `UpdateTimestampAsync(seg,
+AnalysisMode.Recap, …)` and `SetAnalyzed(Recap, Analyzed)`. Episodes it can't handle are returned
+unanalyzed for the next analyzer (the interface contract).
+
+### 4.2 Precedence
+
+In `BaseItemAnalyzerTask.AnalyzeItemsAsync` the Recap branch currently builds
+`[ChapterAnalyzer, ChromaprintAnalyzer]` (`IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs:324-365`).
+Recommended order:
+
+```
+ChapterAnalyzer        (existing; explicit "Recap" chapter wins — cheapest, most authoritative)
+SubtitleRecapAnalyzer  (new; high precision, finds non-zero starts, single-episode)
+ChromaprintAnalyzer    (existing; shared sting fallback)
+```
+
+Slot the `new SubtitleRecapAnalyzer(...)` between lines `327` and `364`. It must also be reachable by
+the `AnalyzerAction` promotion switch (`BaseItemAnalyzerTask.cs:372-390`) — add an
+`AnalyzerAction.Subtitle` (or reuse `Chapter`-like promotion) so a season can be pinned to it.
+Because each analyzer skips already-`Analyzed` episodes via `NeedsAnalysis`
+(`IntroSkipper/Data/QueuedEpisode.cs:131-132`), ordering is pure priority with no double work.
+
+### 4.3 Movies
+
+Recaps are a TV concept; gate the analyzer to non-movie like the existing Recap branch
+(`BaseItemAnalyzerTask.cs:361`).
+
+### 4.4 `TimeAdjustmentHelper` interaction (important)
+
+`AdjustIntroTimesAsync` snaps **start → 0** whenever `rawStart ≤ EndSnapThreshold` (default 2 s)
+(`IntroSkipper/Analyzers/TimeAdjustmentHelper.cs:64-89`). For a recap that opens the episode this is
+fine, but for a recap **after a cold open** (start e.g. 75 s) we must preserve the real start. Two
+options:
+
+- **Preferred:** run the subtitle result through a recap-aware path that applies only **end**
+  adjustments (keyframe/silence snap, `TimeAdjustmentHelper.cs:96-132`) and leaves start untouched, or
+- pass a flag to skip the `≤ EndSnapThreshold` start-snap for `AnalysisMode.Recap`.
+
+The builder already finalizes End via black-frame snap, so keyframe-snapping the end is a nice-to-have,
+not required. Either way the subtitle analyzer must **not** inherit the "force start to 0" behavior of
+the existing recap detectors (see [§9](#9-critical-review-of-the-current-recap-implementation)).
+
+### 4.5 Config surface (`PluginConfiguration`)
+
+Add alongside the existing recap settings (`IntroSkipper/Configuration/PluginConfiguration.cs:254-276`):
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `DetectRecapUsingSubtitles` | `false` (spike) → `true` (ship) | master switch for the analyzer |
+| `RecapSubtitlePhrases` | `RecapPhraseMatcher.DefaultPhrases` joined | newline/`;`-separated phrase list |
+| `RecapSubtitleLanguages` | empty (= any) | ISO-639 filter, e.g. `eng,spa` |
+| `RecapSubtitleMaxWindowSeconds` | `150` | scan window / `MaxWindowSeconds` |
+| `RecapSubtitleClusterGapSeconds` | `12` | `MaxClusterGapSeconds` |
+
+Reuse existing `MinimumRecapDuration`/`MaximumRecapDuration` (`PluginConfiguration.cs:254-261`) for
+the builder's min/max. UI: a checkbox + textarea + language box on the existing Recap section of
+`IntroSkipper/Configuration/configPage.html` (web source under `web/`, built to
+`IntroSkipper/Configuration/introskipper.{js,css}`).
+
+### 4.6 Cache + `ConfigHasher`
+
+- **Analysis hash:** extend the `AnalysisMode.Recap` arm of `ConfigHasher.Analysis`
+  (`IntroSkipper/Helper/ConfigHasher.cs:44-49`) to include the five new settings (a stable hash of the
+  phrase list, language filter, window, gap, enable flag). This makes a phrase-list edit correctly
+  invalidate stored recap segments and re-trigger analysis via `QueueManager.VerifyQueueAsync`
+  (`IntroSkipper/Manager/QueueManager.cs:461-490`).
+- **Extraction cache (optional):** extraction is so cheap (§8) that a dedicated
+  `CacheEntryType.Subtitle` (`IntroSkipper/Data/CacheEntryType.cs`) is optional. If added, key it by
+  `(itemId, Recap, Subtitle, 0, window)` and hash on the language filter only, mirroring
+  `ConfigHasher.DetectionCache` (`ConfigHasher.cs:72-96`). Black-frame results are **already** cached
+  by the existing `CacheEntryType.BlackFrame` path, so the snap step is free on re-runs.
+
+### 4.7 `SegmentProvider`
+
+No change. `AnalysisMode.Recap → MediaSegmentType.Recap` already maps
+(`IntroSkipper/Providers/SegmentProvider.cs:28`), so a subtitle-derived recap surfaces to clients as
+`Recap` (Skip/AskToSkip) like any other.
+
+---
+
+## 5. Algorithm pseudocode
+
+```text
+analyze(episode):
+    if not config.DetectRecapUsingSubtitles: return  # leave for next analyzer
+
+    streams = SubtitleProbe.Parse(ffprobe_show_streams(episode.path))
+    text = pick(streams where IsTextBased,
+                prefer language in config.languages, prefer forced, else first)
+    if text is none:
+        if sidecar(episode.path) exists and is text: payload = read(sidecar)
+        else: return                                  # fall through to chromaprint/blackframe
+    else:
+        payload = ffmpeg_extract_srt(episode.path, stream=text.Index, to=window)   # text-only, cheap
+
+    cues = SubtitleParser.Parse(payload)
+    blackTimes = DetectBlackFramesAsync(episode, [0, window]).map(f -> f.Time)      # cached, reused
+    result = SubtitleRecapSegmentBuilder.Build(cues, matcher, options, blackTimes)
+    if result is null: return
+
+    seg = Segment(episode.Id, result.Start, result.End)   # NOT forced to 0
+    seg = adjustEndOnly(seg)                               # keyframe/silence end-snap; keep start
+    UpdateTimestampAsync(seg, Recap); SetAnalyzed(Recap, Analyzed)
+```
+
+`Build` (the unit-tested core) is the pseudocode of §3, verbatim in
+`IntroSkipper/Subtitles/SubtitleRecapSegmentBuilder.cs`.
+
+---
+
+## 6. Config / UI / hash implications (summary)
+
+- New `PluginConfiguration` fields (§4.5) → must be added to the embedded `configPage.html` + the
+  `web/` TS source and rebuilt (`pnpm build`).
+- `ConfigHasher.Analysis(…, Recap, …)` must include them (§4.6) or edits silently won't re-analyze.
+- `RecapDetectionHelper.GetMaximumBoundaryAsync` (`IntroSkipper/Analyzers/RecapDetectionHelper.cs:21-36`)
+  already computes a sensible scan ceiling (`min(duration, MaximumRecapDetectionDuration, intro.Start)`);
+  the subtitle window should adopt the same ceiling so subtitle/chromaprint/blackframe agree on "how
+  far into the episode a recap can be."
+
+---
+
+## 7. Limits, failure modes, and where it breaks
+
+Honest failure catalogue — this is where subtitles are **not** the answer:
+
+1. **No text subtitles.** Image-only (PGS/VOBSUB/DVB) or no subs at all → analyzer returns nothing,
+   chromaprint/black-frame fallback runs. This is common for older/disc rips and some anime.
+2. **Recap not transcribed.** Some subtitle tracks omit the "Previously on" voiceover or the recap
+   montage entirely (forced-narrative tracks especially) → no cue to match → miss.
+3. **On-screen card only.** Burned-in card with no subtitle/forced track → miss (falls through).
+4. **Foreign-language-only subs vs phrase list.** If the only text track is a language not in the
+   default list, no match. Mitigation: broad default list + user-extensible phrases + language filter.
+5. **Subtitle timing offset / desync.** Sidecar `.srt` mistimed by a few seconds shifts Start/End;
+   the black-frame end-snap absorbs small drift but not gross desync.
+6. **False positives.** A mid-episode "previously on …" line could match — mitigated by
+   `MaxWindowSeconds`, anchored-at-start matching, and multi-word phrases (§2.2/§2.3). Residual risk:
+   a show whose cold open literally opens with someone saying "Last time on …" in dialogue.
+7. **CEA-608 caption quirks.** `eia_608` extraction needs `-f srt` over the decoded captions and can
+   be noisy (all-caps, positioning). Classified as text but flagged lower-confidence.
+8. **Cluster mis-growth.** If recap cues and the first cold-open line are <12 s apart, the cluster can
+   over-extend; the black-frame snap usually corrects the end, but `MaxClusterGapSeconds` is the lever.
+
+Items 1–3 are **fundamental** (no signal in the modality) → subtitles must be a *layer*, not a
+replacement. Items 4–8 are tunable.
+
+---
+
+## 8. Performance vs the "not CPU/GPU heavy" constraint
+
+The maintainers' original constraint (issue #136) was "find a way that's not CPU/GPU heavy."
+Subtitle detection is the **cheapest** signal in the plugin:
+
+| Step | Work | Relative cost |
+|---|---|---|
+| `ffprobe -show_streams` | container header parse | trivial (already done for audio duration, `FFmpegService.cs:322`) |
+| `ffmpeg -map 0:s -to N -f srt` | demux + **subtitle-only** transcode of opening window; **no** video/audio decode | very low — sub-second in the spike |
+| parse + normalize + match + build | pure CPU over a few dozen short strings | negligible (µs–ms) |
+| black-frame snap | **reuses** the cached `BlackFrame` pass | free on re-runs (`FFmpegService.cs:176-180`) |
+
+Contrast with the current recap detectors: chromaprint **decodes and resamples audio** for the whole
+analysis window of *every* episode and does O(n²) cross-episode comparison
+(`ChromaprintAnalyzer.AnalyzeMediaFiles`), and the black-frame fallback **decodes video frames**.
+Subtitle detection decodes neither audio nor video. It comfortably satisfies the constraint and is a
+strict CPU win when it succeeds (it can let chromaprint be skipped for that episode).
+
+Caveat (honest): the **first** extraction still spawns one ffmpeg process per episode (process
+start-up dominates the cost). With ~dozens of ms of subtitle transcode that's still far below a
+chromaprint pass, and results are cacheable.
+
+---
+
+## 9. Critical review of the current recap implementation
+
+Read through the subtitle lens, with what to keep.
+
+### What it gets wrong
+
+1. **Start is structurally forced to 0 — recaps after a cold open are mis-bounded.**
+   - Chromaprint recap: `GetEarliestTimeRange` sets `Start = 0` whenever the shared region starts
+     `≤ 5 s` (`IntroSkipper/Analyzers/ChromaprintAnalyzer.cs:317-325`), and
+     `BuildRecapFromChromaprintCandidateAsync` builds `[0, blackframe]`
+     (`ChromaprintAnalyzer.cs:255-291`).
+   - Chapter/black-frame recap: `BuildRecapFromBlackFrames` **always** returns
+     `new Segment(id, new TimeRange(0, …))` (`IntroSkipper/Analyzers/ChapterAnalyzer.cs:247-273`,
+     esp. `:272`).
+   - The task description itself notes recaps can appear "before a cold open, after a cold open, or
+     after the intro." The current code can only express the first. Subtitle anchoring yields the
+     **true** start (`SubtitleRecapResult.Start`), and `Build` only snaps to 0 when explicitly opted
+     in (§3.4).
+
+2. **Requires cross-episode audio similarity it often won't have.** The chromaprint recap finds the
+   *earliest shared* audio region across episodes (the sting), min 3 s
+   (`ChromaprintAnalyzer.cs:26,221-222`). Recaps are *different every episode* by definition; the only
+   shared audio is a short "Previously on" sting/music bed that many shows **don't have**. It also
+   needs ≥2 episodes and is weak on S01E01. Subtitles need none of this — single episode, episode 1,
+   no sting required.
+
+3. **"Earliest shared region" is a fragile proxy for "recap".** Any early shared audio (a network
+   bumper, a cold-open stinger, a shared SFX) can be selected as the recap card, then the segment is
+   stretched to the next black frame. There's no semantic check that the region *is* a recap.
+   Subtitle text (`"Previously on"`) is a **semantic** cue, not a coincidental-audio cue.
+
+4. **Black-frame-only fallback picks the latest black frame before a boundary, with start 0**
+   (`ChapterAnalyzer.cs:247-273`) — i.e. it assumes the recap is "everything from 0 to the last early
+   fade," which over-captures a cold open that ends in a fade and has no recap at all.
+
+5. **Shipped unvalidated.** Recap (PR #771) shipped broken — `GetFingerprintRange` had no `Recap`
+   case so fingerprinting threw and aborted; the `(0, IntroFingerprintEnd)` case was added later
+   (`IntroSkipper/Data/QueuedEpisode.cs:143-152`). All recap tests are synthetic
+   (`TestRecapDetection.cs`, `TestChapterAnalyzer.cs`) — there is **no** real-media recap test. This
+   spike adds the first real-media (ffmpeg) recap-path test, albeit for the subtitle approach.
+
+### What to keep
+
+- **Black-frame detection + parser** (`FFmpegService.DetectBlackFramesAsync` `:166-199`,
+  `FFmpegOutputParser.ParseBlackFrames` `:76-101`) — excellent **end-boundary** snapper; the subtitle
+  builder reuses it directly and the spike proves it.
+- **`RecapDetectionHelper.GetMaximumBoundaryAsync`** (`:21-36`) — the `min(duration,
+  MaximumRecapDetectionDuration, intro.Start)` ceiling is a good shared scan bound; subtitles should
+  adopt it.
+- **Chromaprint recap as a fallback** — for shows with a genuine shared "Previously on" sting and no
+  usable subtitles, it's still the best available signal. Keep it *after* subtitles in the chain.
+- **The analyzer-chain design** (`BaseItemAnalyzerTask.cs:324-398`) — ordered `IMediaFileAnalyzer`s
+  with `NeedsAnalysis` short-circuiting is exactly the right shape to slot a subtitle analyzer in.
+- **Chapter recap regex** (`PluginConfiguration.cs:369-370`) — when an explicit "Recap" chapter
+  exists it's the most authoritative and cheapest; keep it first.
+
+---
+
+## 10. Pros / cons / risk vs the current implementation
+
+**Pros**
+- Finds recaps with **correct, non-zero starts** (the current code can't).
+- **Single-episode**, works on S01E01 and shows with no shared sting; no O(n²) comparison.
+- **Semantic** cue ("Previously on") → high precision; far fewer false "early shared audio" hits.
+- **Cheapest** signal; decodes neither audio nor video; satisfies the "not heavy" constraint and can
+  save a chromaprint pass.
+- Reuses existing ffprobe/ffmpeg/black-frame plumbing and the cache.
+
+**Cons**
+- Only works with **text** subs that **transcribe** the recap (§7.1–7.4). Coverage is content-dependent.
+- One ffmpeg process per episode on first run (cheap, but non-zero).
+- New config surface, hash entries, and a language/phrase list to maintain.
+
+**Risks**
+- **Coverage gap risk (medium):** users with image-only or sub-less libraries see no benefit → must
+  be layered with the existing detectors, never a replacement. Mitigated by analyzer ordering.
+- **False-positive risk (low):** mitigated by window + anchoring + multi-word phrases; residual on
+  shows whose dialogue opens with "Last time on…".
+- **Maintenance risk (low):** phrase list per language; community-extensible via config.
+- **Integration risk (low–medium):** the `TimeAdjustmentHelper` start-snap (§4.4) must be bypassed for
+  recap or it re-introduces the "force start to 0" bug for post-cold-open recaps.
+
+**Verdict:** Implement as a **new first-class layer** in the Recap chain (after Chapter, before
+Chromaprint), defaulting **on** where a text track exists and silently deferring otherwise. It
+directly fixes the start-at-0 and cross-episode-dependence defects while being the cheapest detector
+in the plugin. It is **not** a standalone replacement.
+
+---
+
+## 11. Verified vs assumed
+
+| Claim | Status | Evidence |
+|---|---|---|
+| ffmpeg can mux text subs (subrip/mov_text) into MKV/MP4 | **Verified** | `extract_spike.sh` step 1b; spike test |
+| ffprobe enumerates subtitle `index`/`codec_name`/`language` | **Verified** | spike output §0; `SubtitleProbe` test |
+| Opening window extractable as SRT to stdout, text-only, cheap | **Verified** | spike output §0 (subrip + mov_text) |
+| `-to N` excludes later cues (windowing works) | **Verified** | cue #3 @30 s excluded by 15 s window |
+| Black frame at recap boundary detected by the plugin's filter/parser | **Verified** | spike output §0; `FFmpegOutputParser.ParseBlackFrames` in spike test |
+| Image-sub `codec_name` strings to skip (PGS/VOBSUB/DVB/xsub) | **Verified** | ffmpeg `-decoders` list; classifier unit tests |
+| Pure parse→match→build core (anchor, cluster, snap, clamp, window) | **Verified** | 58 unit tests |
+| End-to-end real-ffmpeg pipeline → correct `Start≈2`, `End≈10` | **Verified** | `TestSubtitleRecapSpike` |
+| Analyzer wiring / precedence / config / hash / UI | **Designed (assumed)** | §4–§6 — not implemented in this spike |
+| Real-world recall across diverse shows/languages | **Assumed** | needs a media corpus; not measured here |
+| Synthesizing a real PGS/VOBSUB bitmap stream in-env | **Not done** | ffmpeg can't transcode text→bitmap; classification verified on codec strings instead |
+
+---
+
+## Appendix — reproduce
+
+```
+# pure core + classifier + ffprobe parser (no media)
+dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj -p:SkipWebBuild=true \
+  --filter FullyQualifiedName~TestSubtitleRecapDetection
+
+# end-to-end ffmpeg spike (needs ffmpeg on PATH)
+dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj -p:SkipWebBuild=true \
+  --filter FullyQualifiedName~TestSubtitleRecapSpike
+
+# shell reproduction of the extraction pipeline
+bash docs/recap-research/spike/extract_spike.sh
+```

--- a/docs/recap-research/spike/extract_spike.sh
+++ b/docs/recap-research/spike/extract_spike.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# End-to-end de-risking spike for subtitle-driven recap detection (RFC A).
+#
+# Proves, with real ffmpeg/ffprobe, the extraction path the plugin would use:
+#   1. mux a synthetic clip with an embedded TEXT subtitle stream ("Previously on…")
+#      and a fade-to-black at a known time (the recap boundary);
+#   2. enumerate subtitle streams + codec + language with ffprobe (-show_streams);
+#   3. extract ONLY the opening window as SubRip to stdout (cheap, text-only);
+#   4. detect the black frame with the SAME filter the plugin already uses.
+#
+# Run: bash docs/recap-research/spike/extract_spike.sh
+# Requires ffmpeg + ffprobe on PATH. Writes to a temp dir and cleans up.
+set -euo pipefail
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+echo "==> work dir: $WORK"
+
+# (0) A recap subtitle: a dense "Previously on…" cluster, a gap, then a normal cue.
+cat > recap.srt <<'EOF'
+1
+00:00:02,000 --> 00:00:05,000
+Previously on Test Show...
+
+2
+00:00:05,500 --> 00:00:09,000
+...the hero lost everything.
+
+3
+00:00:30,000 --> 00:00:33,000
+Welcome back. Let's begin.
+EOF
+
+# (1a) 40s tiny clip; full-black frames in [10,11] act as the recap fade-out.
+#      Commas inside the enable() expression are backslash-escaped so no shell
+#      quoting is needed (this is exactly how the args are passed to ffmpeg from C#).
+ffmpeg -hide_banner -loglevel error -f lavfi -i testsrc=size=320x240:rate=5:duration=40 \
+  -vf "drawbox=x=0:y=0:w=in_w:h=in_h:color=black:t=fill:enable=between(t\,10\,11)" \
+  -pix_fmt yuv420p video.mp4
+
+# (1b) Mux the subtitle as a TEXT stream into MKV (subrip) and MP4 (mov_text).
+ffmpeg -hide_banner -loglevel error -i video.mp4 -i recap.srt \
+  -c:v copy -c:s srt -metadata:s:s:0 language=eng episode.mkv
+ffmpeg -hide_banner -loglevel error -i video.mp4 -i recap.srt \
+  -c:v copy -c:s mov_text -metadata:s:s:0 language=eng episode.mp4
+
+echo
+echo "==> (2) ffprobe: enumerate subtitle streams (index, codec, language)"
+ffprobe -v error -select_streams s \
+  -show_entries stream=index,codec_name,codec_type,disposition:stream_tags=language \
+  -of json episode.mkv
+
+echo
+echo "==> (3) extract ONLY the opening 15s as SubRip to stdout (mkv/subrip)"
+ffmpeg -hide_banner -loglevel error -i episode.mkv -to 15 -map 0:s:0 -f srt -
+
+echo "==> (3b) same for mp4/mov_text"
+ffmpeg -hide_banner -loglevel error -i episode.mp4 -to 15 -map 0:s:0 -f srt -
+
+echo
+echo "==> (4) black-frame detection in [0,20] (plugin filter: blackframe=amount=50:threshold=28)"
+ffmpeg -hide_banner -loglevel info -ss 0 -i episode.mkv -to 20 -an -dn -sn \
+  -vf blackframe=amount=50:threshold=28 -f null - 2>&1 | grep -i "blackframe" | head -4
+
+echo
+echo "==> spike OK"


### PR DESCRIPTION
**Research + design spike — NOT a mergeable feature.** No analyzer is wired into the runtime chain and no existing files are modified; the new module is dead code at runtime. Goal: design and de-risk the best-possible Recap detection driven by **subtitle/caption phrase detection** ("Previously on…"), and critically review the current recap code from that lens.

Full write-up: `docs/recap-research/A-subtitles.md`.

### What's proven (real ffmpeg) vs designed
- **Proven** — pure parse→match→build core (58 unit tests) and an end-to-end `[FactSkipFFmpegTests]` spike that muxes a synthetic clip, enumerates streams with `ffprobe`, extracts the opening window as SRT, detects the fade-to-black, and runs the real builder → `Start≈2.0` (not 0), `End≈10.0` (snapped). Reproducible shell pipeline in `docs/recap-research/spike/extract_spike.sh`.
- **Designed (not implemented here)** — the `SubtitleRecapAnalyzer`, chain precedence, config/UI, and `ConfigHasher` wiring, all mapped to exact `file:line` in the RFC.

### Prototype (`IntroSkipper/Subtitles/`)
`SubtitleParser` (SRT/WebVTT/ASS), `RecapPhraseMatcher` (normalize + **anchored** multilingual match — strips speaker labels/SFX so `"I told you previously on Tuesday…"` is rejected while `"[NARRATOR] Previously on…"` matches), `SubtitleRecapSegmentBuilder` (start = matched cue, **not forced to 0**; end = dense cue cluster snapped to the existing black-frame pass), `SubtitleCodec`/`SubtitleProbe` (ffprobe enumeration + TEXT vs IMAGE PGS/VOBSUB/DVB classification, scoped out for OCR).

### Why it matters (critical review)
The current recap detectors **force start to 0** (`ChromaprintAnalyzer.cs:317-325`, `ChapterAnalyzer.cs:272`) so they can't express recaps after a cold open, and the chromaprint path needs **cross-episode shared audio** that recaps inherently lack. Subtitles are **semantic**, **single-episode**, and the **cheapest** signal (no audio/video decode) — satisfying the original "not CPU/GPU heavy" constraint. Honest limits (no/image/foreign/mistimed subs → fall through to existing detectors) are catalogued in the RFC. Recommendation: add as a new **layer** between Chapter and Chromaprint, not a replacement.

### Tests
`dotnet test … -p:SkipWebBuild=true` → **374 passed, 1 failed, 0 skipped**. The single failure (`TestAudioFingerprinting.TestSilenceDetection`) is **pre-existing/environmental** (ffmpeg `silencedetect` float rounding) on pristine `10.11`. All 59 added tests pass; web build green.

## Summary by Sourcery

Add a prototype, fully unit-tested subtitle-driven recap detection core and accompanying research RFC without wiring it into the runtime recap analyzer chain.

New Features:
- Introduce a standalone subtitles module that parses text subtitle formats, matches recap-opening phrases, and builds recap segments using subtitle cues and existing black-frame detection.

Enhancements:
- Provide a shell script spike to prove the ffmpeg/ffprobe-based subtitle extraction and black-frame detection pipeline on real media.

Documentation:
- Add an RFC detailing subtitle/caption-driven recap detection design, limitations, and integration plan.

Tests:
- Add extensive unit tests for subtitle parsing, phrase matching, recap segment building, codec classification, and ffprobe JSON parsing, plus an ffmpeg-gated end-to-end spike test.