### PR TITLE
[Recap RFC C] Harden current recap path

### DIFF
--- a/IntroSkipper.Tests/TestRecapHardening.cs
+++ b/IntroSkipper.Tests/TestRecapHardening.cs
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: 2026 AbandonedCart
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Helper;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+/// <summary>
+/// Tests for the hardened recap detection path: cold-open-aware start anchoring, structure-aware
+/// montage-end selection, false-positive guards against the opening theme, the deduplicated scan
+/// window clamp, and the shared Introduction/Recap fingerprint cache key.
+/// </summary>
+public class TestRecapHardening
+{
+    // ---- Bug 1: non-zero start (cold open before recap) ----
+
+    [Fact]
+    public void ColdOpenBeforeRecap_AnchorsStartToStingNotZero()
+    {
+        // Structure: cold open [0,40] | recap montage [40,70] | gap | intro [72,92].
+        // Shared "previously on" sting at [40,44]; fade/black frames at the cold-open boundary (40)
+        // and the montage end (70).
+        var sting = new TimeRange(40, 44);
+        var blackFrames = Frames(40, 70);
+        var context = Context(maxBoundary: 72, introDetected: true);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(40, recap.Start); // NOT 0 — the cold open is preserved.
+        Assert.Equal(70, recap.End);
+    }
+
+    [Fact]
+    public void ColdOpenBeforeRecap_AnchorsToFadeJustBeforeSting()
+    {
+        // The visual recap (and its fade-in) can begin slightly before the shared audio sting.
+        var sting = new TimeRange(40, 44);
+        var blackFrames = Frames(39.5, 70);
+        var context = Context(maxBoundary: 72, introDetected: true);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(39.5, recap.Start);
+        Assert.Equal(70, recap.End);
+    }
+
+    [Fact]
+    public void RecapAtEpisodeStart_NoColdOpen_StartsAtZero()
+    {
+        // Structure: recap [0,30] | intro [32,52]. Sting opens the episode.
+        var sting = new TimeRange(0, 3);
+        var blackFrames = Frames(30);
+        var context = Context(maxBoundary: 32, introDetected: true);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(0, recap.Start);
+        Assert.Equal(30, recap.End);
+    }
+
+    [Fact]
+    public void AllowColdOpenDisabled_PreservesLegacyZeroStart()
+    {
+        // Same cold-open structure as the first test, but the toggle is off: legacy 0:00 start.
+        var sting = new TimeRange(40, 44);
+        var blackFrames = Frames(40, 70);
+        var context = Context(maxBoundary: 72, introDetected: true, allowColdOpen: false);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(0, recap.Start); // legacy behavior swallows the cold open.
+        Assert.Equal(70, recap.End);
+    }
+
+    // ---- Bug 2: structure-aware montage-end selection (overshoot / undershoot / no frame) ----
+
+    [Fact]
+    public void MontageEnd_PicksEarliestValidFrame_NotLatest_AvoidingOvershoot()
+    {
+        // A mid-episode scene change (110) sits beyond the true montage end (70). The legacy
+        // "latest black frame" logic would overshoot to 110 and swallow episode content.
+        var sting = new TimeRange(40, 44);
+        var blackFrames = Frames(40, 70, 110);
+        var context = Context(maxBoundary: 118, introDetected: true);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(40, recap.Start);
+        Assert.Equal(70, recap.End); // earliest qualifying frame, not 110.
+    }
+
+    [Fact]
+    public void MontageEnd_SkipsFramesShorterThanMinimumDuration()
+    {
+        // A black frame at 10 would yield a 10s recap (< 15s floor); it must be skipped in favour
+        // of the real montage end at 30.
+        var sting = new TimeRange(0, 3);
+        var blackFrames = Frames(10, 30);
+        var context = Context(maxBoundary: 40, introDetected: true);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(0, recap.Start);
+        Assert.Equal(30, recap.End);
+    }
+
+    [Fact]
+    public void NoBlackFrame_IntroDetected_LongSharedRegion_UsesSharedBodyAsRecap()
+    {
+        // Shared music bed spanning the montage, no fade detected. With an intro detected the theme
+        // is already excluded, so the shared region itself is the recap body.
+        var sting = new TimeRange(40, 65);
+        var blackFrames = NoFrames();
+        var context = Context(maxBoundary: 70, introDetected: true);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(40, recap.Start);
+        Assert.Equal(65, recap.End);
+    }
+
+    [Fact]
+    public void NoBlackFrame_IntroNotDetected_Rejects()
+    {
+        // Without a fade/black-frame boundary AND without a detected intro to exclude the theme, the
+        // recap cannot be confidently bounded, so detection refuses to guess.
+        var sting = new TimeRange(5, 18);
+        var blackFrames = NoFrames();
+        var context = Context(maxBoundary: 120, introDetected: false);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.Null(recap);
+    }
+
+    // ---- Bug 3: false-positive guard against the opening theme ----
+
+    [Fact]
+    public void IntroTheme_NoIntroDetected_LongSharedRegion_Rejected()
+    {
+        // The earliest shared region is the recurring opening theme [30,55] (25s). With no intro
+        // detected the scan window is not clamped, so the length guard rejects it as a theme.
+        var sting = new TimeRange(30, 55);
+        var blackFrames = Frames(55);
+        var context = Context(maxBoundary: 120, introDetected: false);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.Null(recap);
+    }
+
+    [Fact]
+    public void IntroTheme_IntroDetected_ClampedOutByScanWindow()
+    {
+        // The shared region coincides with the detected intro [30,55]; the intro-clamped window
+        // (MaxBoundary = introStart = 30) makes the candidate fail the fit check.
+        var sting = new TimeRange(30, 55);
+        var blackFrames = Frames(55);
+        var context = Context(maxBoundary: 30, introDetected: true);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.Null(recap);
+    }
+
+    [Fact]
+    public void ShortStingWithMontageBoundary_NoIntroDetected_StillDetected()
+    {
+        // A genuinely short sting [42,46] followed by a montage-end fade (70) is corroborated by
+        // structure, so it survives even when no intro was detected.
+        var sting = new TimeRange(42, 46);
+        var blackFrames = Frames(42, 70);
+        var context = Context(maxBoundary: 120, introDetected: false);
+
+        var recap = RecapDetectionHelper.BuildChromaprintRecap(Guid.NewGuid(), sting, blackFrames, context);
+
+        Assert.NotNull(recap);
+        Assert.Equal(42, recap.Start);
+        Assert.Equal(70, recap.End);
+    }
+
+    // ---- ResolveRecapStart / SelectMontageEnd unit behavior ----
+
+    [Theory]
+    [InlineData(0, true, 0)]    // sting opens episode -> 0
+    [InlineData(3, true, 0)]    // within cold-open threshold -> 0
+    [InlineData(40, true, 40)]  // cold open present, no nearby frame -> sting start
+    [InlineData(40, false, 0)]  // cold open disabled -> legacy 0
+    public void ResolveRecapStart_Behaves(double stingStart, bool allowColdOpen, double expected)
+    {
+        var start = RecapDetectionHelper.ResolveRecapStart(stingStart, NoFrames(), allowColdOpen);
+        Assert.Equal(expected, start);
+    }
+
+    [Fact]
+    public void ResolveRecapStart_IgnoresFrameOutsideLeadInWindow()
+    {
+        // A black frame 10s before the sting is too far back to be the recap boundary (lead-in is
+        // 6s); the sting start is used instead.
+        var start = RecapDetectionHelper.ResolveRecapStart(40, Frames(30), allowColdOpen: true);
+        Assert.Equal(40, start);
+    }
+
+    // ---- Bug 4: deduplicated, pure scan-window clamp ----
+
+    [Theory]
+    [InlineData(1800, 120, null, 120)] // detection cap wins
+    [InlineData(1800, 120, 70.0, 70)]  // intro start wins
+    [InlineData(90, 120, null, 90)]    // short episode duration wins
+    [InlineData(1800, 120, 200.0, 120)] // intro later than cap -> cap wins
+    public void ComputeMaximumBoundary_ClampsToTightestBound(double duration, int maxDetection, double? introStart, double expected)
+    {
+        Assert.Equal(expected, RecapDetectionHelper.ComputeMaximumBoundary(duration, maxDetection, introStart));
+    }
+
+    // ---- Bug 5: shared Introduction/Recap fingerprint cache key (no duplicate decode) ----
+
+    [Theory]
+    [InlineData(AnalysisMode.Recap, AnalysisMode.Introduction)]
+    [InlineData(AnalysisMode.Introduction, AnalysisMode.Introduction)]
+    [InlineData(AnalysisMode.Credits, AnalysisMode.Credits)]
+    public void GetFingerprintCacheMode_MapsRecapToIntroduction(AnalysisMode mode, AnalysisMode expected)
+    {
+        Assert.Equal(expected, QueuedEpisode.GetFingerprintCacheMode(mode));
+    }
+
+    [Fact]
+    public void RecapAndIntroduction_ShareTheSameFingerprintRange()
+    {
+        var episode = new QueuedEpisode { Duration = 1800, IntroFingerprintEnd = 240 };
+
+        // Identical decode range is the reason the cache entry can be shared.
+        Assert.Equal(
+            episode.GetFingerprintRange(AnalysisMode.Introduction),
+            episode.GetFingerprintRange(AnalysisMode.Recap));
+    }
+
+    [Fact]
+    public async Task FingerprintAsync_Recap_ReusesIntroductionCacheEntry_NoDecode()
+    {
+        var cache = new RecordingCacheService();
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Path = "/nonexistent/episode.mkv", // would fail to decode if a cache miss fell through
+            Duration = 1800,
+            IntroFingerprintEnd = 240,
+        };
+
+        uint[] introFingerprint = [1, 2, 3, 4, 5];
+        // Seed only the Introduction-keyed entry (as the Introduction pass would have written).
+        cache.Seed(episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 240, introFingerprint);
+
+        var ffmpeg = new FFmpegService(NullLogger<FFmpegService>.Instance, cache);
+
+        // The Recap pass must hit the shared Introduction entry instead of decoding again.
+        var recapFingerprint = await ffmpeg.FingerprintAsync(episode, AnalysisMode.Recap, CancellationToken.None);
+
+        Assert.Equal(introFingerprint, recapFingerprint);
+        Assert.Contains((AnalysisMode.Introduction, CacheEntryType.Chromaprint), cache.Reads);
+        Assert.DoesNotContain((AnalysisMode.Recap, CacheEntryType.Chromaprint), cache.Reads);
+    }
+
+    // ---- Bug 6: every new knob participates in the config hash ----
+
+    [Fact]
+    public void RecapHash_ChangesWhenColdOpenToggleChanges()
+    {
+        var baseline = new PluginConfiguration();
+        var toggled = new PluginConfiguration { RecapAllowColdOpen = !baseline.RecapAllowColdOpen };
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(baseline, AnalysisMode.Recap, AnalyzerAction.Default),
+            ConfigHasher.Analysis(toggled, AnalysisMode.Recap, AnalyzerAction.Default));
+    }
+
+    private static IReadOnlyList<BlackFrame> Frames(params double[] times)
+    {
+        var frames = new List<BlackFrame>(times.Length);
+        for (var i = 0; i < times.Length; i++)
+        {
+            frames.Add(new BlackFrame(90, times[i], i));
+        }
+
+        return frames;
+    }
+
+    private static IReadOnlyList<BlackFrame> NoFrames() => [];
+
+    private static RecapDetectionHelper.RecapBuildContext Context(
+        double maxBoundary,
+        bool introDetected,
+        bool allowColdOpen = true,
+        int minimumRecapDuration = 15,
+        int maximumRecapDuration = 120,
+        int minimumRecapDetectionDuration = 15)
+        => new(
+            maxBoundary,
+            introDetected,
+            allowColdOpen,
+            minimumRecapDuration,
+            maximumRecapDuration,
+            minimumRecapDetectionDuration);
+
+    private sealed class RecordingCacheService : IDetectionCacheService
+    {
+        private readonly Dictionary<(Guid Id, AnalysisMode Mode, CacheEntryType Type, double Start, double End), Array> _store = [];
+
+        public List<(AnalysisMode Mode, CacheEntryType Type)> Reads { get; } = [];
+
+        public bool IsEnabled => true;
+
+        public void Seed<T>(Guid id, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
+            => _store[(id, mode, type, start, end)] = items;
+
+        public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
+        {
+            Reads.Add((mode, type));
+            if (_store.TryGetValue((itemId, mode, type, start, end), out var stored) && stored is T[] typed)
+            {
+                result = typed;
+                return true;
+            }
+
+            result = [];
+            return false;
+        }
+
+        public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
+        {
+            _store[(itemId, mode, type, start, end)] = items;
+            return true;
+        }
+
+        public void DeleteForItem(Guid itemId)
+        {
+        }
+
+        public void DeleteByMode(AnalysisMode mode)
+        {
+        }
+
+        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode) => false;
+    }
+}

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -220,10 +220,13 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
 
     internal async Task<Segment?> DetectRecapUsingBlackFramesAsync(QueuedEpisode episode, CancellationToken cancellationToken)
     {
-        var maxRecapBoundary = await RecapDetectionHelper.GetMaximumBoundaryAsync(
+        // Black-frame-only fallback (no Chromaprint sting available): there is no shared-audio
+        // anchor, so this path keeps the legacy behavior of a 0:00 start bounded by a black frame.
+        var window = await RecapDetectionHelper.GetRecapScanWindowAsync(
             episode,
             _config,
             cancellationToken).ConfigureAwait(false);
+        var maxRecapBoundary = window.MaxBoundary;
         if (maxRecapBoundary <= 0)
         {
             return null;

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -262,11 +262,11 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             return null;
         }
 
-        var maximumBoundary = await RecapDetectionHelper.GetMaximumBoundaryAsync(
+        var window = await RecapDetectionHelper.GetRecapScanWindowAsync(
             episode,
             _config,
             cancellationToken).ConfigureAwait(false);
-        if (maximumBoundary <= card.End)
+        if (window.MaxBoundary <= card.End)
         {
             return null;
         }
@@ -275,7 +275,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
         {
             blackFrames = await _ffmpegService.DetectBlackFramesAsync(
                 episode,
-                new TimeRange(0, maximumBoundary),
+                new TimeRange(0, window.MaxBoundary),
                 _config.BlackFrameMinimumPercentage,
                 _config.BlackFrameThreshold,
                 AnalysisMode.Recap,
@@ -283,11 +283,19 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             _recapBlackFrameCache[episode.EpisodeId] = blackFrames;
         }
 
-        return ChapterAnalyzer.BuildRecapFromBlackFrames(
+        var context = new RecapDetectionHelper.RecapBuildContext(
+            window.MaxBoundary,
+            window.IntroDetected,
+            _config.RecapAllowColdOpen,
+            _config.MinimumRecapDuration,
+            _config.MaximumRecapDuration,
+            _config.MinimumRecapDetectionDuration);
+
+        return RecapDetectionHelper.BuildChromaprintRecap(
             episode.EpisodeId,
+            new TimeRange(card.Start, card.End),
             blackFrames,
-            Math.Max(_config.MinimumRecapDetectionDuration, (int)Math.Ceiling(card.End)),
-            maximumBoundary);
+            context);
     }
 
     private static (Segment Lhs, Segment Rhs) GetEarliestTimeRange(
@@ -311,18 +319,12 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             }
         }
 
+        // Preserve the true sting start. Unlike introductions, the recap builder needs the real
+        // start of the shared "previously on" sting to anchor a leading cold open
+        // (see RecapDetectionHelper.ResolveRecapStart); snapping it to 0 here would erase that
+        // structure and force every recap to begin at 0:00.
         var lhsRecap = new TimeRange(lhsRanges[earliestIndex]);
         var rhsRecap = new TimeRange(rhsRanges[earliestIndex]);
-
-        if (lhsRecap.Start <= 5)
-        {
-            lhsRecap.Start = 0;
-        }
-
-        if (rhsRecap.Start <= 5)
-        {
-            rhsRecap.Start = 0;
-        }
 
         return (new Segment(lhsId, lhsRecap), new Segment(rhsId, rhsRecap));
     }

--- a/IntroSkipper/Analyzers/RecapDetectionHelper.cs
+++ b/IntroSkipper/Analyzers/RecapDetectionHelper.cs
@@ -9,29 +9,266 @@ namespace IntroSkipper.Analyzers;
 /// <summary>
 /// Shared recap detection helpers.
 /// </summary>
+/// <remarks>
+/// This type is the single source of truth for the recap scan window and for turning a
+/// Chromaprint "previously on" sting plus black-frame structure into a recap segment. Keeping the
+/// clamp and boundary logic here (rather than duplicated inline in the analyzers) means both the
+/// Chromaprint path and the black-frame fallback compute identical windows.
+/// </remarks>
 internal static class RecapDetectionHelper
 {
     /// <summary>
-    /// Gets the latest timestamp that recap boundary detection should scan.
+    /// A sting that begins at or before this offset (seconds) is treated as opening the episode,
+    /// so the recap starts at 0:00. A later sting implies a leading cold open whose boundary must
+    /// be preserved.
+    /// </summary>
+    private const double ColdOpenStartThreshold = 5.0;
+
+    /// <summary>
+    /// How far (seconds) before the sting to look for the fade/black-frame transition that marks
+    /// the cold-open → recap boundary. A frame further back than this is more likely an internal
+    /// cold-open scene cut than the recap boundary, so the sting start is used instead.
+    /// </summary>
+    private const double ColdOpenLeadInWindow = 6.0;
+
+    /// <summary>
+    /// When no introduction has been detected, a shared region longer than this (seconds) is
+    /// treated as the opening theme rather than a recap sting and rejected. Without the
+    /// intro-clamped scan window this is the only signal separating a recurring theme from a short
+    /// "previously on" sting; it is deliberately conservative and is a documented source of missed
+    /// long-sting recaps.
+    /// </summary>
+    private const double StingMaximumDuration = 20.0;
+
+    /// <summary>
+    /// Computes the latest timestamp (seconds) recap boundary detection should scan, clamped to the
+    /// configured detection ceiling, the media duration, and — when supplied — the introduction
+    /// start. This is the single, pure implementation of the recap window clamp.
+    /// </summary>
+    /// <param name="duration">Episode duration in seconds.</param>
+    /// <param name="maximumDetectionDuration">Configured maximum recap detection duration in seconds.</param>
+    /// <param name="introStart">Introduction start in seconds, or <see langword="null"/> when no valid intro exists.</param>
+    /// <returns>The maximum recap boundary in seconds.</returns>
+    internal static double ComputeMaximumBoundary(double duration, int maximumDetectionDuration, double? introStart)
+    {
+        var boundary = Math.Min(duration, maximumDetectionDuration);
+        if (introStart is { } introStartValue)
+        {
+            boundary = Math.Min(boundary, introStartValue);
+        }
+
+        return boundary;
+    }
+
+    /// <summary>
+    /// Gets the recap scan window for an episode: the maximum boundary plus whether a valid
+    /// introduction was detected (which controls how strict the false-positive guard must be).
     /// </summary>
     /// <param name="episode">Queued episode.</param>
     /// <param name="config">Plugin configuration.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The maximum recap boundary in seconds.</returns>
-    internal static async Task<double> GetMaximumBoundaryAsync(
+    /// <returns>The recap scan window.</returns>
+    internal static async Task<RecapScanWindow> GetRecapScanWindowAsync(
         QueuedEpisode episode,
         PluginConfiguration config,
         CancellationToken cancellationToken)
     {
-        var maximumBoundary = Math.Min(episode.Duration, config.MaximumRecapDetectionDuration);
+        ArgumentNullException.ThrowIfNull(episode);
+        ArgumentNullException.ThrowIfNull(config);
+
+        double? introStart = null;
         var timestamps = await Plugin.GetTimestampsAsync(
             episode.EpisodeId,
             cancellationToken).ConfigureAwait(false);
         if (timestamps.TryGetValue(AnalysisMode.Introduction, out var intro) && intro.Valid)
         {
-            maximumBoundary = Math.Min(maximumBoundary, intro.Start);
+            introStart = intro.Start;
         }
 
-        return maximumBoundary;
+        var maximumBoundary = ComputeMaximumBoundary(episode.Duration, config.MaximumRecapDetectionDuration, introStart);
+        return new RecapScanWindow(maximumBoundary, introStart.HasValue);
     }
+
+    /// <summary>
+    /// Builds a recap segment from a Chromaprint shared "previously on" sting and the black-frame
+    /// structure around it. The start is anchored to a leading cold open (if present) rather than
+    /// forced to 0:00, the end is the earliest fade/black-frame transition that closes the montage,
+    /// and the result is duration-sanity checked and guarded against the opening theme.
+    /// </summary>
+    /// <param name="episodeId">Episode id.</param>
+    /// <param name="sting">The shared (sting) region returned by the index search.</param>
+    /// <param name="blackFrames">Black frames detected in the scan window.</param>
+    /// <param name="context">Recap window and configuration bounds.</param>
+    /// <returns>The recap segment, or <see langword="null"/> when no confident recap is found.</returns>
+    internal static Segment? BuildChromaprintRecap(
+        Guid episodeId,
+        TimeRange sting,
+        IReadOnlyList<BlackFrame> blackFrames,
+        RecapBuildContext context)
+    {
+        ArgumentNullException.ThrowIfNull(sting);
+        ArgumentNullException.ThrowIfNull(blackFrames);
+
+        // The shared region must be a real candidate that fits inside the scan window. When an
+        // intro is detected this also rejects a sting that coincides with the intro theme, because
+        // the window has already been clamped to the intro start.
+        if (sting.End <= 0 || context.MaxBoundary <= sting.End)
+        {
+            return null;
+        }
+
+        // False-positive guard: with no intro detected the window is not clamped to the intro, so a
+        // long early shared region is far more likely to be the recurring theme than a recap sting.
+        if (!context.IntroDetected && sting.Duration > StingMaximumDuration)
+        {
+            return null;
+        }
+
+        var start = ResolveRecapStart(sting.Start, blackFrames, context.AllowColdOpen);
+        var minimumEndTime = Math.Max(context.MinimumRecapDetectionDuration, sting.End);
+        var end = SelectMontageEnd(blackFrames, start, sting.End, minimumEndTime, context);
+
+        if (end is null)
+        {
+            // No montage-end black frame exists. Only trust a no-black-frame recap when an intro
+            // was detected (theme already excluded) and the shared region is itself long enough to
+            // be the recap body — i.e. a shared music bed spanning the whole montage. Otherwise we
+            // cannot bound the recap and refuse to guess (which would risk swallowing the episode).
+            if (context.IntroDetected && sting.Duration >= context.MinimumRecapDuration)
+            {
+                end = sting.End;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        var recap = new TimeRange(start, end.Value);
+        return IsWithinBounds(recap, context) ? new Segment(episodeId, recap) : null;
+    }
+
+    /// <summary>
+    /// Resolves the recap start, anchoring it to a leading cold open when one is present instead of
+    /// forcing 0:00.
+    /// </summary>
+    /// <param name="stingStart">Start of the shared sting in seconds.</param>
+    /// <param name="blackFrames">Black frames detected in the scan window.</param>
+    /// <param name="allowColdOpen">Whether non-zero (cold-open) starts are permitted.</param>
+    /// <returns>The resolved recap start in seconds.</returns>
+    internal static double ResolveRecapStart(double stingStart, IReadOnlyList<BlackFrame> blackFrames, bool allowColdOpen)
+    {
+        ArgumentNullException.ThrowIfNull(blackFrames);
+
+        // Legacy behavior: always begin the recap at the episode start.
+        if (!allowColdOpen)
+        {
+            return 0;
+        }
+
+        // A sting that begins at (or within a few seconds of) 0:00 indicates the recap opens the
+        // episode; there is no cold open to preserve.
+        if (stingStart <= ColdOpenStartThreshold)
+        {
+            return 0;
+        }
+
+        // A cold open precedes the recap. Anchor the start to the fade/black-frame transition just
+        // before the sting (closest qualifying frame) when one exists, otherwise to the sting.
+        double? transition = null;
+        foreach (var blackFrame in blackFrames)
+        {
+            if (blackFrame.Time > stingStart || blackFrame.Time < stingStart - ColdOpenLeadInWindow)
+            {
+                continue;
+            }
+
+            if (transition is null || blackFrame.Time > transition.Value)
+            {
+                transition = blackFrame.Time;
+            }
+        }
+
+        return transition ?? stingStart;
+    }
+
+    /// <summary>
+    /// Selects the montage-end black frame: the earliest fade/black-frame transition after the
+    /// sting that produces a recap whose duration is within the configured bounds. Choosing the
+    /// earliest valid frame (rather than the latest) prevents the boundary from overshooting into a
+    /// mid-episode scene change, while the duration floor skips transitions too close to the start.
+    /// </summary>
+    /// <param name="blackFrames">Black frames detected in the scan window.</param>
+    /// <param name="start">Resolved recap start in seconds.</param>
+    /// <param name="stingEnd">End of the shared sting in seconds.</param>
+    /// <param name="minimumEndTime">Earliest allowed recap end time in seconds.</param>
+    /// <param name="context">Recap window and configuration bounds.</param>
+    /// <returns>The montage-end time in seconds, or <see langword="null"/> when no frame qualifies.</returns>
+    internal static double? SelectMontageEnd(
+        IReadOnlyList<BlackFrame> blackFrames,
+        double start,
+        double stingEnd,
+        double minimumEndTime,
+        RecapBuildContext context)
+    {
+        ArgumentNullException.ThrowIfNull(blackFrames);
+
+        double? best = null;
+        foreach (var blackFrame in blackFrames)
+        {
+            var time = blackFrame.Time;
+            if (time <= stingEnd || time < minimumEndTime || time > context.MaxBoundary)
+            {
+                continue;
+            }
+
+            var duration = time - start;
+            if (duration < context.MinimumRecapDuration || duration > context.MaximumRecapDuration)
+            {
+                continue;
+            }
+
+            if (best is null || time < best.Value)
+            {
+                best = time;
+            }
+        }
+
+        return best;
+    }
+
+    private static bool IsWithinBounds(TimeRange recap, RecapBuildContext context)
+    {
+        if (recap.Start < 0 || recap.End <= recap.Start || recap.End > context.MaxBoundary)
+        {
+            return false;
+        }
+
+        var duration = recap.Duration;
+        return duration >= context.MinimumRecapDuration && duration <= context.MaximumRecapDuration;
+    }
+
+    /// <summary>
+    /// The recap scan window for an episode.
+    /// </summary>
+    /// <param name="MaxBoundary">Latest timestamp (seconds) recap detection should scan.</param>
+    /// <param name="IntroDetected">Whether a valid introduction segment exists for the episode.</param>
+    internal readonly record struct RecapScanWindow(double MaxBoundary, bool IntroDetected);
+
+    /// <summary>
+    /// Configuration bounds and scan state passed to <see cref="BuildChromaprintRecap"/>.
+    /// </summary>
+    /// <param name="MaxBoundary">Latest timestamp (seconds) recap detection should scan.</param>
+    /// <param name="IntroDetected">Whether a valid introduction segment exists for the episode.</param>
+    /// <param name="AllowColdOpen">Whether non-zero (cold-open) recap starts are permitted.</param>
+    /// <param name="MinimumRecapDuration">Minimum acceptable recap duration in seconds.</param>
+    /// <param name="MaximumRecapDuration">Maximum acceptable recap duration in seconds.</param>
+    /// <param name="MinimumRecapDetectionDuration">Earliest allowed recap end time in seconds.</param>
+    internal readonly record struct RecapBuildContext(
+        double MaxBoundary,
+        bool IntroDetected,
+        bool AllowColdOpen,
+        int MinimumRecapDuration,
+        int MaximumRecapDuration,
+        int MinimumRecapDetectionDuration);
 }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -276,6 +276,14 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool DetectRecapUsingBlackFrames { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether a Chromaprint recap may begin after a leading cold
+    /// open instead of always starting at 0:00. When enabled, the recap start is anchored to the
+    /// shared "previously on" sting (and the fade/black-frame transition just before it); when
+    /// disabled, the legacy behavior of forcing the recap to start at 0:00 is preserved.
+    /// </summary>
+    public bool RecapAllowColdOpen { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the minimum length of similar audio that will be considered a preview.
     /// </summary>
     public int MinimumPreviewDuration { get; set; } = 15;

--- a/IntroSkipper/Data/QueuedEpisode.cs
+++ b/IntroSkipper/Data/QueuedEpisode.cs
@@ -150,4 +150,16 @@ public class QueuedEpisode
             _ => throw new ArgumentException("Unknown analysis mode " + mode),
         };
     }
+
+    /// <summary>
+    /// Maps an analysis mode to the mode whose Chromaprint fingerprint cache entry it shares.
+    /// Recap fingerprints the identical opening-audio window as Introduction
+    /// (see <see cref="GetFingerprintRange"/> — both are <c>(0, IntroFingerprintEnd)</c>), so the
+    /// two reuse a single cached fingerprint instead of decoding the same PCM twice. Used for the
+    /// Chromaprint fingerprint cache key only; analysis still runs in the caller's real mode.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    /// <returns>The mode under which the Chromaprint fingerprint is cached.</returns>
+    public static AnalysisMode GetFingerprintCacheMode(AnalysisMode mode)
+        => mode == AnalysisMode.Recap ? AnalysisMode.Introduction : mode;
 }

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -139,15 +139,18 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
             return false;
         }
 
-        var (start, end) = episode.GetFingerprintRange(mode);
+        // Recap shares the Introduction fingerprint cache entry (identical opening-audio window),
+        // so normalize the lookup key/hash to the shared mode.
+        var cacheMode = QueuedEpisode.GetFingerprintCacheMode(mode);
+        var (start, end) = episode.GetFingerprintRange(cacheMode);
 
         try
         {
             using var db = Plugin.CreateCacheDbContext();
-            var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), CacheEntryType.Chromaprint, mode);
+            var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), CacheEntryType.Chromaprint, cacheMode);
             if (db.DetectionCache.Any(e =>
                 e.ItemId == episode.EpisodeId &&
-                e.Mode == mode &&
+                e.Mode == cacheMode &&
                 e.Type == CacheEntryType.Chromaprint &&
                 e.Start == start &&
                 e.End == end &&
@@ -158,7 +161,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         }
         catch (DbException ex)
         {
-            LogDetectionCacheReadError(_logger, ex, $"{episode.EpisodeId:N}-{mode}-{CacheEntryType.Chromaprint}");
+            LogDetectionCacheReadError(_logger, ex, $"{episode.EpisodeId:N}-{cacheMode}-{CacheEntryType.Chromaprint}");
         }
 
         return false;

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -120,7 +120,13 @@ public sealed partial class FFmpegService(
         cancellationToken.ThrowIfCancellationRequested();
 
         var (start, end) = episode.GetFingerprintRange(mode);
-        return FingerprintAsync(episode, mode, start, end, cancellationToken);
+
+        // Recap fingerprints the identical opening-audio window as Introduction, so cache it under
+        // the shared Introduction key to avoid decoding the same PCM twice (keeps recap analysis
+        // off the CPU/GPU hot path). The analyzer still runs in its real mode; only the cache key is
+        // normalized.
+        var cacheMode = QueuedEpisode.GetFingerprintCacheMode(mode);
+        return FingerprintAsync(episode, cacheMode, start, end, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -45,6 +45,7 @@ public static class ConfigHasher
                 $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
                 $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
+                $"|coldOpen={config.RecapAllowColdOpen}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}",
                 $"{AdjustmentHash(config)}"),
 

--- a/docs/recap-research/C-harden.md
+++ b/docs/recap-research/C-harden.md
@@ -1,0 +1,361 @@
+# Recap RFC C — Harden the current recap path
+
+Status: draft / design spike with ship-ready prototype
+Scope: keep the existing recap architecture (Chromaprint sting + black-frame boundary), fix its
+conceptual bugs, and be honest about the accuracy ceiling of pure hardening.
+Branch: `recap-rfc-c-harden`
+
+---
+
+## TL;DR verdict
+
+The current recap detector is a thin layer bolted onto the introduction Chromaprint pass. It
+shipped without any real end-to-end validation (PR #771 merged broken; commit `e17f044` "fix
+recap" only added the missing `GetFingerprintRange` case that had been throwing
+`ArgumentException`). Five of the six reported bugs are **confirmed**; one (the "duplicated clamp")
+is **refuted as written** but points at a real, adjacent semantics problem that this RFC still
+fixes.
+
+Hardening meaningfully raises *precision and correctness* for the recap shape the architecture was
+actually designed for — **a short shared "previously on" sting at/near the start of the episode,
+optionally behind a cold open, bounded by a fade/black frame.** For that shape the prototype:
+
+- stops forcing every recap to `0:00` and anchors the start to the cold open (bug 1),
+- stops the end from overshooting into mid-episode scene cuts (bug 2),
+- adds a real false-positive guard against the opening theme (bug 3),
+- removes a wasteful duplicate audio decode (bug 5),
+- and cleans up the window/clamp/semantics and hashing (bugs 4, 6).
+
+What hardening **cannot** do is invent signals that aren't in the audio+black-frame data. The
+honest ceiling: **recaps placed *after* the intro, recaps with no shared audio sting, recaps unique
+to one episode, and "Previously on…" montages distinguished only by subtitles/cross-episode text
+remain undetected** — and at least one (after-intro) is a placement the project wiki explicitly
+lists as valid. See [§ Ceiling](#the-ceiling-what-pure-hardening-cannot-fix).
+
+---
+
+## What a recap is (model used here)
+
+The "Previously on…" montage near the start of an episode. Per-episode the video/audio differ
+*except* possibly a short shared sting ("Previously on <Show>") and sometimes a shared music bed.
+Typically 10–60 s, often bookended by black-frame/fade transitions. Placement **varies**: before a
+cold open, after a cold open, or after the intro. Surfaces as Jellyfin
+`MediaSegmentType.Recap`.
+
+The architecture exploits exactly one of those signals: the **shared sting**, found by the same
+inverted-index Chromaprint search used for intros, plus black frames to bound the montage. Every
+limitation below flows from that single design choice.
+
+---
+
+## Bug-by-bug analysis (confirm / refute + evidence + fix + test)
+
+### Bug 1 — Recap is always forced to start at 0:00 — CONFIRMED
+
+**Evidence (original 10.11 code):**
+
+- `ChromaprintAnalyzer.GetEarliestTimeRange` zeroed the sting start: `if (lhsRecap.Start <= 5) { lhsRecap.Start = 0; }` (and the rhs twin). Original `ChromaprintAnalyzer.cs:317-325`.
+- The operative path never used that start anyway: `BuildRecapFromChromaprintCandidateAsync`
+  delegated to `ChapterAnalyzer.BuildRecapFromBlackFrames`, which **hardcodes** the start —
+  `return new Segment(episodeId, new TimeRange(0, selectedBlackFrame.Time));`
+  `ChapterAnalyzer.cs:275`.
+- `TimeAdjustmentHelper.AdjustIntroTimesAsync` then snaps any start `<= EndSnapThreshold` (default
+  `2.0`) to 0 — `TimeAdjustmentHelper.cs:71-89`. (This is *not* the main driver — black-frame build
+  already returns 0 — but it would re-zero small non-zero starts.)
+
+So a cold-open-before-recap episode `[cold open 0–40][recap 40–70][intro 70+]` was reported as
+`[0–70]`, swallowing the cold open; an at-start recap was correct only by accident.
+
+**Fix design (implemented):** preserve the true sting start through `GetEarliestTimeRange`
+(`ChromaprintAnalyzer.cs:326-329`) and resolve the start structurally in
+`RecapDetectionHelper.ResolveRecapStart`:
+
+- sting start `<= 5 s` ⇒ recap opens the episode ⇒ start `0`;
+- otherwise a cold open precedes it ⇒ anchor to the fade/black frame within a 6 s lead-in just
+  before the sting, else to the sting start itself;
+- gated behind the new `RecapAllowColdOpen` knob (default on) so the legacy `0:00` behavior is one
+  toggle away.
+
+`EndSnapThreshold = 2.0` no longer fights this: a 40 s anchored start is well above the snap
+threshold and survives `TimeAdjustmentHelper`.
+
+**Tests:** `ColdOpenBeforeRecap_AnchorsStartToStingNotZero`,
+`ColdOpenBeforeRecap_AnchorsToFadeJustBeforeSting`, `RecapAtEpisodeStart_NoColdOpen_StartsAtZero`,
+`AllowColdOpenDisabled_PreservesLegacyZeroStart`, `ResolveRecapStart_*`.
+
+---
+
+### Bug 2 — Boundary = "latest black frame before intro/max" overshoots or fails — CONFIRMED
+
+**Evidence:** `ChapterAnalyzer.BuildRecapFromBlackFrames` selects the **maximum-time** qualifying
+black frame (`if (selectedBlackFrame is null || blackFrame.Time > selectedBlackFrame.Time)`,
+`ChapterAnalyzer.cs:264-266`) and returns `null` when none qualifies (`ChapterAnalyzer.cs:270-273`).
+
+- **Overshoot:** with no intro detected, the window is `min(120, duration)`; a mid-episode scene
+  cut at e.g. 110 s becomes the boundary, so `[0, 110]` swallows the episode opening.
+- **Fail:** no black frame in range ⇒ `null` ⇒ no recap, even with a clear shared sting.
+- It also conflates "minimum end **time**" with "minimum **duration**": the floor is applied to
+  `blackFrame.Time` (`ChapterAnalyzer.cs:256`), never to `end − start`. With a non-zero start
+  (bug 1's fix) that conflation would produce wrong-length recaps.
+
+**Fix design (implemented):** for the Chromaprint path, `RecapDetectionHelper.SelectMontageEnd`
+picks the **earliest** black frame *after the sting* that yields a recap whose **duration** is
+within `[MinimumRecapDuration, MaximumRecapDuration]`. Earliest-valid (not latest) prevents
+overshoot into later scene cuts; the duration floor skips fades too close to the start
+(undershoot). No-black-frame is handled explicitly (see bug 3 fix): a long shared region with a
+detected intro falls back to the shared body as the recap; otherwise detection refuses to guess.
+
+The legacy `BuildRecapFromBlackFrames` (latest-frame, `0:00` start) is **intentionally retained**
+for the black-frame-only fallback (`DetectRecapUsingBlackFrames`, default off) because that path has
+no sting to anchor structure — see [§ What I deliberately did not change](#what-i-deliberately-did-not-change).
+
+**Tests:** `MontageEnd_PicksEarliestValidFrame_NotLatest_AvoidingOvershoot`,
+`MontageEnd_SkipsFramesShorterThanMinimumDuration`,
+`NoBlackFrame_IntroDetected_LongSharedRegion_UsesSharedBodyAsRecap`,
+`NoBlackFrame_IntroNotDetected_Rejects`.
+
+---
+
+### Bug 3 — False positive: "earliest shared region" may be the intro theme — CONFIRMED
+
+**Evidence:** recap mode selects the earliest shared region
+(`SelectSharedRegion → GetEarliestTimeRange`, `ChromaprintAnalyzer.cs:240-241`). The only guard was
+`if (maximumBoundary <= card.End) return null;` (original `ChromaprintAnalyzer.cs:269`), where
+`maximumBoundary` is clamped to `intro.Start` (`RecapDetectionHelper.GetMaximumBoundaryAsync`). That
+guard **only works when the introduction was already detected and stored**. With intro detection
+disabled/failed/first-episode-skipped, `maximumBoundary = min(120, duration)` and a shared *theme*
+region `[30,50]` passes (`120 > 50`); the latest black frame at the theme's end then yields a recap
+that is really the theme. The earliest shared region can also be a recurring studio ident / rating
+bumper rather than a recap.
+
+**Fix design (implemented):** `BuildChromaprintRecap` makes strictness depend on whether the intro
+was detected (now returned alongside the boundary via `RecapScanWindow.IntroDetected`):
+
+- **intro detected:** the intro-clamped window already excludes the theme; trust the candidate and
+  use the black-frame montage end (or shared-body fallback).
+- **intro NOT detected:** require a *short* sting — a shared region longer than
+  `StingMaximumDuration = 20 s` is treated as the opening theme and rejected — **and** require a
+  montage-end black frame (no shared-body fallback). A short shared sting corroborated by a montage
+  fade still passes.
+
+This is a heuristic, not a proof (see ceiling). It trades away long-shared-bed recaps when the
+intro is unknown to avoid emitting the theme as a recap.
+
+**Tests:** `IntroTheme_NoIntroDetected_LongSharedRegion_Rejected`,
+`IntroTheme_IntroDetected_ClampedOutByScanWindow`,
+`ShortStingWithMontageBoundary_NoIntroDetected_StillDetected`.
+
+---
+
+### Bug 4 — "Duplicated window-clamp logic (RecapDetectionHelper vs ChromaprintAnalyzer)" — REFUTED as written; real overlap fixed
+
+**Evidence against the literal claim:** the window clamp `min(duration, MaximumRecapDetectionDuration)`
+then `min(…, intro.Start)` lived in exactly **one** place — `RecapDetectionHelper.GetMaximumBoundaryAsync`
+(original `RecapDetectionHelper.cs:21-36`) — and was *called* from both
+`ChromaprintAnalyzer.cs:265` and `ChapterAnalyzer.cs:223`. There was no second inline copy in
+`ChromaprintAnalyzer` on 10.11. (PR #771's intermediate revisions likely had one; it was already
+extracted by merge time.)
+
+**The real, adjacent problem (confirmed and fixed):** `MaximumRecapDetectionDuration` was doing
+**double duty** — the candidate-duration cap in `GetMaximumSegmentDuration` (`ChromaprintAnalyzer.cs:244-253`)
+*and* the scan-window ceiling in the helper — and the recap path mixes **two** near-identical knob
+pairs (`Minimum/MaximumRecapDuration` vs `Minimum/MaximumRecapDetectionDuration`, both default
+15/120) plus the hardcoded `RecapCardMinimumDuration = 3.0` (`ChromaprintAnalyzer.cs:26`). Each was
+read in a different file with no single authority over "what is the recap window / what are the
+duration bounds".
+
+**Fix design (implemented):** `RecapDetectionHelper` is now the single home for the recap window and
+boundary logic. The clamp is a pure function `ComputeMaximumBoundary(duration, maxDetection,
+introStart?)` (`RecapDetectionHelper.cs`), wrapped by `GetRecapScanWindowAsync` which returns a
+`RecapScanWindow(MaxBoundary, IntroDetected)`. The two knob pairs now have **documented, distinct
+roles**: `Minimum/MaximumRecapDetectionDuration` bound the *scan window / earliest end time*;
+`Minimum/MaximumRecapDuration` bound the *final segment duration*. Both analyzers consume the helper;
+nothing re-derives the clamp.
+
+**Tests:** `ComputeMaximumBoundary_ClampsToTightestBound` (theory, 4 cases).
+
+---
+
+### Bug 5 — Duplicate decode: recap re-fingerprints the identical opening audio — CONFIRMED
+
+**Evidence:** `QueuedEpisode.GetFingerprintRange` returns the **same** range for both modes —
+`Introduction => (0, IntroFingerprintEnd)` and `Recap => (0, IntroFingerprintEnd)`
+(`QueuedEpisode.cs:147-148`). But the Chromaprint cache is keyed by `mode`
+(`FFmpegService` cache read/write, and `ConfigHasher.DetectionCache(... Chromaprint, mode)` embeds
+`{mode}` — `ConfigHasher.cs:78-79`). So the Recap pass missed the Introduction-written entry and
+re-decoded the identical opening PCM — directly against the maintainer's "not CPU/GPU heavy"
+constraint. The analyzer chain runs Introduction before Recap (`BaseItemAnalyzerTask.cs:74-80`), so
+the intro fingerprint is reliably present when recap runs.
+
+**Fix design (implemented):** `QueuedEpisode.GetFingerprintCacheMode` maps `Recap → Introduction`
+(`QueuedEpisode.cs:163-164`); `FFmpegService.FingerprintAsync` computes the range from the real mode
+but reads/writes the cache under the shared mode (`FFmpegService.cs:128-129`), and
+`DetectionCacheService.HasCachedFingerprint` normalizes identically (`DetectionCacheService.cs:144-153`).
+Result: the opening audio is decoded at most once per episode; recap reuses it. `DeleteByMode(Recap)`
+still purges recap **black-frame** cache rows (those remain mode-keyed); the shared fingerprint stays
+owned by Introduction, which is correct.
+
+**Tests:** `GetFingerprintCacheMode_MapsRecapToIntroduction` (theory),
+`RecapAndIntroduction_ShareTheSameFingerprintRange`,
+`FingerprintAsync_Recap_ReusesIntroductionCacheEntry_NoDecode` (seeds only the Introduction entry in
+a fake cache, asserts the Recap call hits it and never reads a Recap-keyed entry — no ffmpeg).
+
+---
+
+### Bug 6 — Naming/semantics/hash correctness — CONFIRMED (and guarded going forward)
+
+**Evidence:**
+
+- The "latest black frame" framing (PR #771: "pick the latest valid black frame, not the first") is
+  itself the overshoot bug 2; "latest" was a deliberate choice that's wrong for a bounded montage.
+- Two overlapping knob pairs + a magic `RecapCardMinimumDuration` const, addressed in bug 4.
+- **Hash coverage:** the existing Recap hash (`ConfigHasher.cs:44-49`) did cover all *existing* recap
+  knobs (`detMin/detMax`, `min/max`, `recapBlackFrames`, `bf*`, `pct/limit`, `fpbits/skip/shift`,
+  chapter pattern, adjustment hash). The risk is **future** knobs silently not invalidating cached
+  results.
+
+**Fix design (implemented):** the new `RecapAllowColdOpen` knob is added to the Recap analysis hash
+(`ConfigHasher.cs:48`, `|coldOpen=`), so toggling it re-analyzes. The cold-open thresholds
+(`ColdOpenStartThreshold`, `ColdOpenLeadInWindow`, `StingMaximumDuration`) are compile-time consts —
+they don't vary at runtime, so they correctly do **not** enter the hash. The new montage-end
+selection consumes already-hashed knobs (`Minimum/MaximumRecapDuration`,
+`MinimumRecapDetectionDuration`).
+
+**Tests:** `RecapHash_ChangesWhenColdOpenToggleChanges`; existing
+`RecapHash_ChangesWhenChromaprintTuningChanges` retained.
+
+---
+
+## Critical review — additional findings (file:line)
+
+Findings beyond the six, surfaced while hardening. Not all are fixed in this prototype; flagged
+honestly.
+
+1. **No end-to-end test exists for recap.** Every recap test (`TestRecapDetection.cs`,
+   `TestChapterAnalyzer.cs`) is synthetic and unit-level; nothing exercises
+   `ChromaprintAnalyzer.AnalyzeMediaFiles` in recap mode against media. The broken-on-merge history
+   is the direct consequence. This prototype adds more synthetic coverage but **cannot** close that
+   gap without media fixtures. (Addressed partially: the new tests at least express the real
+   *scenarios*, not just function plumbing.)
+
+2. **Recap rides the Introduction analysis window.** `IntroFingerprintEnd` is derived from
+   `AnalysisPercent`/`AnalysisLengthLimit` for *intros*. A recap that begins later than that window
+   (e.g. after a long cold open in a long episode) is never fingerprinted. `QueuedEpisode.cs:147-148`.
+
+3. **Per-pair commit, earliest-region only.** `GetEarliestTimeRange` (`ChromaprintAnalyzer.cs:301`)
+   returns a single earliest region for a pair. If the earliest shared region is the theme/ident and
+   a *later* region is the real sting, the detector commits to the wrong one and there is no
+   "try the next region" path. The bug-3 guard rejects the theme but then yields **nothing** rather
+   than the real recap.
+
+4. **`maxBoundary <= card.End` over-rejects adjacent recaps.** When a recap ends *exactly* at the
+   detected intro start, `MaxBoundary == card.End` is possible and the strict `<=` drops it. Rare,
+   but it means a recap flush against the intro can be lost. `ChromaprintAnalyzer.cs:267-270`.
+
+5. **`TimeAdjustmentHelper` is intro-shaped.** It applies `IntroStartOffset`/`IntroEndOffset`,
+   chapter/silence/keyframe snapping (`TimeAdjustmentHelper.cs:92-131`) to recaps too. Silence-snap
+   on the *end* is reasonable for a montage→episode fade, but `AdjustIntroBasedOnChapters` (default
+   on) can pull a cold-open-anchored recap start onto an unrelated chapter mark. Left as-is
+   (orthogonal), but worth a recap-specific adjustment profile later.
+
+6. **Black-frame cache is per-analyzer-instance and per-episode only.** `_recapBlackFrameCache`
+   (`ChromaprintAnalyzer.cs:33`) lives on the analyzer instance, which is recreated per mode per
+   season (`BaseItemAnalyzerTask.cs:361-365`), so it does not span modes; the DB cache
+   (`CacheEntryType.BlackFrame`, mode `Recap`) does the real cross-run de-dup. Fine, but the
+   in-memory layer is nearly redundant.
+
+7. **`Segment.Valid` is `End > 0` only** (`Segment.cs:82`). A recap legitimately starting at 0 with
+   `End > 0` is valid; but a degenerate `[0,0]` from a failed build is correctly invalid. No bug —
+   noting because the builder relies on it (`new Segment(episodeId)` sentinels at
+   `ChromaprintAnalyzer.cs:123,127`).
+
+---
+
+## The ceiling — what pure hardening CANNOT fix
+
+Hardening fixes *how we interpret* the two signals we have (shared sting + black frames). It cannot
+manufacture signals. After every fix in this RFC, these real-world recap shapes remain **undetected
+or unreliable**:
+
+1. **Recaps placed *after* the intro.** The scan window is clamped to `intro.Start`
+   (`ComputeMaximumBoundary`), so the searched range is `[0, introStart]`. A recap montage that runs
+   *after* the intro theme is structurally outside the window and cannot be found. The project wiki
+   explicitly lists "after the intro" as a valid placement, so this is a first-class miss, not an
+   edge case. Closing it needs `intro.End` plumbed in plus a second scan window `[introEnd,
+   introEnd + maxRecap]` — more decode, more false-positive surface, deliberately **out of scope**
+   for "harden the current path."
+
+2. **Recaps with no shared audio sting.** If a show's "Previously on…" has unique narration every
+   episode and no shared music bed above the fingerprint threshold, Chromaprint finds nothing and no
+   recap is emitted. Only the black-frame-only fallback (default off, `0:00` start, latest frame)
+   could fire, and it cannot tell a recap from a cold open.
+
+3. **Recaps unique to one episode / unmatched pairs.** Chromaprint needs ≥2 episodes sharing the
+   sting (`ChromaprintAnalyzer.AnalyzeMediaFiles` pairs episodes). A season opener with a unique
+   recap, or a recap present in only one episode, never matches.
+
+4. **Recaps identifiable only by subtitles / on-screen "Previously on" text.** Cross-episode and
+   subtitle signals — exactly the data this architecture does **not** read — are often the only
+   reliable recap discriminator. Out of reach by construction.
+
+5. **Long-sting recaps when the intro was not detected.** The bug-3 guard rejects shared regions
+   longer than `StingMaximumDuration` (20 s) without a detected intro, to avoid emitting the theme.
+   A genuine recap whose shared portion is a long music bed is collateral. Deliberate precision/
+   recall trade-off.
+
+6. **A repeated non-recap sting can still slip through.** A short studio ident / rating bumper that
+   is byte-identical across episodes, followed by a fade, with no intro detected, satisfies the
+   guard (short shared region + montage boundary) and could be emitted as a recap. The guard reduces
+   this class; it does not eliminate it. Eliminating it needs corroboration the architecture lacks
+   (chapter label, subtitle, cross-season consistency).
+
+**Bottom line on accuracy:** for the "short shared sting near the start, optionally behind a cold
+open, bounded by a fade" shape, this prototype turns a detector that produced *systematically wrong
+boundaries* (always `0:00`, frequently overshooting) into one that produces *correct boundaries when
+it fires* and *fires more conservatively*. That is a precision win and a correctness win, not a
+coverage win — the set of recaps it can *see* is essentially unchanged (and is narrower by design
+when the intro is unknown). The headline gaps (after-intro placement, no-shared-audio, single-episode
+recaps, subtitle-only recaps) are unmovable without the cross-episode/subtitle signals this spike was
+asked to assume absent.
+
+---
+
+## Prototype summary
+
+### Behavior changes (all in the Chromaprint recap path)
+- Non-zero, cold-open-aware recap start (`RecapAllowColdOpen`, default on).
+- Earliest-valid montage-end selection with duration sanity (no overshoot/undershoot).
+- Intro-aware false-positive guard (short-sting requirement + black-frame corroboration when no
+  intro is detected; shared-body fallback only when an intro is detected).
+- Single Introduction/Recap fingerprint cache entry (no duplicate decode).
+- Centralized, pure scan-window clamp; documented knob roles; `RecapAllowColdOpen` in the hash.
+
+### Files changed
+- `IntroSkipper/Analyzers/RecapDetectionHelper.cs` — rewritten as the recap logic home
+  (`ComputeMaximumBoundary`, `GetRecapScanWindowAsync`, `BuildChromaprintRecap`, `ResolveRecapStart`,
+  `SelectMontageEnd`, `RecapScanWindow`, `RecapBuildContext`).
+- `IntroSkipper/Analyzers/ChromaprintAnalyzer.cs` — uses the builder; stops zeroing the sting start.
+- `IntroSkipper/Analyzers/ChapterAnalyzer.cs` — fallback uses `GetRecapScanWindowAsync`; legacy
+  black-frame-only behavior retained.
+- `IntroSkipper/Data/QueuedEpisode.cs` — `GetFingerprintCacheMode`.
+- `IntroSkipper/FFmpeg/FFmpegService.cs`, `DetectionCacheService.cs` — shared fingerprint cache key.
+- `IntroSkipper/Configuration/PluginConfiguration.cs`, `Helper/ConfigHasher.cs` — `RecapAllowColdOpen`
+  + hash.
+- `web/src/types.ts`, `web/src/tabs/analysis.ts` — UI for the new knob.
+- `IntroSkipper.Tests/TestRecapHardening.cs` — new scenario tests.
+
+### What I deliberately did not change
+- `ChapterAnalyzer.BuildRecapFromBlackFrames` (and its 3 existing tests) — the black-frame-only
+  fallback (`DetectRecapUsingBlackFrames`, default off). With no Chromaprint sting it has no
+  structure to anchor a cold open, so it keeps `0:00` start + latest-frame. Its overshoot limitation
+  is inherent and documented rather than papered over.
+- `TimeAdjustmentHelper` (intro-shaped post-processing) — orthogonal; flagged in the review.
+- After-intro scanning — out of scope (see ceiling §1).
+
+### Build / test status
+- `web`: `pnpm install --frozen-lockfile && pnpm build` — clean.
+- `IntroSkipper`: builds warning-clean under `TreatWarningsAsErrors` + `AllEnabledByDefault`.
+- `dotnet test`: 341 passed / 1 failed. The single failure is the pre-existing
+  `TestAudioFingerprinting.TestSilenceDetection`, an ffmpeg silence-timestamp precision mismatch
+  (differs at the 4th–5th decimal) present on the pristine 10.11 checkout — unrelated to recap.
+  Baseline before this work was 315/1; this RFC adds 26 passing tests.

--- a/web/src/tabs/analysis.ts
+++ b/web/src/tabs/analysis.ts
@@ -94,6 +94,12 @@ export const analysisTab: Tab = {
                 description:
                     "When recap chapter detection fails, mark recap from 0:00 to the latest detected black frame within the detected recap duration limits and before the intro.",
             }),
+            checkboxField({
+                id: "RecapAllowColdOpen",
+                label: "Allow recap after a cold open",
+                description:
+                    "Anchor a detected recap to its shared 'previously on' sting (and the transition just before it) so a recap that follows a cold open is not forced to start at 0:00. Disable to keep the legacy behavior of starting every recap at 0:00.",
+            }),
             durationPair(
                 "MinimumIntroDuration",
                 "MaximumIntroDuration",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -60,6 +60,7 @@ export interface PluginConfig {
     ScanCredits: boolean;
     ScanRecap: boolean;
     DetectRecapUsingBlackFrames: boolean;
+    RecapAllowColdOpen: boolean;
     ScanPreview: boolean;
     ScanCommercial: boolean;
     EnableMainMenu: boolean;


### PR DESCRIPTION
## Summary by Sourcery

Harden recap detection by centralizing recap window logic, anchoring recap segments more accurately around cold opens and montage boundaries, and tightening false-positive guards against intro themes.

Bug Fixes:
- Prevent recaps from always starting at 0:00 by anchoring them to cold opens or detected sting starts when configured.
- Avoid recap segments overshooting into mid-episode scene changes by choosing the earliest valid montage-end black frame within configured duration bounds.
- Reduce false positive recaps on opening themes by enforcing sting duration limits and requiring structural corroboration when no intro is detected.
- Eliminate redundant Chromaprint decoding for recap analysis by reusing introduction fingerprints via a shared cache key.
- Ensure recap analysis cache invalidation when the cold-open behavior toggle changes.

Enhancements:
- Introduce a unified recap scan window helper and shared structs to consistently clamp detection to episode, config, and intro bounds.
- Refine Chromaprint-based recap construction to use the real sting window, support cold opens, and select montage-end black frames using duration-aware rules.
- Share Chromaprint fingerprint cache entries between introduction and recap analyses to avoid duplicate audio decoding.
- Add a configurable option to allow or disable cold-open-aware recap starts and propagate it through configuration hashing.
- Clarify the separation between recap detection window limits and recap duration limits, and keep legacy black-frame-only fallback behavior for recap detection.

Documentation:
- Add a detailed recap hardening RFC documenting confirmed bugs, architectural limits, and the scope and behavior of the hardening changes.

Tests:
- Add targeted recap hardening tests that cover cold-open anchoring, montage-end selection, false-positive prevention against intro themes, shared fingerprint caching, and config hash behavior.