### PR TITLE
[Recap RFC B] Cross-episode reuse matching

### DIFF
--- a/IntroSkipper.Tests/TestCrossEpisodeReuse.cs
+++ b/IntroSkipper.Tests/TestCrossEpisodeReuse.cs
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Xunit.Abstractions;
+
+/// <summary>
+/// Unit tests + microbenchmark for the RFC B cross-episode reuse-matching spike
+/// (<see cref="CrossEpisodeReuseMatcher"/>). Operates entirely on synthetic <c>uint[]</c> fingerprints,
+/// so it needs no FFmpeg or media files.
+/// </summary>
+public class TestCrossEpisodeReuse(ITestOutputHelper output)
+{
+    private readonly ITestOutputHelper _output = output;
+
+    [Fact]
+    public void SecondsToPoints_MatchesChromaprintHopRate()
+    {
+        // ~8.075 points/second. A 24-minute episode is ~11.6k points.
+        Assert.Equal(8, CrossEpisodeReuseMatcher.SecondsToPoints(1.0));
+        Assert.InRange(CrossEpisodeReuseMatcher.SecondsToPoints(1440), 11_600, 11_650);
+    }
+
+    [Fact]
+    public void FindReusedSpans_LocatesSinglePlantedSpanDeepInReference()
+    {
+        var rng = new Random(1);
+        var reference = RandomFingerprint(12_000, rng); // ~24 min prior episode (full)
+        var query = RandomFingerprint(970, rng);        // ~120 s opening of episode N
+
+        // Plant a reused clip: query[100..399] is footage taken from reference[8100..8399].
+        const int queryStart = 100;
+        const int referenceStart = 8100;
+        const int length = 300; // ~37 s
+        Plant(query, queryStart, reference, referenceStart, length);
+
+        var (spans, diag) = CrossEpisodeReuseMatcher.FindReusedSpans(query, reference);
+
+        Assert.False(diag.EarlyExit);
+        var span = Assert.Single(spans);
+        Assert.Equal(queryStart, span.QueryStart);
+        Assert.Equal(queryStart + length - 1, span.QueryEnd);
+        Assert.Equal(referenceStart, span.ReferenceStart);
+        Assert.Equal(referenceStart - queryStart, span.Shift);
+    }
+
+    [Fact]
+    public void FindReusedSpans_ToleratesMildReencodeNoise()
+    {
+        var rng = new Random(2);
+        var reference = RandomFingerprint(12_000, rng);
+        var query = RandomFingerprint(970, rng);
+
+        const int queryStart = 120;
+        const int length = 260;
+        Plant(query, queryStart, reference, 5_000, length);
+
+        // Model a mild re-encode: ~40% of points drift by 1-5 bits (within the 6-bit similarity
+        // threshold, so extraction still matches them) while ~60% survive byte-identical (so the
+        // shift-discovery phase, which probes only +/- IndexShift in VALUE space, still finds the shift).
+        PerturbForReencode(query, queryStart, length, fraction: 0.40, maxBitsPerPoint: 5, rng);
+
+        var (spans, _) = CrossEpisodeReuseMatcher.FindReusedSpans(query, reference);
+
+        var span = Assert.Single(spans);
+        Assert.Equal(queryStart, span.QueryStart);
+        Assert.Equal(queryStart + length - 1, span.QueryEnd);
+    }
+
+    [Fact]
+    public void FindReusedSpans_RejectsHeavilyAlteredAudio()
+    {
+        var rng = new Random(3);
+        var reference = RandomFingerprint(12_000, rng);
+        var query = RandomFingerprint(970, rng);
+
+        const int queryStart = 120;
+        const int length = 260;
+        Plant(query, queryStart, reference, 5_000, length);
+
+        // A re-mixed recap (music bed / voiceover laid over the clip) diverges far beyond the
+        // 6-bit threshold: flip 12 distinct bits on every point. The reuse must no longer be detectable.
+        FlipBitsEveryPoint(query, queryStart, length, bitsToFlip: 12, rng);
+
+        var (spans, _) = CrossEpisodeReuseMatcher.FindReusedSpans(query, reference);
+
+        Assert.DoesNotContain(spans, s => s.QueryStart <= queryStart + length && queryStart <= s.QueryEnd);
+    }
+
+    [Fact]
+    public void AssembleRecap_StitchesMontageOfThreeClipsIntoOneBoundary()
+    {
+        var rng = new Random(4);
+        var reference = RandomFingerprint(12_000, rng);
+        var query = RandomFingerprint(970, rng);
+
+        // A "previously on" montage: three clips drawn from three different points of the prior
+        // episode, laid back-to-back near the start of episode N (each separated by a ~1 s cut).
+        var clip1 = PlantSeconds(query, reference, queryStartSeconds: 5, referenceStartSeconds: 600, durationSeconds: 12);
+        PlantSeconds(query, reference, queryStartSeconds: 18, referenceStartSeconds: 950, durationSeconds: 10);
+        var clip3 = PlantSeconds(query, reference, queryStartSeconds: 29, referenceStartSeconds: 1300, durationSeconds: 13);
+
+        var (spans, _) = CrossEpisodeReuseMatcher.FindReusedSpans(query, reference);
+
+        // Three disjoint clips, three distinct shifts.
+        Assert.Equal(3, spans.Count);
+        Assert.Equal(3, spans.Select(s => s.Shift).Distinct().Count());
+
+        var recap = CrossEpisodeReuseMatcher.AssembleRecap(spans);
+        Assert.NotNull(recap);
+
+        // The hull spans from the first clip's start to the last clip's end, NOT forced to 0.
+        Assert.True(recap!.Start > 1.0, FormattableString.Invariant($"recap.Start={recap.Start} should not be snapped to 0"));
+        Assert.Equal(clip1.StartSeconds, recap.Start, precision: 0);
+        Assert.Equal(clip3.EndSeconds, recap.End, precision: 0);
+    }
+
+    [Fact]
+    public void FindReusedSpans_EarlyExitsOnUnrelatedEpisodes()
+    {
+        var rng = new Random(5);
+        var reference = RandomFingerprint(12_000, rng);
+        var query = RandomFingerprint(970, rng); // independent content, nothing reused
+
+        var (spans, diag) = CrossEpisodeReuseMatcher.FindReusedSpans(query, reference);
+
+        Assert.True(diag.EarlyExit, FormattableString.Invariant($"expected early exit; overlap was {diag.PointSetOverlap:P2}"));
+        Assert.Empty(spans);
+        Assert.Null(CrossEpisodeReuseMatcher.AssembleRecap(spans));
+    }
+
+    /// <summary>
+    /// The make-or-break structural claim of the RFC: intro detection is opening-vs-opening at the SAME
+    /// offset, while a recap reuses footage from ANYWHERE in a prior episode (a large offset). The shipped
+    /// <see cref="ChromaprintAnalyzer.CompareEpisodes"/> can find the former but not the latter; the spike
+    /// finds both.
+    /// </summary>
+    [Fact]
+    public void Production_FindsAlignedReuse_ButMissesDeepReuse_WhereSpikeSucceeds()
+    {
+        var analyzer = new ChromaprintAnalyzer(NullLogger<ChromaprintAnalyzer>.Instance, null!, null!);
+        var lhsId = Guid.NewGuid();
+        var rhsId = Guid.NewGuid();
+        const int length = 300; // ~37 s, comfortably above the 15 s intro floor
+
+        // CASE A — intro-like: shared block sits at nearly the SAME offset in both episodes (shift ~50).
+        var aligned = NewAlignedPair(seed: 10, length, lhsStart: 100, rhsStart: 150);
+        var (alignedLhs, _) = analyzer.CompareEpisodes(lhsId, aligned.Lhs, rhsId, aligned.Rhs);
+        Assert.True(alignedLhs.Valid, "production should detect a reused block at a small (intro-like) offset");
+
+        // CASE B — recap-like: the SAME block is reused deep inside the prior episode (shift ~8000),
+        // with episode N's side being only a short opening window.
+        var deep = NewAlignedPair(seed: 10, length, lhsStart: 100, rhsStart: 8100, rhsLength: 12_000, lhsLength: 970);
+        var (deepLhs, _) = analyzer.CompareEpisodes(lhsId, deep.Lhs, rhsId, deep.Rhs);
+        Assert.False(deepLhs.Valid, "production's FindContiguous cannot reach a deep-offset reuse (min(len)-|shift| < 0)");
+
+        // The spike recovers the deep reuse the production engine misses.
+        var (spans, _) = CrossEpisodeReuseMatcher.FindReusedSpans(deep.Lhs, deep.Rhs);
+        var span = Assert.Single(spans);
+        Assert.Equal(100, span.QueryStart);
+        Assert.Equal(8000, span.Shift);
+    }
+
+    /// <summary>
+    /// Microbenchmark substantiating the RFC's cost analysis. Measures wall time, distinct shift count,
+    /// and pre-filter overlap on realistic fingerprint sizes. Writes a markdown snippet to a temp file
+    /// (and the test log) so the numbers can be transcribed into the RFC.
+    /// </summary>
+    [Fact]
+    public void Benchmark_RealisticSizes_IsCheap()
+    {
+        var report = new StringBuilder();
+        report.AppendLine("| prior-episode size | query window | distinct shifts | shifts scanned | spans | avg ms / pair |");
+        report.AppendLine("|---|---|---|---|---|---|");
+
+        // (full prior-episode points, label)
+        var sizes = new (int Points, string Label)[]
+        {
+            (10_659, "22 min (1320 s)"),
+            (11_628, "24 min (1440 s)"),
+            (20_349, "42 min (2520 s)"),
+            (29_070, "60 min (3600 s)"),
+        };
+
+        const int queryPoints = 970; // ~120 s opening window
+        const int iterations = 200;
+
+        foreach (var (points, label) in sizes)
+        {
+            var rng = new Random(99);
+            var reference = RandomFingerprint(points, rng);
+            var query = RandomFingerprint(queryPoints, rng);
+
+            // Plant a 3-clip montage so the timed path includes real extraction work.
+            PlantSeconds(query, reference, 5, 600, 12);
+            PlantSeconds(query, reference, 18, Math.Min(950, points / 12), 10);
+            PlantSeconds(query, reference, 29, Math.Min(1300, points / 9), 13);
+
+            // Warm up (JIT) and capture a representative result.
+            var (spans, diag) = CrossEpisodeReuseMatcher.FindReusedSpans(query, reference);
+
+            var sw = Stopwatch.StartNew();
+            for (var i = 0; i < iterations; i++)
+            {
+                CrossEpisodeReuseMatcher.FindReusedSpans(query, reference);
+            }
+
+            sw.Stop();
+
+            var avgMs = sw.Elapsed.TotalMilliseconds / iterations;
+            report.AppendLine(CultureInfo.InvariantCulture, $"| {label} ({points} pts) | {queryPoints} pts | {diag.DistinctShiftsDiscovered} | {diag.ShiftsScanned} | {spans.Count} | {avgMs:F3} |");
+
+            // A single audio comparison must be cheap; even the largest case must stay well under 50 ms.
+            Assert.True(avgMs < 50, FormattableString.Invariant($"reuse matching took {avgMs:F2} ms for {label}, expected < 50 ms"));
+            Assert.True(spans.Count >= 1, FormattableString.Invariant($"expected to recover planted montage for {label}"));
+        }
+
+        var text = report.ToString();
+        _output.WriteLine(text);
+
+        var path = Path.Combine(Path.GetTempPath(), "recap-rfc-b-bench.md");
+        File.WriteAllText(path, text);
+        _output.WriteLine(FormattableString.Invariant($"benchmark table written to {path}"));
+    }
+
+    private static uint[] RandomFingerprint(int length, Random rng)
+    {
+        var fingerprint = new uint[length];
+        Span<byte> bytes = stackalloc byte[4];
+        for (var i = 0; i < length; i++)
+        {
+            rng.NextBytes(bytes);
+            fingerprint[i] = BitConverter.ToUInt32(bytes);
+        }
+
+        return fingerprint;
+    }
+
+    private static void Plant(uint[] destination, int destinationStart, uint[] source, int sourceStart, int length)
+        => Array.Copy(source, sourceStart, destination, destinationStart, length);
+
+    private static (double StartSeconds, double EndSeconds) PlantSeconds(
+        uint[] query,
+        uint[] reference,
+        double queryStartSeconds,
+        double referenceStartSeconds,
+        double durationSeconds)
+    {
+        var queryStart = CrossEpisodeReuseMatcher.SecondsToPoints(queryStartSeconds);
+        var referenceStart = CrossEpisodeReuseMatcher.SecondsToPoints(referenceStartSeconds);
+        var length = CrossEpisodeReuseMatcher.SecondsToPoints(durationSeconds);
+        Plant(query, queryStart, reference, referenceStart, length);
+        return (
+            queryStart * ChromaprintConstants.SampleDuration,
+            (queryStart + length) * ChromaprintConstants.SampleDuration);
+    }
+
+    // Mild re-encode: only a fraction of points drift, each by a few bits within the similarity
+    // threshold; the rest stay byte-identical so the shift-discovery phase still anchors.
+    private static void PerturbForReencode(uint[] array, int start, int length, double fraction, int maxBitsPerPoint, Random rng)
+    {
+        for (var i = start; i < start + length; i++)
+        {
+            if (rng.NextDouble() >= fraction)
+            {
+                continue;
+            }
+
+            FlipDistinctBits(array, i, 1 + rng.Next(maxBitsPerPoint), rng);
+        }
+    }
+
+    // Heavy alteration: flip the same number of distinct bits on every point (defeats both phases).
+    private static void FlipBitsEveryPoint(uint[] array, int start, int length, int bitsToFlip, Random rng)
+    {
+        for (var i = start; i < start + length; i++)
+        {
+            FlipDistinctBits(array, i, bitsToFlip, rng);
+        }
+    }
+
+    private static void FlipDistinctBits(uint[] array, int index, int bitsToFlip, Random rng)
+    {
+        var chosen = new HashSet<int>();
+        while (chosen.Count < bitsToFlip)
+        {
+            chosen.Add(rng.Next(32));
+        }
+
+        foreach (var bit in chosen)
+        {
+            array[index] ^= 1u << bit;
+        }
+    }
+
+    private static (uint[] Lhs, uint[] Rhs) NewAlignedPair(
+        int seed,
+        int length,
+        int lhsStart,
+        int rhsStart,
+        int rhsLength = 1_000,
+        int lhsLength = 1_000)
+    {
+        var rng = new Random(seed);
+        var lhs = RandomFingerprint(lhsLength, rng);
+        var rhs = RandomFingerprint(rhsLength, rng);
+        Plant(lhs, lhsStart, rhs, rhsStart, length);
+        return (lhs, rhs);
+    }
+}

--- a/IntroSkipper/Analyzers/CrossEpisodeReuseMatcher.cs
+++ b/IntroSkipper/Analyzers/CrossEpisodeReuseMatcher.cs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Analyzers;
+
+/// <summary>
+/// RESEARCH SPIKE (RFC B): cross-episode content-reuse matching for recap detection.
+///
+/// <para>
+/// This is a self-contained, dependency-free prototype that proves the core mechanism behind
+/// <c>docs/recap-research/B-cross-episode.md</c>. It is NOT wired into the analyzer chain. It locates
+/// reused audio sub-segments of a "query" fingerprint (the opening of episode N) inside a "reference"
+/// fingerprint (a PRIOR episode's full fingerprint) and assembles the disjoint reused spans of a
+/// montage into a single recap boundary.
+/// </para>
+///
+/// <para>
+/// It deliberately mirrors the primitives the production <see cref="ChromaprintAnalyzer"/> already
+/// uses — an inverted index of fingerprint points, a per-shift XOR/popcount comparison, and a
+/// longest-contiguous-run extraction — so the cost and behaviour map directly onto the shipped engine.
+/// The one structural change required for reuse matching (vs the shipped intro matcher) is documented
+/// on <see cref="ExtractContiguousRunAtShift"/>.
+/// </para>
+/// </summary>
+public static class CrossEpisodeReuseMatcher
+{
+    /// <summary>
+    /// Converts a duration in seconds to a number of fingerprint points.
+    /// </summary>
+    /// <param name="seconds">Duration in seconds.</param>
+    /// <returns>Equivalent number of fingerprint points (rounded).</returns>
+    public static int SecondsToPoints(double seconds) =>
+        (int)Math.Round(seconds / ChromaprintConstants.SampleDuration);
+
+    /// <summary>
+    /// Cheap coarse pre-filter: the fraction of the query's distinct point values that also appear
+    /// in the reference. This is the prototype's stand-in for a MinHash estimate; on real data a
+    /// MinHash sketch gives the same signal in O(k) instead of O(n).
+    /// </summary>
+    /// <param name="query">Query fingerprint (opening of episode N).</param>
+    /// <param name="reference">Reference fingerprint (prior episode).</param>
+    /// <returns>Overlap fraction in [0, 1].</returns>
+    public static double PointSetOverlap(uint[] query, uint[] reference)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reference);
+
+        if (query.Length == 0)
+        {
+            return 0;
+        }
+
+        var referenceSet = new HashSet<uint>(reference);
+        var queryDistinct = new HashSet<uint>(query);
+        var shared = queryDistinct.Count(referenceSet.Contains);
+        return (double)shared / queryDistinct.Count;
+    }
+
+    /// <summary>
+    /// Builds a multimap inverted index (point value -> every index it occurs at) for the reference.
+    /// The shipped <see cref="ChromaprintAnalyzer.CreateInvertedIndex"/> keeps only the LAST occurrence,
+    /// which is adequate for opening-vs-opening intro matching but loses reused occurrences when the
+    /// reference is a full episode; reuse matching needs every occurrence to vote.
+    /// </summary>
+    /// <param name="reference">Reference fingerprint.</param>
+    /// <returns>Multimap of point value to ascending indices.</returns>
+    public static Dictionary<uint, List<int>> BuildMultimapIndex(uint[] reference)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+
+        var index = new Dictionary<uint, List<int>>(reference.Length);
+        for (var i = 0; i < reference.Length; i++)
+        {
+            if (!index.TryGetValue(reference[i], out var list))
+            {
+                list = [];
+                index[reference[i]] = list;
+            }
+
+            list.Add(i);
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// Locates every reused span of <paramref name="query"/> inside <paramref name="reference"/>.
+    /// </summary>
+    /// <param name="query">Query fingerprint — the opening window of episode N.</param>
+    /// <param name="reference">Reference fingerprint — a prior episode's FULL fingerprint.</param>
+    /// <param name="options">Tuning parameters (uses production-equivalent defaults when null).</param>
+    /// <returns>Reused spans (query coordinates) and cost diagnostics.</returns>
+    public static (IReadOnlyList<ReusedSpan> Spans, ReuseMatchDiagnostics Diagnostics) FindReusedSpans(
+        uint[] query,
+        uint[] reference,
+        ReuseMatchOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reference);
+        options ??= new ReuseMatchOptions();
+
+        var overlap = PointSetOverlap(query, reference);
+        if (query.Length == 0 || reference.Length == 0 || overlap < options.PreFilterMinOverlap)
+        {
+            return ([], new ReuseMatchDiagnostics(0, 0, overlap, EarlyExit: true));
+        }
+
+        var referenceIndex = BuildMultimapIndex(reference);
+
+        // Shift voting: every query point votes for the offset (referenceIndex - queryIndex) of each
+        // near-equal reference occurrence. A genuinely reused clip of length L produces ~L votes at a
+        // single shift, dwarfing the ~1-2 votes random coincidences scatter across many shifts.
+        var votes = new Dictionary<int, int>();
+        for (var q = 0; q < query.Length; q++)
+        {
+            var basePoint = query[q];
+            for (var delta = -options.IndexShift; delta <= options.IndexShift; delta++)
+            {
+                var probe = unchecked((uint)(basePoint + delta));
+                if (!referenceIndex.TryGetValue(probe, out var occurrences))
+                {
+                    continue;
+                }
+
+                var voteBudget = Math.Min(occurrences.Count, options.MaxVotesPerPoint);
+                for (var k = 0; k < voteBudget; k++)
+                {
+                    var shift = occurrences[k] - q;
+                    votes[shift] = votes.GetValueOrDefault(shift) + 1;
+                }
+            }
+        }
+
+        var distinctShifts = votes.Count;
+
+        // Only the strongest shifts are fully scanned; this caps the expensive phase.
+        var scannedShifts = votes
+            .OrderByDescending(static kvp => kvp.Value)
+            .Take(options.TopShifts)
+            .Select(static kvp => kvp.Key)
+            .ToList();
+
+        var spans = new List<ReusedSpan>();
+        foreach (var shift in scannedShifts)
+        {
+            var span = ExtractContiguousRunAtShift(query, reference, shift, options);
+            if (span is not null)
+            {
+                spans.Add(span.Value);
+            }
+        }
+
+        // Deduplicate spans that overlap heavily in query space (different shifts can re-find the same
+        // clip when the reference contains near-duplicate audio); keep the longest per query region.
+        var deduped = DeduplicateByQueryOverlap(spans);
+
+        return (deduped, new ReuseMatchDiagnostics(distinctShifts, scannedShifts.Count, overlap, EarlyExit: false));
+    }
+
+    /// <summary>
+    /// Finds the longest contiguous run of matching points between query and reference at a fixed shift.
+    ///
+    /// <para>
+    /// This is the corrected analogue of <see cref="ChromaprintAnalyzer"/>'s private <c>FindContiguous</c>.
+    /// The shipped version computes its scan length as <c>min(lhs, rhs) - |shift|</c>, which assumes both
+    /// fingerprints are of comparable length and aligned near the front (true for intros). When the query
+    /// is a short opening window and the reference is a full episode, a reused clip sitting deep in the
+    /// reference implies a large shift, and <c>min(len) - |shift|</c> goes negative — so the shipped loop
+    /// never runs and the reuse is invisible. Here the valid query range is derived from the actual index
+    /// bounds of BOTH arrays, so arbitrarily large shifts work.
+    /// </para>
+    /// </summary>
+    /// <param name="query">Query fingerprint.</param>
+    /// <param name="reference">Reference fingerprint.</param>
+    /// <param name="shift">Reference-minus-query index offset to test.</param>
+    /// <param name="options">Tuning parameters.</param>
+    /// <returns>The longest qualifying run, or null when none reaches <see cref="ReuseMatchOptions.MinRunPoints"/>.</returns>
+    public static ReusedSpan? ExtractContiguousRunAtShift(
+        uint[] query,
+        uint[] reference,
+        int shift,
+        ReuseMatchOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reference);
+        ArgumentNullException.ThrowIfNull(options);
+
+        // referenceIndex = queryIndex + shift must be in [0, reference.Length).
+        var qStart = Math.Max(0, -shift);
+        var qEnd = Math.Min(query.Length, reference.Length - shift); // exclusive
+        if (qEnd - qStart < options.MinRunPoints)
+        {
+            return null;
+        }
+
+        var bestStart = -1;
+        var bestEnd = -1;
+        var bestMatches = 0;
+
+        var runStart = -1;
+        var lastMatch = -1;
+        var runMatches = 0;
+
+        for (var q = qStart; q < qEnd; q++)
+        {
+            var diff = query[q] ^ reference[q + shift];
+            var similar = ChromaprintAnalyzer.CountBits(diff) <= options.MaxBitDifferences;
+
+            if (similar)
+            {
+                if (runStart < 0)
+                {
+                    runStart = q;
+                    runMatches = 0;
+                }
+
+                lastMatch = q;
+                runMatches++;
+                continue;
+            }
+
+            // A non-matching point only breaks the run if the gap since the last match exceeds the
+            // permitted skip (mirrors MaximumTimeSkip tolerance in production).
+            if (runStart >= 0 && q - lastMatch > options.MaxGapPoints)
+            {
+                CommitRun(runStart, lastMatch, runMatches, ref bestStart, ref bestEnd, ref bestMatches);
+                runStart = -1;
+            }
+        }
+
+        if (runStart >= 0)
+        {
+            CommitRun(runStart, lastMatch, runMatches, ref bestStart, ref bestEnd, ref bestMatches);
+        }
+
+        // Require enough GENUINE matches (not merely a wide first-to-last span): real reuse is ~100%
+        // dense, whereas coincidental matches at a spurious shift are extremely sparse. This rejects the
+        // degenerate case where two unrelated points happen to fall within MaxGapPoints of each other.
+        if (bestMatches < options.MinRunPoints)
+        {
+            return null;
+        }
+
+        return new ReusedSpan(bestStart, bestEnd, bestStart + shift, shift);
+    }
+
+    /// <summary>
+    /// Assembles a set of reused spans into a single recap boundary by clustering spans that are
+    /// contiguous in episode N (a montage = several back-to-back reused clips). The recap is the hull
+    /// of the earliest qualifying cluster. The start is NOT forced to 0 — the boundary tracks the actual
+    /// reused content, so a cold open before the "previously on" is excluded.
+    /// </summary>
+    /// <param name="spans">Reused spans (query coordinates).</param>
+    /// <param name="options">Tuning parameters (uses defaults when null).</param>
+    /// <returns>The recap time range in seconds, or null when no cluster qualifies.</returns>
+    public static TimeRange? AssembleRecap(IReadOnlyList<ReusedSpan> spans, ReuseMatchOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(spans);
+        options ??= new ReuseMatchOptions();
+
+        if (spans.Count == 0)
+        {
+            return null;
+        }
+
+        var ordered = spans.OrderBy(static s => s.QueryStart).ToList();
+
+        // Greedily merge spans whose query-space gap is small into clusters.
+        var clusters = new List<(int Start, int End)>();
+        var clusterStart = ordered[0].QueryStart;
+        var clusterEnd = ordered[0].QueryEnd;
+
+        for (var i = 1; i < ordered.Count; i++)
+        {
+            var span = ordered[i];
+            if (span.QueryStart - clusterEnd <= options.MaxMontageGapPoints)
+            {
+                clusterEnd = Math.Max(clusterEnd, span.QueryEnd);
+            }
+            else
+            {
+                clusters.Add((clusterStart, clusterEnd));
+                clusterStart = span.QueryStart;
+                clusterEnd = span.QueryEnd;
+            }
+        }
+
+        clusters.Add((clusterStart, clusterEnd));
+
+        // Recaps lead the episode: choose the earliest cluster that is at least one clip long.
+        foreach (var (start, end) in clusters.OrderBy(static c => c.Start))
+        {
+            if (end - start + 1 >= options.MinRunPoints)
+            {
+                return new TimeRange(
+                    start * ChromaprintConstants.SampleDuration,
+                    (end + 1) * ChromaprintConstants.SampleDuration);
+            }
+        }
+
+        return null;
+    }
+
+    private static void CommitRun(int start, int end, int matches, ref int bestStart, ref int bestEnd, ref int bestMatches)
+    {
+        if (matches > bestMatches)
+        {
+            bestMatches = matches;
+            bestStart = start;
+            bestEnd = end;
+        }
+    }
+
+    private static List<ReusedSpan> DeduplicateByQueryOverlap(List<ReusedSpan> spans)
+    {
+        var ordered = spans
+            .OrderByDescending(static s => s.LengthPoints)
+            .ToList();
+
+        var kept = new List<ReusedSpan>();
+        foreach (var span in ordered)
+        {
+            var overlaps = kept.Any(k => span.QueryStart <= k.QueryEnd && k.QueryStart <= span.QueryEnd);
+            if (!overlaps)
+            {
+                kept.Add(span);
+            }
+        }
+
+        return [.. kept.OrderBy(static s => s.QueryStart)];
+    }
+}

--- a/IntroSkipper/Analyzers/ReuseMatchDiagnostics.cs
+++ b/IntroSkipper/Analyzers/ReuseMatchDiagnostics.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Analyzers;
+
+/// <summary>
+/// Cost diagnostics emitted alongside a <see cref="CrossEpisodeReuseMatcher"/> search, used to
+/// substantiate the RFC's cost claims.
+/// </summary>
+/// <remarks>
+/// RESEARCH SPIKE (RFC B) — see <c>docs/recap-research/B-cross-episode.md</c>.
+/// </remarks>
+/// <param name="DistinctShiftsDiscovered">Number of distinct candidate shifts found during voting.</param>
+/// <param name="ShiftsScanned">Number of shifts actually scanned (bounded by <see cref="ReuseMatchOptions.TopShifts"/>).</param>
+/// <param name="PointSetOverlap">Distinct-point overlap fraction used for early-exit.</param>
+/// <param name="EarlyExit">Whether the pre-filter short-circuited the search.</param>
+public readonly record struct ReuseMatchDiagnostics(
+    int DistinctShiftsDiscovered,
+    int ShiftsScanned,
+    double PointSetOverlap,
+    bool EarlyExit);

--- a/IntroSkipper/Analyzers/ReuseMatchOptions.cs
+++ b/IntroSkipper/Analyzers/ReuseMatchOptions.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Analyzers;
+
+/// <summary>
+/// Tunable parameters for a <see cref="CrossEpisodeReuseMatcher"/> pass. Defaults are translated from
+/// the shipped <see cref="Configuration.PluginConfiguration"/> Chromaprint tuning so the prototype
+/// behaves like production.
+/// </summary>
+/// <remarks>
+/// RESEARCH SPIKE (RFC B) — see <c>docs/recap-research/B-cross-episode.md</c>.
+/// </remarks>
+public sealed class ReuseMatchOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum number of differing bits (out of 32) for two points to be "equal".
+    /// Mirrors <c>PluginConfiguration.MaximumFingerprintPointDifferences</c> (default 6).
+    /// </summary>
+    public int MaxBitDifferences { get; set; } = 6;
+
+    /// <summary>
+    /// Gets or sets the +/- jitter applied when probing the reference index during shift voting.
+    /// Mirrors <c>PluginConfiguration.InvertedIndexShift</c> (default 2).
+    /// </summary>
+    public int IndexShift { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets the maximum gap (in points) between two matched positions before a contiguous run
+    /// is broken. Mirrors <c>PluginConfiguration.MaximumTimeSkip</c> (3.5 s) converted to points.
+    /// </summary>
+    public int MaxGapPoints { get; set; } = CrossEpisodeReuseMatcher.SecondsToPoints(3.5);
+
+    /// <summary>
+    /// Gets or sets the minimum length (in points) of a single reused clip. Mirrors
+    /// <c>ChromaprintAnalyzer.RecapCardMinimumDuration</c> (3 s) converted to points.
+    /// </summary>
+    public int MinRunPoints { get; set; } = CrossEpisodeReuseMatcher.SecondsToPoints(3.0);
+
+    /// <summary>
+    /// Gets or sets the maximum number of candidate shifts that are fully scanned. This is the hard
+    /// upper bound on the expensive phase: cost is <c>TopShifts * O(query length)</c>.
+    /// </summary>
+    public int TopShifts { get; set; } = 16;
+
+    /// <summary>
+    /// Gets or sets the maximum gap (in points) between two reused clips that should still be merged
+    /// into the same montage (covers hard cuts / short black-frame transitions between clips).
+    /// </summary>
+    public int MaxMontageGapPoints { get; set; } = CrossEpisodeReuseMatcher.SecondsToPoints(6.0);
+
+    /// <summary>
+    /// Gets or sets the minimum distinct-point overlap fraction required before a full search runs.
+    /// Used for cheap early-exit on shows that do not reuse footage.
+    /// </summary>
+    public double PreFilterMinOverlap { get; set; } = 0.02;
+
+    /// <summary>
+    /// Gets or sets a cap on how many reference occurrences of a single point value are allowed to vote.
+    /// Bounds worst-case voting cost when a point value is pathologically common in the reference.
+    /// </summary>
+    public int MaxVotesPerPoint { get; set; } = 8;
+}

--- a/IntroSkipper/Analyzers/ReusedSpan.cs
+++ b/IntroSkipper/Analyzers/ReusedSpan.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Analyzers;
+
+/// <summary>
+/// One reused span located by <see cref="CrossEpisodeReuseMatcher"/>: a contiguous block of
+/// <see cref="QueryStart"/>..<see cref="QueryEnd"/> (inclusive point indices, in episode N) that matches
+/// reference points starting at <see cref="ReferenceStart"/> (in the prior episode), at <see cref="Shift"/>.
+/// </summary>
+/// <remarks>
+/// RESEARCH SPIKE (RFC B) — see <c>docs/recap-research/B-cross-episode.md</c>.
+/// </remarks>
+/// <param name="QueryStart">First matched point index in the query (episode N).</param>
+/// <param name="QueryEnd">Last matched point index in the query (episode N).</param>
+/// <param name="ReferenceStart">First matched point index in the reference (prior episode).</param>
+/// <param name="Shift">Reference-minus-query index offset of this span.</param>
+public readonly record struct ReusedSpan(int QueryStart, int QueryEnd, int ReferenceStart, int Shift)
+{
+    /// <summary>Gets the length of the span in fingerprint points.</summary>
+    public int LengthPoints => QueryEnd - QueryStart + 1;
+
+    /// <summary>Gets the start of the span in seconds (relative to the start of episode N).</summary>
+    public double QueryStartSeconds => QueryStart * ChromaprintConstants.SampleDuration;
+
+    /// <summary>Gets the end of the span in seconds (relative to the start of episode N).</summary>
+    public double QueryEndSeconds => (QueryEnd + 1) * ChromaprintConstants.SampleDuration;
+}

--- a/docs/recap-research/B-cross-episode.md
+++ b/docs/recap-research/B-cross-episode.md
@@ -1,0 +1,354 @@
+# RFC B — Recap detection via cross-episode content-reuse matching
+
+> **Status:** research + design spike (NOT a mergeable feature). Prototype + tests included; analyzer is **not** wired into the chain.
+> **Author:** spike investigation on branch `recap-rfc-b-cross-episode-reuse`.
+> **Scope:** design and de-risk recap detection by matching the opening of episode *N* against **prior** episodes to find reused footage/audio, and critically review the current recap implementation from that lens.
+> **Environment for all measurements:** Ubuntu 24.04 (x86-64), .NET 10.0.102 SDK building `net9.0`, system `ffmpeg 6.1.1`, **Debug** build, single thread. Numbers are conservative (Debug, not Release).
+
+---
+
+## 0. TL;DR verdict
+
+* **A recap is reused footage/audio from earlier episodes.** The defining property is *cross-episode reuse*: the recap’s audio does not match episode *N*’s new content but **does** match spans somewhere inside prior episodes. Intro detection is *opening-vs-opening at the same offset*; recap detection is *opening-vs-**anywhere-in-prior***.
+* **The shipped recap detector cannot do this.** It is the **degenerate special case** of reuse matching: it fingerprints only `(0, IntroFingerprintEnd)` of *both* episodes [[QueuedEpisode.cs:148]](../../IntroSkipper/Data/QueuedEpisode.cs#L148) and finds the *earliest shared* opening region [[ChromaprintAnalyzer.cs:293-328]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L293-L328). That only ever finds a recurring “Previously on…” **bumper sting**, never the reused **clips** (which live deep in the prior episode and are never fingerprinted). The recap’s *extent* is then guessed from black frames, not audio.
+* **I found a concrete bug** that makes true reuse matching impossible with the shipped primitive: `FindContiguous` computes its scan length as `min(lhs, rhs) - |shift|` [[ChromaprintAnalyzer.cs:453]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L453), which goes **negative** for the large shifts a deep reuse implies, so the comparison loop never runs. A unit test demonstrates production missing a deep reuse the spike finds.
+* **The audio approach is cheap enough.** Measured on this VM: the per-pair comparison is **2.9–7.4 ms** even against a 60-min reference; the real cost is obtaining the prior episode’s **full** fingerprint, which is **one cached ~4.6 s ffmpeg audio decode per episode (~310× realtime, zero GPU)** — the same order as the per-episode fingerprinting the plugin already performs for Introduction/Credits, and far below Prime Video’s per-shot **video** alignment.
+* **Honest limits.** Reuse matching cannot detect recaps that are **re-mixed** (a music bed / narration laid over the clips changes the audio spectrum and defeats fingerprinting), shows that **don’t reuse footage** (newly-shot “story so far”), or **season-premiere** recaps of the previous season unless prior selection crosses the season boundary. The shift-discovery phase is also more fragile to re-encoding than the extraction phase (see §7.4 / §9).
+
+**Recommendation:** worth prototyping into an opt-in analyzer **for the audio path only**, scoped to *N* vs *N-1* (and optionally *N-2*), with a MinHash/point-set pre-filter and a bounded top-T shift search. Do **not** pursue video corroboration under the “not heavy” constraint. Keep the existing black-frame boundary snap as an optional refinement, not the primary signal.
+
+---
+
+## 1. What a recap is, and why reuse matching is the right model
+
+A recap (“Previously on…”) is a montage near the start of an episode assembled from **clips taken from earlier episodes**. Concretely:
+
+* The recap’s **audio/video is literally reused** from prior episodes; it differs from episode *N*’s new content.
+* It is short (≈10–60 s), often a **montage of several disjoint clips** stitched back-to-back, sometimes bounded by black-frame/fade transitions.
+* Placement varies: before or after the cold open, before or after the intro.
+* It surfaces in Jellyfin as `MediaSegmentType.Recap` [[SegmentProvider.cs:28]](../../IntroSkipper/Providers/SegmentProvider.cs#L28).
+
+The reuse property gives a precise detector: **take episode *N*’s opening window and find which chunks of it are reused from prior episode(s)** — those reused chunks *are* the recap.
+
+| | **Intro** (shipped) | **Recap** (this RFC) |
+|---|---|---|
+| Compare | opening of *A* ↔ opening of *B* | opening of *N* ↔ **full** prior episode(s) |
+| Alignment | shared region at ~**same offset** in both (small shift) | reused clips at **arbitrary offsets** in the prior (large, varied shifts) |
+| Result shape | one contiguous shared region | **several disjoint** reused spans, contiguous in *N* (a montage) |
+| Reference window | opening only (`0..IntroFingerprintEnd`) | **whole** prior episode |
+
+---
+
+## 2. Fingerprint mechanics (the units everything is measured in)
+
+Chromaprint emits one 32-bit point per hop. The hop duration is the single source of truth for all time↔point conversions:
+
+```
+SampleDuration = 4096 / 11025 / 3 ≈ 0.1238397 s/point   // ChromaprintConstants.cs:22
+points/second  = 1 / SampleDuration ≈ 8.075
+```
+[[ChromaprintConstants.cs:22]](../../IntroSkipper/Data/ChromaprintConstants.cs#L22)
+
+Measured point counts (full episode, via `ffmpeg -f chromaprint`), matching the model:
+
+| Episode length | Seconds | Points (predicted 8.075/s) | Points (measured) |
+|---|---|---|---|
+| 22 min | 1320 | 10,659 | — |
+| **24 min** | **1440** | **11,628** | **11,614** ✅ |
+| 42 min | 2520 | 20,349 | — |
+| 60 min | 3600 | 29,070 | — |
+
+The **current recap fingerprint window** is only the opening: `Recap => (0, IntroFingerprintEnd)` [[QueuedEpisode.cs:148]](../../IntroSkipper/Data/QueuedEpisode.cs#L148), and `IntroFingerprintEnd` is computed in the queue as [[QueueManager.cs:245-247]](../../IntroSkipper/Manager/QueueManager.cs#L245-L247):
+
+```
+IntroFingerprintEnd = min( duration≥300 ? duration·AnalysisPercent : duration,
+                           60 · AnalysisLengthLimit )
+defaults: AnalysisPercent = 25 %, AnalysisLengthLimit = 10  ⇒ cap = 600 s
+  24-min ep ⇒ min(360, 600) = 360 s ≈ 2,907 points
+  42-min ep ⇒ min(630, 600) = 600 s ≈ 4,845 points
+```
+
+**Key consequence:** today, recap mode only ever has the **first 360–600 s** of each episode fingerprinted. The reused clips of a montage come from the *body* of prior episodes (e.g. t≈900 s), which are **never fingerprinted** — so true reuse matching is structurally impossible with the current fingerprint range. This is the architectural gap RFC B closes.
+
+---
+
+## 3. Exact map of the current recap implementation
+
+Recap is wired as: ChapterAnalyzer (regex / SponsorBlock / optional black-frame fallback) → ChromaprintAnalyzer (audio).
+
+1. **Mode list & chain.** Recap is enabled by `ScanRecap` [[BaseItemAnalyzerTask.cs:77]](../../IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs#L77); the Chromaprint analyzer is appended for non-movie items with valid ffmpeg [[BaseItemAnalyzerTask.cs:361-365]](../../IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs#L361-L365).
+
+2. **Fingerprint range.** `FingerprintAsync` reads `GetFingerprintRange(Recap) = (0, IntroFingerprintEnd)` [[QueuedEpisode.cs:143-152]](../../IntroSkipper/Data/QueuedEpisode.cs#L143-L152), [[FFmpegService.cs:118-124]](../../IntroSkipper/FFmpeg/FFmpegService.cs#L118-L124). This case **was missing until commit `e17f044` “fix recap”** (Jun 27 2026); before it, recap fingerprinting threw `ArgumentException` and aborted analysis — strong evidence the recap path was never validated end-to-end.
+
+3. **Pairwise comparison.** `AnalyzeMediaFiles` fingerprints every episode in the season, then runs an **all-pairs** loop (pop one, compare against all remaining) [[ChromaprintAnalyzer.cs:90-180]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L90-L180). For each pair `CompareEpisodes` → `SearchInvertedIndex` → `FindContiguous` [[ChromaprintAnalyzer.cs:193-213]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L193-L213).
+
+4. **Inverted index.** `CreateInvertedIndex` maps each point value to the **last** index it appears at — `invIndex[point] = i` overwrites earlier occurrences [[ChromaprintAnalyzer.cs:498-519]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L498-L519).
+
+5. **Shift discovery.** For each point in LHS, probe RHS at `±InvertedIndexShift` (default ±2) **in value space**; each hit yields one candidate shift `rhsLast - lhsLast` [[ChromaprintAnalyzer.cs:379-424]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L379-L424).
+
+6. **Contiguous match.** For each shift, `FindContiguous` XORs the two arrays and keeps points whose popcount ≤ `MaximumFingerprintPointDifferences` (default 6) [[ChromaprintAnalyzer.cs:432-490]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L432-L490).
+
+7. **Recap selection.** In recap mode, `SelectSharedRegion` picks the **earliest** shared region (≥ `RecapCardMinimumDuration = 3 s`) [[ChromaprintAnalyzer.cs:26]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L26), [[ChromaprintAnalyzer.cs:234-242]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L234-L242), [[ChromaprintAnalyzer.cs:293-328]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L293-L328), and **snaps the start to 0** when it begins within 5 s [[ChromaprintAnalyzer.cs:317-325]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L317-L325).
+
+8. **Boundary from black frames.** `BuildRecapFromChromaprintCandidateAsync` then ignores the audio region’s *end* and re-derives the recap end as the **latest black frame** before the intro [[ChromaprintAnalyzer.cs:255-291]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L255-L291) → `ChapterAnalyzer.BuildRecapFromBlackFrames` [[ChapterAnalyzer.cs:247-273]](../../IntroSkipper/Analyzers/ChapterAnalyzer.cs#L247-L273), bounded by `RecapDetectionHelper.GetMaximumBoundaryAsync` (min of `MaximumRecapDetectionDuration` and the detected intro start) [[RecapDetectionHelper.cs:21-36]](../../IntroSkipper/Analyzers/RecapDetectionHelper.cs#L21-L36).
+
+9. **Cache & config hashing.** Fingerprints are Brotli-cached in SQLite keyed by `(ItemId, Mode, Type, Start, End)` + a config hash [[DetectionCacheService.cs:30-73]](../../IntroSkipper/FFmpeg/DetectionCacheService.cs#L30-L73), [[DbDetectionCache.cs]](../../IntroSkipper/Db/DbDetectionCache.cs). The cache key’s `Start/End` come from `GetFingerprintRange` and are compared with `==`, so they must round-trip bit-exactly. Analysis output is hashed per mode incl. the Recap case [[ConfigHasher.cs:44-49]](../../IntroSkipper/Helper/ConfigHasher.cs#L44-L49); the Chromaprint cache hash is mode-scoped [[ConfigHasher.cs:78-79]](../../IntroSkipper/Helper/ConfigHasher.cs#L78-L79).
+
+---
+
+## 4. The bug: `FindContiguous` cannot reach a deep reuse
+
+`FindContiguous` is built for two arrays of **comparable length, aligned near the front** (intros). Its scan length is [[ChromaprintAnalyzer.cs:453]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L453):
+
+```csharp
+var upperLimit = Math.Min(lhs.Length, rhs.Length) - Math.Abs(shiftAmount);
+for (var i = 0; i < upperLimit; i++) { ... }   // ChromaprintAnalyzer.cs:456
+```
+
+A recap reuses footage from **deep** inside a prior episode. If the reused clip is at reference index ≈ 8000 but query index ≈ 100, the discovered shift is ≈ **7900**. With a short opening query (`min(len)` ≈ 970) the scan length is `970 - 7900 < 0`, so **the loop never executes** and the reuse is invisible. The shipped engine can therefore only match reuse at **small** shifts (intro-like alignment), never the large shifts that define a recap.
+
+This is proven by the test `Production_FindsAlignedReuse_ButMissesDeepReuse_WhereSpikeSucceeds` [[TestCrossEpisodeReuse.cs]](../../IntroSkipper.Tests/TestCrossEpisodeReuse.cs): the **same** planted block is found by `ChromaprintAnalyzer.CompareEpisodes` at a small offset (CASE A, `Valid == true`) but **not** at a deep offset (CASE B, `Valid == false`), while the spike recovers CASE B.
+
+The fix is structural, not a one-liner tweak: derive the valid scan range from the **actual index bounds of both arrays** so any shift works. See `CrossEpisodeReuseMatcher.ExtractContiguousRunAtShift` [[CrossEpisodeReuseMatcher.cs:183-250]](../../IntroSkipper/Analyzers/CrossEpisodeReuseMatcher.cs#L183-L250):
+
+```
+qStart = max(0, -shift)
+qEnd   = min(query.Length, reference.Length - shift)   // overlap given an arbitrary shift
+```
+
+---
+
+## 5. Algorithm (audio path)
+
+Spike implementation: `IntroSkipper/Analyzers/CrossEpisodeReuseMatcher.cs` (+ `ReuseMatchOptions`, `ReusedSpan`, `ReuseMatchDiagnostics`). Defaults are translated from the shipped Chromaprint tuning so behaviour maps onto production.
+
+**Inputs**
+* `query` = episode *N*’s opening window, e.g. first **120 s** (≈ 969 points). (Today’s `(0, IntroFingerprintEnd)` = 360–600 s also works but is larger than necessary.)
+* `reference` = a prior episode’s **full** fingerprint (≈ 11.6k points for 24 min).
+
+**Pseudocode**
+
+```
+FindReusedSpans(query, reference, opts):
+    # (1) Cheap pre-filter / early-exit — skip shows that don't reuse footage
+    overlap = |distinct(query) ∩ distinct(reference)| / |distinct(query)|     # MinHash on real data
+    if overlap < opts.PreFilterMinOverlap: return [] , earlyExit=true
+
+    # (2) Multimap inverted index of the reference (EVERY occurrence, not just the last)
+    refIndex : point -> [all indices]          # vs production's last-occurrence-only index
+
+    # (3) Shift voting (a 1-D Hough transform over offsets)
+    votes : shift -> count
+    for q in query:
+        for delta in [-IndexShift .. +IndexShift]:           # value-space jitter, like production
+            for refIdx in refIndex[query[q] + delta] (capped at MaxVotesPerPoint):
+                votes[refIdx - q] += 1
+    #   a reused clip of length L produces ~L votes at ONE shift; noise scatters ~1-2 across many
+
+    # (4) Bounded extraction — only the strongest TopShifts are fully scanned (hard cost cap)
+    spans = []
+    for shift in top-T(votes, opts.TopShifts):
+        span = ExtractContiguousRunAtShift(query, reference, shift, opts)   # corrected bounds (§4)
+        if span: spans.append(span)
+    return dedupeByQueryOverlap(spans)
+
+AssembleRecap(spans, opts):
+    # (5) A montage = several disjoint reused spans that are CONTIGUOUS in episode N.
+    cluster spans whose query-space gap ≤ MaxMontageGapPoints   # absorbs cuts / short fades
+    return hull(earliest qualifying cluster) in seconds         # start NOT forced to 0
+```
+
+**Why two phases matter.** Discovery (step 3) needs only *near-exact* value matches to *locate* a shift; extraction (step 4) then tolerates up to 6 differing bits to measure the clip’s full extent. A genuine clip of length *L* yields a vote peak of ≈ *L* at its true shift, trivially separable from the ≈1–2 votes random coincidences scatter (validated in the benchmark: only **3–4 distinct shifts** arise from a 3-clip montage in noise).
+
+**Robustness guard.** Extraction requires `MinRunPoints` *genuine* matches, not merely a wide first-to-last span, so two coincidental matches that happen to fall within the gap tolerance cannot fake a run [[CrossEpisodeReuseMatcher.cs:241-247]](../../IntroSkipper/Analyzers/CrossEpisodeReuseMatcher.cs#L241-L247).
+
+**Boundary construction.** The recap is the **hull of the earliest contiguous cluster**, converted to seconds. Start is **not** forced to 0, so a cold open before “Previously on…” is correctly excluded — a direct improvement over `GetEarliestTimeRange`’s `Start ≤ 5 ⇒ 0` snap [[ChromaprintAnalyzer.cs:317-325]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L317-L325). The shipped black-frame snap can still be applied as an optional *refinement* to land on a clean cut.
+
+---
+
+## 6. Cost & memory analysis vs the “not CPU/GPU heavy” constraint
+
+The maintainer constraint (issue #136) is *“find a way that’s not CPU/GPU heavy.”* Two costs, analyzed separately.
+
+### 6.1 Comparison CPU (runs every analysis, even on cache hits)
+
+Per episode pair, dominated by: build reference multimap `O(n)`; pre-filter set ops `O(n+m)`; voting `O(m·(2·shift+1))` lookups; extraction `TopShifts · O(m)`. **`TopShifts` (default 16) hard-caps the expensive phase regardless of input.**
+
+Measured by `Benchmark_RealisticSizes_IsCheap` (Debug, single thread, 200 iterations, 3-clip montage planted in random noise):
+
+| prior-episode size | query window | distinct shifts | shifts scanned | spans | **avg ms / pair** |
+|---|---|---|---|---|---|
+| 22 min (10,659 pts) | 970 pts | 4 | 4 | 3 | **2.86** |
+| 24 min (11,628 pts) | 970 pts | 3 | 3 | 3 | **4.82** |
+| 42 min (20,349 pts) | 970 pts | 3 | 3 | 3 | **4.74** |
+| 60 min (29,070 pts) | 970 pts | 3 | 3 | 3 | **7.45** |
+
+Growth tracks reference size (the `O(n)` index build + allocations dominate), **not** the search. For a 12-episode season compared *N* vs *N-1* (11 pairs): **≈ 40–80 ms of pure comparison CPU for the entire season**, in Debug. Release would be materially faster. This is negligible. **Zero GPU.**
+
+> **Honesty caveat:** the benchmark uses *uniform-random* `uint[]`, which understates real chromaprint behaviour — real points are temporally correlated and skewed, so real data will produce **more** spurious votes and distinct shifts than the 3–4 seen here. That only inflates the voting tally and the *candidate* shift count; the `TopShifts` cap keeps the extraction cost fixed, so the worst case stays bounded. The risk it introduces is *quality* (a real shift pushed out of the top-T by spurious peaks), not *cost*.
+
+### 6.2 Decode CPU (one-time per episode, cached)
+
+True reuse matching needs the prior episode’s **full** fingerprint, which the current pipeline never produces for recap. Measured full-episode chromaprint decode (24-min / 1440 s audio, median of 3):
+
+```
+~4.6 s wall/CPU per 24-min episode  ⇒  ~310× realtime, single core, no GPU
+```
+
+Context:
+* Today’s recap decodes only `(0, 360 s)` ≈ **1.1 s**; the reference upgrade adds ≈ **3.5 s/episode** (24-min) — **one-time and cached** (Brotli SQLite). Re-runs and settled-season re-analysis reuse it.
+* It is the **same order** as the per-episode fingerprinting the plugin already performs for Introduction (`0..360 s`) and Credits (tail ≈ 360–450 s) — combined those already decode ≈ half the episode under *different* cache keys.
+* It is **dramatically** below Prime Video’s published recap/intro/credits approach, which aligns recap **shots to prior-episode video** (decode + downscale + per-frame hashing + alignment over image-scale data).
+
+### 6.3 Memory
+
+| structure | size (24 min / 60 min) | notes |
+|---|---|---|
+| full fingerprint `uint[]` | 46 KB / 116 KB | one per episode |
+| multimap `Dictionary<uint,List<int>>` | ≈ 0.8 MB / 2.1 MB | heaviest; per-entry `List<int>` allocs |
+| pre-filter `HashSet<uint>` | ≈ 0.2 MB / 0.5 MB | transient |
+
+A 12-episode season held in memory (fingerprints + on-demand indexes) is **single-digit MB**, on par with the existing `fingerprintCache`/`_invertedIndexCache` the analyzer already keeps for a season. The multimap is the obvious optimization target (replace with a sorted `(value,index)` array + binary search to remove per-point list allocations) if memory ever matters.
+
+### 6.4 Worst case vs typical
+
+* **Typical** (*N* vs *N-1*, 120 s window, MinHash prefilter): ≈ 5 ms + amortized index per pair; one cached 4.6 s decode/episode.
+* **Worst case** *if naively copied from the shipped all-pairs loop* [[ChromaprintAnalyzer.cs:90-180]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L90-L180): `O(E²)` pairs each against a full-episode reference. For E=24 that’s ~276 pairs × ~5 ms ≈ 1.4 s comparison — still cheap, but pointless. **Recommendation: recap reuse matching must be sequential (*N* vs *N-1*, optionally *N-2*), not all-pairs.**
+
+**Verdict on the bar:** the **audio** path meets “not CPU/GPU heavy.” The comparison is trivial; the only real cost is a cached, one-time, single-core, ~310×-realtime full-episode audio decode — strictly more than today’s opening-only recap decode, but the same order as existing per-episode fingerprinting and orders of magnitude below any video approach.
+
+---
+
+## 7. Cheap-enough variant (minimal viable subset)
+
+If even one extra full decode per episode is unacceptable, the cheapest viable subset that still detects the common case:
+
+1. **Window the query to ≤ 90–120 s** of *N* (recaps lead the episode) → ≈ 727–969 query points.
+2. **Compare only against *N-1*.** Most recaps draw heavily from the immediately preceding episode.
+3. **MinHash (k≈64–128) pre-filter** on the prior episode → `O(k)` early-exit for shows that don’t reuse footage, before any full search or even full index build.
+4. **Bounded top-T (≤16) shift extraction** with early-exit once a cluster covering ≥ `MinimumRecapDetectionDuration` is assembled.
+5. **Reuse cached fingerprints** and, ideally, make the *full-episode* fingerprint serve both Introduction and Recap so the marginal decode is shared (see §8).
+
+This keeps comparison at single-digit ms/pair and decode at one cached pass/episode. The accuracy cost of *N-1*-only is missing montage clips sourced from *N-2…N-k* (see §9).
+
+---
+
+## 8. Integration design
+
+**Where it sits.** A new opt-in `CrossEpisodeReuseAnalyzer : IMediaFileAnalyzer` in the Recap chain, **after** ChapterAnalyzer (cheap regex/SponsorBlock wins first) and **replacing** the recap special-case currently bolted onto `ChromaprintAnalyzer` [[ChromaprintAnalyzer.cs:118-135]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L118-L135). It would run only when `ScanRecap` and ffmpeg are valid [[BaseItemAnalyzerTask.cs:361-365]](../../IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs#L361-L365), gated behind a new `DetectRecapUsingReuse` config flag (default off while experimental).
+
+**Fingerprints it needs.**
+* Query side: episode *N*’s opening. `(0, IntroFingerprintEnd)` is reusable as-is, or a tighter `(0, 120 s)` window.
+* Reference side: prior episode’s **full** fingerprint `(0, Duration)`. This does **not** exist today and **cannot be reused** from `(0, IntroFingerprintEnd)` (opening only) or Credits `(CreditsFingerprintStart, End)` (tail only) — the reused clips are typically in the body. Requires a new fingerprint range.
+
+**`GetFingerprintRange` / cache implications.** Add a dedicated full-episode range. Because the cache key is `(ItemId, Mode, Type, Start, End)` compared with `==` [[DetectionCacheService.cs:46-47]](../../IntroSkipper/FFmpeg/DetectionCacheService.cs#L46-L47), the cleanest options are:
+  * (a) introduce a distinct reference range (e.g. a new `CacheEntryType` or a Recap-reference start/end of `(0, Duration)`) so it round-trips bit-exactly and never collides with the opening entry; **or**
+  * (b) **promote Introduction to fingerprint the full episode** and have both Introduction and Recap read the same `(0, Duration)` entry — this *removes* a redundant decode (Intro already decodes `(0, 360)`) and gives recap its reference for free, at the cost of a larger Intro fingerprint. This is the most cost-efficient integration and worth a follow-up spike.
+
+**`ConfigHasher` implications.** Add the new knobs (`DetectRecapUsingReuse`, query-window length, prior-episode count, `TopShifts`, `MinRunPoints`, `PreFilterMinOverlap`, montage gap) to the Recap analysis hash [[ConfigHasher.cs:44-49]](../../IntroSkipper/Helper/ConfigHasher.cs#L44-L49) so changing them invalidates stored recap segments; and to the Chromaprint detection-cache hash [[ConfigHasher.cs:78-79]](../../IntroSkipper/Helper/ConfigHasher.cs#L78-L79) **only if** the *fingerprint range* changes (the fingerprint bytes don’t depend on matching tuning, so matching knobs must stay out of the cache hash to avoid needless re-decodes).
+
+**Prior selection / cross-season.** `QueueManager` groups by season, so *N-1* within a season is available; **season premieres** need the previous season’s finale, which the per-season queue doesn’t expose today — a queue change is required to handle S0xE01 recaps (see §9).
+
+**Boundary.** Emit `Segment(N, hull)` with a non-zero start; optionally snap the end to the nearest black frame via the existing `BuildRecapFromBlackFrames` [[ChapterAnalyzer.cs:247-273]](../../IntroSkipper/Analyzers/ChapterAnalyzer.cs#L247-L273) as a refinement, then run the normal `TimeAdjustmentHelper`.
+
+---
+
+## 9. Failure modes (honest)
+
+| Failure mode | Effect | Mitigation |
+|---|---|---|
+| **Re-mixed recap** (music bed / VO laid over clips) | Audio spectrum changes → fingerprint diverges > 6 bits → **miss**. The single biggest limit; many shows score their montages. | None on the audio path. Demonstrated by `FindReusedSpans_RejectsHeavilyAlteredAudio`. |
+| **Re-encode / re-grade** of clips | Mild drift is tolerated by extraction (≤6 bits), **but shift *discovery* needs near-exact value matches** (`±IndexShift` in value space). If too few points survive near-exactly, the shift is never found. | Demonstrated by `FindReusedSpans_ToleratesMildReencodeNoise` (≈60 % survive ⇒ found). Consider a bit-tolerant LSH index for discovery if real data proves fragile. |
+| **Shows that don’t reuse footage** (newly-shot “story so far”, animated recap) | No audio match → **no detection**. Fundamental to reuse matching (Prime Video shares this limit). | Pre-filter early-exits cheaply; fall back to chapter/black-frame signals. |
+| **Season-premiere recap** of previous season | *N-1* is in a different season / absent → **miss**. | Extend prior selection across the season boundary (queue change). |
+| **First episode of a series** | No prior → no recap. | Correct behaviour. |
+| **Montage clips from *N-2…N-k*** | *N-1*-only comparison finds only the *N-1*-sourced clips → **under-segments**. | Compare against a small window of priors; cost scales linearly with *k*. |
+| **Recurring non-recap shared audio** (theme, sponsor bumper, stock stinger reused across eps) | Could be matched as “reuse”. | The reuse-from-*body* signal (large, varied shifts + montage clustering) already distinguishes a recap from an opening bumper; add a min-total-reused-duration gate. |
+| **Real-data spurious shifts** (correlated chromaprint points) | More candidate shifts than the synthetic 3–4. | `TopShifts` caps cost; vote-peak separation keeps quality (monitor on real media). |
+
+---
+
+## 10. Critical review of the current “earliest shared sting” recap
+
+**What it actually does.** It fingerprints `(0, IntroFingerprintEnd)` of **both** episodes (opening-vs-opening) [[QueuedEpisode.cs:148]](../../IntroSkipper/Data/QueuedEpisode.cs#L148), finds shared audio regions with the intro machinery, takes the **earliest** one (≥ 3 s) [[ChromaprintAnalyzer.cs:293-328]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L293-L328), snaps its start to 0 [[ChromaprintAnalyzer.cs:317-325]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L317-L325), and then derives the recap **end** from the latest black frame before the intro [[ChromaprintAnalyzer.cs:255-291]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L255-L291).
+
+**Why it is a *degenerate special case* of reuse matching.** A “Previously on Show X…” **bumper sting** (its title VO + music) is itself reused content that recurs at the **top of every episode**. Opening-vs-opening therefore matches the **bumper**, not the recap **clips** — and only because the bumper happens to sit in both episodes’ `(0, 360 s)` windows. The actual reused clips live in the prior episode’s **body**, which the current fingerprint range never covers (§2). So the method detects *“this episode has a recap bumper”* and then leans entirely on **black frames** for the extent.
+
+**Shortfalls.**
+1. **Conflates bumper with content.** A show that cuts straight into clips with **no** shared sting yields nothing, even though reuse matching would catch it.
+2. **No audio extent.** The end is a black-frame heuristic; shows without a black frame between recap and cold open get a wrong or missing boundary.
+3. **Start forced to 0** [[ChromaprintAnalyzer.cs:317-325]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L317-L325) mis-handles cold-open-then-recap ordering.
+4. **“Earliest shared” ≠ recap.** The earliest shared opening region could be the main-title theme or a sponsor bumper; nothing verifies the region is *reused-from-elsewhere*, the defining recap property.
+5. **Pairing fragility.** It needs two episodes that *both* carry the bumper near the top; partial-season or mixed-recap seasons pair poorly. The all-pairs loop [[ChromaprintAnalyzer.cs:90-180]](../../IntroSkipper/Analyzers/ChromaprintAnalyzer.cs#L90-L180) is also `O(E²)`.
+6. **Shipped broken**, fixed only by adding the missing `GetFingerprintRange` case in `e17f044`; no real-media tests exist (`TestRecapDetection.cs` is synthetic).
+
+**What to keep.**
+* The **inverted-index + shift + contiguous-run** primitive is the right core; reuse matching extends it (with the corrected bounds of §4 and a multimap index).
+* The **black-frame end snap** (`BuildRecapFromBlackFrames`) is a good *optional refinement* to land on a clean cut — keep it, demote it from primary signal.
+* The config plumbing — `Min/MaximumRecapDetectionDuration`, `RecapCardMinimumDuration`, the Recap `ConfigHasher` case, `DetectRecapUsingBlackFrames`, `GetMaximumBoundaryAsync` — is reusable.
+* The query-side window `(0, IntroFingerprintEnd)` is fine; what’s missing is the **prior episode’s full fingerprint** on the reference side.
+
+---
+
+## 11. Optional video corroboration (and why I recommend against it)
+
+A coarse perceptual hash (downscaled grayscale **dHash** at low fps) could confirm reused **shots**. Honest assessment:
+
+* **Strictly heavier than audio.** It requires decoding **video** frames (even at 1–2 fps, that’s image-scale decode + scaling + per-frame hashing) — categorically more than the audio-only path the plugin already pays for. It pushes directly against the “not heavy” constraint.
+* **Audio already disambiguates reuse.** When the recap reuses the original audio, the audio fingerprint is a stronger, cheaper signal than low-fps dHash (which is coarse and prone to false matches on similar scenes/letterboxing/fades).
+* **It only helps the case audio can’t.** The one scenario where video wins is a **re-dubbed / re-scored** recap (reused video, replaced audio) — rare. Even then, dHash at low fps is fragile to re-grading/cropping, exactly the transforms recaps apply.
+
+**Verdict:** not worth it under the constraint. Video corroboration is strictly worse on cost and only marginally better on the rare re-scored case. If pursued, it should be a last-resort confirmation gated behind an explicit “heavy” opt-in, not part of the default path.
+
+---
+
+## 12. Honest verdict vs the current approach
+
+| | Current (earliest shared sting) | RFC B (cross-episode reuse) |
+|---|---|---|
+| Detects recaps **without** a shared bumper | ❌ | ✅ |
+| Measures recap **extent from audio** | ❌ (black-frame guess) | ✅ (reused-span hull) |
+| Correct **non-zero start** | ❌ (snaps to 0) | ✅ |
+| Distinguishes recap from theme/bumper | ❌ | ✅ (reuse-from-body + montage) |
+| Handles **re-mixed** recaps | ❌ | ❌ (fundamental audio limit) |
+| Handles shows that **don’t reuse** footage | ❌ | ❌ (fundamental) |
+| Season-premiere recaps | ❌ | ⚠️ needs cross-season queue |
+| Extra decode cost | opening only (~1.1 s) | **full prior episode (~4.6 s, cached)** |
+| Comparison CPU | intro-scale | **2.9–7.4 ms/pair** (Debug) |
+| GPU | none | none |
+
+**Bottom line:** RFC B is a genuine accuracy upgrade for the common “reused original audio” recap and removes the bumper/black-frame dependency, at the cost of one cached full-episode audio decode per episode and a structural fix to the contiguous matcher. It is **not** a silver bullet — re-mixed recaps and non-reusing shows remain undetectable by any audio method, and season boundaries need a queue change. It comfortably meets “not CPU/GPU heavy” on the audio path; video corroboration does not and should be avoided.
+
+---
+
+## 13. Prototype & reproduction
+
+Files (this branch):
+* `IntroSkipper/Analyzers/CrossEpisodeReuseMatcher.cs` — algorithm (pre-filter, multimap index, shift voting, corrected extraction, montage assembly). Self-contained; reuses `ChromaprintAnalyzer.CountBits` and `ChromaprintConstants.SampleDuration`.
+* `IntroSkipper/Analyzers/ReuseMatchOptions.cs`, `ReusedSpan.cs`, `ReuseMatchDiagnostics.cs` — supporting types.
+* `IntroSkipper.Tests/TestCrossEpisodeReuse.cs` — 8 tests: single planted span, mild-reencode tolerance, heavy-alteration rejection, **3-clip montage assembly**, no-match early-exit, **production-limitation demo**, hop-rate sanity, and the realistic-size **microbenchmark**.
+
+Run:
+```bash
+cd /home/intro-skipper/web && pnpm install --frozen-lockfile && pnpm build
+cd /home/intro-skipper && dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj -p:SkipWebBuild=true \
+  --filter FullyQualifiedName~TestCrossEpisodeReuse
+# benchmark table is written to $TMPDIR/recap-rfc-b-bench.md
+```
+
+**Result:** 8/8 spike tests pass; full suite **323 passed, 1 failed, 324 total**. The single failure is the pre-existing `TestAudioFingerprinting.TestSilenceDetection`, an environmental artifact (system ffmpeg 6.1.1 emits 3-decimal silence timestamps vs the 6-decimal literals baked against jellyfin-ffmpeg7) — unrelated to recap and present on a pristine checkout.
+
+---
+
+## 14. Appendix — measured data (this VM)
+
+**Full-episode chromaprint decode** (synth 24-min/1440 s audio, `ffmpeg -ac 2 -f chromaprint -fp_format raw`): 4.08 s / 4.91 s / 4.64 s ⇒ median **4.6 s**, 11,614 points, **≈310× realtime**.
+
+**Comparison microbenchmark** (Debug, 200 iters/size):
+
+| prior-episode size | distinct shifts | shifts scanned | spans | avg ms/pair |
+|---|---|---|---|---|
+| 10,659 pts | 4 | 4 | 3 | 2.86 |
+| 11,628 pts | 3 | 3 | 3 | 4.82 |
+| 20,349 pts | 3 | 3 | 3 | 4.74 |
+| 29,070 pts | 3 | 3 | 3 | 7.45 |


### PR DESCRIPTION
**Research + design spike — NOT a mergeable feature.** No production code paths are changed; the new analyzer is **not** wired into the chain. Deliverable is the RFC + a unit-tested prototype proving the mechanism.

## What this explores
Detect recaps by **cross-episode content reuse**: take episode *N*'s opening window and find which chunks are reused from a **prior** episode's *full* fingerprint — those reused chunks are the recap. Contrast with intro detection (opening-vs-opening at the same offset); recap = opening-vs-*anywhere-in-prior*, and a montage = several disjoint reused spans contiguous in *N*.

## Deliverables
- **`docs/recap-research/B-cross-episode.md`** — the RFC: exact codebase map (file:line), the bug found in the shipped matcher, a measurement-backed cost/memory analysis vs the "not CPU/GPU heavy" constraint, failure modes, integration design, a critical review of the current recap code, and an honest verdict.
- **`IntroSkipper/Analyzers/CrossEpisodeReuseMatcher.cs`** (+ `ReuseMatchOptions`, `ReusedSpan`, `ReuseMatchDiagnostics`) — self-contained prototype: point-set pre-filter -> multimap shift-voting -> corrected contiguous extraction -> montage assembly. Reuses `ChromaprintAnalyzer.CountBits` and `ChromaprintConstants.SampleDuration`.
- **`IntroSkipper.Tests/TestCrossEpisodeReuse.cs`** — 8 tests: single planted span, 3-clip montage assembly, mild-reencode tolerance, heavy-alteration rejection, no-match early-exit, **production-limitation demo**, hop-rate sanity, realistic-size microbenchmark.

## Key findings
1. **The shipped recap detector is the degenerate special case of reuse matching.** It fingerprints only `(0, IntroFingerprintEnd)` of *both* episodes and picks the *earliest shared* opening region — which only finds the recurring "previously on" **bumper sting**, never the reused **clips** (which live deep in the prior episode and are never fingerprinted). Extent is then guessed from black frames, not audio.
2. **Bug:** `ChromaprintAnalyzer.FindContiguous` scan length `min(lhs,rhs) - |shift|` goes **negative** for the large shifts a deep reuse implies, so the loop never runs and deep reuse is invisible. Proven by `Production_FindsAlignedReuse_ButMissesDeepReuse_WhereSpikeSucceeds`.
3. **Cost (measured, this VM, Debug):** comparison **2.9-7.4 ms/pair** against a 10.6k-29k-point reference; the real cost is one **cached** full-episode chromaprint decode (**~4.6 s, ~310x realtime, no GPU**). The audio path meets the "not heavy" bar; **video corroboration does not** and is recommended against.

## Honest limits
Re-mixed recaps (music/VO over clips), shows that don't reuse footage, and season-premiere recaps (need cross-season prior selection) remain undetectable/under-served by any audio method.

## Benchmark (this VM, Debug, 200 iters/size)
| prior-episode size | distinct shifts | shifts scanned | spans | avg ms/pair |
|---|---|---|---|---|
| 10,659 pts (22 min) | 4 | 4 | 3 | 2.86 |
| 11,628 pts (24 min) | 3 | 3 | 3 | 4.82 |
| 20,349 pts (42 min) | 3 | 3 | 3 | 4.74 |
| 29,070 pts (60 min) | 3 | 3 | 3 | 7.45 |

## Tests
Full suite: **323 passed, 1 failed, 324 total**. The single failure is the pre-existing `TestAudioFingerprinting.TestSilenceDetection` — environmental (system ffmpeg 6.1.1 emits 3-decimal silence timestamps vs the 6-decimal literals baked against jellyfin-ffmpeg7), present on a pristine checkout and unrelated to recap.

## Summary by Sourcery

Introduce a research-only cross-episode audio reuse matching prototype for recap detection, with supporting documentation, diagnostics, and tests, without wiring it into production pipelines.

New Features:
- Prototype cross-episode audio reuse matcher for recap detection, including configurable options, span representation, and diagnostics types.

Enhancements:
- Document and analyze a new recap detection approach based on cross-episode content reuse, including detailed mapping and critique of the existing implementation.

Documentation:
- Add an RFC describing recap detection via cross-episode content reuse, including architecture, performance analysis, limitations, and integration design.

Tests:
- Add a synthetic test suite and microbenchmark for the cross-episode reuse matcher, including cases for single spans, montages, re-encode tolerance, failure modes, and a comparison with the existing matcher.