### PR TITLE
Optimization to prevent marking analyzed episodes

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -310,8 +310,8 @@ public sealed class TestCacheOperations
         // Toggling the non-black fallback changes credits output (when its analyzer is active), so it
         // must invalidate stored credits analysis instead of hash-matching a stale result.
         Assert.NotEqual(
-            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true),
-            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true));
+            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default),
+            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default));
     }
 
     [Fact]
@@ -323,8 +323,8 @@ public sealed class TestCacheOperations
         // The default BlackFrameAnalyzer cannot observe DetectNonBlackCredits, so toggling it must not
         // invalidate stored credits analysis on that path.
         Assert.Equal(
-            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true),
-            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true));
+            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default),
+            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default));
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestRecapDetection.cs
+++ b/IntroSkipper.Tests/TestRecapDetection.cs
@@ -84,8 +84,8 @@ public class TestRecapDetection
             MaximumFingerprintPointDifferences = baseline.MaximumFingerprintPointDifferences + 1,
         };
 
-        var hashBaseline = ConfigHasher.Analysis(baseline, AnalysisMode.Recap, AnalyzerAction.Default, ffmpegValid: true);
-        var hashTuned = ConfigHasher.Analysis(tuned, AnalysisMode.Recap, AnalyzerAction.Default, ffmpegValid: true);
+        var hashBaseline = ConfigHasher.Analysis(baseline, AnalysisMode.Recap, AnalyzerAction.Default);
+        var hashTuned = ConfigHasher.Analysis(tuned, AnalysisMode.Recap, AnalyzerAction.Default);
 
         Assert.NotEqual(hashBaseline, hashTuned);
     }

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
@@ -198,16 +200,16 @@ public sealed class TestSeasonReanalysisPlanner
     }
 
     [Fact]
-    public void ShouldAnalyzeItems_ReturnsTrue_ForNotAnalyzedEpisodes()
+    public void HasUncachedAnalysisWork_ReturnsTrue_ForNotAnalyzedEpisodes()
     {
         var episode = new QueuedEpisode();
         episode.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.NotAnalyzed);
 
-        Assert.True(BaseItemAnalyzerTask.ShouldAnalyzeItems([episode], AnalysisMode.Introduction));
+        Assert.True(BaseItemAnalyzerTask.HasUncachedAnalysisWork([episode], AnalysisMode.Introduction));
     }
 
     [Fact]
-    public void ShouldAnalyzeItems_ReturnsFalse_ForSettledNoSegmentsEpisodes()
+    public void HasUncachedAnalysisWork_ReturnsFalse_ForSettledNoSegmentsEpisodes()
     {
         // NoSegments is a negative-cache result for the current configuration. The season pass is
         // skipped here and only reopened once an episode is reset to NotAnalyzed (new episode,
@@ -215,11 +217,11 @@ public sealed class TestSeasonReanalysisPlanner
         var episode = new QueuedEpisode();
         episode.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.NoSegments);
 
-        Assert.False(BaseItemAnalyzerTask.ShouldAnalyzeItems([episode], AnalysisMode.Introduction));
+        Assert.False(BaseItemAnalyzerTask.HasUncachedAnalysisWork([episode], AnalysisMode.Introduction));
     }
 
     [Fact]
-    public void ShouldAnalyzeItems_ReturnsTrue_WhenAnyEpisodeNotAnalyzed()
+    public void HasUncachedAnalysisWork_ReturnsTrue_WhenAnyEpisodeNotAnalyzed()
     {
         // A freshly added (NotAnalyzed) episode reopens the whole season pass; the analyzers then
         // give the settled NoSegments episodes another chance via NeedsAnalysis().
@@ -228,18 +230,18 @@ public sealed class TestSeasonReanalysisPlanner
         var fresh = new QueuedEpisode();
         fresh.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.NotAnalyzed);
 
-        Assert.True(BaseItemAnalyzerTask.ShouldAnalyzeItems([settled, fresh], AnalysisMode.Introduction));
+        Assert.True(BaseItemAnalyzerTask.HasUncachedAnalysisWork([settled, fresh], AnalysisMode.Introduction));
     }
 
     [Fact]
-    public void ShouldAnalyzeItems_ReturnsFalse_WhenAllEpisodesAreHandled()
+    public void HasUncachedAnalysisWork_ReturnsFalse_WhenAllEpisodesAreHandled()
     {
         var analyzed = new QueuedEpisode();
         analyzed.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.Analyzed);
         var userProvided = new QueuedEpisode();
         userProvided.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.UserProvided);
 
-        Assert.False(BaseItemAnalyzerTask.ShouldAnalyzeItems([analyzed, userProvided], AnalysisMode.Introduction));
+        Assert.False(BaseItemAnalyzerTask.HasUncachedAnalysisWork([analyzed, userProvided], AnalysisMode.Introduction));
     }
 
     [Theory]
@@ -649,22 +651,26 @@ public sealed class TestSeasonReanalysisReset
                 var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
                 EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
 
-                var queueManager = new QueueManager(
+                var unavailableQueueManager = new QueueManager(
                     NullLogger<QueueManager>.Instance,
                     libraryManager,
                     providerManager: null!,
                     fileSystem: null!,
-                    ffmpegService: null!);
-                var stillUnavailable = await queueManager.VerifyQueueAsync(
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: false));
+                var stillUnavailable = await unavailableQueueManager.VerifyQueueAsync(
                     [CreateQueuedEpisode(episodeId, seasonId)],
-                    [AnalysisMode.Introduction],
-                    ffmpegValid: false);
+                    [AnalysisMode.Introduction]);
                 Assert.Equal(EpisodeState.NoSegments, stillUnavailable.Single().GetAnalyzed(AnalysisMode.Introduction));
 
-                var reopened = await queueManager.VerifyQueueAsync(
+                var availableQueueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+                var reopened = await availableQueueManager.VerifyQueueAsync(
                     [CreateQueuedEpisode(episodeId, seasonId)],
-                    [AnalysisMode.Introduction],
-                    ffmpegValid: true);
+                    [AnalysisMode.Introduction]);
                 Assert.Equal(EpisodeState.NotAnalyzed, reopened.Single().GetAnalyzed(AnalysisMode.Introduction));
             }
         }
@@ -687,6 +693,43 @@ public sealed class TestSeasonReanalysisReset
             Name = "S01E01",
             SeriesName = "Rick and Morty",
         };
+
+    private sealed class FakeFfmpegService(bool ffmpegValid) : IFFmpegService
+    {
+        public Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default) => Task.FromResult(ffmpegValid);
+
+        public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(
+            QueuedEpisode episode,
+            TimeRange range,
+            int minimum,
+            int threshold,
+            AnalysisMode mode,
+            CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<KeyframeVisual[]> DetectKeyframeVisualsAsync(QueuedEpisode episode, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<BlackInterval[]> DetectBlackIntervalsAsync(QueuedEpisode episode, TimeRange range, int threshold, int minimum, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
+        public string GetChromaprintLogs() => string.Empty;
+    }
 
     // Mirrors the production eligibility decision in BaseItemAnalyzerTask.GetSettleReanalysisModesAsync,
     // exercising the same batch read (GetSettleReanalysisStatesAsync) and set comparison the analyzer uses.

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -19,6 +19,16 @@ public static class ConfigHasher
     /// <param name="config">Plugin configuration.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="action">Analyzer priority/action used for the season.</param>
+    /// <returns>A compact hex hash assuming Chromaprint is available.</returns>
+    public static string Analysis(PluginConfiguration config, AnalysisMode mode, AnalyzerAction action)
+        => Analysis(config, mode, action, ffmpegValid: true);
+
+    /// <summary>
+    /// Computes a hash for a stored analysis result.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="action">Analyzer priority/action used for the season.</param>
     /// <param name="ffmpegValid">Whether the current FFmpeg build supports Chromaprint. Folded into the
     /// hash for Chromaprint-capable modes so a settled <see cref="EpisodeState.NoSegments"/> season is
     /// re-analyzed once when Chromaprint becomes available instead of being skipped forever.</param>

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -41,6 +41,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly Dictionary<Guid, List<QueuedEpisode>> _queuedEpisodes = [];
     private readonly HashSet<Guid> _refreshedEpisodes = [];
+    private bool? _ffmpegValid;
     private double _analysisPercent;
     private ExclusionPolicy _exclusionPolicy = ExclusionPolicy.Empty;
 
@@ -51,6 +52,18 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// <returns>Queued media items.</returns>
     public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
         => GetMediaItems(includeExcluded: false, cancellationToken);
+
+    internal async Task<bool> GetFfmpegValidAsync(CancellationToken cancellationToken = default)
+    {
+        if (_ffmpegValid is { } cached)
+        {
+            return cached;
+        }
+
+        var ffmpegValid = await _ffmpegService.CheckFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
+        _ffmpegValid = ffmpegValid;
+        return ffmpegValid;
+    }
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
     {
@@ -419,10 +432,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// </summary>
     /// <param name="candidates">Queued media items.</param>
     /// <param name="modes">Analysis modes.</param>
-    /// <param name="ffmpegValid">Whether the current FFmpeg build supports Chromaprint; folded into the expected config hash so settled NoSegments seasons are re-checked when Chromaprint availability changes.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Media items that have been verified to exist in Jellyfin and in storage.</returns>
-    internal async Task<IReadOnlyList<QueuedEpisode>> VerifyQueueAsync(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes, bool ffmpegValid, CancellationToken cancellationToken = default)
+    internal async Task<IReadOnlyList<QueuedEpisode>> VerifyQueueAsync(IReadOnlyList<QueuedEpisode> candidates, IReadOnlyCollection<AnalysisMode> modes, CancellationToken cancellationToken = default)
     {
         if (candidates == null || candidates.Count == 0)
         {
@@ -432,6 +444,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         var verified = new List<QueuedEpisode>(candidates.Count);
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var policy = ExclusionPolicy.FromConfiguration(plugin.Configuration);
+        var ffmpegValid = await GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
         var snapshot = await Plugin.GetSeasonQueueSnapshotAsync(candidates[0].SeasonId, [.. candidates.Select(c => c.EpisodeId)], cancellationToken).ConfigureAwait(false);
 
         foreach (var candidate in candidates)

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -221,7 +221,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     internal string GetItemPath(Guid id) => GetItem(id) is var item && item is not null ? item.Path : string.Empty;
 
-    internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? [];
+    internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? Array.Empty<ChapterInfo>();
 
     internal async Task UpdateTimestampAsync(
         Segment segment,

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -79,15 +79,15 @@ public partial class BaseItemAnalyzerTask(
             .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
-        var ffmpegValid = await _ffmpegService.CheckFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
-
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager,
             _providerManager,
             _fileSystem,
             _ffmpegService);
+
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+        var ffmpegValid = await queueManager.GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
 
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
 
@@ -121,7 +121,7 @@ public partial class BaseItemAnalyzerTask(
             var updateMediaSegments = false;
             IReadOnlyList<AnalysisMode> settledResetModes = [];
 
-            var episodes = await queueManager.VerifyQueueAsync(season.Value, modes, ffmpegValid, ct).ConfigureAwait(false);
+            var episodes = await queueManager.VerifyQueueAsync(season.Value, modes, ct).ConfigureAwait(false);
             if (episodes.Count == 0)
             {
                 return;
@@ -265,7 +265,7 @@ public partial class BaseItemAnalyzerTask(
     }
 
     /// <summary>
-    /// Returns <see langword="true"/> when at least one episode still needs a fresh analysis pass for
+    /// Returns <see langword="true"/> when at least one episode has no cached analysis result for
     /// the given mode (state <see cref="EpisodeState.NotAnalyzed"/>). Episodes already settled as
     /// <see cref="EpisodeState.NoSegments"/> are a negative-cache result for the current configuration
     /// and are intentionally not re-analyzed here; they are reconsidered only when the season is reset
@@ -275,7 +275,7 @@ public partial class BaseItemAnalyzerTask(
     /// <param name="items">Episodes in the current season pass.</param>
     /// <param name="mode">Analysis mode being processed.</param>
     /// <returns><see langword="true"/> when analyzer execution should continue.</returns>
-    internal static bool ShouldAnalyzeItems(IReadOnlyList<QueuedEpisode> items, AnalysisMode mode)
+    internal static bool HasUncachedAnalysisWork(IReadOnlyList<QueuedEpisode> items, AnalysisMode mode)
     {
         return items.Any(e => e.GetAnalyzed(mode) == EpisodeState.NotAnalyzed);
     }
@@ -296,7 +296,7 @@ public partial class BaseItemAnalyzerTask(
         bool ffmpegValid,
         CancellationToken cancellationToken)
     {
-        if (!ShouldAnalyzeItems(items, mode))
+        if (!HasUncachedAnalysisWork(items, mode))
         {
             return 0;
         }


### PR DESCRIPTION
## Summary by Sourcery

Cache FFmpeg capability in the queue manager and fold Chromaprint availability into analysis configuration hashing so seasons with previously unavailable Chromaprint are re-opened for analysis, while ensuring analyzers only run when episodes lack cached results and plugin chapter retrieval gracefully handles missing chapter data.

New Features:
- Add caching of FFmpeg validity in the queue manager and expose it via a helper method.
- Include Chromaprint availability in analysis configuration hashes for modes that use audio fingerprinting.
- Ensure plugin chapter retrieval returns an empty list when the chapter repository yields no chapters.

Bug Fixes:
- Prevent reanalysis passes from running when all episodes in a season already have cached analysis results for a mode.
- Reopen previously settled NoSegments seasons for analysis when Chromaprint support becomes available instead of permanently skipping them.
- Avoid null reference issues when chapter data is unavailable by returning an empty chapter collection.

Enhancements:
- Route FFmpeg validity checks through the queue manager and reuse the result across analysis and queue verification.
- Refine analyzer queue verification to use configuration hashes that reflect Chromaprint capability, aligning stored season state with actual analysis conditions.

Tests:
- Add unit tests covering uncached analysis work detection across episode states.
- Add unit tests verifying analysis hash behavior with and without Chromaprint for different analysis modes.
- Add integration-style tests ensuring season queues are reopened when Chromaprint becomes available and that chapter retrieval handles null chapter manager responses.