### PR TITLE
Support multiple credit segments for movies

### DIFF
--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -997,6 +997,22 @@ public class TestBlackFrames
     }
 
     [Fact]
+    public async Task TestDetectCreditSegmentsAsync_ReturnsMultipleCreditBlocks()
+    {
+        var ffmpeg = new FakeFFmpegService(CreateStingerSplitFrames());
+        var analyzer = CreateCreditsBlackFrameAnalyzer(ffmpeg);
+        var episode = CreateQueuedCreditsEpisode(creditsFingerprintStart: 100);
+
+        var results = await analyzer.DetectCreditSegmentsAsync(episode, 85, 32, 15);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(190, results[0].Start);
+        Assert.Equal(220, results[0].End);
+        Assert.Equal(100, results[1].Start);
+        Assert.Equal(120, results[1].End);
+    }
+
+    [Fact]
     public async Task TestDetectCreditsAsync_DisabledBoundaryRefinement_UsesKeyframeStart()
     {
         var frames = new List<BlackFrame>();

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -8,9 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
-using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Entities.Movies;
-using MediaBrowser.Controller.Entities.TV;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -762,19 +759,19 @@ public sealed class TestDbSegmentStorage
 
             using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
             {
-                BaseItem item = movie ? CreateMovie(itemId) : CreateEpisode(itemId);
                 var plugin = Plugin.Instance!;
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager(item));
 
                 await plugin.UpdateTimestampAsync(
                     new Segment(itemId, new TimeRange(100, 120)),
                     AnalysisMode.Credits,
-                    append: true);
+                    append: true,
+                    mediaCategory: movie ? QueuedMediaCategory.Movie : QueuedMediaCategory.Episode);
                 await plugin.UpdateTimestampAsync(
                     new Segment(itemId, new TimeRange(200, 220)),
                     AnalysisMode.Credits,
-                    append: true);
+                    append: true,
+                    mediaCategory: movie ? QueuedMediaCategory.Movie : QueuedMediaCategory.Episode);
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))
@@ -795,22 +792,6 @@ public sealed class TestDbSegmentStorage
         {
             DeleteSqliteFiles(dbPath);
         }
-    }
-
-    private static Movie CreateMovie(Guid id)
-    {
-        var item = new Movie();
-        EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
-        EntrypointTestHelpers.EnsureNonVirtual(item);
-        return item;
-    }
-
-    private static Episode CreateEpisode(Guid id)
-    {
-        var item = new Episode();
-        EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
-        EntrypointTestHelpers.EnsureNonVirtual(item);
-        return item;
     }
 
     private static async Task<bool> TableExistsAsync(IntroSkipperDbContext db, string tableName)

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -8,6 +8,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -48,6 +51,67 @@ public sealed class TestDbSegmentStorage
         {
             var count = db.DbSegment.Count(segment => segment.ItemId == itemId && segment.Type == AnalysisMode.Commercial);
             Assert.Equal(2, count);
+        }
+    }
+
+    [Fact]
+    public void AllowsMultipleCreditSegments()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<IntroSkipperDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var itemId = Guid.NewGuid();
+
+        using (var db = new IntroSkipperDbContext(options))
+        {
+            db.Database.EnsureCreated();
+
+            db.DbSegment.AddRange(
+                new DbSegment(new Segment(itemId, new TimeRange(0, 10)), AnalysisMode.Credits),
+                new DbSegment(new Segment(itemId, new TimeRange(20, 30)), AnalysisMode.Credits));
+            db.SaveChanges();
+        }
+
+        using (var db = new IntroSkipperDbContext(options))
+        {
+            var count = db.DbSegment.Count(segment => segment.ItemId == itemId && segment.Type == AnalysisMode.Credits);
+            Assert.Equal(2, count);
+        }
+    }
+
+    [Fact]
+    public void CreditUniqueIndexPreventsInsertingDuplicateRangeForSameItemAndType()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<IntroSkipperDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var itemId = Guid.NewGuid();
+
+        using (var db = new IntroSkipperDbContext(options))
+        {
+            db.Database.EnsureCreated();
+
+            db.DbSegment.Add(new DbSegment(
+                new Segment(itemId, new TimeRange(0, 10)),
+                AnalysisMode.Credits));
+            db.SaveChanges();
+        }
+
+        using (var db = new IntroSkipperDbContext(options))
+        {
+            db.DbSegment.Add(new DbSegment(
+                new Segment(itemId, new TimeRange(0, 10)),
+                AnalysisMode.Credits));
+
+            Assert.Throws<DbUpdateException>(() => db.SaveChanges());
         }
     }
 
@@ -670,6 +734,83 @@ public sealed class TestDbSegmentStorage
         {
             DeleteSqliteFiles(dbPath);
         }
+    }
+
+    [Theory]
+    [InlineData(true, 2)]
+    [InlineData(false, 1)]
+    public async Task UpdateTimestampAsync_AppendsMultipleCreditsOnlyForMovies(bool movie, int expectedCount)
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        var dbFileName = Guid.NewGuid().ToString("N") + ".db";
+        if (Path.IsPathRooted(dbFileName))
+        {
+            throw new ArgumentException("dbFileName must be a relative file name.", nameof(dbFileName));
+        }
+
+        var dbPath = Path.Join(tempDir, dbFileName);
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                BaseItem item = movie ? CreateMovie(itemId) : CreateEpisode(itemId);
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager(item));
+
+                await plugin.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(100, 120)),
+                    AnalysisMode.Credits,
+                    append: true);
+                await plugin.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(200, 220)),
+                    AnalysisMode.Credits,
+                    append: true);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var segments = db.DbSegment
+                    .Where(s => s.ItemId == itemId && s.Type == AnalysisMode.Credits)
+                    .OrderBy(s => s.Start)
+                    .ToList();
+
+                Assert.Equal(expectedCount, segments.Count);
+                if (!movie)
+                {
+                    Assert.Equal(200, segments[0].Start);
+                }
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    private static Movie CreateMovie(Guid id)
+    {
+        var item = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
+        EntrypointTestHelpers.EnsureNonVirtual(item);
+        return item;
+    }
+
+    private static Episode CreateEpisode(Guid id)
+    {
+        var item = new Episode();
+        EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
+        EntrypointTestHelpers.EnsureNonVirtual(item);
+        return item;
     }
 
     private static async Task<bool> TableExistsAsync(IntroSkipperDbContext db, string tableName)

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -794,6 +794,116 @@ public sealed class TestDbSegmentStorage
         }
     }
 
+    [Fact]
+    public async Task UpdateTimestampAsync_RollbackRestoreForMovieCreditsPreservesOtherCreditSegments()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        var dbFileName = Guid.NewGuid().ToString("N") + ".db";
+        if (Path.IsPathRooted(dbFileName))
+        {
+            throw new ArgumentException("dbFileName must be a relative file name.", nameof(dbFileName));
+        }
+
+        var dbPath = Path.Join(tempDir, dbFileName);
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+        var itemId = Guid.NewGuid();
+        var first = new Segment(itemId, new TimeRange(100, 120));
+        var second = new Segment(itemId, new TimeRange(200, 220));
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+
+                await plugin.UpdateTimestampAsync(first, AnalysisMode.Credits, append: true, mediaCategory: QueuedMediaCategory.Movie);
+                await plugin.UpdateTimestampAsync(second, AnalysisMode.Credits, append: true, mediaCategory: QueuedMediaCategory.Movie);
+
+                await Plugin.DeleteTimestampAsync(itemId, AnalysisMode.Credits, first);
+
+                await plugin.UpdateTimestampAsync(first, AnalysisMode.Credits, append: true, mediaCategory: QueuedMediaCategory.Movie);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var segments = db.DbSegment
+                    .Where(s => s.ItemId == itemId && s.Type == AnalysisMode.Credits)
+                    .OrderBy(s => s.Start)
+                    .ToList();
+
+                Assert.Equal(2, segments.Count);
+                Assert.Equal(100, segments[0].Start);
+                Assert.Equal(200, segments[1].Start);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateTimestampAsync_FirstMovieCreditWriteReplacesStaleCreditsThenAppends()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        var dbFileName = Guid.NewGuid().ToString("N") + ".db";
+        if (Path.IsPathRooted(dbFileName))
+        {
+            throw new ArgumentException("dbFileName must be a relative file name.", nameof(dbFileName));
+        }
+
+        var dbPath = Path.Join(tempDir, dbFileName);
+        Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+
+        var itemId = Guid.NewGuid();
+        var stale = new Segment(itemId, new TimeRange(50, 70));
+        var first = new Segment(itemId, new TimeRange(100, 120));
+        var second = new Segment(itemId, new TimeRange(200, 220));
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+
+                await plugin.UpdateTimestampAsync(stale, AnalysisMode.Credits, append: true, mediaCategory: QueuedMediaCategory.Movie);
+
+                await plugin.UpdateTimestampAsync(first, AnalysisMode.Credits, append: false, mediaCategory: QueuedMediaCategory.Movie);
+                await plugin.UpdateTimestampAsync(second, AnalysisMode.Credits, append: true, mediaCategory: QueuedMediaCategory.Movie);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var segments = db.DbSegment
+                    .Where(s => s.ItemId == itemId && s.Type == AnalysisMode.Credits)
+                    .OrderBy(s => s.Start)
+                    .ToList();
+
+                Assert.Equal(2, segments.Count);
+                Assert.DoesNotContain(segments, s => s.Start == stale.Start);
+                Assert.Equal(100, segments[0].Start);
+                Assert.Equal(200, segments[1].Start);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
     private static async Task<bool> TableExistsAsync(IntroSkipperDbContext db, string tableName)
     {
         var connection = db.Database.GetDbConnection();

--- a/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
@@ -7,6 +7,7 @@ using IntroSkipper.Manager;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Model.Configuration;
@@ -90,6 +91,42 @@ public sealed class TestMediaSegmentEditorService
 
         // Commercial segments are never deleted; only the non-duplicate is added.
         Assert.Empty(manager.DeletedSegmentIds);
+        Assert.Equal(1, manager.CreateCount);
+    }
+
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_AllowsMultipleMovieCredits()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var existing = CreateSegment(MediaSegmentType.Outro, 10, 20, Guid.NewGuid());
+        var manager = new FakeMediaSegmentManager
+        {
+            Providers = [(Plugin.Instance!.Name, "intro-skipper")],
+            ExistingSegments = [existing]
+        };
+        var service = CreateService(manager);
+
+        await service.CreateOrReplaceSegmentAsync(CreateMovie(Guid.NewGuid()), CreateSegment(MediaSegmentType.Outro, 30, 40), CancellationToken.None);
+
+        Assert.Empty(manager.DeletedSegmentIds);
+        Assert.Equal(1, manager.CreateCount);
+    }
+
+    [Fact]
+    public async Task CreateOrReplaceSegmentAsync_ReplacesExistingTelevisionCredits()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var existing = CreateSegment(MediaSegmentType.Outro, 10, 20, Guid.NewGuid());
+        var manager = new FakeMediaSegmentManager
+        {
+            Providers = [(Plugin.Instance!.Name, "intro-skipper")],
+            ExistingSegments = [existing]
+        };
+        var service = CreateService(manager);
+
+        await service.CreateOrReplaceSegmentAsync(CreateEpisode(Guid.NewGuid()), CreateSegment(MediaSegmentType.Outro, 30, 40), CancellationToken.None);
+
+        Assert.Equal([existing.Id], manager.DeletedSegmentIds);
         Assert.Equal(1, manager.CreateCount);
     }
 
@@ -269,6 +306,14 @@ public sealed class TestMediaSegmentEditorService
     private static Movie CreateMovie(Guid id)
     {
         var item = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
+        EntrypointTestHelpers.EnsureNonVirtual(item);
+        return item;
+    }
+
+    private static Episode CreateEpisode(Guid id)
+    {
+        var item = new Episode();
         EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
         EntrypointTestHelpers.EnsureNonVirtual(item);
         return item;

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -61,19 +61,32 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
 
             try
             {
-                var credit = await DetectCreditsAsync(episode, minimumPercentage, threshold, minimumDuration, cancellationToken).ConfigureAwait(false);
+                var credits = await DetectCreditSegmentsAsync(episode, minimumPercentage, threshold, minimumDuration, cancellationToken).ConfigureAwait(false);
 
-                if (credit is null || !credit.Valid)
+                if (credits.Count == 0)
                 {
                     LogNoValidCreditsFound(episode.Name);
                     continue;
                 }
 
-                credit = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, credit, cancellationToken: cancellationToken).ConfigureAwait(false);
-                LogFoundCredits(episode.Name, credit.Start);
+                var segmentsToStore = episode.Category == QueuedMediaCategory.Movie
+                    ? credits.OrderBy(segment => segment.Start)
+                    : credits.Take(1);
+
+                foreach (var credit in segmentsToStore)
+                {
+                    var adjustedCredit = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, credit, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    LogFoundCredits(episode.Name, adjustedCredit.Start);
+
+                    await plugin.UpdateTimestampAsync(
+                        adjustedCredit,
+                        mode,
+                        configHash: episode.AnalysisConfigHash,
+                        append: episode.Category == QueuedMediaCategory.Movie,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await plugin.UpdateTimestampAsync(credit, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -105,23 +118,43 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
     /// <returns>A task that returns the time range of the detected credits.</returns>
     public async Task<Segment?> DetectCreditsAsync(QueuedEpisode episode, int minimumPercentage, int threshold, int minimumDuration, CancellationToken cancellationToken = default)
     {
+        var segments = await DetectCreditSegmentsAsync(episode, minimumPercentage, threshold, minimumDuration, cancellationToken).ConfigureAwait(false);
+        return segments.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Detects credit segments from FFmpeg keyframe evidence.
+    /// </summary>
+    /// <remarks>
+    /// Multiple segments are returned for movie recording. Television callers should keep using
+    /// <see cref="DetectCreditsAsync"/> or otherwise select a single segment.
+    /// </remarks>
+    /// <param name="episode">Media file to analyze.</param>
+    /// <param name="minimumPercentage">Minimum percentage of the frame that must be black.</param>
+    /// <param name="threshold">Threshold for black frame detection.</param>
+    /// <param name="minimumDuration">Minimum duration of the credits.</param>
+    /// <param name="cancellationToken">Token used to cancel FFmpeg probing.</param>
+    /// <returns>A task that returns the detected credits segments.</returns>
+    public async Task<IReadOnlyList<Segment>> DetectCreditSegmentsAsync(QueuedEpisode episode, int minimumPercentage, int threshold, int minimumDuration, CancellationToken cancellationToken = default)
+    {
         var blackFrames = (await _ffmpegService.DetectBlackFramesAsync(episode, threshold, cancellationToken).ConfigureAwait(false)).ToList();
 
-        var segment = blackFrames.Count > 0
+        IReadOnlyList<Segment> segments = blackFrames.Count > 0
             ? await DetectBlackFrameCreditsAsync(episode, blackFrames, minimumPercentage, threshold, minimumDuration, cancellationToken).ConfigureAwait(false)
-            : null;
+            : [];
 
-        if (segment is not null)
+        if (segments.Count > 0)
         {
-            return segment;
+            return segments;
         }
 
         if (_config.DetectNonBlackCredits)
         {
-            return await DetectNonBlackCreditsAsync(episode, minimumDuration, cancellationToken).ConfigureAwait(false);
+            var segment = await DetectNonBlackCreditsAsync(episode, minimumDuration, cancellationToken).ConfigureAwait(false);
+            return segment is null ? [] : [segment];
         }
 
-        return null;
+        return [];
     }
 
     /// <summary>
@@ -133,8 +166,8 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
     /// <param name="threshold">Threshold for black frame detection.</param>
     /// <param name="minimumDuration">Minimum duration of the credits.</param>
     /// <param name="cancellationToken">Token used to cancel FFmpeg probing.</param>
-    /// <returns>A task that returns the detected credits segment, or <see langword="null" /> when no valid black-frame credits exist.</returns>
-    private async Task<Segment?> DetectBlackFrameCreditsAsync(QueuedEpisode episode, List<BlackFrame> blackFrames, int minimumPercentage, int threshold, int minimumDuration, CancellationToken cancellationToken)
+    /// <returns>A task that returns the detected credits segments, or an empty list when no valid black-frame credits exist.</returns>
+    private async Task<IReadOnlyList<Segment>> DetectBlackFrameCreditsAsync(QueuedEpisode episode, List<BlackFrame> blackFrames, int minimumPercentage, int threshold, int minimumDuration, CancellationToken cancellationToken)
     {
         var (minimum, sceneChange) = NormalizeThreshold(blackFrames, minimumPercentage);
         var scenes = CreditSceneBuilder.DetectCreditScenes(blackFrames, minimum, sceneChange, minimumDuration, _config.RefineCreditsBoundary);
@@ -145,14 +178,14 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
             var candidates = CreditSceneBuilder.DetectCreditSceneCandidates(blackFrames, minimum);
             if (candidates.Count == 0)
             {
-                return null;
+                return [];
             }
 
             blackIntervals = await DetectBlackIntervalsForCandidatesOrEmptyAsync(episode, candidates, threshold, minimum, minimumDuration, cancellationToken).ConfigureAwait(false);
             scenes = CreditSceneBuilder.DetectIntervalSupportedCreditScenes(blackFrames, blackIntervals, minimum, minimumDuration);
             if (scenes.Count == 0)
             {
-                return null;
+                return [];
             }
         }
         else if (scenes.Count == 1 && CreditSceneMetricsCalculator.Calculate(blackFrames, scenes[0], minimum).IsSparse(scenes[0], minimumDuration))
@@ -167,6 +200,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
 
         var ranked = RankCreditCandidates(scenes, blackIntervals);
         var boundaryRefiner = _config.RefineCreditsBoundary ? new CreditsBoundaryRefiner(_ffmpegService) : null;
+        var segments = new List<Segment>(ranked.Count);
 
         foreach (var scene in ranked)
         {
@@ -186,11 +220,11 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
             {
                 LogFoundValidCreditsSegment(segment.Start, segment.End, segment.Duration);
 
-                return segment;
+                segments.Add(segment);
             }
         }
 
-        return null;
+        return segments;
     }
 
     /// <summary>

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -83,6 +83,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
                         mode,
                         configHash: episode.AnalysisConfigHash,
                         append: episode.Category == QueuedMediaCategory.Movie,
+                        mediaCategory: episode.Category,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
 
@@ -119,7 +120,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
     public async Task<Segment?> DetectCreditsAsync(QueuedEpisode episode, int minimumPercentage, int threshold, int minimumDuration, CancellationToken cancellationToken = default)
     {
         var segments = await DetectCreditSegmentsAsync(episode, minimumPercentage, threshold, minimumDuration, cancellationToken).ConfigureAwait(false);
-        return segments.FirstOrDefault();
+        return segments.Count > 0 ? segments[0] : null;
     }
 
     /// <summary>

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -69,12 +69,14 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
                     continue;
                 }
 
-                var segmentsToStore = episode.Category == QueuedMediaCategory.Movie
-                    ? credits.OrderBy(segment => segment.Start)
-                    : credits.Take(1);
+                var appendMovieCredits = episode.Category == QueuedMediaCategory.Movie;
+                List<Segment> segmentsToStore = appendMovieCredits
+                    ? credits.OrderBy(segment => segment.Start).ToList()
+                    : [credits[0]];
 
-                foreach (var credit in segmentsToStore)
+                for (var i = 0; i < segmentsToStore.Count; i++)
                 {
+                    var credit = segmentsToStore[i];
                     var adjustedCredit = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, credit, cancellationToken: cancellationToken).ConfigureAwait(false);
                     LogFoundCredits(episode.Name, adjustedCredit.Start);
 
@@ -82,7 +84,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
                         adjustedCredit,
                         mode,
                         configHash: episode.AnalysisConfigHash,
-                        append: episode.Category == QueuedMediaCategory.Movie,
+                        append: appendMovieCredits && i > 0,
                         mediaCategory: episode.Category,
                         cancellationToken: cancellationToken).ConfigureAwait(false);
                 }

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -77,7 +77,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         var seg = new Segment(itemId, new TimeRange(TimeSpan.FromTicks(segment.StartTicks).TotalSeconds, TimeSpan.FromTicks(segment.EndTicks).TotalSeconds));
         var mode = Plugin.MapSegmentTypeToMode(segment.Type);
 
-        await Plugin.Instance!.UpdateTimestampAsync(seg, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await Plugin.Instance!.UpdateTimestampAsync(seg, mode, isUserProvided: true, append: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await _mediaSegmentEditorService.CreateOrReplaceSegmentAsync(item, segment, cancellationToken).ConfigureAwait(false);
 

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -8,6 +8,7 @@ using System.Net.Mime;
 using IntroSkipper.Data;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.MediaSegments;
 using MediaBrowser.Model.Querying;
@@ -77,7 +78,8 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         var seg = new Segment(itemId, new TimeRange(TimeSpan.FromTicks(segment.StartTicks).TotalSeconds, TimeSpan.FromTicks(segment.EndTicks).TotalSeconds));
         var mode = Plugin.MapSegmentTypeToMode(segment.Type);
 
-        await Plugin.Instance!.UpdateTimestampAsync(seg, mode, isUserProvided: true, append: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var mediaCategory = item is Movie ? QueuedMediaCategory.Movie : QueuedMediaCategory.Episode;
+        await Plugin.Instance!.UpdateTimestampAsync(seg, mode, isUserProvided: true, append: true, mediaCategory: mediaCategory, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await _mediaSegmentEditorService.CreateOrReplaceSegmentAsync(item, segment, cancellationToken).ConfigureAwait(false);
 

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -143,6 +143,9 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             wasUserProvided = matchingSegment.IsUserProvided;
         }
 
+        var deletedItem = Plugin.Instance!.GetItem(itemId);
+        var mediaCategory = deletedItem is Movie ? QueuedMediaCategory.Movie : QueuedMediaCategory.Episode;
+
         // Delete from the plugin DB first so it is consistent even if the Jellyfin delete fails.
         await Plugin.DeleteTimestampAsync(itemId, mode, dbSegment, cancellationToken).ConfigureAwait(false);
 
@@ -155,7 +158,13 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             // Jellyfin delete failed — restore the plugin DB entry to avoid an orphaned Jellyfin segment.
             if (dbSegment is not null)
             {
-                await Plugin.Instance!.UpdateTimestampAsync(dbSegment, mode, isUserProvided: wasUserProvided, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                await Plugin.Instance!.UpdateTimestampAsync(
+                    dbSegment,
+                    mode,
+                    isUserProvided: wasUserProvided,
+                    append: true,
+                    mediaCategory: mediaCategory,
+                    cancellationToken: CancellationToken.None).ConfigureAwait(false);
             }
 
             throw;
@@ -163,7 +172,6 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
 
         // Jellyfin delete succeeded — remove the episode from the season's analyzed-state list so
         // that the episode returns to NotAnalyzed and can be re-processed by the next analysis run.
-        var deletedItem = Plugin.Instance!.GetItem(itemId);
         if (deletedItem is not null)
         {
             var seasonId = deletedItem is Episode ep ? ep.SeasonId : deletedItem.Id;

--- a/IntroSkipper/Db/DbSegmentIndexSql.cs
+++ b/IntroSkipper/Db/DbSegmentIndexSql.cs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 AbandonedCart
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Current DbSegment index and duplicate-cleanup SQL shared by migrations and legacy schema repair.
+/// </summary>
+internal static class DbSegmentIndexSql
+{
+    /// <summary>
+    /// Numeric database value for credits segments.
+    /// </summary>
+    internal const int CreditsType = (int)AnalysisMode.Credits;
+
+    /// <summary>
+    /// Numeric database value for commercial segments.
+    /// </summary>
+    internal const int CommercialType = (int)AnalysisMode.Commercial;
+
+    /// <summary>
+    /// Item lookup index name.
+    /// </summary>
+    internal const string ItemIndexName = "IX_DbSegment_ItemId";
+
+    /// <summary>
+    /// Commercial unique index name.
+    /// </summary>
+    internal const string CommercialUniqueIndexName = "IX_DbSegment_Commercial_Unique";
+
+    /// <summary>
+    /// Credits unique index name.
+    /// </summary>
+    internal const string CreditsUniqueIndexName = "IX_DbSegment_Credits_Unique";
+
+    /// <summary>
+    /// Single-entry segment unique index name.
+    /// </summary>
+    internal const string NonCommercialUniqueIndexName = "IX_DbSegment_NonCommercial_Unique";
+
+    /// <summary>
+    /// Gets the SQLite filter for commercial segments.
+    /// </summary>
+    internal static string CommercialFilter => $"Type = {CommercialType}";
+
+    /// <summary>
+    /// Gets the SQLite filter for credits segments.
+    /// </summary>
+    internal static string CreditsFilter => $"Type = {CreditsType}";
+
+    /// <summary>
+    /// Gets the SQLite filter for segment types that allow only one row per item.
+    /// </summary>
+    internal static string SingleSegmentFilter => $"Type != {CommercialType} AND Type != {CreditsType}";
+
+    /// <summary>
+    /// Gets the SQL that creates the item lookup index.
+    /// </summary>
+    internal static string CreateItemIndexSql =>
+        """
+        CREATE INDEX IF NOT EXISTS "IX_DbSegment_ItemId" ON "DbSegment" ("ItemId")
+        """;
+
+    /// <summary>
+    /// Gets the SQL that removes duplicate commercial rows before creating the commercial unique index.
+    /// </summary>
+    internal static string DeleteDuplicateCommercialSegmentsSql =>
+        $$"""
+        DELETE FROM "DbSegment"
+        WHERE "Type" = {{CommercialType}}
+        AND "Id" NOT IN (
+            SELECT MAX("Id")
+            FROM "DbSegment"
+            WHERE "Type" = {{CommercialType}}
+            GROUP BY "ItemId", "Type", "Start", "End"
+        )
+        """;
+
+    /// <summary>
+    /// Gets the SQL that creates the commercial unique index.
+    /// </summary>
+    internal static string CreateCommercialUniqueIndexSql =>
+        $$"""
+        CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_Commercial_Unique" ON "DbSegment" ("ItemId", "Type", "Start", "End")
+            WHERE "Type" = {{CommercialType}}
+        """;
+
+    /// <summary>
+    /// Gets the SQL that removes duplicate credit rows before creating the credits unique index.
+    /// </summary>
+    internal static string DeleteDuplicateCreditSegmentsSql =>
+        $$"""
+        DELETE FROM "DbSegment"
+        WHERE "Type" = {{CreditsType}}
+        AND "Id" NOT IN (
+            SELECT MAX("Id")
+            FROM "DbSegment"
+            WHERE "Type" = {{CreditsType}}
+            GROUP BY "ItemId", "Type", "Start", "End"
+        )
+        """;
+
+    /// <summary>
+    /// Gets the SQL that creates the credits unique index.
+    /// </summary>
+    internal static string CreateCreditsUniqueIndexSql =>
+        $$"""
+        CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_Credits_Unique" ON "DbSegment" ("ItemId", "Type", "Start", "End")
+            WHERE "Type" = {{CreditsType}}
+        """;
+
+    /// <summary>
+    /// Gets the SQL that drops the legacy single-row non-commercial unique index.
+    /// </summary>
+    internal static string DropNonCommercialUniqueIndexSql =>
+        """
+        DROP INDEX IF EXISTS "IX_DbSegment_NonCommercial_Unique"
+        """;
+
+    /// <summary>
+    /// Gets the SQL that removes duplicate single-entry segment rows before creating the single-entry unique index.
+    /// </summary>
+    internal static string DeleteDuplicateSingleSegmentsSql =>
+        $$"""
+        DELETE FROM "DbSegment"
+        WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
+        AND "Id" NOT IN (
+            SELECT MAX("Id")
+            FROM "DbSegment"
+            WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
+            GROUP BY "ItemId", "Type"
+        )
+        """;
+
+    /// <summary>
+    /// Gets the SQL that creates the unique index for segment types that allow only one row per item.
+    /// </summary>
+    internal static string CreateNonCommercialUniqueIndexSql =>
+        $$"""
+        CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_NonCommercial_Unique" ON "DbSegment" ("ItemId", "Type")
+            WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
+        """;
+}

--- a/IntroSkipper/Db/DbSegmentIndexSql.cs
+++ b/IntroSkipper/Db/DbSegmentIndexSql.cs
@@ -59,8 +59,8 @@ internal static class DbSegmentIndexSql
     /// Gets the SQL that creates the item lookup index.
     /// </summary>
     internal static string CreateItemIndexSql =>
-        """
-        CREATE INDEX IF NOT EXISTS "IX_DbSegment_ItemId" ON "DbSegment" ("ItemId")
+        $$"""
+        CREATE INDEX IF NOT EXISTS "{{ItemIndexName}}" ON "DbSegment" ("ItemId")
         """;
 
     /// <summary>
@@ -83,7 +83,7 @@ internal static class DbSegmentIndexSql
     /// </summary>
     internal static string CreateCommercialUniqueIndexSql =>
         $$"""
-        CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_Commercial_Unique" ON "DbSegment" ("ItemId", "Type", "Start", "End")
+        CREATE UNIQUE INDEX IF NOT EXISTS "{{CommercialUniqueIndexName}}" ON "DbSegment" ("ItemId", "Type", "Start", "End")
             WHERE "Type" = {{CommercialType}}
         """;
 
@@ -139,7 +139,7 @@ internal static class DbSegmentIndexSql
     /// </summary>
     internal static string CreateNonCommercialUniqueIndexSql =>
         $$"""
-        CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_NonCommercial_Unique" ON "DbSegment" ("ItemId", "Type")
+        CREATE UNIQUE INDEX IF NOT EXISTS "{{NonCommercialUniqueIndexName}}" ON "DbSegment" ("ItemId", "Type")
             WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
         """;
 }

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -20,9 +20,6 @@ namespace IntroSkipper.Db;
 /// </remarks>
 public class IntroSkipperDbContext : DbContext
 {
-    private const int CreditsType = (int)AnalysisMode.Credits;
-    private const int CommercialType = (int)AnalysisMode.Commercial;
-
     private static readonly SqlitePragmaInterceptor _pragmaInterceptor = new();
     private static readonly string[] _currentMigrationIds =
     [
@@ -93,16 +90,16 @@ public class IntroSkipperDbContext : DbContext
 
             entity.HasIndex(e => e.ItemId);
             entity.HasIndex(e => new { e.ItemId, e.Type, e.Start, e.End })
-                .HasDatabaseName("IX_DbSegment_Commercial_Unique")
-                .HasFilter($"Type = {CommercialType}")
+                .HasDatabaseName(DbSegmentIndexSql.CommercialUniqueIndexName)
+                .HasFilter(DbSegmentIndexSql.CommercialFilter)
                 .IsUnique();
             entity.HasIndex(e => new { e.ItemId, e.Type, e.Start, e.End })
-                .HasDatabaseName("IX_DbSegment_Credits_Unique")
-                .HasFilter($"Type = {CreditsType}")
+                .HasDatabaseName(DbSegmentIndexSql.CreditsUniqueIndexName)
+                .HasFilter(DbSegmentIndexSql.CreditsFilter)
                 .IsUnique();
             entity.HasIndex(e => new { e.ItemId, e.Type })
-                .HasDatabaseName("IX_DbSegment_NonCommercial_Unique")
-                .HasFilter($"Type != {CommercialType} AND Type != {CreditsType}")
+                .HasDatabaseName(DbSegmentIndexSql.NonCommercialUniqueIndexName)
+                .HasFilter(DbSegmentIndexSql.SingleSegmentFilter)
                 .IsUnique();
 
             entity.Property(e => e.Start)
@@ -462,61 +459,14 @@ public class IntroSkipperDbContext : DbContext
 
     private void EnsureDbSegmentIndexes()
     {
-        Database.ExecuteSqlRaw("CREATE INDEX IF NOT EXISTS \"IX_DbSegment_ItemId\" ON \"DbSegment\" (\"ItemId\")");
-        Database.ExecuteSqlRaw(
-            $$"""
-            DELETE FROM "DbSegment"
-            WHERE "Type" = {{CommercialType}}
-            AND "Id" NOT IN (
-                SELECT MAX("Id")
-                FROM "DbSegment"
-                WHERE "Type" = {{CommercialType}}
-                GROUP BY "ItemId", "Type", "Start", "End"
-            )
-            """);
-
-        Database.ExecuteSqlRaw(
-            $$"""
-            CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_Commercial_Unique" ON "DbSegment" ("ItemId", "Type", "Start", "End")
-                WHERE "Type" = {{CommercialType}}
-            """);
-
-        Database.ExecuteSqlRaw(
-            $$"""
-            DELETE FROM "DbSegment"
-            WHERE "Type" = {{CreditsType}}
-            AND "Id" NOT IN (
-                SELECT MAX("Id")
-                FROM "DbSegment"
-                WHERE "Type" = {{CreditsType}}
-                GROUP BY "ItemId", "Type", "Start", "End"
-            )
-            """);
-
-        Database.ExecuteSqlRaw(
-            $$"""
-            CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_Credits_Unique" ON "DbSegment" ("ItemId", "Type", "Start", "End")
-                WHERE "Type" = {{CreditsType}}
-            """);
-
-        Database.ExecuteSqlRaw("DROP INDEX IF EXISTS \"IX_DbSegment_NonCommercial_Unique\"");
-        Database.ExecuteSqlRaw(
-            $$"""
-            DELETE FROM "DbSegment"
-            WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
-            AND "Id" NOT IN (
-                SELECT MAX("Id")
-                FROM "DbSegment"
-                WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
-                GROUP BY "ItemId", "Type"
-            )
-            """);
-
-        Database.ExecuteSqlRaw(
-            $$"""
-            CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_NonCommercial_Unique" ON "DbSegment" ("ItemId", "Type")
-                WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
-            """);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.CreateItemIndexSql);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.DeleteDuplicateCommercialSegmentsSql);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.CreateCommercialUniqueIndexSql);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.DeleteDuplicateCreditSegmentsSql);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.CreateCreditsUniqueIndexSql);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.DropNonCommercialUniqueIndexSql);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.DeleteDuplicateSingleSegmentsSql);
+        Database.ExecuteSqlRaw(DbSegmentIndexSql.CreateNonCommercialUniqueIndexSql);
     }
 
     private void EnsureMigrationHistoryForCurrentSchema()
@@ -550,10 +500,10 @@ public class IntroSkipperDbContext : DbContext
             && ColumnExists("DbSegment", "End")
             && ColumnExists("DbSegment", "IsUserProvided")
             && ColumnExists("DbSegment", "ConfigHash")
-            && IndexExists("DbSegment", "IX_DbSegment_ItemId")
-            && IndexExists("DbSegment", "IX_DbSegment_Commercial_Unique")
-            && IndexExists("DbSegment", "IX_DbSegment_Credits_Unique")
-            && IndexExists("DbSegment", "IX_DbSegment_NonCommercial_Unique")
+            && IndexExists("DbSegment", DbSegmentIndexSql.ItemIndexName)
+            && IndexExists("DbSegment", DbSegmentIndexSql.CommercialUniqueIndexName)
+            && IndexExists("DbSegment", DbSegmentIndexSql.CreditsUniqueIndexName)
+            && IndexExists("DbSegment", DbSegmentIndexSql.NonCommercialUniqueIndexName)
             && TableExists("DbSeasonState")
             && ColumnExists("DbSeasonState", "SeasonId")
             && ColumnExists("DbSeasonState", "Type")

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -20,6 +20,7 @@ namespace IntroSkipper.Db;
 /// </remarks>
 public class IntroSkipperDbContext : DbContext
 {
+    private const int CreditsType = (int)AnalysisMode.Credits;
     private const int CommercialType = (int)AnalysisMode.Commercial;
 
     private static readonly SqlitePragmaInterceptor _pragmaInterceptor = new();
@@ -30,7 +31,8 @@ public class IntroSkipperDbContext : DbContext
         "20260314184512_AddDbSegmentIdentity",
         "20260316060001_AddNonCommercialUniqueIndex",
         "20260519073000_AddConfigHashes",
-        "20260613185809_ReplaceSeasonInfoWithSeasonState"
+        "20260613185809_ReplaceSeasonInfoWithSeasonState",
+        "20260706000000_AddCreditsMultiSegmentIndex"
     ];
 
     private readonly string? _dbPath;
@@ -94,9 +96,13 @@ public class IntroSkipperDbContext : DbContext
                 .HasDatabaseName("IX_DbSegment_Commercial_Unique")
                 .HasFilter($"Type = {CommercialType}")
                 .IsUnique();
+            entity.HasIndex(e => new { e.ItemId, e.Type, e.Start, e.End })
+                .HasDatabaseName("IX_DbSegment_Credits_Unique")
+                .HasFilter($"Type = {CreditsType}")
+                .IsUnique();
             entity.HasIndex(e => new { e.ItemId, e.Type })
                 .HasDatabaseName("IX_DbSegment_NonCommercial_Unique")
-                .HasFilter($"Type != {CommercialType}")
+                .HasFilter($"Type != {CommercialType} AND Type != {CreditsType}")
                 .IsUnique();
 
             entity.Property(e => e.Start)
@@ -478,11 +484,30 @@ public class IntroSkipperDbContext : DbContext
         Database.ExecuteSqlRaw(
             $$"""
             DELETE FROM "DbSegment"
-            WHERE "Type" != {{CommercialType}}
+            WHERE "Type" = {{CreditsType}}
             AND "Id" NOT IN (
                 SELECT MAX("Id")
                 FROM "DbSegment"
-                WHERE "Type" != {{CommercialType}}
+                WHERE "Type" = {{CreditsType}}
+                GROUP BY "ItemId", "Type", "Start", "End"
+            )
+            """);
+
+        Database.ExecuteSqlRaw(
+            $$"""
+            CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_Credits_Unique" ON "DbSegment" ("ItemId", "Type", "Start", "End")
+                WHERE "Type" = {{CreditsType}}
+            """);
+
+        Database.ExecuteSqlRaw("DROP INDEX IF EXISTS \"IX_DbSegment_NonCommercial_Unique\"");
+        Database.ExecuteSqlRaw(
+            $$"""
+            DELETE FROM "DbSegment"
+            WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
+            AND "Id" NOT IN (
+                SELECT MAX("Id")
+                FROM "DbSegment"
+                WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
                 GROUP BY "ItemId", "Type"
             )
             """);
@@ -490,7 +515,7 @@ public class IntroSkipperDbContext : DbContext
         Database.ExecuteSqlRaw(
             $$"""
             CREATE UNIQUE INDEX IF NOT EXISTS "IX_DbSegment_NonCommercial_Unique" ON "DbSegment" ("ItemId", "Type")
-                WHERE "Type" != {{CommercialType}}
+                WHERE "Type" != {{CommercialType}} AND "Type" != {{CreditsType}}
             """);
     }
 
@@ -527,6 +552,7 @@ public class IntroSkipperDbContext : DbContext
             && ColumnExists("DbSegment", "ConfigHash")
             && IndexExists("DbSegment", "IX_DbSegment_ItemId")
             && IndexExists("DbSegment", "IX_DbSegment_Commercial_Unique")
+            && IndexExists("DbSegment", "IX_DbSegment_Credits_Unique")
             && IndexExists("DbSegment", "IX_DbSegment_NonCommercial_Unique")
             && TableExists("DbSeasonState")
             && ColumnExists("DbSeasonState", "SeasonId")

--- a/IntroSkipper/Manager/MediaSegmentEditorService.cs
+++ b/IntroSkipper/Manager/MediaSegmentEditorService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Model.MediaSegments;
@@ -64,7 +63,7 @@ public partial class MediaSegmentEditorService(
                 .GetSegmentsAsync(item, [segment.Type], MediaSegmentProviderDefaults.ExternalProviders, filterByProvider: false)
                 .ConfigureAwait(false);
 
-            if (AllowsMultipleSegments(item, segment.Type))
+            if (MediaSegmentRules.AllowsMultipleSegments(segment.Type, item))
             {
                 // Multiple matching segments per item are valid for commercials and movie credits;
                 // skip creation only when an identical entry (same start and end) is already present.
@@ -111,9 +110,6 @@ public partial class MediaSegmentEditorService(
             itemLock.Release();
         }
     }
-
-    private static bool AllowsMultipleSegments(BaseItem item, MediaSegmentType type)
-        => type == MediaSegmentType.Commercial || (type == MediaSegmentType.Outro && item is Movie);
 
     /// <summary>
     /// Deletes a segment.

--- a/IntroSkipper/Manager/MediaSegmentEditorService.cs
+++ b/IntroSkipper/Manager/MediaSegmentEditorService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Model.MediaSegments;
@@ -34,9 +35,10 @@ public partial class MediaSegmentEditorService(
     /// Operates only on segments of the supplied type, leaving all other types untouched.
     /// </summary>
     /// <remarks>
-    /// Non-commercial segments are replaced: any existing Jellyfin segment of the same type
-    /// is deleted before the new one is created. Commercial segments are deduplicated by
-    /// start/end ticks: the new segment is only created when no identical entry already exists.
+    /// Single-entry segments are replaced: any existing Jellyfin segment of the same type
+    /// is deleted before the new one is created. Commercial segments and movie credits are
+    /// deduplicated by start/end ticks: the new segment is only created when no identical entry
+    /// already exists.
     /// </remarks>
     /// <param name="item">The media item that owns the segment.</param>
     /// <param name="segment">The segment DTO to persist in Jellyfin's database.</param>
@@ -62,10 +64,10 @@ public partial class MediaSegmentEditorService(
                 .GetSegmentsAsync(item, [segment.Type], MediaSegmentProviderDefaults.ExternalProviders, filterByProvider: false)
                 .ConfigureAwait(false);
 
-            if (segment.Type == MediaSegmentType.Commercial)
+            if (AllowsMultipleSegments(item, segment.Type))
             {
-                // Multiple commercial segments per item are valid; skip creation only when an
-                // identical entry (same start and end) is already present.
+                // Multiple matching segments per item are valid for commercials and movie credits;
+                // skip creation only when an identical entry (same start and end) is already present.
                 if (existingSegments.Any(e => e.StartTicks == segment.StartTicks && e.EndTicks == segment.EndTicks))
                 {
                     return;
@@ -73,7 +75,7 @@ public partial class MediaSegmentEditorService(
             }
             else
             {
-                // Only one segment of each non-commercial type is kept per item.
+                // Only one segment of each single-entry type is kept per item.
                 // Deletes run in parallel; individual failures are logged but do not abort the others.
                 await Task.WhenAll(existingSegments.Select(async e =>
                 {
@@ -109,6 +111,9 @@ public partial class MediaSegmentEditorService(
             itemLock.Release();
         }
     }
+
+    private static bool AllowsMultipleSegments(BaseItem item, MediaSegmentType type)
+        => type == MediaSegmentType.Commercial || (type == MediaSegmentType.Outro && item is Movie);
 
     /// <summary>
     /// Deletes a segment.

--- a/IntroSkipper/Manager/MediaSegmentRules.cs
+++ b/IntroSkipper/Manager/MediaSegmentRules.cs
@@ -1,7 +1,7 @@
 using IntroSkipper.Data;
+using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
-using MediaBrowser.Model.MediaSegments;
 
 namespace IntroSkipper.Manager;
 

--- a/IntroSkipper/Manager/MediaSegmentRules.cs
+++ b/IntroSkipper/Manager/MediaSegmentRules.cs
@@ -1,0 +1,45 @@
+using IntroSkipper.Data;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.MediaSegments;
+
+namespace IntroSkipper.Manager;
+
+/// <summary>
+/// Shared rules for segment cardinality across plugin and Jellyfin media-segment storage.
+/// </summary>
+internal static class MediaSegmentRules
+{
+    /// <summary>
+    /// Determines whether plugin DB segments may contain multiple rows for the supplied mode and queued media category.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="category">Queued media category.</param>
+    /// <returns><see langword="true" /> when multiple segments are allowed.</returns>
+    internal static bool AllowsMultipleSegments(AnalysisMode mode, QueuedMediaCategory category)
+        => AllowsMultipleSegments(mode, category == QueuedMediaCategory.Movie);
+
+    /// <summary>
+    /// Determines whether plugin DB segments may contain multiple rows for the supplied mode and item.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="item">Media item.</param>
+    /// <returns><see langword="true" /> when multiple segments are allowed.</returns>
+    internal static bool AllowsMultipleSegments(AnalysisMode mode, BaseItem? item)
+        => AllowsMultipleSegments(mode, item is Movie);
+
+    /// <summary>
+    /// Determines whether Jellyfin media segments may contain multiple rows for the supplied type and item.
+    /// </summary>
+    /// <param name="type">Jellyfin media segment type.</param>
+    /// <param name="item">Media item.</param>
+    /// <returns><see langword="true" /> when multiple segments are allowed.</returns>
+    internal static bool AllowsMultipleSegments(MediaSegmentType type, BaseItem? item)
+        => AllowsMultipleSegments(type, item is Movie);
+
+    private static bool AllowsMultipleSegments(AnalysisMode mode, bool isMovie)
+        => mode == AnalysisMode.Commercial || (mode == AnalysisMode.Credits && isMovie);
+
+    private static bool AllowsMultipleSegments(MediaSegmentType type, bool isMovie)
+        => type == MediaSegmentType.Commercial || (type == MediaSegmentType.Outro && isMovie);
+}

--- a/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.Designer.cs
+++ b/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IntroSkipper.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IntroSkipper.Migrations
 {
     [DbContext(typeof(IntroSkipperDbContext))]
-    partial class IntroSkipperDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706000000_AddCreditsMultiSegmentIndex")]
+    partial class AddCreditsMultiSegmentIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.11");

--- a/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.cs
+++ b/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.cs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 AbandonedCart
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IntroSkipper.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCreditsMultiSegmentIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            const int creditsType = 1;
+            const int commercialType = 4;
+
+            migrationBuilder.DropIndex(
+                name: "IX_DbSegment_NonCommercial_Unique",
+                table: "DbSegment");
+
+            migrationBuilder.Sql(
+                $$"""
+                DELETE FROM "DbSegment"
+                WHERE "Type" = {{creditsType}}
+                AND "Id" NOT IN (
+                    SELECT MAX("Id")
+                    FROM "DbSegment"
+                    WHERE "Type" = {{creditsType}}
+                    GROUP BY "ItemId", "Type", "Start", "End"
+                );
+                DELETE FROM "DbSegment"
+                WHERE "Type" != {{commercialType}} AND "Type" != {{creditsType}}
+                AND "Id" NOT IN (
+                    SELECT MAX("Id")
+                    FROM "DbSegment"
+                    WHERE "Type" != {{commercialType}} AND "Type" != {{creditsType}}
+                    GROUP BY "ItemId", "Type"
+                );
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DbSegment_Credits_Unique",
+                table: "DbSegment",
+                columns: ["ItemId", "Type", "Start", "End"],
+                unique: true,
+                filter: $"Type = {creditsType}");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DbSegment_NonCommercial_Unique",
+                table: "DbSegment",
+                columns: ["ItemId", "Type"],
+                unique: true,
+                filter: $"Type != {commercialType} AND Type != {creditsType}");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            const int commercialType = 4;
+
+            migrationBuilder.DropIndex(
+                name: "IX_DbSegment_Credits_Unique",
+                table: "DbSegment");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DbSegment_NonCommercial_Unique",
+                table: "DbSegment");
+
+            migrationBuilder.Sql(
+                $$"""
+                DELETE FROM "DbSegment"
+                WHERE "Type" != {{commercialType}}
+                AND "Id" NOT IN (
+                    SELECT MAX("Id")
+                    FROM "DbSegment"
+                    WHERE "Type" != {{commercialType}}
+                    GROUP BY "ItemId", "Type"
+                );
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DbSegment_NonCommercial_Unique",
+                table: "DbSegment",
+                columns: ["ItemId", "Type"],
+                unique: true,
+                filter: $"Type != {commercialType}");
+        }
+    }
+}

--- a/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.cs
+++ b/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 AbandonedCart
 // SPDX-License-Identifier: GPL-3.0-only
 
+using IntroSkipper.Db;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -13,46 +14,11 @@ namespace IntroSkipper.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            const int creditsType = 1;
-            const int commercialType = 4;
-
-            migrationBuilder.DropIndex(
-                name: "IX_DbSegment_NonCommercial_Unique",
-                table: "DbSegment");
-
-            migrationBuilder.Sql(
-                $$"""
-                DELETE FROM "DbSegment"
-                WHERE "Type" = {{creditsType}}
-                AND "Id" NOT IN (
-                    SELECT MAX("Id")
-                    FROM "DbSegment"
-                    WHERE "Type" = {{creditsType}}
-                    GROUP BY "ItemId", "Type", "Start", "End"
-                );
-                DELETE FROM "DbSegment"
-                WHERE "Type" != {{commercialType}} AND "Type" != {{creditsType}}
-                AND "Id" NOT IN (
-                    SELECT MAX("Id")
-                    FROM "DbSegment"
-                    WHERE "Type" != {{commercialType}} AND "Type" != {{creditsType}}
-                    GROUP BY "ItemId", "Type"
-                );
-                """);
-
-            migrationBuilder.CreateIndex(
-                name: "IX_DbSegment_Credits_Unique",
-                table: "DbSegment",
-                columns: ["ItemId", "Type", "Start", "End"],
-                unique: true,
-                filter: $"Type = {creditsType}");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_DbSegment_NonCommercial_Unique",
-                table: "DbSegment",
-                columns: ["ItemId", "Type"],
-                unique: true,
-                filter: $"Type != {commercialType} AND Type != {creditsType}");
+            migrationBuilder.Sql(DbSegmentIndexSql.DropNonCommercialUniqueIndexSql);
+            migrationBuilder.Sql(DbSegmentIndexSql.DeleteDuplicateCreditSegmentsSql);
+            migrationBuilder.Sql(DbSegmentIndexSql.CreateCreditsUniqueIndexSql);
+            migrationBuilder.Sql(DbSegmentIndexSql.DeleteDuplicateSingleSegmentsSql);
+            migrationBuilder.Sql(DbSegmentIndexSql.CreateNonCommercialUniqueIndexSql);
         }
 
         /// <inheritdoc />

--- a/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.cs
+++ b/IntroSkipper/Migrations/20260706000000_AddCreditsMultiSegmentIndex.cs
@@ -24,7 +24,7 @@ namespace IntroSkipper.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            const int commercialType = 4;
+            const int commercialType = DbSegmentIndexSql.CommercialType;
 
             migrationBuilder.DropIndex(
                 name: "IX_DbSegment_Credits_Unique",

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -12,13 +12,13 @@ using System.Collections.Concurrent;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
+using IntroSkipper.Manager;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
@@ -230,6 +230,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         bool isUserProvided = false,
         string configHash = "",
         bool append = false,
+        QueuedMediaCategory? mediaCategory = null,
         CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
@@ -238,7 +239,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         {
             var dbSegment = new DbSegment(segment, mode, isUserProvided, configHash);
             var appendSegment = mode == AnalysisMode.Commercial ||
-                (append && mode == AnalysisMode.Credits && IsMovie(segment.EpisodeId));
+                (append && AllowsMultipleSegments(mode, segment.EpisodeId, mediaCategory));
 
             if (mode != AnalysisMode.Commercial)
             {
@@ -320,10 +321,14 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         }
     }
 
-    private bool IsMovie(Guid itemId)
+    private bool AllowsMultipleSegments(AnalysisMode mode, Guid itemId, QueuedMediaCategory? mediaCategory)
     {
-        var item = itemId != Guid.Empty ? _libraryManager.GetItemById(itemId) : null;
-        return item is Movie;
+        if (mediaCategory.HasValue)
+        {
+            return MediaSegmentRules.AllowsMultipleSegments(mode, mediaCategory.Value);
+        }
+
+        return MediaSegmentRules.AllowsMultipleSegments(mode, GetItem(itemId));
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -18,6 +18,7 @@ using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
@@ -228,6 +229,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         AnalysisMode mode,
         bool isUserProvided = false,
         string configHash = "",
+        bool append = false,
         CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
@@ -235,8 +237,41 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         try
         {
             var dbSegment = new DbSegment(segment, mode, isUserProvided, configHash);
+            var appendSegment = mode == AnalysisMode.Commercial ||
+                (append && mode == AnalysisMode.Credits && IsMovie(segment.EpisodeId));
 
-            if (mode == AnalysisMode.Commercial)
+            if (mode != AnalysisMode.Commercial)
+            {
+                var existingSegments = await db.DbSegment
+                    .AsNoTracking()
+                    .Where(s => s.ItemId == segment.EpisodeId && s.Type == mode)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Do not overwrite a user-provided segment with an analysis result.
+                if (!isUserProvided && existingSegments.Any(s => s.IsUserProvided))
+                {
+                    return;
+                }
+
+                // Guard: prevent auto-detected credits from overlapping with the introduction.
+                if (mode == AnalysisMode.Credits && !isUserProvided)
+                {
+                    var intro = await db.DbSegment
+                        .AsNoTracking()
+                        .Where(s => s.ItemId == segment.EpisodeId && s.Type == AnalysisMode.Introduction)
+                        .FirstOrDefaultAsync(cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (intro is not null && segment.Start < intro.End && intro.Start < segment.End)
+                    {
+                        LogCreditsOverlapWithIntro(_logger, segment.EpisodeId);
+                        return;
+                    }
+                }
+            }
+
+            if (appendSegment)
             {
                 var exists = await db.DbSegment
                     .AnyAsync(
@@ -263,28 +298,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                         .ToListAsync(cancellationToken)
                         .ConfigureAwait(false);
 
-                    // Do not overwrite a user-provided segment with an analysis result.
-                    if (!isUserProvided && existingSegments.Any(s => s.IsUserProvided))
-                    {
-                        return;
-                    }
-
-                    // Guard: prevent auto-detected credits from overlapping with the introduction.
-                    if (mode == AnalysisMode.Credits && !isUserProvided)
-                    {
-                        var intro = await db.DbSegment
-                            .AsNoTracking()
-                            .Where(s => s.ItemId == segment.EpisodeId && s.Type == AnalysisMode.Introduction)
-                            .FirstOrDefaultAsync(cancellationToken)
-                            .ConfigureAwait(false);
-
-                        if (intro is not null && segment.Start < intro.End && intro.Start < segment.End)
-                        {
-                            LogCreditsOverlapWithIntro(_logger, segment.EpisodeId);
-                            return;
-                        }
-                    }
-
                     if (existingSegments.Count > 0)
                     {
                         db.DbSegment.RemoveRange(existingSegments);
@@ -305,6 +318,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             LogFailedToUpdateTimestamp(_logger, ex, segment.EpisodeId);
             throw;
         }
+    }
+
+    private bool IsMovie(Guid itemId)
+    {
+        var item = itemId != Guid.Empty ? _libraryManager.GetItemById(itemId) : null;
+        return item is Movie;
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using IntroSkipper.Data;
+using IntroSkipper.Manager;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -57,7 +58,7 @@ namespace IntroSkipper.Providers
                     continue;
                 }
 
-                if (!AllowsMultipleSegments(item, segment.Type) && !dedupedModes.Add(segment.Type))
+                if (!MediaSegmentRules.AllowsMultipleSegments(segment.Type, item) && !dedupedModes.Add(segment.Type))
                 {
                     continue;
                 }
@@ -79,8 +80,5 @@ namespace IntroSkipper.Providers
 
         /// <inheritdoc/>
         public ValueTask<bool> Supports(BaseItem item) => ValueTask.FromResult(item is Episode or Movie);
-
-        private static bool AllowsMultipleSegments(BaseItem? item, AnalysisMode mode)
-            => mode == AnalysisMode.Commercial || (mode == AnalysisMode.Credits && item is Movie);
     }
 }

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -41,6 +41,7 @@ namespace IntroSkipper.Providers
             ArgumentNullException.ThrowIfNull(Plugin.Instance);
 
             var segments = new List<MediaSegmentDto>();
+            var item = Plugin.Instance.GetItem(request.ItemId);
             var itemSegments = await Plugin.GetSegmentsAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
             var dedupedModes = new HashSet<AnalysisMode>();
 
@@ -56,7 +57,7 @@ namespace IntroSkipper.Providers
                     continue;
                 }
 
-                if (segment.Type != AnalysisMode.Commercial && !dedupedModes.Add(segment.Type))
+                if (!AllowsMultipleSegments(item, segment.Type) && !dedupedModes.Add(segment.Type))
                 {
                     continue;
                 }
@@ -78,5 +79,8 @@ namespace IntroSkipper.Providers
 
         /// <inheritdoc/>
         public ValueTask<bool> Supports(BaseItem item) => ValueTask.FromResult(item is Episode or Movie);
+
+        private static bool AllowsMultipleSegments(BaseItem? item, AnalysisMode mode)
+            => mode == AnalysisMode.Commercial || (mode == AnalysisMode.Credits && item is Movie);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Allow multiple credits segments for movies while keeping a single outro/credits segment for TV episodes, and align detection, storage, and Jellyfin integration with the new rules.

New Features:
- Support detection and storage of multiple credit segments per movie, including appending additional credit ranges without overwriting existing ones.
- Introduce centralized media segment cardinality rules shared between the plugin database, Jellyfin segment editor, and segment provider.

Enhancements:
- Refine credits analysis pipeline to return and persist multiple credit segments when applicable, while preserving single-segment behavior for television content.
- Extend plugin UpdateTimestampAsync to optionally append segments based on media type and mode, and to avoid overwriting user-provided segments or overlapping intros under the new multi-segment rules.
- Update segment editor and API controller logic to honor movie/TV differences when creating, replacing, and rolling back credit segments.
- Factor DbSegment index and cleanup SQL into a shared helper and extend indexing to support multiple credits per item alongside commercials.

Tests:
- Add database, analyzer, and media segment editor tests covering multiple credit segments for movies, uniqueness constraints, rollback behavior, and TV vs movie semantics.