### PR TITLE
refactor(core): optimize queue verification and cleanup hash

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -310,8 +310,8 @@ public sealed class TestCacheOperations
         // Toggling the non-black fallback changes credits output (when its analyzer is active), so it
         // must invalidate stored credits analysis instead of hash-matching a stale result.
         Assert.NotEqual(
-            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default),
-            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default));
+            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true));
     }
 
     [Fact]
@@ -323,8 +323,8 @@ public sealed class TestCacheOperations
         // The default BlackFrameAnalyzer cannot observe DetectNonBlackCredits, so toggling it must not
         // invalidate stored credits analysis on that path.
         Assert.Equal(
-            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default),
-            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default));
+            ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(changed, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true));
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestRecapDetection.cs
+++ b/IntroSkipper.Tests/TestRecapDetection.cs
@@ -84,8 +84,8 @@ public class TestRecapDetection
             MaximumFingerprintPointDifferences = baseline.MaximumFingerprintPointDifferences + 1,
         };
 
-        var hashBaseline = ConfigHasher.Analysis(baseline, AnalysisMode.Recap, AnalyzerAction.Default);
-        var hashTuned = ConfigHasher.Analysis(tuned, AnalysisMode.Recap, AnalyzerAction.Default);
+        var hashBaseline = ConfigHasher.Analysis(baseline, AnalysisMode.Recap, AnalyzerAction.Default, ffmpegValid: true);
+        var hashTuned = ConfigHasher.Analysis(tuned, AnalysisMode.Recap, AnalyzerAction.Default, ffmpegValid: true);
 
         Assert.NotEqual(hashBaseline, hashTuned);
     }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -473,10 +473,6 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             rhsTimes.Add(rhsTime);
         }
 
-        // Ensure the last timestamp is checked
-        lhsTimes.Add(double.MaxValue);
-        rhsTimes.Add(double.MaxValue);
-
         // Now that both fingerprints have been compared at this shift, see if there's a contiguous time range.
         var lContiguous = TimeRangeHelpers.FindContiguous([.. lhsTimes], _config.MaximumTimeSkip);
         if (lContiguous is null || lContiguous.Duration < GetMinimumRegionDuration(_analysisMode, _config.MinimumIntroDuration))

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -19,16 +19,6 @@ public static class ConfigHasher
     /// <param name="config">Plugin configuration.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="action">Analyzer priority/action used for the season.</param>
-    /// <returns>A compact hex hash assuming Chromaprint is available.</returns>
-    public static string Analysis(PluginConfiguration config, AnalysisMode mode, AnalyzerAction action)
-        => Analysis(config, mode, action, ffmpegValid: true);
-
-    /// <summary>
-    /// Computes a hash for a stored analysis result.
-    /// </summary>
-    /// <param name="config">Plugin configuration.</param>
-    /// <param name="mode">Analysis mode.</param>
-    /// <param name="action">Analyzer priority/action used for the season.</param>
     /// <param name="ffmpegValid">Whether the current FFmpeg build supports Chromaprint. Folded into the
     /// hash for Chromaprint-capable modes so a settled <see cref="EpisodeState.NoSegments"/> season is
     /// re-analyzed once when Chromaprint becomes available instead of being skipped forever.</param>

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -447,6 +447,19 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         var ffmpegValid = await GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
         var snapshot = await Plugin.GetSeasonQueueSnapshotAsync(candidates[0].SeasonId, [.. candidates.Select(c => c.EpisodeId)], cancellationToken).ConfigureAwait(false);
 
+        // The expected config hash depends on the season-level analyzer action and mode, not on the
+        // individual episode, so compute it once per mode instead of once per episode and mode.
+        var hashMatchesByMode = new Dictionary<AnalysisMode, bool>(modes.Count);
+        foreach (var mode in modes)
+        {
+            var action = snapshot.AnalyzerActionByMode.TryGetValue(mode, out var savedAction)
+                ? savedAction
+                : AnalyzerAction.Default;
+            var expectedHash = ConfigHasher.Analysis(plugin.Configuration, mode, action, ffmpegValid);
+            hashMatchesByMode[mode] = snapshot.ConfigHashByMode.TryGetValue(mode, out var savedHash) &&
+                string.Equals(savedHash, expectedHash, StringComparison.Ordinal);
+        }
+
         foreach (var candidate in candidates)
         {
             try
@@ -474,12 +487,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
                 foreach (var mode in modes)
                 {
-                    var action = snapshot.AnalyzerActionByMode.TryGetValue(mode, out var savedAction)
-                        ? savedAction
-                        : AnalyzerAction.Default;
-                    var expectedHash = ConfigHasher.Analysis(plugin.Configuration, mode, action, ffmpegValid);
-                    var hashMatches = snapshot.ConfigHashByMode.TryGetValue(mode, out var savedHash) &&
-                        string.Equals(savedHash, expectedHash, StringComparison.Ordinal);
+                    var hashMatches = hashMatchesByMode[mode];
 
                     if (snapshot.SegmentsByEpisodeId.TryGetValue(candidate.EpisodeId, out var hasSegments) &&
                         hasSegments.TryGetValue(mode, out _))


### PR DESCRIPTION
This PR optimizes `VerifyQueueAsync` by computing config hashes once per mode instead of per episode. It also removes the `ConfigHasher.Analysis` overload defaulting `ffmpegValid` to `true` and cleans up obsolete sentinel values.

*   `IntroSkipper/Manager/QueueManager.cs`: Compute hash matches once per mode in `VerifyQueueAsync` instead of per episode to reduce redundant hashing operations.
*   `IntroSkipper/Helper/ConfigHasher.cs`: Remove `Analysis` overload that defaulted `ffmpegValid` to `true`, ensuring callers explicitly declare capability status.
*   `IntroSkipper/Analyzers/ChromaprintAnalyzer.cs`: Remove redundant `double.MaxValue` sentinel values no longer required by `FindContiguous`.
*   `IntroSkipper.Tests/TestCacheOperations.cs`, `IntroSkipper.Tests/TestRecapDetection.cs`: Update test calls to pass `ffmpegValid` explicitly.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/445292cb-6fcf-441b-ab86-e932fca3d0dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-059" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/445292cb-6fcf-441b-ab86-e932fca3d0dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-059&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-059"><img alt="INTRO-059" src="https://capy.ai/api/badge/thread.svg?label=INTRO-059"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Optimize queue verification by reusing per-mode configuration hashes and require explicit ffmpeg capability when hashing analysis configuration.

Enhancements:
- Compute configuration hash matches once per analysis mode during queue verification instead of per episode to reduce redundant work.
- Remove the ConfigHasher.Analysis overload that implicitly assumed ffmpeg support, clarifying callers’ capability assumptions.
- Simplify ChromaprintAnalyzer contiguous time range detection by removing obsolete sentinel timestamp values.

Tests:
- Update analysis hash and recap detection tests to pass ffmpeg capability explicitly when computing configuration hashes.