### PR TITLE
Add adaptive recap black frame detection

### DIFF
--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -9,11 +9,18 @@ namespace IntroSkipper.Tests;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Model.Entities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -95,6 +102,48 @@ public class TestChapterAnalyzer
         var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(Guid.NewGuid(), frames, minimumRecapDuration: 5, maximumRecapBoundary: 120);
 
         Assert.Null(recap);
+    }
+
+    [Fact]
+    public async Task DetectRecapUsingBlackFrames_UsesAdaptiveThresholdWithCurrentBlackFrameScan()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var dbPath = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + "-segments.db");
+        EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
+        EntrypointTestHelpers.SetPropertyOrField(
+            Plugin.Instance!,
+            "Configuration",
+            new PluginConfiguration
+            {
+                BlackFrameMinimumPercentage = 85,
+                BlackFrameThreshold = 32,
+                MinimumRecapDetectionDuration = 5,
+                MaximumRecapDetectionDuration = 120,
+            });
+        await using (var db = new IntroSkipperDbContext(dbPath))
+        {
+            await db.Database.EnsureCreatedAsync();
+        }
+
+        var ffmpeg = new RecapBlackFrameFfmpeg(
+        [
+            new(50, 20, 10),
+            new(95, 40, 20),
+            new(88, 80, 30),
+        ]);
+        var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, ffmpeg);
+
+        var recap = await analyzer.DetectRecapUsingBlackFramesAsync(
+            new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 200, Path = "episode.mkv" },
+            CancellationToken.None);
+
+        Assert.NotNull(recap);
+        Assert.Equal(40, recap.End);
+        Assert.Equal(50, ffmpeg.LastMinimum);
+        Assert.Equal(32, ffmpeg.LastThreshold);
+        Assert.Equal(AnalysisMode.Recap, ffmpeg.LastMode);
+        Assert.Equal(0, ffmpeg.LastRange?.Start);
+        Assert.Equal(120, ffmpeg.LastRange?.End);
     }
 
     [Theory]
@@ -303,6 +352,58 @@ public class TestChapterAnalyzer
             Name = name,
             StartPositionTicks = TimeSpan.FromSeconds(position).Ticks
         };
+    }
+
+    private sealed class RecapBlackFrameFfmpeg(BlackFrame[] frames) : IFFmpegService
+    {
+        public TimeRange? LastRange { get; private set; }
+
+        public int? LastMinimum { get; private set; }
+
+        public int? LastThreshold { get; private set; }
+
+        public AnalysisMode? LastMode { get; private set; }
+
+        public Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(
+            QueuedEpisode episode,
+            TimeRange range,
+            int minimum,
+            int threshold,
+            AnalysisMode mode,
+            CancellationToken cancellationToken = default)
+        {
+            LastRange = range;
+            LastMinimum = minimum;
+            LastThreshold = threshold;
+            LastMode = mode;
+            return Task.FromResult(frames);
+        }
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<KeyframeVisual[]> DetectKeyframeVisualsAsync(QueuedEpisode episode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackInterval[]> DetectBlackIntervalsAsync(QueuedEpisode episode, TimeRange range, int threshold, int minimum, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public string GetChromaprintLogs() => string.Empty;
     }
 
     private class NullChapterManager : DispatchProxy

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -108,42 +108,51 @@ public class TestChapterAnalyzer
     public async Task DetectRecapUsingBlackFrames_UsesAdaptiveThresholdWithCurrentBlackFrameScan()
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
-        var dbPath = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + "-segments.db");
-        EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
-        EntrypointTestHelpers.SetPropertyOrField(
-            Plugin.Instance!,
-            "Configuration",
-            new PluginConfiguration
-            {
-                BlackFrameMinimumPercentage = 85,
-                BlackFrameThreshold = 32,
-                MinimumRecapDetectionDuration = 5,
-                MaximumRecapDetectionDuration = 120,
-            });
-        await using (var db = new IntroSkipperDbContext(dbPath))
+        var dbDirectory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dbDirectory);
+        try
         {
-            await db.Database.EnsureCreatedAsync();
+            var dbPath = Path.Combine(dbDirectory, "segments.db");
+            EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
+            EntrypointTestHelpers.SetPropertyOrField(
+                Plugin.Instance!,
+                "Configuration",
+                new PluginConfiguration
+                {
+                    BlackFrameMinimumPercentage = 85,
+                    BlackFrameThreshold = 32,
+                    MinimumRecapDetectionDuration = 5,
+                    MaximumRecapDetectionDuration = 120,
+                });
+            await using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            var ffmpeg = new RecapBlackFrameFfmpeg(
+            [
+                new(50, 20, 10),
+                new(95, 40, 20),
+                new(88, 80, 30),
+            ]);
+            var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, ffmpeg);
+
+            var recap = await analyzer.DetectRecapUsingBlackFramesAsync(
+                new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 200, Path = "episode.mkv" },
+                CancellationToken.None);
+
+            Assert.NotNull(recap);
+            Assert.Equal(40, recap.End);
+            Assert.Equal(50, ffmpeg.LastMinimum);
+            Assert.Equal(32, ffmpeg.LastThreshold);
+            Assert.Equal(AnalysisMode.Recap, ffmpeg.LastMode);
+            Assert.Equal(0, ffmpeg.LastRange?.Start);
+            Assert.Equal(120, ffmpeg.LastRange?.End);
         }
-
-        var ffmpeg = new RecapBlackFrameFfmpeg(
-        [
-            new(50, 20, 10),
-            new(95, 40, 20),
-            new(88, 80, 30),
-        ]);
-        var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, ffmpeg);
-
-        var recap = await analyzer.DetectRecapUsingBlackFramesAsync(
-            new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 200, Path = "episode.mkv" },
-            CancellationToken.None);
-
-        Assert.NotNull(recap);
-        Assert.Equal(40, recap.End);
-        Assert.Equal(50, ffmpeg.LastMinimum);
-        Assert.Equal(32, ffmpeg.LastThreshold);
-        Assert.Equal(AnalysisMode.Recap, ffmpeg.LastMode);
-        Assert.Equal(0, ffmpeg.LastRange?.Start);
-        Assert.Equal(120, ffmpeg.LastRange?.End);
+        finally
+        {
+            Directory.Delete(dbDirectory, recursive: true);
+        }
     }
 
     [Theory]

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -9,18 +9,15 @@ namespace IntroSkipper.Tests;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
-using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Model.Entities;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -105,54 +102,36 @@ public class TestChapterAnalyzer
     }
 
     [Fact]
-    public async Task DetectRecapUsingBlackFrames_UsesAdaptiveThresholdWithCurrentBlackFrameScan()
+    public async Task DetectAdaptiveRecapBlackFrames_UsesAdaptiveThresholdWithCurrentBlackFrameScan()
     {
-        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
-        var dbDirectory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dbDirectory);
-        try
+        var config = new PluginConfiguration
         {
-            var dbPath = Path.Combine(dbDirectory, "segments.db");
-            EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
-            EntrypointTestHelpers.SetPropertyOrField(
-                Plugin.Instance!,
-                "Configuration",
-                new PluginConfiguration
-                {
-                    BlackFrameMinimumPercentage = 85,
-                    BlackFrameThreshold = 32,
-                    MinimumRecapDetectionDuration = 5,
-                    MaximumRecapDetectionDuration = 120,
-                });
-            await using (var db = new IntroSkipperDbContext(dbPath))
-            {
-                await db.Database.EnsureCreatedAsync();
-            }
+            BlackFrameMinimumPercentage = 85,
+            BlackFrameThreshold = 32,
+            MinimumRecapDetectionDuration = 5,
+            MaximumRecapDetectionDuration = 120,
+        };
+        var ffmpeg = new RecapBlackFrameFfmpeg(
+        [
+            new(50, 20, 10),
+            new(95, 40, 20),
+            new(88, 80, 30),
+        ]);
+        var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, ffmpeg, config);
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 200, Path = "episode.mkv" };
 
-            var ffmpeg = new RecapBlackFrameFfmpeg(
-            [
-                new(50, 20, 10),
-                new(95, 40, 20),
-                new(88, 80, 30),
-            ]);
-            var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, ffmpeg);
+        var blackFrames = await analyzer.DetectAdaptiveRecapBlackFramesAsync(episode, 120, CancellationToken.None);
+        var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120);
 
-            var recap = await analyzer.DetectRecapUsingBlackFramesAsync(
-                new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 200, Path = "episode.mkv" },
-                CancellationToken.None);
-
-            Assert.NotNull(recap);
-            Assert.Equal(40, recap.End);
-            Assert.Equal(50, ffmpeg.LastMinimum);
-            Assert.Equal(32, ffmpeg.LastThreshold);
-            Assert.Equal(AnalysisMode.Recap, ffmpeg.LastMode);
-            Assert.Equal(0, ffmpeg.LastRange?.Start);
-            Assert.Equal(120, ffmpeg.LastRange?.End);
-        }
-        finally
-        {
-            Directory.Delete(dbDirectory, recursive: true);
-        }
+        Assert.Single(blackFrames);
+        Assert.Equal(95, blackFrames[0].Percentage);
+        Assert.NotNull(recap);
+        Assert.Equal(40, recap.End);
+        Assert.Equal(50, ffmpeg.LastMinimum);
+        Assert.Equal(32, ffmpeg.LastThreshold);
+        Assert.Equal(AnalysisMode.Recap, ffmpeg.LastMode);
+        Assert.Equal(0, ffmpeg.LastRange?.Start);
+        Assert.Equal(120, ffmpeg.LastRange?.End);
     }
 
     [Theory]

--- a/IntroSkipper/Analyzers/BlackFrameThresholdHelper.cs
+++ b/IntroSkipper/Analyzers/BlackFrameThresholdHelper.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 AbandonedCart
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Analyzers;
+
+/// <summary>
+/// Shared black-frame threshold normalization helpers.
+/// </summary>
+internal static class BlackFrameThresholdHelper
+{
+    /// <summary>
+    /// Normalizes black-frame thresholds against the darkest frames in a scan.
+    /// </summary>
+    /// <param name="frames">The black-frame scan results.</param>
+    /// <param name="minimumPercentage">The configured minimum black percentage.</param>
+    /// <returns>The normalized black-frame and scene-change thresholds.</returns>
+    internal static (int Minimum, int SceneChange) NormalizeThreshold(
+        IReadOnlyList<BlackFrame> frames,
+        int minimumPercentage)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(frames.Count, nameof(frames));
+
+        var orderedFrames = frames.OrderBy(f => f.Percentage).ToList();
+        // Clamp into range: for short/sparse scans, frames.Count * 0.01 floors to 0,
+        // so the floor becomes the single least-black frame. The 30-cap bounds that
+        // frame's influence.
+        var percentileIndex = Math.Clamp((int)(frames.Count * 0.01), 0, frames.Count - 1);
+        var floor = Math.Min(orderedFrames[percentileIndex].Percentage, 30);
+        var minimum = (minimumPercentage * (100 - floor) / 100) + floor;
+        var sceneChange = (95 * (100 - floor) / 100) + floor;
+        return (minimum, sceneChange);
+    }
+}

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -25,7 +25,7 @@ namespace IntroSkipper.Analyzers;
 /// <param name="ffmpegService">FFmpeg service.</param>
 public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegService ffmpegService) : IMediaFileAnalyzer
 {
-    private const int RecapAdaptiveBlackFrameScanFloor = 50;
+    private const int RecapAdaptiveBlackFrameScanMinimumPercentageCap = 50;
 
     private readonly ILogger<ChapterAnalyzer> _logger = logger;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
@@ -248,7 +248,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
         var blackFrames = (await _ffmpegService.DetectBlackFramesAsync(
             episode,
             new TimeRange(0, maxRecapBoundary),
-            Math.Min(_config.BlackFrameMinimumPercentage, RecapAdaptiveBlackFrameScanFloor),
+            Math.Min(_config.BlackFrameMinimumPercentage, RecapAdaptiveBlackFrameScanMinimumPercentageCap),
             _config.BlackFrameThreshold,
             AnalysisMode.Recap,
             cancellationToken).ConfigureAwait(false)).ToList();

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -25,6 +25,8 @@ namespace IntroSkipper.Analyzers;
 /// <param name="ffmpegService">FFmpeg service.</param>
 public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegService ffmpegService) : IMediaFileAnalyzer
 {
+    // Keep the adaptive discovery scan broad enough to find darker recap boundaries; the
+    // configured percentage is applied afterward when the scan results are normalized.
     private const int RecapAdaptiveBlackFrameScanMinimumPercentageCap = 50;
 
     private readonly ILogger<ChapterAnalyzer> _logger = logger;
@@ -258,7 +260,8 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
         }
 
         var (minimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(blackFrames, _config.BlackFrameMinimumPercentage);
-        return [.. blackFrames.Where(frame => frame.Percentage >= minimum)];
+        blackFrames.RemoveAll(frame => frame.Percentage < minimum);
+        return [.. blackFrames];
     }
 
     internal static Segment? BuildRecapFromBlackFrames(

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -229,19 +229,35 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
             return null;
         }
 
-        var blackFrames = await _ffmpegService.DetectBlackFramesAsync(
-            episode,
-            new TimeRange(0, maxRecapBoundary),
-            _config.BlackFrameMinimumPercentage,
-            _config.BlackFrameThreshold,
-            AnalysisMode.Recap,
-            cancellationToken).ConfigureAwait(false);
+        var blackFrames = await DetectAdaptiveRecapBlackFramesAsync(episode, maxRecapBoundary, cancellationToken).ConfigureAwait(false);
 
         return BuildRecapFromBlackFrames(
             episode.EpisodeId,
             blackFrames,
             _config.MinimumRecapDetectionDuration,
             maxRecapBoundary);
+    }
+
+    private async Task<BlackFrame[]> DetectAdaptiveRecapBlackFramesAsync(
+        QueuedEpisode episode,
+        double maxRecapBoundary,
+        CancellationToken cancellationToken)
+    {
+        const int adaptiveScanFloor = 50;
+        var blackFrames = (await _ffmpegService.DetectBlackFramesAsync(
+            episode,
+            new TimeRange(0, maxRecapBoundary),
+            Math.Min(_config.BlackFrameMinimumPercentage, adaptiveScanFloor),
+            _config.BlackFrameThreshold,
+            AnalysisMode.Recap,
+            cancellationToken).ConfigureAwait(false)).ToList();
+        if (blackFrames.Count == 0)
+        {
+            return [];
+        }
+
+        var (minimum, _) = CreditsBlackFrameAnalyzer.NormalizeThreshold(blackFrames, _config.BlackFrameMinimumPercentage);
+        return [.. blackFrames.Where(frame => frame.Percentage >= minimum)];
     }
 
     internal static Segment? BuildRecapFromBlackFrames(

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -25,6 +25,8 @@ namespace IntroSkipper.Analyzers;
 /// <param name="ffmpegService">FFmpeg service.</param>
 public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegService ffmpegService) : IMediaFileAnalyzer
 {
+    private const int RecapAdaptiveBlackFrameScanFloor = 50;
+
     private readonly ILogger<ChapterAnalyzer> _logger = logger;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
@@ -243,11 +245,10 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
         double maxRecapBoundary,
         CancellationToken cancellationToken)
     {
-        const int adaptiveScanFloor = 50;
         var blackFrames = (await _ffmpegService.DetectBlackFramesAsync(
             episode,
             new TimeRange(0, maxRecapBoundary),
-            Math.Min(_config.BlackFrameMinimumPercentage, adaptiveScanFloor),
+            Math.Min(_config.BlackFrameMinimumPercentage, RecapAdaptiveBlackFrameScanFloor),
             _config.BlackFrameThreshold,
             AnalysisMode.Recap,
             cancellationToken).ConfigureAwait(false)).ToList();
@@ -256,7 +257,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
             return [];
         }
 
-        var (minimum, _) = CreditsBlackFrameAnalyzer.NormalizeThreshold(blackFrames, _config.BlackFrameMinimumPercentage);
+        var (minimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(blackFrames, _config.BlackFrameMinimumPercentage);
         return [.. blackFrames.Where(frame => frame.Percentage >= minimum)];
     }
 

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -23,7 +23,11 @@ namespace IntroSkipper.Analyzers;
 /// </remarks>
 /// <param name="logger">Logger.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
-public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegService ffmpegService) : IMediaFileAnalyzer
+/// <param name="configuration">Plugin configuration, or <see langword="null"/> to use the active plugin configuration.</param>
+public partial class ChapterAnalyzer(
+    ILogger<ChapterAnalyzer> logger,
+    IFFmpegService ffmpegService,
+    PluginConfiguration? configuration = null) : IMediaFileAnalyzer
 {
     // Keep the adaptive discovery scan broad enough to find darker recap boundaries; the
     // configured percentage is applied afterward when the scan results are normalized.
@@ -31,7 +35,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
 
     private readonly ILogger<ChapterAnalyzer> _logger = logger;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
-    private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+    private readonly PluginConfiguration _config = configuration ?? Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private static readonly ImmutableHashSet<string> _ambiguousSponsorBlockChapterLabels =
         ImmutableHashSet.Create(
             StringComparer.OrdinalIgnoreCase,
@@ -242,26 +246,25 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
             maxRecapBoundary);
     }
 
-    private async Task<BlackFrame[]> DetectAdaptiveRecapBlackFramesAsync(
+    internal async Task<BlackFrame[]> DetectAdaptiveRecapBlackFramesAsync(
         QueuedEpisode episode,
         double maxRecapBoundary,
         CancellationToken cancellationToken)
     {
-        var blackFrames = (await _ffmpegService.DetectBlackFramesAsync(
+        var blackFrames = await _ffmpegService.DetectBlackFramesAsync(
             episode,
             new TimeRange(0, maxRecapBoundary),
             Math.Min(_config.BlackFrameMinimumPercentage, RecapAdaptiveBlackFrameScanMinimumPercentageCap),
             _config.BlackFrameThreshold,
             AnalysisMode.Recap,
-            cancellationToken).ConfigureAwait(false)).ToList();
-        if (blackFrames.Count == 0)
+            cancellationToken).ConfigureAwait(false);
+        if (blackFrames.Length == 0)
         {
             return [];
         }
 
         var (minimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(blackFrames, _config.BlackFrameMinimumPercentage);
-        blackFrames.RemoveAll(frame => frame.Percentage < minimum);
-        return [.. blackFrames];
+        return blackFrames.Where(frame => frame.Percentage >= minimum).ToArray();
     }
 
     internal static Segment? BuildRecapFromBlackFrames(

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -264,7 +264,7 @@ public partial class ChapterAnalyzer(
         }
 
         var (minimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(blackFrames, _config.BlackFrameMinimumPercentage);
-        return blackFrames.Where(frame => frame.Percentage >= minimum).ToArray();
+        return [.. blackFrames.Where(frame => frame.Percentage >= minimum)];
     }
 
     internal static Segment? BuildRecapFromBlackFrames(

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -270,17 +270,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
     /// <returns>The normalized black-frame and scene-change thresholds.</returns>
     internal static (int Minimum, int SceneChange) NormalizeThreshold(List<BlackFrame> frames, int minimumPercentage)
     {
-        ArgumentOutOfRangeException.ThrowIfZero(frames.Count, nameof(frames));
-
-        var orderedFrames = frames.OrderBy(f => f.Percentage).ToList();
-        // Clamp into range: for scans under 100 keyframes (the common short/sparse-GOP credits
-        // window) frames.Count * 0.01 floors to 0, so the floor becomes the single least-black
-        // keyframe. The clamp guards the index, and the 30-cap below bounds that frame's influence.
-        var percentileIndex = Math.Clamp((int)(frames.Count * 0.01), 0, frames.Count - 1);
-        var floor = Math.Min(orderedFrames[percentileIndex].Percentage, 30);
-        var minimum = (minimumPercentage * (100 - floor) / 100) + floor;
-        var sceneChange = (95 * (100 - floor) / 100) + floor;
-        return (minimum, sceneChange);
+        return BlackFrameThresholdHelper.NormalizeThreshold(frames, minimumPercentage);
     }
 
     /// <summary>

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -47,7 +47,7 @@ public static class ConfigHasher
             AnalysisMode.Recap => Invariant(
                 $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
-                $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
+                $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfrecapAdaptive=1",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
                 $"{AdjustmentHash(config)}"),
 

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -45,9 +45,9 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Recap => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
+                $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
-                $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfrecapAdaptive=1",
+                $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
                 $"{AdjustmentHash(config)}"),
 


### PR DESCRIPTION
## Summary by Sourcery

Implement adaptive recap black-frame detection using normalized thresholds and shared helpers.

Enhancements:
- Introduce adaptive recap black-frame detection that normalizes black-frame thresholds based on scan results before building recap segments.
- Extract shared black-frame threshold normalization logic into a reusable helper used by both recap and credits analyzers.
- Allow ChapterAnalyzer to accept an explicit plugin configuration for easier testing and configurability.
- Cap recap adaptive black-frame scan minimum percentage to keep scans broad before normalization.

Tests:
- Add unit tests with a fake FFmpeg service to validate adaptive recap black-frame detection behavior and configuration usage.