### PR TITLE
fix(data): correct TimeRange.Intersects containment and identity handling

### DIFF
--- a/IntroSkipper.Tests/TestContiguous.cs
+++ b/IntroSkipper.Tests/TestContiguous.cs
@@ -111,6 +111,11 @@ public class TestTimeRanges
     [InlineData(7, 8, true)]    // in the middle
     [InlineData(9, 12, true)]   // intersects on the right
     [InlineData(13, 15, false)] // too late
+    [InlineData(6, 8, true)]    // fully inside
+    [InlineData(3, 12, true)]   // fully contains the range
+    [InlineData(5, 10, true)]   // identical range
+    [InlineData(0, 5, false)]   // touches the start boundary only
+    [InlineData(10, 15, false)] // touches the end boundary only
     public void TestTimeRangeIntersection(int start, int end, bool expected)
     {
         var large = new TimeRange(5, 10);

--- a/IntroSkipper/Data/TimeRange.cs
+++ b/IntroSkipper/Data/TimeRange.cs
@@ -75,14 +75,16 @@ public class TimeRange : IComparable
 
     /// <summary>
     /// Tests if this TimeRange object intersects the provided TimeRange.
+    /// The comparison is strictly non-touching: ranges that only meet at a shared endpoint
+    /// (for example <c>[0, 5]</c> and <c>[5, 10]</c>) are not treated as intersecting.
     /// </summary>
-    /// <param name="tr">Second TimeRange object to test.</param>
-    /// <returns>true if time range intersects the current TimeRange, false otherwise.</returns>
-    public bool Intersects(TimeRange tr)
+    /// <param name="other">TimeRange to test against the current range.</param>
+    /// <returns>true if the ranges overlap, excluding ranges that merely touch at an endpoint; otherwise false.</returns>
+    public bool Intersects(TimeRange other)
     {
         // Two ranges overlap when each one starts before the other ends. Testing only whether one
         // range's endpoints fall strictly inside the other misses the cases where a range fully
         // contains the other (or the two are identical), so compare the spans directly instead.
-        return Start < tr.End && tr.Start < End;
+        return Start < other.End && other.Start < End;
     }
 }

--- a/IntroSkipper/Data/TimeRange.cs
+++ b/IntroSkipper/Data/TimeRange.cs
@@ -80,8 +80,9 @@ public class TimeRange : IComparable
     /// <returns>true if time range intersects the current TimeRange, false otherwise.</returns>
     public bool Intersects(TimeRange tr)
     {
-        return
-            (Start < tr.Start && tr.Start < End) ||
-            (Start < tr.End && tr.End < End);
+        // Two ranges overlap when each one starts before the other ends. Testing only whether one
+        // range's endpoints fall strictly inside the other misses the cases where a range fully
+        // contains the other (or the two are identical), so compare the spans directly instead.
+        return Start < tr.End && tr.Start < End;
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes `TimeRange.Intersects()` to correctly identify overlapping ranges when one range fully contains the other (or when ranges are identical). The original implementation only returned `true` for partial overlaps where one endpoint fell strictly inside the other span, missing containment cases.

- **TimeRange.Intersects**: Replace the two `AND` clauses with a single span-comparison (`Start < tr.End && tr.Start < End`). This preserves exclusive-boundary semantics (ranges touching at an endpoint do not intersect) while properly detecting containment and identity.
- **TestContiguous**: Add regression test cases for fully-inside, fully-contains, identical-range, and boundary-touching scenarios.

The fix is exercised by the existing silence detection path in `TimeAdjustmentHelper.AdjustIntroEndBasedOnSilenceAsync()`, which filters candidate silence ranges against a search window using `Intersects`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/f0e99297-ed2b-4934-8e7a-7d227a89f06d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-058" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/f0e99297-ed2b-4934-8e7a-7d227a89f06d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-058&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-058"><img alt="INTRO-058" src="https://capy.ai/api/badge/thread.svg?label=INTRO-058"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Fix time range intersection logic to correctly treat fully-contained and identical ranges as overlapping while preserving exclusive boundary behavior.

Bug Fixes:
- Correct TimeRange.Intersects to detect overlaps when one range fully contains another or when ranges are identical.

Tests:
- Extend TimeRange intersection tests to cover fully-contained, fully-containing, identical, and boundary-touching scenarios.