### PR TITLE
refactor(db): add EF-idiomatic DB layer (Theory C)

### DIFF
--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
 using IntroSkipper.Services;
@@ -22,6 +23,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -29,6 +31,25 @@ using Xunit;
 internal static class EntrypointTestHelpers
 {
     internal static readonly byte[] EmptyJsonArray = Encoding.UTF8.GetBytes("[]");
+
+    /// <summary>
+    /// Creates a <see cref="DetectionCacheService"/> backed by a factory that resolves the cache
+    /// database path from <see cref="Plugin.Instance"/> at context-creation time, matching the
+    /// pre-DI behavior of <c>Plugin.CreateCacheDbContext()</c>.
+    /// </summary>
+    internal static DetectionCacheService CreateDetectionCacheService()
+        => new(NullLogger<DetectionCacheService>.Instance, new PluginCacheDbContextFactory());
+
+    internal static DatabaseInitializer CreateDatabaseInitializer(string dbPath, string cacheDbPath)
+    {
+        var segmentOptions = new DbContextOptionsBuilder<IntroSkipperDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+        var cacheOptions = new DbContextOptionsBuilder<DetectionCacheDbContext>()
+            .UseSqlite($"Data Source={cacheDbPath}")
+            .Options;
+        return new DatabaseInitializer(NullLogger<DatabaseInitializer>.Instance, segmentOptions, cacheOptions);
+    }
 
     internal static Entrypoint CreateEntrypoint(bool autoDetectIntros)
     {
@@ -43,7 +64,7 @@ internal static class EntrypointTestHelpers
             providerManager: null!,
             fileSystem: null!,
             taskManager: null!,
-            cacheService: new DetectionCacheService(NullLogger<DetectionCacheService>.Instance),
+            cacheService: CreateDetectionCacheService(),
             ffmpegService: null!,
             logger: logger,
             loggerFactory: loggerFactory,
@@ -210,6 +231,23 @@ internal static class EntrypointTestHelpers
         var dir = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", "chromaprints", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         return dir;
+    }
+
+    /// <summary>
+    /// Test <see cref="IDbContextFactory{TContext}"/> for the segment database bound to a fixed file path.
+    /// </summary>
+    internal sealed class FixedPathIntroSkipperDbContextFactory(string dbPath) : IDbContextFactory<IntroSkipperDbContext>
+    {
+        public IntroSkipperDbContext CreateDbContext() => new(dbPath);
+    }
+
+    /// <summary>
+    /// Test <see cref="IDbContextFactory{TContext}"/> that resolves the cache database path from
+    /// <see cref="Plugin.Instance"/> at context-creation time.
+    /// </summary>
+    internal sealed class PluginCacheDbContextFactory : IDbContextFactory<DetectionCacheDbContext>
+    {
+        public DetectionCacheDbContext CreateDbContext() => new(Plugin.Instance!.CacheDbPath);
     }
 
     internal sealed class PluginInstanceScope : IDisposable

--- a/IntroSkipper.Tests/TestAudioFingerprinting.cs
+++ b/IntroSkipper.Tests/TestAudioFingerprinting.cs
@@ -162,7 +162,7 @@ public class TestAudioFingerprinting
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static ChromaprintAnalyzer CreateChromaprintAnalyzer()

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1801,7 +1801,7 @@ public class TestBlackFrames
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static BlackFrameAnalyzer CreateBlackFrameAnalyzer()

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -613,8 +613,7 @@ public sealed class TestCacheOperations
                     new PluginConfiguration { CacheFingerprints = true });
             }
 
-            CacheService = new DetectionCacheService(
-                NullLogger<DetectionCacheService>.Instance);
+            CacheService = EntrypointTestHelpers.CreateDetectionCacheService();
         }
 
         public DetectionCacheService CacheService { get; }

--- a/IntroSkipper.Tests/TestDbOperations.cs
+++ b/IntroSkipper.Tests/TestDbOperations.cs
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+/// <summary>
+/// Tests for the context-extension operations layer (<see cref="SegmentOperations"/> /
+/// <see cref="SeasonStateOperations"/>) and the <see cref="DatabaseInitializer"/> init gate.
+/// All tests run against real SQLite files, matching the repository's testing convention.
+/// </summary>
+public sealed class TestDbOperations
+{
+    [Fact]
+    public async Task UpdateTimestampAsync_DoesNotOverwriteUserProvidedSegment()
+    {
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                await db.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(10, 60)),
+                    AnalysisMode.Introduction,
+                    isUserProvided: true);
+            }
+
+            // An automatic analysis result must not replace the user-provided segment.
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(20, 80)),
+                    AnalysisMode.Introduction,
+                    isUserProvided: false);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var segment = await db.DbSegment.SingleAsync(s => s.ItemId == itemId);
+                Assert.True(segment.IsUserProvided);
+                Assert.Equal(10, segment.Start);
+                Assert.Equal(60, segment.End);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateTimestampAsync_UserProvidedReplacesAutomaticSegment()
+    {
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                await db.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(10, 60)),
+                    AnalysisMode.Introduction,
+                    isUserProvided: false);
+                await db.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(15, 65)),
+                    AnalysisMode.Introduction,
+                    isUserProvided: true);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var segment = await db.DbSegment.SingleAsync(s => s.ItemId == itemId);
+                Assert.True(segment.IsUserProvided);
+                Assert.Equal(15, segment.Start);
+                Assert.Equal(65, segment.End);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Theory]
+    [InlineData(60.0, 1440.0, false, 0)]   // overlapping, auto-detected → rejected
+    [InlineData(1200.0, 1440.0, false, 1)] // non-overlapping, auto-detected → accepted
+    [InlineData(60.0, 1440.0, true, 1)]    // overlapping, user-provided → accepted
+    public async Task UpdateTimestampAsync_CreditsOverlapGuard(
+        double creditsStart, double creditsEnd, bool isUserProvided, int expectedCount)
+    {
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+
+                // Store an intro: 0–90 s.
+                await db.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(0, 90)),
+                    AnalysisMode.Introduction);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.UpdateTimestampAsync(
+                    new Segment(itemId, new TimeRange(creditsStart, creditsEnd)),
+                    AnalysisMode.Credits,
+                    isUserProvided);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var count = db.DbSegment.Count(s => s.ItemId == itemId && s.Type == AnalysisMode.Credits);
+                Assert.Equal(expectedCount, count);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task CleanTimestampsAsync_ChunksDeletes_WhenStaleIdCountExceedsLegacyParameterLimit()
+    {
+        // 1500 stale items forces multiple 500-ID batches and would exceed the classic
+        // 999-parameter SQLite limit if the IDs were sent as one unchunked parameter list.
+        const int StaleItemCount = 1_500;
+
+        var dbPath = CreateTempDbPath();
+        var retainedItemId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSegment.Add(new DbSegment(new Segment(retainedItemId, new TimeRange(0, 10)), AnalysisMode.Introduction));
+                for (var i = 0; i < StaleItemCount; i++)
+                {
+                    db.DbSegment.Add(new DbSegment(new Segment(Guid.NewGuid(), new TimeRange(0, 10)), AnalysisMode.Introduction));
+                }
+
+                await db.SaveChangesAsync();
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.CleanTimestampsAsync([retainedItemId]);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var itemId = Assert.Single(await db.DbSegment.Select(s => s.ItemId).ToListAsync());
+                Assert.Equal(retainedItemId, itemId);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task CleanStaleAutomaticSegmentsAsync_PreservesUserProvidedSegments_AcrossChunks()
+    {
+        // More than one 500-ID chunk, with a user-provided segment and a hash-matching
+        // segment sprinkled in; only stale automatic segments may be deleted.
+        const int ItemCount = 700;
+
+        var dbPath = CreateTempDbPath();
+        var itemIds = Enumerable.Range(0, ItemCount).Select(_ => Guid.NewGuid()).ToArray();
+        var userProvidedItemId = itemIds[0];
+        var currentHashItemId = itemIds[1];
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                foreach (var itemId in itemIds)
+                {
+                    var isUserProvided = itemId == userProvidedItemId;
+                    var configHash = itemId == currentHashItemId ? "current" : "stale";
+                    db.DbSegment.Add(new DbSegment(
+                        new Segment(itemId, new TimeRange(0, 10)),
+                        AnalysisMode.Introduction,
+                        isUserProvided,
+                        configHash));
+                }
+
+                await db.SaveChangesAsync();
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.CleanStaleAutomaticSegmentsAsync(itemIds, AnalysisMode.Introduction, "current");
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var remaining = await db.DbSegment.Select(s => s.ItemId).ToListAsync();
+                Assert.Equal(2, remaining.Count);
+                Assert.Contains(userProvidedItemId, remaining);
+                Assert.Contains(currentHashItemId, remaining);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetSegmentsAsync_CompiledQuery_WorksAcrossPathAndOptionsBasedContexts()
+    {
+        // GetSegmentsAsync uses EF.CompileAsyncQuery. This guards against the compiled
+        // delegate being bound to a single model: both context construction styles used in
+        // this repository (string path + OnConfiguring, and explicit DbContextOptions) must
+        // be able to execute it within one process.
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                await db.UpdateTimestampAsync(new Segment(itemId, new TimeRange(5, 42)), AnalysisMode.Introduction);
+                var viaPathContext = await db.GetSegmentsAsync(itemId);
+                Assert.Single(viaPathContext);
+            }
+
+            var options = new DbContextOptionsBuilder<IntroSkipperDbContext>()
+                .UseSqlite($"Data Source={dbPath}")
+                .Options;
+            using (var db = new IntroSkipperDbContext(options))
+            {
+                var viaOptionsContext = await db.GetSegmentsAsync(itemId);
+                var segment = Assert.Single(viaOptionsContext);
+                Assert.Equal(5, segment.Start);
+                Assert.Equal(42, segment.End);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GatedFactory_AppliesMigrationsBeforeHandingOutContexts()
+    {
+        var dbPath = CreateTempDbPath();
+        var cacheDbPath = CreateTempDbPath();
+
+        try
+        {
+            var initializer = EntrypointTestHelpers.CreateDatabaseInitializer(dbPath, cacheDbPath);
+            var options = new DbContextOptionsBuilder<IntroSkipperDbContext>()
+                .UseSqlite($"Data Source={dbPath}")
+                .Options;
+            var factory = new GatedIntroSkipperDbContextFactory(initializer, options);
+
+            // The very first context handed out must already see a fully migrated database.
+            var db = await factory.CreateDbContextAsync();
+            await using (db.ConfigureAwait(false))
+            {
+                Assert.Empty(await db.Database.GetPendingMigrationsAsync());
+                await db.UpdateTimestampAsync(new Segment(Guid.NewGuid(), new TimeRange(1, 2)), AnalysisMode.Introduction);
+            }
+
+            // Initialization is one-time: a second context creation must succeed unchanged.
+            var db2 = await factory.CreateDbContextAsync();
+            await using (db2.ConfigureAwait(false))
+            {
+                Assert.Equal(1, await db2.DbSegment.CountAsync());
+            }
+
+            // The cache database was initialized by the same gate.
+            using (var cacheDb = new DetectionCacheDbContext(cacheDbPath))
+            {
+                Assert.False(await cacheDb.DetectionCache.AnyAsync());
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    private static string CreateTempDbPath()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests", "db-operations");
+        Directory.CreateDirectory(tempDir);
+        return Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+    }
+
+    private static void DeleteSqliteFiles(string dbPath)
+    {
+        SqliteConnection.ClearAllPools();
+
+        foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestDbOperations.cs
+++ b/IntroSkipper.Tests/TestDbOperations.cs
@@ -11,6 +11,7 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 /// <summary>
@@ -138,32 +139,35 @@ public sealed class TestDbOperations
     }
 
     [Fact]
-    public async Task CleanTimestampsAsync_ChunksDeletes_WhenStaleIdCountExceedsLegacyParameterLimit()
+    public async Task CleanTimestampsAsync_HandlesEnabledIdSetAboveSqliteParameterLimit()
     {
-        // 1500 stale items forces multiple 500-ID batches and would exceed the classic
-        // 999-parameter SQLite limit if the IDs were sent as one unchunked parameter list.
-        const int StaleItemCount = 1_500;
+        // 33,000 IDs > SQLITE_MAX_VARIABLE_NUMBER (32,766). The EF.Parameter (json_each)
+        // translation must send the whole set as a single JSON parameter; the default
+        // one-scalar-parameter-per-element translation would throw 'too many SQL variables'.
+        const int EnabledIdCount = 33_000;
 
         var dbPath = CreateTempDbPath();
         var retainedItemId = Guid.NewGuid();
+        var staleItemId = Guid.NewGuid();
+        var enabledEpisodeIds = Enumerable.Range(0, EnabledIdCount - 1)
+            .Select(_ => Guid.NewGuid())
+            .Append(retainedItemId)
+            .ToArray();
 
         try
         {
             using (var db = new IntroSkipperDbContext(dbPath))
             {
                 await db.Database.EnsureCreatedAsync();
-                db.DbSegment.Add(new DbSegment(new Segment(retainedItemId, new TimeRange(0, 10)), AnalysisMode.Introduction));
-                for (var i = 0; i < StaleItemCount; i++)
-                {
-                    db.DbSegment.Add(new DbSegment(new Segment(Guid.NewGuid(), new TimeRange(0, 10)), AnalysisMode.Introduction));
-                }
-
+                db.DbSegment.AddRange(
+                    new DbSegment(new Segment(retainedItemId, new TimeRange(0, 10)), AnalysisMode.Introduction),
+                    new DbSegment(new Segment(staleItemId, new TimeRange(20, 30)), AnalysisMode.Introduction));
                 await db.SaveChangesAsync();
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
-                await db.CleanTimestampsAsync([retainedItemId]);
+                await db.CleanTimestampsAsync(enabledEpisodeIds);
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))
@@ -179,33 +183,32 @@ public sealed class TestDbOperations
     }
 
     [Fact]
-    public async Task CleanStaleAutomaticSegmentsAsync_PreservesUserProvidedSegments_AcrossChunks()
+    public async Task CleanStaleAutomaticSegmentsAsync_PreservesUserProvidedSegments_AboveSqliteParameterLimit()
     {
-        // More than one 500-ID chunk, with a user-provided segment and a hash-matching
-        // segment sprinkled in; only stale automatic segments may be deleted.
-        const int ItemCount = 700;
+        // 33,000 item IDs (> 32,766) in one call; a user-provided segment and a hash-matching
+        // segment must survive, only the stale automatic segment may be deleted.
+        const int ItemIdCount = 33_000;
 
         var dbPath = CreateTempDbPath();
-        var itemIds = Enumerable.Range(0, ItemCount).Select(_ => Guid.NewGuid()).ToArray();
-        var userProvidedItemId = itemIds[0];
-        var currentHashItemId = itemIds[1];
+        var userProvidedItemId = Guid.NewGuid();
+        var currentHashItemId = Guid.NewGuid();
+        var staleItemId = Guid.NewGuid();
+        var itemIds = Enumerable.Range(0, ItemIdCount - 3)
+            .Select(_ => Guid.NewGuid())
+            .Append(userProvidedItemId)
+            .Append(currentHashItemId)
+            .Append(staleItemId)
+            .ToArray();
 
         try
         {
             using (var db = new IntroSkipperDbContext(dbPath))
             {
                 await db.Database.EnsureCreatedAsync();
-                foreach (var itemId in itemIds)
-                {
-                    var isUserProvided = itemId == userProvidedItemId;
-                    var configHash = itemId == currentHashItemId ? "current" : "stale";
-                    db.DbSegment.Add(new DbSegment(
-                        new Segment(itemId, new TimeRange(0, 10)),
-                        AnalysisMode.Introduction,
-                        isUserProvided,
-                        configHash));
-                }
-
+                db.DbSegment.AddRange(
+                    new DbSegment(new Segment(userProvidedItemId, new TimeRange(0, 10)), AnalysisMode.Introduction, isUserProvided: true, configHash: "stale"),
+                    new DbSegment(new Segment(currentHashItemId, new TimeRange(0, 10)), AnalysisMode.Introduction, isUserProvided: false, configHash: "current"),
+                    new DbSegment(new Segment(staleItemId, new TimeRange(0, 10)), AnalysisMode.Introduction, isUserProvided: false, configHash: "stale"));
                 await db.SaveChangesAsync();
             }
 
@@ -220,6 +223,93 @@ public sealed class TestDbOperations
                 Assert.Equal(2, remaining.Count);
                 Assert.Contains(userProvidedItemId, remaining);
                 Assert.Contains(currentHashItemId, remaining);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ResetSeasonForReanalysisAsync_HandlesEpisodeIdSetAboveSqliteParameterLimit()
+    {
+        const int EpisodeIdCount = 33_000;
+
+        var dbPath = CreateTempDbPath();
+        var seasonId = Guid.NewGuid();
+        var autoItemId = Guid.NewGuid();
+        var userItemId = Guid.NewGuid();
+        var episodeIds = Enumerable.Range(0, EpisodeIdCount - 2)
+            .Select(_ => Guid.NewGuid())
+            .Append(autoItemId)
+            .Append(userItemId)
+            .ToArray();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSegment.AddRange(
+                    new DbSegment(new Segment(autoItemId, new TimeRange(0, 10)), AnalysisMode.Introduction),
+                    new DbSegment(new Segment(userItemId, new TimeRange(0, 10)), AnalysisMode.Credits, isUserProvided: true));
+                db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, episodeIds));
+                await db.SaveChangesAsync();
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.ResetSeasonForReanalysisAsync(seasonId, episodeIds, [AnalysisMode.Introduction, AnalysisMode.Credits]);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var remaining = await db.DbSegment.ToListAsync();
+                var survivor = Assert.Single(remaining);
+                Assert.Equal(userItemId, survivor.ItemId);
+                Assert.True(survivor.IsUserProvided);
+
+                var state = await db.DbSeasonState.SingleAsync(s => s.SeasonId == seasonId);
+                Assert.Empty(state.EpisodeIds);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetSeasonQueueSnapshotAsync_HandlesEpisodeIdSetAboveSqliteParameterLimit()
+    {
+        const int EpisodeIdCount = 33_000;
+
+        var dbPath = CreateTempDbPath();
+        var seasonId = Guid.NewGuid();
+        var episodeWithSegmentId = Guid.NewGuid();
+        var episodeIds = Enumerable.Range(0, EpisodeIdCount - 1)
+            .Select(_ => Guid.NewGuid())
+            .Append(episodeWithSegmentId)
+            .ToArray();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSegment.Add(new DbSegment(new Segment(episodeWithSegmentId, new TimeRange(0, 30)), AnalysisMode.Introduction));
+                db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, [episodeWithSegmentId], "snapshot-config"));
+                await db.SaveChangesAsync();
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var snapshot = await db.GetSeasonQueueSnapshotAsync(seasonId, episodeIds);
+                Assert.True(snapshot.SegmentsByEpisodeId.TryGetValue(episodeWithSegmentId, out var segmentsByMode));
+                Assert.True(segmentsByMode!.ContainsKey(AnalysisMode.Introduction));
+                Assert.True(snapshot.ConfigHashByMode.TryGetValue(AnalysisMode.Introduction, out var configHash));
+                Assert.Equal("snapshot-config", configHash);
             }
         }
         finally
@@ -294,8 +384,13 @@ public sealed class TestDbOperations
                 Assert.Equal(1, await db2.DbSegment.CountAsync());
             }
 
-            // The cache database was initialized by the same gate.
-            using (var cacheDb = new DetectionCacheDbContext(cacheDbPath))
+            // The cache database has its own independent gate behind its own factory.
+            var cacheOptions = new DbContextOptionsBuilder<DetectionCacheDbContext>()
+                .UseSqlite($"Data Source={cacheDbPath}")
+                .Options;
+            var cacheFactory = new GatedDetectionCacheDbContextFactory(initializer, cacheOptions);
+            var cacheDb = await cacheFactory.CreateDbContextAsync();
+            await using (cacheDb.ConfigureAwait(false))
             {
                 Assert.False(await cacheDb.DetectionCache.AnyAsync());
             }
@@ -304,6 +399,45 @@ public sealed class TestDbOperations
         {
             DeleteSqliteFiles(dbPath);
             DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    [Fact]
+    public async Task CacheInitializationFailure_DoesNotBlockSegmentDatabaseAccess()
+    {
+        // Fault-containment: the cache gate failing (here with an InvalidOperationException,
+        // an exception type outside the old IOException/SqliteException filter) must neither
+        // fault the segment gate nor propagate from EnsureInitializedAsync (which would abort
+        // host startup via the hosted initialization service).
+        var dbPath = CreateTempDbPath();
+
+        try
+        {
+            var segmentOptions = new DbContextOptionsBuilder<IntroSkipperDbContext>()
+                .UseSqlite($"Data Source={dbPath}")
+                .Options;
+
+            // No provider configured: any use throws InvalidOperationException during init.
+            var brokenCacheOptions = new DbContextOptionsBuilder<DetectionCacheDbContext>().Options;
+
+            var initializer = new DatabaseInitializer(NullLogger<DatabaseInitializer>.Instance, segmentOptions, brokenCacheOptions);
+
+            // The combined gate (used by the hosted service) must complete without throwing.
+            await initializer.EnsureInitializedAsync();
+
+            // The segment factory must still hand out fully migrated contexts.
+            var factory = new GatedIntroSkipperDbContextFactory(initializer, segmentOptions);
+            var db = await factory.CreateDbContextAsync();
+            await using (db.ConfigureAwait(false))
+            {
+                Assert.Empty(await db.Database.GetPendingMigrationsAsync());
+                await db.UpdateTimestampAsync(new Segment(Guid.NewGuid(), new TimeRange(1, 2)), AnalysisMode.Introduction);
+                Assert.Equal(1, await db.DbSegment.CountAsync());
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
         }
     }
 

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -218,7 +218,7 @@ public class TestFFmpegService
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static QueuedEpisode QueueFile(string path)

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -32,7 +32,7 @@ public sealed class TestSkipIntroController
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+        var controller = CreateController(refresher, dbPath, pluginScope.CacheDbPath);
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -66,7 +66,7 @@ public sealed class TestSkipIntroController
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+        var controller = CreateController(refresher, dbPath, pluginScope.CacheDbPath);
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -76,6 +76,16 @@ public sealed class TestSkipIntroController
 
         Assert.IsType<NoContentResult>(result);
         Assert.Equal(0, refresher.ItemCallCount);
+    }
+
+    private static SkipIntroController CreateController(IMediaSegmentRefresher refresher, string dbPath, string cacheDbPath)
+    {
+        return new SkipIntroController(
+            refresher,
+            EntrypointTestHelpers.CreateDetectionCacheService(),
+            new EntrypointTestHelpers.FixedPathIntroSkipperDbContextFactory(dbPath),
+            EntrypointTestHelpers.CreateDatabaseInitializer(dbPath, cacheDbPath),
+            NullLogger<SkipIntroController>.Instance);
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid itemId, bool updateMediaSegments, out Movie item)

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -130,7 +130,7 @@ public sealed class TestVisualizationController
             fileSystem: null!,
             loggerFactory,
             ffmpegService: null!,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -36,7 +36,7 @@ public sealed class TestVisualizationController
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath);
 
         var actionTask = controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
 
@@ -67,7 +67,7 @@ public sealed class TestVisualizationController
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath);
 
         var result = await controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
 
@@ -98,7 +98,7 @@ public sealed class TestVisualizationController
         await SeedCacheAsync(excludedId, includedId);
         var refresher = new RecordingMediaSegmentRefresher();
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath);
 
         var result = await controller.ClearExcludedTimestampsAsync(CancellationToken.None);
 
@@ -120,7 +120,7 @@ public sealed class TestVisualizationController
         Assert.True(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == includedId));
     }
 
-    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory)
+    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory, string dbPath)
     {
         return new VisualizationController(
             NullLogger<VisualizationController>.Instance,
@@ -130,7 +130,9 @@ public sealed class TestVisualizationController
             fileSystem: null!,
             loggerFactory,
             ffmpegService: null!,
-            EntrypointTestHelpers.CreateDetectionCacheService());
+            EntrypointTestHelpers.CreateDetectionCacheService(),
+            new EntrypointTestHelpers.FixedPathIntroSkipperDbContextFactory(dbPath),
+            new EntrypointTestHelpers.PluginCacheDbContextFactory());
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -9,6 +9,7 @@
 
 using System.Net.Mime;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
@@ -17,19 +18,33 @@ using MediaBrowser.Controller.Entities.TV;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Controllers;
 
 /// <summary>
 /// Skip intro controller.
 /// </summary>
+/// <param name="mediaSegmentRefresher">Media segment refresher.</param>
+/// <param name="cacheService">Detection cache service.</param>
+/// <param name="dbContextFactory">Factory for the segment database context.</param>
+/// <param name="databaseInitializer">Database lifecycle owner (used for rebuild).</param>
+/// <param name="logger">Logger.</param>
 [Authorize]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
-public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, IDetectionCacheService cacheService) : ControllerBase
+public class SkipIntroController(
+    IMediaSegmentRefresher mediaSegmentRefresher,
+    IDetectionCacheService cacheService,
+    IDbContextFactory<IntroSkipperDbContext> dbContextFactory,
+    DatabaseInitializer databaseInitializer,
+    ILogger<SkipIntroController> logger) : ControllerBase
 {
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly IDbContextFactory<IntroSkipperDbContext> _dbContextFactory = dbContextFactory;
+    private readonly DatabaseInitializer _databaseInitializer = databaseInitializer;
+    private readonly ILogger<SkipIntroController> _logger = logger;
 
     /// <summary>
     /// Updates the timestamps for the provided episode.
@@ -65,12 +80,16 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
             (AnalysisMode.Commercial, timestamps.Commercial)
         };
 
-        foreach (var (mode, segment) in segmentTypes)
+        var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
         {
-            if (segment.Valid)
+            foreach (var (mode, segment) in segmentTypes)
             {
-                segment.EpisodeId = id;
-                await Plugin.Instance!.UpdateTimestampAsync(segment, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (segment.Valid)
+                {
+                    segment.EpisodeId = id;
+                    await db.UpdateTimestampAsync(segment, mode, isUserProvided: true, logger: _logger, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 
@@ -102,7 +121,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
         }
 
         var times = new TimeStamps();
-        var segments = await Plugin.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
+        var segments = await GetTimestampsFromDbAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (segments.TryGetValue(AnalysisMode.Introduction, out var introSegment))
         {
@@ -142,7 +161,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     [HttpGet("Episode/{id}/IntroSkipperSegments")]
     public async Task<ActionResult<Dictionary<AnalysisMode, Segment>>> GetSkippableSegments([FromRoute] Guid id, CancellationToken cancellationToken = default)
     {
-        var segments = await Plugin.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
+        var segments = await GetTimestampsFromDbAsync(id, cancellationToken).ConfigureAwait(false);
         var result = new Dictionary<AnalysisMode, Segment>();
 
         if (segments.TryGetValue(AnalysisMode.Introduction, out var introSegment))
@@ -185,11 +204,16 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     [HttpPost("Intros/EraseTimestamps")]
     public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false, CancellationToken cancellationToken = default)
     {
-        using var db = Plugin.CreateDbContext();
-        await db.DbSegment
-            .Where(s => s.Type == mode)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        // Single-query call site: inline LINQ against the factory-created context is the
+        // convention here; only segment writes must go through SegmentOperations.
+        var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            await db.DbSegment
+                .Where(s => s.Type == mode)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {
@@ -211,8 +235,16 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     public async Task<ActionResult> RebuildDatabase()
     {
         // Database rebuild is destructive and must run to completion — do not bind to HttpContext.RequestAborted.
-        using var db = Plugin.CreateDbContext();
-        await db.RebuildDatabaseAsync(Plugin.CreateDbContext).ConfigureAwait(false);
+        await _databaseInitializer.RebuildDatabaseAsync().ConfigureAwait(false);
         return NoContent();
+    }
+
+    private async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsFromDbAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            return await db.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -8,6 +8,7 @@
 using System.Net.Mime;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
@@ -38,11 +39,23 @@ namespace IntroSkipper.Controllers;
 /// <param name="loggerFactory">loggerFactory.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="cacheService">Detection cache service.</param>
+/// <param name="dbContextFactory">Factory for the segment database context.</param>
+/// <param name="cacheDbContextFactory">Factory for the detection cache database context.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("Intros")]
-public partial class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentRefresher mediaSegmentRefresher, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem, ILoggerFactory loggerFactory, IFFmpegService ffmpegService, IDetectionCacheService cacheService) : ControllerBase
+public partial class VisualizationController(
+    ILogger<VisualizationController> logger,
+    IMediaSegmentRefresher mediaSegmentRefresher,
+    ILibraryManager libraryManager,
+    IProviderManager providerManager,
+    IFileSystem fileSystem,
+    ILoggerFactory loggerFactory,
+    IFFmpegService ffmpegService,
+    IDetectionCacheService cacheService,
+    IDbContextFactory<IntroSkipperDbContext> dbContextFactory,
+    IDbContextFactory<DetectionCacheDbContext> cacheDbContextFactory) : ControllerBase
 {
     private readonly ILogger<VisualizationController> _logger = logger;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
@@ -52,6 +65,8 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly IDbContextFactory<IntroSkipperDbContext> _dbContextFactory = dbContextFactory;
+    private readonly IDbContextFactory<DetectionCacheDbContext> _cacheDbContextFactory = cacheDbContextFactory;
 
     /// <summary>
     /// Returns the analyzer actions for the provided season.
@@ -128,42 +143,44 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
         try
         {
-            using var db = Plugin.CreateDbContext();
-
-            // ExecuteDeleteAsync runs a single server-side DELETE and bypasses the change tracker.
-            // This is safe here because the tracked operations below target DbSeasonState, not DbSegment.
-            var episodeIds = episodes.Select(e => e.EpisodeId).ToHashSet();
-            await db.DbSegment
-                .Where(s => episodeIds.Contains(s.ItemId))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            if (eraseCache)
+            var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            await using (db.ConfigureAwait(false))
             {
-                // Cache deletion must run to completion — the DB rows are already gone,
-                // so aborting here would leave orphaned files with no way to clean them up.
-                foreach (var episode in episodes)
+                // ExecuteDeleteAsync runs a single server-side DELETE and bypasses the change tracker.
+                // This is safe here because the tracked operations below target DbSeasonState, not DbSegment.
+                var episodeIds = episodes.Select(e => e.EpisodeId).ToHashSet();
+                await db.DbSegment
+                    .Where(s => episodeIds.Contains(s.ItemId))
+                    .ExecuteDeleteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (eraseCache)
                 {
-                    await Task.Run(() => _cacheService.DeleteForItem(episode.EpisodeId), CancellationToken.None).ConfigureAwait(false);
+                    // Cache deletion must run to completion — the DB rows are already gone,
+                    // so aborting here would leave orphaned files with no way to clean them up.
+                    foreach (var episode in episodes)
+                    {
+                        await Task.Run(() => _cacheService.DeleteForItem(episode.EpisodeId), CancellationToken.None).ConfigureAwait(false);
+                    }
                 }
-            }
 
-            // Batch-load season state and clear episode IDs.
-            var seasonStates = await db.DbSeasonState
-                .Where(s => s.SeasonId == seasonId)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                // Batch-load season state and clear episode IDs.
+                var seasonStates = await db.DbSeasonState
+                    .Where(s => s.SeasonId == seasonId)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
 
-            foreach (var state in seasonStates)
-            {
-                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
-            }
+                foreach (var state in seasonStates)
+                {
+                    db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
+                }
 
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-            if (Plugin.Instance.Configuration.UpdateMediaSegments)
-            {
-                await _mediaSegmentRefresher.RefreshAsync(episodeIds, cancellationToken).ConfigureAwait(false);
+                if (Plugin.Instance!.Configuration.UpdateMediaSegments)
+                {
+                    await _mediaSegmentRefresher.RefreshAsync(episodeIds, cancellationToken).ConfigureAwait(false);
+                }
             }
 
             return NoContent();
@@ -205,7 +222,8 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
                 .ToDictionary(g => g.Key, g => g.Select(e => e.EpisodeId).ToHashSet());
 
             int removedSegments;
-            using (var db = Plugin.CreateDbContext())
+            var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            await using (db.ConfigureAwait(false))
             {
                 removedSegments = await db.DbSegment
                     .Where(s => excludedIds.Contains(s.ItemId))
@@ -231,11 +249,13 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
             }
 
             int removedCacheEntries;
-            using (var cacheDb = Plugin.CreateCacheDbContext())
+
+            // Cache deletion must run to completion — the segment and season-state rows
+            // above are already deleted, so aborting here would leave orphaned cache
+            // entries out of sync with the database.
+            var cacheDb = await _cacheDbContextFactory.CreateDbContextAsync(CancellationToken.None).ConfigureAwait(false);
+            await using (cacheDb.ConfigureAwait(false))
             {
-                // Cache deletion must run to completion — the segment and season-state rows
-                // above are already deleted, so aborting here would leave orphaned cache
-                // entries out of sync with the database.
                 removedCacheEntries = await cacheDb.DetectionCache
                     .Where(e => excludedIds.Contains(e.ItemId))
                     .ExecuteDeleteAsync(CancellationToken.None)

--- a/IntroSkipper/Db/DatabaseInitializationService.cs
+++ b/IntroSkipper/Db/DatabaseInitializationService.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.Extensions.Hosting;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Hosted service that eagerly kicks off one-time database initialization at server startup
+/// so the first playback query does not pay the migration cost. Correctness does not depend
+/// on this service: the gated context factories await the same init task lazily.
+/// </summary>
+internal sealed class DatabaseInitializationService : IHostedService
+{
+    private readonly DatabaseInitializer _initializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatabaseInitializationService"/> class.
+    /// </summary>
+    /// <param name="initializer">Database initializer.</param>
+    public DatabaseInitializationService(DatabaseInitializer initializer)
+    {
+        _initializer = initializer;
+    }
+
+    /// <inheritdoc/>
+    public Task StartAsync(CancellationToken cancellationToken)
+        => _initializer.EnsureInitializedAsync(cancellationToken);
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/IntroSkipper/Db/DatabaseInitializer.cs
+++ b/IntroSkipper/Db/DatabaseInitializer.cs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Owns the lifecycle of both plugin databases: migrations and legacy schema repair
+/// for <c>introskipper.db</c>, create-or-recover for <c>introskipper-cache.db</c>, and
+/// the destructive rebuild flow. Initialization runs exactly once per process and is
+/// awaited by the gated <see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/>
+/// implementations before any context is handed out, so no query can observe an
+/// unmigrated database.
+/// </summary>
+public sealed partial class DatabaseInitializer
+{
+    private readonly ILogger<DatabaseInitializer> _logger;
+    private readonly DbContextOptions<IntroSkipperDbContext> _segmentOptions;
+    private readonly DbContextOptions<DetectionCacheDbContext> _cacheOptions;
+    private readonly object _initLock = new();
+    private Task? _initTask;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatabaseInitializer"/> class.
+    /// </summary>
+    /// <param name="logger">Logger.</param>
+    /// <param name="segmentOptions">Options for the segment database context.</param>
+    /// <param name="cacheOptions">Options for the detection cache database context.</param>
+    public DatabaseInitializer(
+        ILogger<DatabaseInitializer> logger,
+        DbContextOptions<IntroSkipperDbContext> segmentOptions,
+        DbContextOptions<DetectionCacheDbContext> cacheOptions)
+    {
+        _logger = logger;
+        _segmentOptions = segmentOptions;
+        _cacheOptions = cacheOptions;
+    }
+
+    /// <summary>
+    /// Ensures one-time database initialization has completed, starting it if necessary.
+    /// Safe to call concurrently from any thread; only the first caller triggers the work.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token (abandons the wait, not the initialization).</param>
+    /// <returns>A task that completes when initialization has finished.</returns>
+    public Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
+        => GetOrStartInitTask().WaitAsync(cancellationToken);
+
+    /// <summary>
+    /// Synchronously ensures one-time database initialization has completed.
+    /// Used by the synchronous <c>CreateDbContext</c> factory path.
+    /// </summary>
+    public void EnsureInitialized() => GetOrStartInitTask().GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Rebuilds the segment database, salvaging valid rows where possible.
+    /// Runs to completion regardless of request cancellation because the rebuild is destructive.
+    /// </summary>
+    /// <param name="forceCleanOnBackupFailure">
+    /// When <see langword="true"/>, rebuilds an empty database if the backup read fails;
+    /// otherwise the rebuild aborts to avoid data loss.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task RebuildDatabaseAsync(bool forceCleanOnBackupFailure = false, CancellationToken cancellationToken = default)
+    {
+        // Never rebuild concurrently with (or before) first-time initialization.
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+
+        using var db = new IntroSkipperDbContext(_segmentOptions);
+        await db.RebuildDatabaseAsync(
+            () => new IntroSkipperDbContext(_segmentOptions),
+            forceCleanOnBackupFailure,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void EnsureDatabaseDirectoryExists(DbContextOptions options)
+    {
+        var dbPath = IntroSkipperDatabase.GetDatabasePath(options);
+        if (!string.IsNullOrEmpty(dbPath) && Path.GetDirectoryName(dbPath) is { Length: > 0 } directory)
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+
+    private Task GetOrStartInitTask()
+    {
+        lock (_initLock)
+        {
+            return _initTask ??= Task.Run(InitializeCore);
+        }
+    }
+
+    private void InitializeCore()
+    {
+        // Initialize the segment database. Failures are logged but never thrown so a broken
+        // database does not take the whole plugin down — matches the previous Plugin-ctor behavior.
+        try
+        {
+            EnsureDatabaseDirectoryExists(_segmentOptions);
+            using var db = new IntroSkipperDbContext(_segmentOptions);
+
+            // Legacy databases may be missing migration history or columns that EF migrations expect.
+            // Normalize those schemas first so recovery does not log a false initialization failure.
+            db.EnsureLegacySchemaCompatibility();
+            db.ApplyMigrations();
+        }
+        catch (Exception ex)
+        {
+            LogDatabaseInitializationError(_logger, ex);
+        }
+
+        // Initialize the detection cache database (delete-and-recreate on corruption).
+        try
+        {
+            EnsureDatabaseDirectoryExists(_cacheOptions);
+            using var cacheDb = new DetectionCacheDbContext(_cacheOptions);
+            cacheDb.EnsureSchema();
+        }
+        catch (Exception ex) when (ex is IOException or SqliteException)
+        {
+            LogCacheDbInitializationError(_logger, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
+    private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
+    private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
+}

--- a/IntroSkipper/Db/DatabaseInitializer.cs
+++ b/IntroSkipper/Db/DatabaseInitializer.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 intro-skipper contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -10,10 +9,15 @@ namespace IntroSkipper.Db;
 /// <summary>
 /// Owns the lifecycle of both plugin databases: migrations and legacy schema repair
 /// for <c>introskipper.db</c>, create-or-recover for <c>introskipper-cache.db</c>, and
-/// the destructive rebuild flow. Initialization runs exactly once per process and is
-/// awaited by the gated <see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/>
-/// implementations before any context is handed out, so no query can observe an
-/// unmigrated database.
+/// the destructive rebuild flow.
+///
+/// <para>Each database has its own independent one-time initialization gate, awaited by the
+/// matching gated <see cref="IDbContextFactory{TContext}"/> before any context is handed out,
+/// so no query can observe an unmigrated database. The gates are isolated on purpose: the two
+/// databases live in separate files precisely so cache corruption cannot affect segment data,
+/// and a cache initialization failure must therefore never block segment-database access.
+/// Initialization never throws — failures are logged and surface later as per-query errors,
+/// matching the previous Plugin-constructor behavior.</para>
 /// </summary>
 public sealed partial class DatabaseInitializer
 {
@@ -21,7 +25,8 @@ public sealed partial class DatabaseInitializer
     private readonly DbContextOptions<IntroSkipperDbContext> _segmentOptions;
     private readonly DbContextOptions<DetectionCacheDbContext> _cacheOptions;
     private readonly object _initLock = new();
-    private Task? _initTask;
+    private Task? _segmentInitTask;
+    private Task? _cacheInitTask;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DatabaseInitializer"/> class.
@@ -40,19 +45,43 @@ public sealed partial class DatabaseInitializer
     }
 
     /// <summary>
-    /// Ensures one-time database initialization has completed, starting it if necessary.
-    /// Safe to call concurrently from any thread; only the first caller triggers the work.
+    /// Ensures one-time initialization of both databases has completed, starting it if necessary.
+    /// Safe to call concurrently from any thread; never throws initialization errors.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token (abandons the wait, not the initialization).</param>
-    /// <returns>A task that completes when initialization has finished.</returns>
+    /// <returns>A task that completes when initialization of both databases has finished.</returns>
     public Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
-        => GetOrStartInitTask().WaitAsync(cancellationToken);
+        => Task.WhenAll(GetOrStartSegmentInitTask(), GetOrStartCacheInitTask()).WaitAsync(cancellationToken);
 
     /// <summary>
-    /// Synchronously ensures one-time database initialization has completed.
-    /// Used by the synchronous <c>CreateDbContext</c> factory path.
+    /// Ensures one-time initialization of the segment database has completed.
     /// </summary>
-    public void EnsureInitialized() => GetOrStartInitTask().GetAwaiter().GetResult();
+    /// <param name="cancellationToken">Cancellation token (abandons the wait, not the initialization).</param>
+    /// <returns>A task that completes when segment database initialization has finished.</returns>
+    public Task EnsureSegmentDatabaseInitializedAsync(CancellationToken cancellationToken = default)
+        => GetOrStartSegmentInitTask().WaitAsync(cancellationToken);
+
+    /// <summary>
+    /// Ensures one-time initialization of the detection cache database has completed.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token (abandons the wait, not the initialization).</param>
+    /// <returns>A task that completes when cache database initialization has finished.</returns>
+    public Task EnsureCacheDatabaseInitializedAsync(CancellationToken cancellationToken = default)
+        => GetOrStartCacheInitTask().WaitAsync(cancellationToken);
+
+    /// <summary>
+    /// Synchronously ensures one-time initialization of the segment database has completed.
+    /// Used only by the synchronous <c>CreateDbContext</c> factory path; async call sites must
+    /// use <c>CreateDbContextAsync</c> so a slow first migration does not pin thread-pool threads.
+    /// </summary>
+    public void EnsureSegmentDatabaseInitialized() => GetOrStartSegmentInitTask().GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Synchronously ensures one-time initialization of the detection cache database has completed.
+    /// Used only by the synchronous <c>CreateDbContext</c> factory path (e.g. the synchronous
+    /// <c>IDetectionCacheService</c> surface).
+    /// </summary>
+    public void EnsureCacheDatabaseInitialized() => GetOrStartCacheInitTask().GetAwaiter().GetResult();
 
     /// <summary>
     /// Rebuilds the segment database, salvaging valid rows where possible.
@@ -67,7 +96,7 @@ public sealed partial class DatabaseInitializer
     public async Task RebuildDatabaseAsync(bool forceCleanOnBackupFailure = false, CancellationToken cancellationToken = default)
     {
         // Never rebuild concurrently with (or before) first-time initialization.
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureSegmentDatabaseInitializedAsync(cancellationToken).ConfigureAwait(false);
 
         using var db = new IntroSkipperDbContext(_segmentOptions);
         await db.RebuildDatabaseAsync(
@@ -85,18 +114,26 @@ public sealed partial class DatabaseInitializer
         }
     }
 
-    private Task GetOrStartInitTask()
+    private Task GetOrStartSegmentInitTask()
     {
         lock (_initLock)
         {
-            return _initTask ??= Task.Run(InitializeCore);
+            return _segmentInitTask ??= Task.Run(InitializeSegmentDatabaseCore);
         }
     }
 
-    private void InitializeCore()
+    private Task GetOrStartCacheInitTask()
     {
-        // Initialize the segment database. Failures are logged but never thrown so a broken
-        // database does not take the whole plugin down — matches the previous Plugin-ctor behavior.
+        lock (_initLock)
+        {
+            return _cacheInitTask ??= Task.Run(InitializeCacheDatabaseCore);
+        }
+    }
+
+    private void InitializeSegmentDatabaseCore()
+    {
+        // Failures are logged but never thrown so a broken database cannot fault the shared
+        // init task (which would poison every later context creation) or abort host startup.
         try
         {
             EnsureDatabaseDirectoryExists(_segmentOptions);
@@ -111,15 +148,20 @@ public sealed partial class DatabaseInitializer
         {
             LogDatabaseInitializationError(_logger, ex);
         }
+    }
 
-        // Initialize the detection cache database (delete-and-recreate on corruption).
+    private void InitializeCacheDatabaseCore()
+    {
+        // Catch-all on purpose: any escaped exception type (UnauthorizedAccessException,
+        // InvalidOperationException, ...) would otherwise fault the cache gate permanently.
+        // The cache is reconstructable; per-query failures are handled by DetectionCacheService.
         try
         {
             EnsureDatabaseDirectoryExists(_cacheOptions);
             using var cacheDb = new DetectionCacheDbContext(_cacheOptions);
             cacheDb.EnsureSchema();
         }
-        catch (Exception ex) when (ex is IOException or SqliteException)
+        catch (Exception ex)
         {
             LogCacheDbInitializationError(_logger, ex);
         }

--- a/IntroSkipper/Db/GatedDetectionCacheDbContextFactory.cs
+++ b/IntroSkipper/Db/GatedDetectionCacheDbContextFactory.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// <see cref="IDbContextFactory{TContext}"/> for <see cref="DetectionCacheDbContext"/> that
+/// blocks context creation until one-time database initialization (create-or-recover) has completed.
+/// </summary>
+internal sealed class GatedDetectionCacheDbContextFactory : IDbContextFactory<DetectionCacheDbContext>
+{
+    private readonly DatabaseInitializer _initializer;
+    private readonly DbContextOptions<DetectionCacheDbContext> _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GatedDetectionCacheDbContextFactory"/> class.
+    /// </summary>
+    /// <param name="initializer">Database initializer providing the init gate.</param>
+    /// <param name="options">Context options.</param>
+    public GatedDetectionCacheDbContextFactory(DatabaseInitializer initializer, DbContextOptions<DetectionCacheDbContext> options)
+    {
+        _initializer = initializer;
+        _options = options;
+    }
+
+    /// <inheritdoc/>
+    public DetectionCacheDbContext CreateDbContext()
+    {
+        _initializer.EnsureInitialized();
+        return new DetectionCacheDbContext(_options);
+    }
+
+    /// <inheritdoc/>
+    public async Task<DetectionCacheDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+    {
+        await _initializer.EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return new DetectionCacheDbContext(_options);
+    }
+}

--- a/IntroSkipper/Db/GatedDetectionCacheDbContextFactory.cs
+++ b/IntroSkipper/Db/GatedDetectionCacheDbContextFactory.cs
@@ -28,14 +28,14 @@ internal sealed class GatedDetectionCacheDbContextFactory : IDbContextFactory<De
     /// <inheritdoc/>
     public DetectionCacheDbContext CreateDbContext()
     {
-        _initializer.EnsureInitialized();
+        _initializer.EnsureCacheDatabaseInitialized();
         return new DetectionCacheDbContext(_options);
     }
 
     /// <inheritdoc/>
     public async Task<DetectionCacheDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
     {
-        await _initializer.EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await _initializer.EnsureCacheDatabaseInitializedAsync(cancellationToken).ConfigureAwait(false);
         return new DetectionCacheDbContext(_options);
     }
 }

--- a/IntroSkipper/Db/GatedIntroSkipperDbContextFactory.cs
+++ b/IntroSkipper/Db/GatedIntroSkipperDbContextFactory.cs
@@ -30,14 +30,14 @@ internal sealed class GatedIntroSkipperDbContextFactory : IDbContextFactory<Intr
     /// <inheritdoc/>
     public IntroSkipperDbContext CreateDbContext()
     {
-        _initializer.EnsureInitialized();
+        _initializer.EnsureSegmentDatabaseInitialized();
         return new IntroSkipperDbContext(_options);
     }
 
     /// <inheritdoc/>
     public async Task<IntroSkipperDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
     {
-        await _initializer.EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        await _initializer.EnsureSegmentDatabaseInitializedAsync(cancellationToken).ConfigureAwait(false);
         return new IntroSkipperDbContext(_options);
     }
 }

--- a/IntroSkipper/Db/GatedIntroSkipperDbContextFactory.cs
+++ b/IntroSkipper/Db/GatedIntroSkipperDbContextFactory.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// <see cref="IDbContextFactory{TContext}"/> for <see cref="IntroSkipperDbContext"/> that
+/// blocks context creation until one-time database initialization (legacy repair plus
+/// migrations) has completed. Because every runtime consumer obtains contexts through this
+/// factory, no query can run against an unmigrated database.
+/// </summary>
+internal sealed class GatedIntroSkipperDbContextFactory : IDbContextFactory<IntroSkipperDbContext>
+{
+    private readonly DatabaseInitializer _initializer;
+    private readonly DbContextOptions<IntroSkipperDbContext> _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GatedIntroSkipperDbContextFactory"/> class.
+    /// </summary>
+    /// <param name="initializer">Database initializer providing the init gate.</param>
+    /// <param name="options">Context options.</param>
+    public GatedIntroSkipperDbContextFactory(DatabaseInitializer initializer, DbContextOptions<IntroSkipperDbContext> options)
+    {
+        _initializer = initializer;
+        _options = options;
+    }
+
+    /// <inheritdoc/>
+    public IntroSkipperDbContext CreateDbContext()
+    {
+        _initializer.EnsureInitialized();
+        return new IntroSkipperDbContext(_options);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IntroSkipperDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+    {
+        await _initializer.EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return new IntroSkipperDbContext(_options);
+    }
+}

--- a/IntroSkipper/Db/IntroSkipperDatabase.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.cs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using MediaBrowser.Common.Configuration;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Central definition of the plugin's database file locations and SQLite options.
+/// Shared by the DI registrations in <c>PluginServiceRegistrator</c>, the
+/// <see cref="DatabaseInitializer"/>, and <c>Plugin</c> so every component agrees
+/// on paths and connection configuration.
+/// </summary>
+public static class IntroSkipperDatabase
+{
+    private const string PluginDirectoryName = "introskipper";
+    private const string SegmentDatabaseFileName = "introskipper.db";
+    private const string CacheDatabaseFileName = "introskipper-cache.db";
+
+    private static readonly SqlitePragmaInterceptor _pragmaInterceptor = new();
+
+    /// <summary>
+    /// Gets the plugin data directory (containing both database files).
+    /// </summary>
+    /// <param name="applicationPaths">Jellyfin application paths.</param>
+    /// <returns>The plugin data directory.</returns>
+    public static string GetPluginDirectory(IApplicationPaths applicationPaths)
+    {
+        ArgumentNullException.ThrowIfNull(applicationPaths);
+        return Path.Join(applicationPaths.DataPath, PluginDirectoryName);
+    }
+
+    /// <summary>
+    /// Gets the path of the segment/season-state database (<c>introskipper.db</c>).
+    /// </summary>
+    /// <param name="applicationPaths">Jellyfin application paths.</param>
+    /// <returns>The segment database path.</returns>
+    public static string GetSegmentDatabasePath(IApplicationPaths applicationPaths)
+        => Path.Join(GetPluginDirectory(applicationPaths), SegmentDatabaseFileName);
+
+    /// <summary>
+    /// Gets the path of the detection cache database (<c>introskipper-cache.db</c>).
+    /// </summary>
+    /// <param name="applicationPaths">Jellyfin application paths.</param>
+    /// <returns>The cache database path.</returns>
+    public static string GetCacheDatabasePath(IApplicationPaths applicationPaths)
+        => Path.Join(GetPluginDirectory(applicationPaths), CacheDatabaseFileName);
+
+    /// <summary>
+    /// Applies the plugin's standard SQLite configuration (connection string and
+    /// PRAGMA interceptor) to a context options builder. This is the single source
+    /// of truth for runtime connection configuration; the string-path context
+    /// constructors apply the equivalent configuration in <c>OnConfiguring</c>.
+    /// </summary>
+    /// <param name="optionsBuilder">The options builder to configure.</param>
+    /// <param name="dbPath">Path of the SQLite database file.</param>
+    internal static void ConfigureSqlite(DbContextOptionsBuilder optionsBuilder, string dbPath)
+    {
+        optionsBuilder
+            .UseSqlite($"Data Source={dbPath}")
+            .AddInterceptors(_pragmaInterceptor);
+    }
+
+    /// <summary>
+    /// Extracts the database file path from configured context options, or
+    /// <see langword="null"/> when no file-backed data source is configured.
+    /// </summary>
+    /// <param name="options">Configured context options.</param>
+    /// <returns>The database file path, or <see langword="null"/>.</returns>
+    internal static string? GetDatabasePath(DbContextOptions options)
+    {
+        var extension = options.Extensions
+            .OfType<Microsoft.EntityFrameworkCore.Infrastructure.RelationalOptionsExtension>()
+            .FirstOrDefault();
+        var connectionString = extension?.ConnectionString;
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return null;
+        }
+
+        var builder = new SqliteConnectionStringBuilder(connectionString);
+        return builder.DataSource is not (null or "" or ":memory:") ? builder.DataSource : null;
+    }
+}

--- a/IntroSkipper/Db/SeasonStateOperations.cs
+++ b/IntroSkipper/Db/SeasonStateOperations.cs
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Shared operations on <see cref="IntroSkipperDbContext.DbSeasonState"/>, exposed as
+/// extension methods on the context. See <see cref="SegmentOperations"/> for the
+/// conventions governing this operations layer.
+/// </summary>
+public static class SeasonStateOperations
+{
+    /// <summary>
+    /// Sets the analyzer actions for a season.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="analyzerActions">Analyzer actions keyed by analysis mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task SetAnalyzerActionAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(analyzerActions);
+
+        var existingEntries = await db.DbSeasonState
+            .Where(s => s.SeasonId == seasonId)
+            .ToDictionaryAsync(s => s.Type, cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var (mode, action) in analyzerActions)
+        {
+            if (existingEntries.TryGetValue(mode, out var existing))
+            {
+                db.Entry(existing).Property(s => s.Action).CurrentValue = action;
+            }
+            else
+            {
+                db.DbSeasonState.Add(new DbSeasonState(seasonId, mode, action));
+            }
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Records the analyzed episode IDs for a season and mode.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="episodeIds">Analyzed episode IDs.</param>
+    /// <param name="configHash">Analysis configuration hash.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task SetEpisodeIdsAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        AnalysisMode mode,
+        IEnumerable<Guid> episodeIds,
+        string configHash = "",
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        var seasonState = await db.DbSeasonState
+            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (seasonState is null)
+        {
+            seasonState = new DbSeasonState(seasonId, mode, AnalyzerAction.Default, episodeIds, configHash);
+            db.DbSeasonState.Add(seasonState);
+        }
+        else
+        {
+            db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
+            db.Entry(seasonState).Property(s => s.ConfigHash).CurrentValue = configHash;
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Removes a single episode ID from the season's analyzed-state list for the given mode.
+    /// The read and write share the caller's context to keep the window for concurrent
+    /// overwrites as small as possible, and the write is skipped entirely when the ID is not
+    /// present in the stored list.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="episodeId">Episode ID to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task RemoveEpisodeIdAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        AnalysisMode mode,
+        Guid episodeId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        var seasonState = await db.DbSeasonState
+            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (seasonState is null)
+        {
+            return;
+        }
+
+        var currentIds = seasonState.EpisodeIds.ToList();
+        if (!currentIds.Remove(episodeId))
+        {
+            return; // Episode was not in the list — no write needed.
+        }
+
+        db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = currentIds;
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the analyzed episode IDs for all modes in a season.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Episode IDs keyed by analysis mode.</returns>
+    public static async Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        return await db.DbSeasonState.Where(s => s.SeasonId == seasonId)
+            .ToDictionaryAsync(s => s.Type, s => s.EpisodeIds, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the settled-season reanalysis state for all modes in a season.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Settled reanalysis state keyed by analysis mode.</returns>
+    public static async Task<IReadOnlyDictionary<AnalysisMode, (AnalyzerAction Action, IReadOnlySet<Guid> SettledReanalysisEpisodeIds)>> GetSettleReanalysisStatesAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        var states = await db.DbSeasonState
+            .AsNoTracking()
+            .Where(s => s.SeasonId == seasonId)
+            .Select(s => new
+            {
+                s.Type,
+                s.Action,
+                s.SettledReanalysisEpisodeIds
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return states.ToDictionary(
+            s => s.Type,
+            s => (s.Action, (IReadOnlySet<Guid>)s.SettledReanalysisEpisodeIds.ToHashSet()));
+    }
+
+    /// <summary>
+    /// Records that season analysis modes have been re-analyzed for the given episode set so the
+    /// exact completed set is not repeated on subsequent scans or after a plugin restart. Call only
+    /// after the reset has committed.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="modes">Analysis modes that were re-analyzed.</param>
+    /// <param name="episodeIds">Episode IDs that were re-analyzed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task RecordSettleReanalysisAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        IReadOnlyCollection<AnalysisMode> modes,
+        IReadOnlyCollection<Guid> episodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(modes);
+        ArgumentNullException.ThrowIfNull(episodeIds);
+
+        if (modes.Count == 0)
+        {
+            return;
+        }
+
+        var settledEpisodeIds = DbSeasonState.SerializeEpisodeIds(episodeIds);
+
+        foreach (var mode in modes)
+        {
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "DbSeasonState" ("SeasonId", "Type", "Action", "EpisodeIds", "ConfigHash", "SettledReanalysisEpisodeIds")
+                VALUES ({seasonId}, {(int)mode}, {(int)AnalyzerAction.Default}, {"[]"}, {string.Empty}, {settledEpisodeIds})
+                ON CONFLICT("SeasonId", "Type") DO UPDATE SET
+                    "SettledReanalysisEpisodeIds" = excluded."SettledReanalysisEpisodeIds"
+                """,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Clears stored automatic analysis state for a season so it is re-analyzed from scratch on the
+    /// current pass. Automatic segments for the supplied modes are deleted and the season's analyzed
+    /// episode lists are cleared; user-provided segments and the fingerprint cache are preserved.
+    /// The deletes and the episode-list clear run in a single transaction so a cancelled reset cannot
+    /// leave segments deleted while their episodes are still recorded as analyzed.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID whose analyzed-state lists should be cleared.</param>
+    /// <param name="episodeIds">Episode IDs whose automatic segments should be removed.</param>
+    /// <param name="modes">Analysis modes to reset.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task ResetSeasonForReanalysisAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        IEnumerable<Guid> episodeIds,
+        IReadOnlyCollection<AnalysisMode> modes,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(episodeIds);
+        ArgumentNullException.ThrowIfNull(modes);
+
+        var ids = episodeIds.Distinct().ToArray();
+        var modeArray = modes.ToArray();
+        if (ids.Length == 0 || modeArray.Length == 0)
+        {
+            return;
+        }
+
+        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            foreach (var batch in ids.Chunk(SegmentOperations.SqliteParameterBatchSize))
+            {
+                await db.DbSegment
+                    .Where(s => batch.Contains(s.ItemId) && modeArray.Contains(s.Type) && !s.IsUserProvided)
+                    .ExecuteDeleteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            // Clear the analyzed-episode lists so VerifyQueueAsync treats every episode as NotAnalyzed.
+            // Committing this together with the deletes guarantees the episodes are re-analyzed (either
+            // on this pass or a later one) instead of being stranded as NoSegments.
+            var seasonStates = await db.DbSeasonState
+                .Where(s => s.SeasonId == seasonId && modeArray.Contains(s.Type))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var state in seasonStates)
+            {
+                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
+            }
+
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await transaction.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Loads a combined snapshot of season state and segments for a season in a bounded number
+    /// of round-trips. Segment loads are batched to stay below the SQLite parameter limit.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="episodeIds">Episode IDs in the season.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The season queue snapshot.</returns>
+    internal static async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        IReadOnlyCollection<Guid> episodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(episodeIds);
+
+        var episodeIdArray = (Guid[])[.. episodeIds.Distinct()];
+
+        var seasonStates = await db.DbSeasonState
+            .AsNoTracking()
+            .Where(s => s.SeasonId == seasonId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var segments = new List<DbSegment>();
+        foreach (var batch in episodeIdArray.Chunk(SegmentOperations.SqliteParameterBatchSize))
+        {
+            segments.AddRange(await db.DbSegment
+                .AsNoTracking()
+                .Where(s => batch.Contains(s.ItemId))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false));
+        }
+
+        return new SeasonQueueSnapshot(
+            seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
+            seasonStates.ToDictionary(s => s.Type, s => s.ConfigHash),
+            seasonStates.ToDictionary(s => s.Type, s => s.Action),
+            segments
+                .GroupBy(s => s.ItemId)
+                .ToDictionary(
+                    group => group.Key,
+                    group => SegmentOperations.ToTimestampDictionary([.. group])),
+            segments
+                .Where(s => s.IsUserProvided)
+                .GroupBy(s => s.Type)
+                .ToDictionary(
+                    group => group.Key,
+                    group => (IReadOnlySet<Guid>)group.Select(s => s.ItemId).ToHashSet()));
+    }
+
+    /// <summary>
+    /// Returns the analyzer actions for all modes in a season, filling in defaults for missing modes.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Analyzer actions keyed by analysis mode.</returns>
+    public static async Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        var states = await db.DbSeasonState
+            .Where(s => s.SeasonId == seasonId)
+            .ToDictionaryAsync(s => s.Type, s => s.Action, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Fill in defaults for any missing modes
+        var result = new Dictionary<AnalysisMode, AnalyzerAction>();
+        foreach (var mode in Enum.GetValues<AnalysisMode>())
+        {
+            result[mode] = states.TryGetValue(mode, out var action) ? action : AnalyzerAction.Default;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns the analyzer action for a season and mode, or the default action when unset.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The analyzer action.</returns>
+    public static async Task<AnalyzerAction> GetAnalyzerActionAsync(
+        this IntroSkipperDbContext db,
+        Guid seasonId,
+        AnalysisMode mode,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        var state = await db.DbSeasonState
+            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
+        return state?.Action ?? AnalyzerAction.Default;
+    }
+
+    /// <summary>
+    /// Deletes season state for seasons that are no longer present in the library.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="validSeasonIds">Season IDs that still exist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task CleanSeasonStateAsync(
+        this IntroSkipperDbContext db,
+        IEnumerable<Guid> validSeasonIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(validSeasonIds);
+
+        await db.DbSeasonState
+            .Where(s => !validSeasonIds.Contains(s.SeasonId))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/IntroSkipper/Db/SeasonStateOperations.cs
+++ b/IntroSkipper/Db/SeasonStateOperations.cs
@@ -254,13 +254,12 @@ public static class SeasonStateOperations
         var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            foreach (var batch in ids.Chunk(SegmentOperations.SqliteParameterBatchSize))
-            {
-                await db.DbSegment
-                    .Where(s => batch.Contains(s.ItemId) && modeArray.Contains(s.Type) && !s.IsUserProvided)
-                    .ExecuteDeleteAsync(cancellationToken)
-                    .ConfigureAwait(false);
-            }
+            // Single set-based delete; the ID collection travels as one JSON parameter
+            // (EF.Parameter → json_each on SQLite), immune to the host-parameter limit.
+            await db.DbSegment
+                .Where(s => EF.Parameter(ids).Contains(s.ItemId) && modeArray.Contains(s.Type) && !s.IsUserProvided)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             // Clear the analyzed-episode lists so VerifyQueueAsync treats every episode as NotAnalyzed.
             // Committing this together with the deletes guarantees the episodes are re-analyzed (either
@@ -285,8 +284,9 @@ public static class SeasonStateOperations
     }
 
     /// <summary>
-    /// Loads a combined snapshot of season state and segments for a season in a bounded number
-    /// of round-trips. Segment loads are batched to stay below the SQLite parameter limit.
+    /// Loads a combined snapshot of season state and segments for a season in two round-trips.
+    /// The episode ID collection travels as a single JSON parameter (<see cref="EF.Parameter{T}(T)"/>
+    /// → <c>json_each</c> on SQLite), so it is not subject to the SQLite host-parameter limit.
     /// </summary>
     /// <param name="db">Database context.</param>
     /// <param name="seasonId">Season ID.</param>
@@ -310,15 +310,11 @@ public static class SeasonStateOperations
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var segments = new List<DbSegment>();
-        foreach (var batch in episodeIdArray.Chunk(SegmentOperations.SqliteParameterBatchSize))
-        {
-            segments.AddRange(await db.DbSegment
-                .AsNoTracking()
-                .Where(s => batch.Contains(s.ItemId))
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false));
-        }
+        var segments = await db.DbSegment
+            .AsNoTracking()
+            .Where(s => EF.Parameter(episodeIdArray).Contains(s.ItemId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         return new SeasonQueueSnapshot(
             seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
@@ -390,6 +386,8 @@ public static class SeasonStateOperations
 
     /// <summary>
     /// Deletes season state for seasons that are no longer present in the library.
+    /// The ID collection travels as a single JSON parameter (<see cref="EF.Parameter{T}(T)"/>
+    /// → <c>json_each</c> on SQLite), so it is not subject to the SQLite host-parameter limit.
     /// </summary>
     /// <param name="db">Database context.</param>
     /// <param name="validSeasonIds">Season IDs that still exist.</param>
@@ -403,8 +401,10 @@ public static class SeasonStateOperations
         ArgumentNullException.ThrowIfNull(db);
         ArgumentNullException.ThrowIfNull(validSeasonIds);
 
+        var seasonIds = validSeasonIds.Distinct().ToArray();
+
         await db.DbSeasonState
-            .Where(s => !validSeasonIds.Contains(s.SeasonId))
+            .Where(s => !EF.Parameter(seasonIds).Contains(s.SeasonId))
             .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);
     }

--- a/IntroSkipper/Db/SegmentOperations.cs
+++ b/IntroSkipper/Db/SegmentOperations.cs
@@ -21,15 +21,6 @@ namespace IntroSkipper.Db;
 /// </summary>
 public static partial class SegmentOperations
 {
-    /// <summary>
-    /// Maximum number of SQL parameters used per batch when translating ID collections.
-    /// EF Core 10 translates parameterized collections to one scalar parameter per element
-    /// (padded), and SQLite rejects statements above SQLITE_MAX_VARIABLE_NUMBER (32766 for
-    /// SQLite ≥ 3.32). 500 keeps individual statements small and plans cacheable while
-    /// staying far below the hard limit.
-    /// </summary>
-    internal const int SqliteParameterBatchSize = 500;
-
     private const double SegmentComparisonEpsilon = 0.001;
 
     private static readonly Func<IntroSkipperDbContext, Guid, IAsyncEnumerable<DbSegment>> _segmentsForItemQuery =
@@ -246,7 +237,9 @@ public static partial class SegmentOperations
 
     /// <summary>
     /// Deletes segments belonging to items that are no longer in any enabled library.
-    /// Deletes are batched to stay below the SQLite parameter limit.
+    /// The ID collection is passed as a single JSON parameter (<see cref="EF.Parameter{T}(T)"/>
+    /// → <c>json_each</c> on SQLite), so it is not subject to the SQLite host-parameter limit
+    /// regardless of collection size.
     /// </summary>
     /// <param name="db">Database context.</param>
     /// <param name="enabledEpisodeIds">Episode IDs that remain enabled.</param>
@@ -260,32 +253,19 @@ public static partial class SegmentOperations
         ArgumentNullException.ThrowIfNull(db);
         ArgumentNullException.ThrowIfNull(enabledEpisodeIds);
 
-        var enabledIds = enabledEpisodeIds.ToHashSet();
+        var enabledIds = enabledEpisodeIds.Distinct().ToArray();
 
-        var segmentEpisodeIds = await db.DbSegment
-            .AsNoTracking()
-            .Select(s => s.ItemId)
-            .Distinct()
-            .ToListAsync(cancellationToken)
+        await db.DbSegment
+            .Where(s => !EF.Parameter(enabledIds).Contains(s.ItemId))
+            .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);
-
-        var staleEpisodeIds = segmentEpisodeIds
-            .Where(id => !enabledIds.Contains(id))
-            .ToArray();
-
-        foreach (var staleEpisodeIdBatch in staleEpisodeIds.Chunk(SqliteParameterBatchSize))
-        {
-            await db.DbSegment
-                .Where(s => staleEpisodeIdBatch.Contains(s.ItemId))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
     }
 
     /// <summary>
     /// Removes stale automatic segments for the supplied items and mode.
     /// User-provided segments are intentionally preserved.
-    /// Deletes are batched to stay below the SQLite parameter limit.
+    /// The ID collection is passed as a single JSON parameter (<see cref="EF.Parameter{T}(T)"/>
+    /// → <c>json_each</c> on SQLite), so it is not subject to the SQLite host-parameter limit.
     /// </summary>
     /// <param name="db">Database context.</param>
     /// <param name="itemIds">Item IDs to inspect.</param>
@@ -309,16 +289,13 @@ public static partial class SegmentOperations
             return;
         }
 
-        foreach (var batch in ids.Chunk(SqliteParameterBatchSize))
-        {
-            await db.DbSegment
-                .Where(s => batch.Contains(s.ItemId)
-                    && s.Type == mode
-                    && !s.IsUserProvided
-                    && s.ConfigHash != configHash)
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await db.DbSegment
+            .Where(s => EF.Parameter(ids).Contains(s.ItemId)
+                && s.Type == mode
+                && !s.IsUserProvided
+                && s.ConfigHash != configHash)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/IntroSkipper/Db/SegmentOperations.cs
+++ b/IntroSkipper/Db/SegmentOperations.cs
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Shared operations on <see cref="IntroSkipperDbContext.DbSegment"/>, exposed as extension
+/// methods on the context so multi-step logic and domain invariants have exactly one home
+/// while callers keep full control over context lifetime and transactions.
+///
+/// <para><b>Invariant home:</b> <see cref="UpdateTimestampAsync"/> is the ONLY code path that
+/// may insert or replace <see cref="DbSegment"/> rows. It enforces two domain rules:
+/// (1) analysis results never overwrite user-provided segments, and
+/// (2) auto-detected credits are rejected when they overlap the stored introduction.
+/// New call sites must not use <c>DbSegment.Add</c>/<c>AddRange</c> directly — reads and
+/// deletes may be written inline, writes may not.</para>
+/// </summary>
+public static partial class SegmentOperations
+{
+    /// <summary>
+    /// Maximum number of SQL parameters used per batch when translating ID collections.
+    /// EF Core 10 translates parameterized collections to one scalar parameter per element
+    /// (padded), and SQLite rejects statements above SQLITE_MAX_VARIABLE_NUMBER (32766 for
+    /// SQLite ≥ 3.32). 500 keeps individual statements small and plans cacheable while
+    /// staying far below the hard limit.
+    /// </summary>
+    internal const int SqliteParameterBatchSize = 500;
+
+    private const double SegmentComparisonEpsilon = 0.001;
+
+    private static readonly Func<IntroSkipperDbContext, Guid, IAsyncEnumerable<DbSegment>> _segmentsForItemQuery =
+        EF.CompileAsyncQuery((IntroSkipperDbContext db, Guid itemId) =>
+            db.DbSegment.AsNoTracking().Where(s => s.ItemId == itemId));
+
+    /// <summary>
+    /// Inserts or replaces the stored segment for an item and analysis mode, enforcing the
+    /// domain invariants described on <see cref="SegmentOperations"/>.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="segment">Segment to store.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="isUserProvided">Whether the segment was provided by a user.</param>
+    /// <param name="configHash">Analysis configuration hash.</param>
+    /// <param name="logger">Optional logger for invariant diagnostics.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task UpdateTimestampAsync(
+        this IntroSkipperDbContext db,
+        Segment segment,
+        AnalysisMode mode,
+        bool isUserProvided = false,
+        string configHash = "",
+        ILogger? logger = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(segment);
+
+        try
+        {
+            var dbSegment = new DbSegment(segment, mode, isUserProvided, configHash);
+
+            if (mode == AnalysisMode.Commercial)
+            {
+                var exists = await db.DbSegment
+                    .AnyAsync(
+                        s => s.ItemId == segment.EpisodeId
+                             && s.Type == mode
+                             && Math.Abs(s.Start - dbSegment.Start) <= SegmentComparisonEpsilon
+                             && Math.Abs(s.End - dbSegment.End) <= SegmentComparisonEpsilon,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (!exists)
+                {
+                    db.DbSegment.Add(dbSegment);
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var existingSegments = await db.DbSegment
+                        .Where(s => s.ItemId == segment.EpisodeId && s.Type == mode)
+                        .ToListAsync(cancellationToken)
+                        .ConfigureAwait(false);
+
+                    // Do not overwrite a user-provided segment with an analysis result.
+                    if (!isUserProvided && existingSegments.Any(s => s.IsUserProvided))
+                    {
+                        return;
+                    }
+
+                    // Guard: prevent auto-detected credits from overlapping with the introduction.
+                    if (mode == AnalysisMode.Credits && !isUserProvided)
+                    {
+                        var intro = await db.DbSegment
+                            .AsNoTracking()
+                            .Where(s => s.ItemId == segment.EpisodeId && s.Type == AnalysisMode.Introduction)
+                            .FirstOrDefaultAsync(cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (intro is not null && segment.Start < intro.End && intro.Start < segment.End)
+                        {
+                            if (logger is not null)
+                            {
+                                LogCreditsOverlapWithIntro(logger, segment.EpisodeId);
+                            }
+
+                            return;
+                        }
+                    }
+
+                    if (existingSegments.Count > 0)
+                    {
+                        db.DbSegment.RemoveRange(existingSegments);
+                    }
+
+                    db.DbSegment.Add(dbSegment);
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    await transaction.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            if (logger is not null)
+            {
+                LogFailedToUpdateTimestamp(logger, ex, segment.EpisodeId);
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Returns all stored segments for an item.
+    /// Hot path: runs for every playback via <c>SegmentProvider</c>, so the query is compiled.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>All stored segments for the item.</returns>
+    public static async Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(
+        this IntroSkipperDbContext db,
+        Guid itemId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        var segments = new List<DbSegment>();
+        await foreach (var segment in _segmentsForItemQuery(db, itemId).WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            segments.Add(segment);
+        }
+
+        return segments;
+    }
+
+    /// <summary>
+    /// Returns the earliest stored segment per analysis mode for an item.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Timestamps keyed by analysis mode.</returns>
+    public static async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(
+        this IntroSkipperDbContext db,
+        Guid itemId,
+        CancellationToken cancellationToken = default)
+    {
+        var segments = await db.GetSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
+        return ToTimestampDictionary(segments);
+    }
+
+    /// <summary>
+    /// Deletes all segments stored for an item.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task DeleteItemSegmentsAsync(
+        this IntroSkipperDbContext db,
+        Guid itemId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        await db.DbSegment
+            .Where(s => s.ItemId == itemId)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes a stored segment for the specified item and analysis mode, optionally matching
+    /// exact start/end times (required to disambiguate commercial segments).
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="segment">Optional segment details used to remove a specific entry.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task DeleteTimestampAsync(
+        this IntroSkipperDbContext db,
+        Guid itemId,
+        AnalysisMode mode,
+        Segment? segment = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+
+        if (segment is null && mode == AnalysisMode.Commercial)
+        {
+            return;
+        }
+
+        var query = db.DbSegment.Where(s => s.ItemId == itemId && s.Type == mode);
+
+        if (segment is not null)
+        {
+            query = query.Where(s =>
+                Math.Abs(s.Start - segment.Start) <= SegmentComparisonEpsilon
+                && Math.Abs(s.End - segment.End) <= SegmentComparisonEpsilon);
+        }
+
+        var entries = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
+        if (entries.Count > 0)
+        {
+            db.DbSegment.RemoveRange(entries);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Deletes segments belonging to items that are no longer in any enabled library.
+    /// Deletes are batched to stay below the SQLite parameter limit.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="enabledEpisodeIds">Episode IDs that remain enabled.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task CleanTimestampsAsync(
+        this IntroSkipperDbContext db,
+        IEnumerable<Guid> enabledEpisodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(enabledEpisodeIds);
+
+        var enabledIds = enabledEpisodeIds.ToHashSet();
+
+        var segmentEpisodeIds = await db.DbSegment
+            .AsNoTracking()
+            .Select(s => s.ItemId)
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var staleEpisodeIds = segmentEpisodeIds
+            .Where(id => !enabledIds.Contains(id))
+            .ToArray();
+
+        foreach (var staleEpisodeIdBatch in staleEpisodeIds.Chunk(SqliteParameterBatchSize))
+        {
+            await db.DbSegment
+                .Where(s => staleEpisodeIdBatch.Contains(s.ItemId))
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Removes stale automatic segments for the supplied items and mode.
+    /// User-provided segments are intentionally preserved.
+    /// Deletes are batched to stay below the SQLite parameter limit.
+    /// </summary>
+    /// <param name="db">Database context.</param>
+    /// <param name="itemIds">Item IDs to inspect.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="configHash">Current configuration hash.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    public static async Task CleanStaleAutomaticSegmentsAsync(
+        this IntroSkipperDbContext db,
+        IEnumerable<Guid> itemIds,
+        AnalysisMode mode,
+        string configHash,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(itemIds);
+
+        var ids = itemIds.Distinct().ToArray();
+        if (ids.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var batch in ids.Chunk(SqliteParameterBatchSize))
+        {
+            await db.DbSegment
+                .Where(s => batch.Contains(s.ItemId)
+                    && s.Type == mode
+                    && !s.IsUserProvided
+                    && s.ConfigHash != configHash)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Groups segments by analysis mode, keeping the earliest segment per mode.
+    /// </summary>
+    /// <param name="segments">Segments to group.</param>
+    /// <returns>Timestamps keyed by analysis mode.</returns>
+    internal static IReadOnlyDictionary<AnalysisMode, Segment> ToTimestampDictionary(IReadOnlyList<DbSegment> segments)
+        => segments
+            .GroupBy(segment => segment.Type)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(segment => segment.Start).First().ToSegment());
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping credits for episode {EpisodeId}: detected segment overlaps with introduction")]
+    private static partial void LogCreditsOverlapWithIntro(ILogger logger, Guid episodeId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update timestamp for episode {EpisodeId}")]
+    private static partial void LogFailedToUpdateTimestamp(ILogger logger, Exception ex, Guid episodeId);
+}

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -19,9 +19,13 @@ namespace IntroSkipper.FFmpeg;
 /// Initializes a new instance of the <see cref="DetectionCacheService"/> class.
 /// </remarks>
 /// <param name="logger">The logger instance.</param>
-public sealed partial class DetectionCacheService(ILogger<DetectionCacheService> logger) : IDetectionCacheService
+/// <param name="dbContextFactory">Factory for the detection cache database context.</param>
+public sealed partial class DetectionCacheService(
+    ILogger<DetectionCacheService> logger,
+    IDbContextFactory<DetectionCacheDbContext> dbContextFactory) : IDetectionCacheService
 {
     private readonly ILogger<DetectionCacheService> _logger = logger;
+    private readonly IDbContextFactory<DetectionCacheDbContext> _dbContextFactory = dbContextFactory;
 
     /// <inheritdoc/>
     public bool IsEnabled => Plugin.Instance?.Configuration.CacheFingerprints ?? false;
@@ -38,7 +42,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
         try
         {
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = _dbContextFactory.CreateDbContext();
 
             // NOTE: Start/End are compared with == which is safe only because the exact same
             // double values that were written are used for lookup (no intermediate arithmetic).
@@ -89,7 +93,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
         try
         {
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = _dbContextFactory.CreateDbContext();
 
             UpsertEntry(db, itemId, mode, type, start, end, data, configHash);
             db.SaveChanges();
@@ -115,7 +119,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         try
         {
             // Delete from the SQLite cache database.
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = _dbContextFactory.CreateDbContext();
             db.DetectionCache.Where(e => e.ItemId == itemId).ExecuteDelete();
         }
         catch (Exception ex) when (ex is DbUpdateException or DbException)
@@ -134,7 +138,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         try
         {
             // Delete from the SQLite cache database.
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = _dbContextFactory.CreateDbContext();
             db.DetectionCache.Where(e => e.Mode == mode).ExecuteDelete();
         }
         catch (Exception ex) when (ex is DbUpdateException or DbException)
@@ -159,7 +163,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
         try
         {
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = _dbContextFactory.CreateDbContext();
             var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), CacheEntryType.Chromaprint, mode);
             if (db.DetectionCache.Any(e =>
                 e.ItemId == episode.EpisodeId &&

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -226,49 +226,49 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         string configHash = "",
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.UpdateTimestampAsync(segment, mode, isUserProvided, configHash, _logger, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await db.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await db.GetSegmentsAsync(id, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task DeleteItemSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.DeleteItemSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.CleanTimestampsAsync(episodeIds, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.SetAnalyzerActionAsync(id, analyzerActions, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.SetEpisodeIdsAsync(id, mode, episodeIds, configHash, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.RemoveEpisodeIdAsync(seasonId, mode, episodeId, cancellationToken).ConfigureAwait(false);
     }
 
@@ -278,13 +278,13 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         string configHash,
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.CleanStaleAutomaticSegmentsAsync(itemIds, mode, configHash, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await db.GetEpisodeIdsAsync(id, cancellationToken).ConfigureAwait(false);
     }
 
@@ -292,7 +292,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         Guid seasonId,
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await db.GetSettleReanalysisStatesAsync(seasonId, cancellationToken).ConfigureAwait(false);
     }
 
@@ -316,7 +316,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         IReadOnlyCollection<Guid> episodeIds,
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.RecordSettleReanalysisAsync(seasonId, modes, episodeIds, cancellationToken).ConfigureAwait(false);
     }
 
@@ -326,31 +326,31 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         IReadOnlyCollection<AnalysisMode> modes,
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.ResetSeasonForReanalysisAsync(seasonId, episodeIds, modes, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await db.GetSeasonQueueSnapshotAsync(seasonId, episodeIds, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await db.GetAllAnalyzerActionsAsync(seasonId, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<AnalyzerAction> GetAnalyzerActionAsync(Guid id, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         return await db.GetAnalyzerActionAsync(id, mode, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task CleanSeasonStateAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.CleanSeasonStateAsync(ids, cancellationToken).ConfigureAwait(false);
     }
 
@@ -373,8 +373,16 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         Segment? segment = null,
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
+        using var db = await CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await db.DeleteTimestampAsync(itemId, mode, segment, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IntroSkipperDbContext> CreateDbContextAsync(CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance._dbContextFactory is { } factory
+            ? await factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false)
+            : new IntroSkipperDbContext(Instance.DbPath);
     }
 
     private void MigrateLegacyExcludeSeries()

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -22,7 +22,6 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -31,14 +30,20 @@ namespace IntroSkipper;
 /// <summary>
 /// Intro skipper plugin. Uses audio analysis to find common sequences of audio shared between episodes.
 /// </summary>
+/// <remarks>
+/// Database access lives in <see cref="IntroSkipper.Db"/> (context extension methods plus
+/// <see cref="DatabaseInitializer"/>). The DB members that remain on this class are thin
+/// delegations kept only for call sites that are not yet constructor-injected; new code should
+/// inject <see cref="IDbContextFactory{TContext}"/> directly.
+/// </remarks>
 public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
-    private const double SegmentComparisonEpsilon = 0.001;
-    private const int SqliteParameterBatchSize = 500;
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
     private readonly IPluginManager _pluginManager;
     private readonly ILogger<Plugin> _logger;
+    private readonly IDbContextFactory<IntroSkipperDbContext>? _dbContextFactory;
+    private readonly IDbContextFactory<DetectionCacheDbContext>? _cacheDbContextFactory;
     private readonly string _dbPath;
     private readonly string _cacheDbPath;
 
@@ -52,6 +57,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="chapterRepository">Chapter repository.</param>
     /// <param name="pluginManager">Plugin manager.</param>
     /// <param name="logger">Logger.</param>
+    /// <param name="dbContextFactory">Factory for the segment database context.</param>
+    /// <param name="cacheDbContextFactory">Factory for the detection cache database context.</param>
     public Plugin(
         IApplicationPaths applicationPaths,
         IXmlSerializer xmlSerializer,
@@ -59,7 +66,9 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         ILibraryManager libraryManager,
         IChapterManager chapterRepository,
         IPluginManager pluginManager,
-        ILogger<Plugin> logger)
+        ILogger<Plugin> logger,
+        IDbContextFactory<IntroSkipperDbContext> dbContextFactory,
+        IDbContextFactory<DetectionCacheDbContext> cacheDbContextFactory)
         : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
@@ -68,49 +77,28 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         _chapterRepository = chapterRepository;
         _pluginManager = pluginManager;
         _logger = logger;
+        _dbContextFactory = dbContextFactory;
+        _cacheDbContextFactory = cacheDbContextFactory;
 
         FFmpegPath = serverConfiguration.GetEncodingOptions().EncoderAppPathDisplay;
 
         ArgumentNullException.ThrowIfNull(applicationPaths);
 
-        var pluginDirName = "introskipper";
         var pluginCachePath = "chromaprints";
 
-        var introsDirectory = Path.Join(applicationPaths.DataPath, pluginDirName);
+        var introsDirectory = IntroSkipperDatabase.GetPluginDirectory(applicationPaths);
         FingerprintCachePath = Path.Join(introsDirectory, pluginCachePath);
 
-        _dbPath = Path.Join(introsDirectory, "introskipper.db");
-        _cacheDbPath = Path.Join(introsDirectory, "introskipper-cache.db");
+        _dbPath = IntroSkipperDatabase.GetSegmentDatabasePath(applicationPaths);
+        _cacheDbPath = IntroSkipperDatabase.GetCacheDatabasePath(applicationPaths);
 
         // Create the base directories (if needed).
         // Directory.CreateDirectory is already a no-op when the directory exists, so we can call it unconditionally without checking first.
         Directory.CreateDirectory(introsDirectory);
 
-        // Initialize segment database.
-        try
-        {
-            using var db = CreateDbContext();
-            // Legacy databases may be missing migration history or columns that EF migrations expect.
-            // Normalize those schemas first so recovery does not log a false initialization failure.
-            db.EnsureLegacySchemaCompatibility();
-            db.ApplyMigrations();
-        }
-        catch (Exception ex)
-        {
-            LogDatabaseInitializationError(_logger, ex);
-        }
-
-        // Initialize detection cache database.
-        try
-        {
-            using var cacheDb = CreateCacheDbContext();
-            cacheDb.EnsureSchema();
-        }
-        catch (Exception ex) when (ex is IOException or SqliteException)
-        {
-            LogCacheDbInitializationError(_logger, ex);
-        }
-
+        // Database initialization (migrations, legacy repair, cache recovery) is owned by
+        // DatabaseInitializer. It runs eagerly via DatabaseInitializationService and is awaited
+        // lazily by the gated context factories, so no query can run before it completes.
         MigrateLegacyExcludeSeries();
 
         Configuration.FileTransformationPluginEnabled = _pluginManager
@@ -171,24 +159,32 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     /// <summary>
     /// Creates a new <see cref="IntroSkipperDbContext"/> instance configured for the plugin database.
+    /// Delegates to the DI-provided gated factory (which awaits database initialization); test
+    /// instances materialized without DI fall back to a path-based context.
     /// </summary>
     /// <returns>A new <see cref="IntroSkipperDbContext"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
     public static IntroSkipperDbContext CreateDbContext()
     {
         ArgumentNullException.ThrowIfNull(Instance);
-        return new IntroSkipperDbContext(Instance.DbPath);
+        return Instance._dbContextFactory is { } factory
+            ? factory.CreateDbContext()
+            : new IntroSkipperDbContext(Instance.DbPath);
     }
 
     /// <summary>
     /// Creates a new <see cref="DetectionCacheDbContext"/> instance configured for the plugin cache database.
+    /// Delegates to the DI-provided gated factory (which awaits database initialization); test
+    /// instances materialized without DI fall back to a path-based context.
     /// </summary>
     /// <returns>A new <see cref="DetectionCacheDbContext"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
     public static DetectionCacheDbContext CreateCacheDbContext()
     {
         ArgumentNullException.ThrowIfNull(Instance);
-        return new DetectionCacheDbContext(Instance.CacheDbPath);
+        return Instance._cacheDbContextFactory is { } factory
+            ? factory.CreateDbContext()
+            : new DetectionCacheDbContext(Instance.CacheDbPath);
     }
 
     /// <inheritdoc />
@@ -231,287 +227,73 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-
-        try
-        {
-            var dbSegment = new DbSegment(segment, mode, isUserProvided, configHash);
-
-            if (mode == AnalysisMode.Commercial)
-            {
-                var exists = await db.DbSegment
-                    .AnyAsync(
-                        s => s.ItemId == segment.EpisodeId
-                             && s.Type == mode
-                             && Math.Abs(s.Start - dbSegment.Start) <= SegmentComparisonEpsilon
-                             && Math.Abs(s.End - dbSegment.End) <= SegmentComparisonEpsilon,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (!exists)
-                {
-                    db.DbSegment.Add(dbSegment);
-                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-                try
-                {
-                    var existingSegments = await db.DbSegment
-                        .Where(s => s.ItemId == segment.EpisodeId && s.Type == mode)
-                        .ToListAsync(cancellationToken)
-                        .ConfigureAwait(false);
-
-                    // Do not overwrite a user-provided segment with an analysis result.
-                    if (!isUserProvided && existingSegments.Any(s => s.IsUserProvided))
-                    {
-                        return;
-                    }
-
-                    // Guard: prevent auto-detected credits from overlapping with the introduction.
-                    if (mode == AnalysisMode.Credits && !isUserProvided)
-                    {
-                        var intro = await db.DbSegment
-                            .AsNoTracking()
-                            .Where(s => s.ItemId == segment.EpisodeId && s.Type == AnalysisMode.Introduction)
-                            .FirstOrDefaultAsync(cancellationToken)
-                            .ConfigureAwait(false);
-
-                        if (intro is not null && segment.Start < intro.End && intro.Start < segment.End)
-                        {
-                            LogCreditsOverlapWithIntro(_logger, segment.EpisodeId);
-                            return;
-                        }
-                    }
-
-                    if (existingSegments.Count > 0)
-                    {
-                        db.DbSegment.RemoveRange(existingSegments);
-                    }
-
-                    db.DbSegment.Add(dbSegment);
-                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-                }
-                finally
-                {
-                    await transaction.DisposeAsync().ConfigureAwait(false);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            LogFailedToUpdateTimestamp(_logger, ex, segment.EpisodeId);
-            throw;
-        }
+        await db.UpdateTimestampAsync(segment, mode, isUserProvided, configHash, _logger, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var segments = await db.DbSegment
-            .AsNoTracking()
-            .Where(s => s.ItemId == id)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return segments
-            .GroupBy(segment => segment.Type)
-            .ToDictionary(
-                group => group.Key,
-                group => group.OrderBy(segment => segment.Start).First().ToSegment());
+        return await db.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        return await db.DbSegment
-            .AsNoTracking()
-            .Where(s => s.ItemId == id)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
+        return await db.GetSegmentsAsync(id, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task DeleteItemSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        await db.DbSegment
-            .Where(s => s.ItemId == itemId)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        await db.DeleteItemSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        var enabledEpisodeIds = episodeIds.ToHashSet();
-
         using var db = CreateDbContext();
-        var segmentEpisodeIds = await db.DbSegment
-            .AsNoTracking()
-            .Select(s => s.ItemId)
-            .Distinct()
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        var staleEpisodeIds = segmentEpisodeIds
-            .Where(id => !enabledEpisodeIds.Contains(id))
-            .ToArray();
-
-        foreach (var staleEpisodeIdBatch in staleEpisodeIds.Chunk(SqliteParameterBatchSize))
-        {
-            await db.DbSegment
-                .Where(s => staleEpisodeIdBatch.Contains(s.ItemId))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await db.CleanTimestampsAsync(episodeIds, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var existingEntries = await db.DbSeasonState
-            .Where(s => s.SeasonId == id)
-            .ToDictionaryAsync(s => s.Type, cancellationToken)
-            .ConfigureAwait(false);
-
-        foreach (var (mode, action) in analyzerActions)
-        {
-            if (existingEntries.TryGetValue(mode, out var existing))
-            {
-                db.Entry(existing).Property(s => s.Action).CurrentValue = action;
-            }
-            else
-            {
-                db.DbSeasonState.Add(new DbSeasonState(id, mode, action));
-            }
-        }
-
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await db.SetAnalyzerActionAsync(id, analyzerActions, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var seasonState = await db.DbSeasonState
-            .FirstOrDefaultAsync(s => s.SeasonId == id && s.Type == mode, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (seasonState is null)
-        {
-            seasonState = new DbSeasonState(id, mode, AnalyzerAction.Default, episodeIds, configHash);
-            db.DbSeasonState.Add(seasonState);
-        }
-        else
-        {
-            db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
-            db.Entry(seasonState).Property(s => s.ConfigHash).CurrentValue = configHash;
-        }
-
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await db.SetEpisodeIdsAsync(id, mode, episodeIds, configHash, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Removes a single episode ID from the season's analyzed-state list for the given mode.
-    /// The read and write share one <see cref="IntroSkipperDbContext"/> to keep the window for
-    /// concurrent overwrites as small as possible, and the write is skipped entirely when the
-    /// ID is not present in the stored list.
-    /// </summary>
-    /// <param name="seasonId">Season ID.</param>
-    /// <param name="mode">Analysis mode.</param>
-    /// <param name="episodeId">Episode ID to remove.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     internal static async Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var seasonState = await db.DbSeasonState
-            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (seasonState is null)
-        {
-            return;
-        }
-
-        var currentIds = seasonState.EpisodeIds.ToList();
-        if (!currentIds.Remove(episodeId))
-        {
-            return; // Episode was not in the list — no write needed.
-        }
-
-        db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = currentIds;
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await db.RemoveEpisodeIdAsync(seasonId, mode, episodeId, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Removes stale automatic segments for the supplied items and mode.
-    /// User-provided segments are intentionally preserved.
-    /// </summary>
-    /// <param name="itemIds">Item IDs to inspect.</param>
-    /// <param name="mode">Analysis mode.</param>
-    /// <param name="configHash">Current configuration hash.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     internal static async Task CleanStaleAutomaticSegmentsAsync(
         IEnumerable<Guid> itemIds,
         AnalysisMode mode,
         string configHash,
         CancellationToken cancellationToken = default)
     {
-        var ids = itemIds.Distinct().ToArray();
-        if (ids.Length == 0)
-        {
-            return;
-        }
-
         using var db = CreateDbContext();
-        foreach (var batch in ids.Chunk(SqliteParameterBatchSize))
-        {
-            await db.DbSegment
-                .Where(s => batch.Contains(s.ItemId)
-                    && s.Type == mode
-                    && !s.IsUserProvided
-                    && s.ConfigHash != configHash)
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await db.CleanStaleAutomaticSegmentsAsync(itemIds, mode, configHash, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid id, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        return await db.DbSeasonState.Where(s => s.SeasonId == id)
-            .ToDictionaryAsync(s => s.Type, s => s.EpisodeIds, cancellationToken)
-            .ConfigureAwait(false);
+        return await db.GetEpisodeIdsAsync(id, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Returns the settled-season reanalysis state for all modes in a season.
-    /// </summary>
-    /// <param name="seasonId">Season ID.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Settled reanalysis state keyed by analysis mode.</returns>
     internal static async Task<IReadOnlyDictionary<AnalysisMode, (AnalyzerAction Action, IReadOnlySet<Guid> SettledReanalysisEpisodeIds)>> GetSettleReanalysisStatesAsync(
         Guid seasonId,
         CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var states = await db.DbSeasonState
-            .AsNoTracking()
-            .Where(s => s.SeasonId == seasonId)
-            .Select(s => new
-            {
-                s.Type,
-                s.Action,
-                s.SettledReanalysisEpisodeIds
-            })
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return states.ToDictionary(
-            s => s.Type,
-            s => (s.Action, (IReadOnlySet<Guid>)s.SettledReanalysisEpisodeIds.ToHashSet()));
+        return await db.GetSettleReanalysisStatesAsync(seasonId, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -528,181 +310,48 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         IReadOnlyCollection<Guid> episodeIds)
         => settledEpisodeIds.Count != episodeIds.Count || episodeIds.Any(id => !settledEpisodeIds.Contains(id));
 
-    /// <summary>
-    /// Records that season analysis modes have been re-analyzed for the given episode set so the
-    /// exact completed set is not repeated on subsequent scans or after a plugin restart. Call only
-    /// after the reset has committed.
-    /// </summary>
-    /// <param name="seasonId">Season ID.</param>
-    /// <param name="modes">Analysis modes that were re-analyzed.</param>
-    /// <param name="episodeIds">Episode IDs that were re-analyzed.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     internal static async Task RecordSettleReanalysisAsync(
         Guid seasonId,
         IReadOnlyCollection<AnalysisMode> modes,
         IReadOnlyCollection<Guid> episodeIds,
         CancellationToken cancellationToken = default)
     {
-        if (modes.Count == 0)
-        {
-            return;
-        }
-
-        var settledEpisodeIds = DbSeasonState.SerializeEpisodeIds(episodeIds);
-
         using var db = CreateDbContext();
-        foreach (var mode in modes)
-        {
-            await db.Database.ExecuteSqlInterpolatedAsync(
-                $"""
-                INSERT INTO "DbSeasonState" ("SeasonId", "Type", "Action", "EpisodeIds", "ConfigHash", "SettledReanalysisEpisodeIds")
-                VALUES ({seasonId}, {(int)mode}, {(int)AnalyzerAction.Default}, {"[]"}, {string.Empty}, {settledEpisodeIds})
-                ON CONFLICT("SeasonId", "Type") DO UPDATE SET
-                    "SettledReanalysisEpisodeIds" = excluded."SettledReanalysisEpisodeIds"
-                """,
-                cancellationToken).ConfigureAwait(false);
-        }
+        await db.RecordSettleReanalysisAsync(seasonId, modes, episodeIds, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Clears stored automatic analysis state for a season so it is re-analyzed from scratch on the
-    /// current pass. Automatic segments for the supplied modes are deleted and the season's analyzed
-    /// episode lists are cleared; user-provided segments and the fingerprint cache are preserved.
-    /// The deletes and the episode-list clear run in a single transaction so a cancelled reset cannot
-    /// leave segments deleted while their episodes are still recorded as analyzed.
-    /// </summary>
-    /// <param name="seasonId">Season ID whose analyzed-state lists should be cleared.</param>
-    /// <param name="episodeIds">Episode IDs whose automatic segments should be removed.</param>
-    /// <param name="modes">Analysis modes to reset.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     internal static async Task ResetSeasonForReanalysisAsync(
         Guid seasonId,
         IEnumerable<Guid> episodeIds,
         IReadOnlyCollection<AnalysisMode> modes,
         CancellationToken cancellationToken = default)
     {
-        var ids = episodeIds.Distinct().ToArray();
-        var modeArray = modes.ToArray();
-        if (ids.Length == 0 || modeArray.Length == 0)
-        {
-            return;
-        }
-
         using var db = CreateDbContext();
-
-        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            foreach (var batch in ids.Chunk(SqliteParameterBatchSize))
-            {
-                await db.DbSegment
-                    .Where(s => batch.Contains(s.ItemId) && modeArray.Contains(s.Type) && !s.IsUserProvided)
-                    .ExecuteDeleteAsync(cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            // Clear the analyzed-episode lists so VerifyQueueAsync treats every episode as NotAnalyzed.
-            // Committing this together with the deletes guarantees the episodes are re-analyzed (either
-            // on this pass or a later one) instead of being stranded as NoSegments.
-            var seasonStates = await db.DbSeasonState
-                .Where(s => s.SeasonId == seasonId && modeArray.Contains(s.Type))
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            foreach (var state in seasonStates)
-            {
-                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
-            }
-
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            await transaction.DisposeAsync().ConfigureAwait(false);
-        }
+        await db.ResetSeasonForReanalysisAsync(seasonId, episodeIds, modes, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var episodeIdArray = (Guid[])[.. episodeIds.Distinct()];
-
-        var seasonStates = await db.DbSeasonState
-            .AsNoTracking()
-            .Where(s => s.SeasonId == seasonId)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        var allSegments = new List<DbSegment>();
-        foreach (var batch in episodeIdArray.Chunk(SqliteParameterBatchSize))
-        {
-            allSegments.AddRange(await db.DbSegment
-                .AsNoTracking()
-                .Where(s => batch.Contains(s.ItemId))
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false));
-        }
-
-        var segments = allSegments;
-
-        return new SeasonQueueSnapshot(
-            seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
-            seasonStates.ToDictionary(s => s.Type, s => s.ConfigHash),
-            seasonStates.ToDictionary(s => s.Type, s => s.Action),
-            segments
-                .GroupBy(s => s.ItemId)
-                .ToDictionary(
-                    group => group.Key,
-                    group => (IReadOnlyDictionary<AnalysisMode, Segment>)group
-                        .GroupBy(segment => segment.Type)
-                        .ToDictionary(
-                            segmentGroup => segmentGroup.Key,
-                            segmentGroup => segmentGroup.OrderBy(segment => segment.Start).First().ToSegment())),
-            segments
-                .Where(s => s.IsUserProvided)
-                .GroupBy(s => s.Type)
-                .ToDictionary(
-                    group => group.Key,
-                    group => (IReadOnlySet<Guid>)group.Select(s => s.ItemId).ToHashSet()));
+        return await db.GetSeasonQueueSnapshotAsync(seasonId, episodeIds, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var states = await db.DbSeasonState
-            .Where(s => s.SeasonId == seasonId)
-            .ToDictionaryAsync(s => s.Type, s => s.Action, cancellationToken)
-            .ConfigureAwait(false);
-
-        // Fill in defaults for any missing modes
-        var result = new Dictionary<AnalysisMode, AnalyzerAction>();
-        foreach (var mode in Enum.GetValues<AnalysisMode>())
-        {
-            result[mode] = states.TryGetValue(mode, out var action) ? action : AnalyzerAction.Default;
-        }
-
-        return result;
+        return await db.GetAllAnalyzerActionsAsync(seasonId, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task<AnalyzerAction> GetAnalyzerActionAsync(Guid id, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var state = await db.DbSeasonState
-            .FirstOrDefaultAsync(s => s.SeasonId == id && s.Type == mode, cancellationToken)
-            .ConfigureAwait(false);
-        return state?.Action ?? AnalyzerAction.Default;
+        return await db.GetAnalyzerActionAsync(id, mode, cancellationToken).ConfigureAwait(false);
     }
 
     internal static async Task CleanSeasonStateAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        await db.DbSeasonState
-            .Where(s => !ids.Contains(s.SeasonId))
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        await db.CleanSeasonStateAsync(ids, cancellationToken).ConfigureAwait(false);
     }
 
     internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
@@ -718,14 +367,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         };
     }
 
-    /// <summary>
-    /// Deletes a stored timestamp (DbSegment) for the specified item and analysis mode.
-    /// </summary>
-    /// <param name="itemId">The item id whose timestamp should be removed.</param>
-    /// <param name="mode">The analysis mode representing the segment type.</param>
-    /// <param name="segment">Optional segment details used to remove a specific entry.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     internal static async Task DeleteTimestampAsync(
         Guid itemId,
         AnalysisMode mode,
@@ -733,26 +374,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        if (segment is null && mode == AnalysisMode.Commercial)
-        {
-            return;
-        }
-
-        var query = db.DbSegment.Where(s => s.ItemId == itemId && s.Type == mode);
-
-        if (segment is not null)
-        {
-            query = query.Where(s =>
-                Math.Abs(s.Start - segment.Start) <= SegmentComparisonEpsilon
-                && Math.Abs(s.End - segment.End) <= SegmentComparisonEpsilon);
-        }
-
-        var entries = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
-        if (entries.Count > 0)
-        {
-            db.DbSegment.RemoveRange(entries);
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
+        await db.DeleteTimestampAsync(itemId, mode, segment, cancellationToken).ConfigureAwait(false);
     }
 
     private void MigrateLegacyExcludeSeries()
@@ -774,16 +396,4 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         Configuration.ExcludeSeries = string.Empty;
         SaveConfiguration();
     }
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
-    private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
-    private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping credits for episode {EpisodeId}: detected segment overlaps with introduction")]
-    private static partial void LogCreditsOverlapWithIntro(ILogger logger, Guid episodeId);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update timestamp for episode {EpisodeId}")]
-    private static partial void LogFailedToUpdateTimestamp(ILogger logger, Exception ex, Guid episodeId);
 }

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -3,15 +3,18 @@
 // SPDX-FileCopyrightText: 2024-2026 AbandonedCart
 // SPDX-License-Identifier: GPL-3.0-only
 
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Filters;
 using IntroSkipper.Manager;
 using IntroSkipper.Providers;
 using IntroSkipper.Services;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace IntroSkipper
@@ -24,6 +27,20 @@ namespace IntroSkipper
         /// <inheritdoc />
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
+            // Database layer: DbContext factories are the data-access seam (no repository layer).
+            // The gated factory implementations await one-time initialization (legacy repair +
+            // migrations + cache recovery) before handing out a context.
+            serviceCollection.AddSingleton<DatabaseInitializer>();
+            serviceCollection.AddHostedService<DatabaseInitializationService>();
+            serviceCollection.AddDbContextFactory<IntroSkipperDbContext, GatedIntroSkipperDbContextFactory>((serviceProvider, options) =>
+                IntroSkipperDatabase.ConfigureSqlite(
+                    options,
+                    IntroSkipperDatabase.GetSegmentDatabasePath(serviceProvider.GetRequiredService<IApplicationPaths>())));
+            serviceCollection.AddDbContextFactory<DetectionCacheDbContext, GatedDetectionCacheDbContextFactory>((serviceProvider, options) =>
+                IntroSkipperDatabase.ConfigureSqlite(
+                    options,
+                    IntroSkipperDatabase.GetCacheDatabasePath(serviceProvider.GetRequiredService<IApplicationPaths>())));
+
             serviceCollection.AddHostedService<Entrypoint>();
             serviceCollection.AddSingleton<IDetectionCacheService, DetectionCacheService>();
             serviceCollection.AddSingleton<IFFmpegService, FFmpegService>();

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -11,13 +12,18 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Model;
 using MediaBrowser.Model.MediaSegments;
+using Microsoft.EntityFrameworkCore;
 
 namespace IntroSkipper.Providers
 {
     /// <summary>
     /// Introskipper media segment provider.
     /// </summary>
-    public class SegmentProvider : IMediaSegmentProvider
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="SegmentProvider"/> class.
+    /// </remarks>
+    /// <param name="dbContextFactory">Factory for the segment database context.</param>
+    public class SegmentProvider(IDbContextFactory<IntroSkipperDbContext> dbContextFactory) : IMediaSegmentProvider
     {
         /// <summary>
         /// Mappings between AnalysisMode and MediaSegmentType.
@@ -31,6 +37,8 @@ namespace IntroSkipper.Providers
             [AnalysisMode.Commercial] = MediaSegmentType.Commercial
         };
 
+        private readonly IDbContextFactory<IntroSkipperDbContext> _dbContextFactory = dbContextFactory;
+
         /// <inheritdoc/>
         public string Name => Plugin.Instance!.Name;
 
@@ -38,10 +46,15 @@ namespace IntroSkipper.Providers
         public async Task<IReadOnlyList<MediaSegmentDto>> GetMediaSegments(MediaSegmentGenerationRequest request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
-            ArgumentNullException.ThrowIfNull(Plugin.Instance);
 
             var segments = new List<MediaSegmentDto>();
-            var itemSegments = await Plugin.GetSegmentsAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
+            IReadOnlyList<DbSegment> itemSegments;
+            var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            await using (db.ConfigureAwait(false))
+            {
+                itemSegments = await db.GetSegmentsAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
+            }
+
             var dedupedModes = new HashSet<AnalysisMode>();
 
             foreach (var segment in itemSegments.OrderBy(segment => segment.Start))
@@ -79,8 +92,11 @@ namespace IntroSkipper.Providers
         /// <inheritdoc/>
         public async Task CleanupExtractedData(Guid itemId, CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(Plugin.Instance);
-            await Plugin.DeleteItemSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
+            var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            await using (db.ConfigureAwait(false))
+            {
+                await db.DeleteItemSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         /// <inheritdoc/>

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Data.Common;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
 using MediaBrowser.Controller.Library;
@@ -25,13 +26,15 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="providerManager">Provider manager.</param>
 /// <param name="fileSystem">File system.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
+/// <param name="cacheDbContextFactory">Factory for the detection cache database context.</param>
 public partial class CleanCacheTask(
     ILogger<CleanCacheTask> logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
     IProviderManager providerManager,
     IFileSystem fileSystem,
-    IFFmpegService ffmpegService) : IScheduledTask
+    IFFmpegService ffmpegService,
+    IDbContextFactory<DetectionCacheDbContext> cacheDbContextFactory) : IScheduledTask
 {
     private readonly ILogger<CleanCacheTask> _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
@@ -39,6 +42,7 @@ public partial class CleanCacheTask(
     private readonly IProviderManager _providerManager = providerManager;
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly IDbContextFactory<DetectionCacheDbContext> _cacheDbContextFactory = cacheDbContextFactory;
 
     /// <summary>
     /// Gets the task name.
@@ -97,13 +101,14 @@ public partial class CleanCacheTask(
 
         // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
         HashSet<Guid> invalidEpisodeIds;
-        using (var cacheDb = Plugin.CreateCacheDbContext())
+        var cacheDb = await _cacheDbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (cacheDb.ConfigureAwait(false))
         {
             invalidEpisodeIds = cacheDb.DetectionCache
                 .Select(e => e.ItemId)
                 .Distinct()
-                .Where(id => !enabledLibraryEpisodeIds.Contains(id))
                 .ToHashSet();
+            invalidEpisodeIds.ExceptWith(enabledLibraryEpisodeIds);
         }
 
         // Log and batch-delete all invalid episode DB rows in a single round-trip.
@@ -116,11 +121,15 @@ public partial class CleanCacheTask(
         {
             try
             {
-                using var deleteDb = Plugin.CreateCacheDbContext();
-                await deleteDb.DetectionCache
-                    .Where(e => invalidEpisodeIds.Contains(e.ItemId))
-                    .ExecuteDeleteAsync(cancellationToken)
-                    .ConfigureAwait(false);
+                var invalidIds = invalidEpisodeIds.ToArray();
+                var deleteDb = await _cacheDbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+                await using (deleteDb.ConfigureAwait(false))
+                {
+                    await deleteDb.DetectionCache
+                        .Where(e => EF.Parameter(invalidIds).Contains(e.ItemId))
+                        .ExecuteDeleteAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
             catch (Exception ex) when (ex is DbUpdateException or DbException)
             {

--- a/docs/db-redesign/theory-c.md
+++ b/docs/db-redesign/theory-c.md
@@ -1,9 +1,10 @@
 # Theory C: No Repository — `DbContext` *is* the Repository
 
-**Status:** exploration spike (branch `12.0` derivative), competing with two rival designs
-(layered stores, facade). Prototype compiles StyleCop-clean and passes the full test suite
-(376 passing; only the known environmental `TestAudioFingerprinting.TestSilenceDetection`
-failure remains).
+**Status:** exploration spike (branch `capy/theory-c-db-layer`, round 2), competing with
+two rival designs (layered stores, facade). Prototype compiles StyleCop-clean and passes
+the full test suite (379 passing; only the known environmental
+`TestAudioFingerprinting.TestSilenceDetection` failure remains). Round-2 coordinator
+feedback is addressed in §12.
 
 ---
 
@@ -69,8 +70,9 @@ repository with a different spelling.
   statement (`ExecuteDelete`, `Any`, `FirstOrDefault`). Example: `ResetIntroTimestamps`.
 - **Must be a shared operation:** (a) anything that **inserts or replaces `DbSegment`
   rows** — that is exclusively `SegmentOperations.UpdateTimestampAsync`, the invariant
-  home (§6); (b) any multi-statement flow used from ≥ 2 call sites; (c) anything needing
-  chunked batching (the batching policy must not be re-derived at call sites).
+  home (§6); (b) any multi-statement flow used from ≥ 2 call sites; (c) anything whose ID
+  collection can be unbounded (the `EF.Parameter`/`json_each` translation policy must not
+  be re-derived at call sites).
 - `DetectionCacheService` keeps its inline LINQ: it *is* the single consumer-facing owner
   of the cache table plus its compression/config-hash logic; wrapping it again would be
   the repository anti-pattern this theory rejects.
@@ -92,16 +94,16 @@ deletes the delegator and injects the factory at the listed consumers.
 | 3 | `GetSegmentsAsync` | `SegmentOperations.GetSegmentsAsync` (ext, compiled query) | SegmentProvider (**done**), SegmentEditorController, BaseItemAnalyzerTask | Prototype + delegating |
 | 4 | `DeleteItemSegmentsAsync` | `SegmentOperations.DeleteItemSegmentsAsync` (ext) | SegmentProvider (**done**) | Prototype + delegating |
 | 5 | `DeleteTimestampAsync` | `SegmentOperations.DeleteTimestampAsync` (ext) | SegmentEditorController | Delegating |
-| 6 | `CleanTimestampsAsync` | `SegmentOperations.CleanTimestampsAsync` (ext, chunked) | CleanCacheTask | Prototype (op + tests) + delegating |
-| 7 | `CleanStaleAutomaticSegmentsAsync` | `SegmentOperations.CleanStaleAutomaticSegmentsAsync` (ext, chunked) | BaseItemAnalyzerTask | Prototype (op + tests) + delegating |
+| 6 | `CleanTimestampsAsync` | `SegmentOperations.CleanTimestampsAsync` (ext, `EF.Parameter` NOT-IN delete) | CleanCacheTask | Prototype (op + tests) + delegating |
+| 7 | `CleanStaleAutomaticSegmentsAsync` | `SegmentOperations.CleanStaleAutomaticSegmentsAsync` (ext, `EF.Parameter` IN delete) | BaseItemAnalyzerTask | Prototype (op + tests) + delegating |
 | 8 | `SetAnalyzerActionAsync` | `SeasonStateOperations.SetAnalyzerActionAsync` (ext) | VisualizationController | Delegating |
 | 9 | `SetEpisodeIdsAsync` | `SeasonStateOperations.SetEpisodeIdsAsync` (ext) | BaseItemAnalyzerTask | Delegating |
 | 10 | `RemoveEpisodeIdAsync` | `SeasonStateOperations.RemoveEpisodeIdAsync` (ext) | SegmentEditorController | Delegating |
 | 11 | `GetEpisodeIdsAsync` | `SeasonStateOperations.GetEpisodeIdsAsync` (ext) | (currently unused externally) | Delegating |
 | 12 | `GetSettleReanalysisStatesAsync` | `SeasonStateOperations.GetSettleReanalysisStatesAsync` (ext) | BaseItemAnalyzerTask | Delegating |
 | 13 | `RecordSettleReanalysisAsync` | `SeasonStateOperations.RecordSettleReanalysisAsync` (ext) | BaseItemAnalyzerTask | Delegating |
-| 14 | `ResetSeasonForReanalysisAsync` | `SeasonStateOperations.ResetSeasonForReanalysisAsync` (ext, chunked + transaction) | BaseItemAnalyzerTask | Delegating |
-| 15 | `GetSeasonQueueSnapshotAsync` | `SeasonStateOperations.GetSeasonQueueSnapshotAsync` (ext, chunked) | QueueManager | Delegating |
+| 14 | `ResetSeasonForReanalysisAsync` | `SeasonStateOperations.ResetSeasonForReanalysisAsync` (ext, `EF.Parameter` + transaction) | BaseItemAnalyzerTask | Delegating |
+| 15 | `GetSeasonQueueSnapshotAsync` | `SeasonStateOperations.GetSeasonQueueSnapshotAsync` (ext, `EF.Parameter`) | QueueManager | Delegating |
 | 16 | `GetAllAnalyzerActionsAsync` | `SeasonStateOperations.GetAllAnalyzerActionsAsync` (ext) | VisualizationController | Delegating |
 | 17 | `GetAnalyzerActionAsync` | `SeasonStateOperations.GetAnalyzerActionAsync` (ext) | BaseItemAnalyzerTask | Delegating |
 | 18 | `CleanSeasonStateAsync` | `SeasonStateOperations.CleanSeasonStateAsync` (ext) | CleanCacheTask | Delegating |
@@ -116,10 +118,10 @@ they have no business on `Plugin` either, but they are not DB code).
 |---|---|---|---|
 | `SkipIntroController.ResetIntroTimestamps` | `Plugin.CreateDbContext()` + `ExecuteDelete` | **Inline** against injected factory (single-query delete) | **Done** |
 | `SkipIntroController.RebuildDatabase` | `db.RebuildDatabaseAsync(Plugin.CreateDbContext)` | `DatabaseInitializer.RebuildDatabaseAsync()` (lifecycle owner) | **Done** |
-| `VisualizationController.EraseSeasonAsync` | segment `ExecuteDelete` + season-state clear on one context | Shared op `SeasonStateOperations.EraseSeasonDataAsync(db, seasonId, episodeIds)` — multi-statement, also invoked by `ScanSeason`; cache deletion stays in the controller (cross-store orchestration is caller concern) | End state |
-| `VisualizationController.ClearExcludedTimestampsAsync` (segment db) | inline multi-statement | Shared op `SeasonStateOperations.ClearEpisodesAsync(db, idsBySeason)` (multi-statement, returns counts) | End state |
-| `VisualizationController.ClearExcludedTimestampsAsync` (cache db) | `Plugin.CreateCacheDbContext()` + `ExecuteDelete` | Inline against injected `IDbContextFactory<DetectionCacheDbContext>` | End state |
-| `CleanCacheTask` (2 cache sites) | `Plugin.CreateCacheDbContext()` | Inline against injected cache factory (single-query read + single-query delete) | End state |
+| `VisualizationController.EraseSeasonAsync` | segment `ExecuteDelete` + season-state clear on one context | Now on injected factory (async creation); extraction into shared op `SeasonStateOperations.EraseSeasonDataAsync(db, seasonId, episodeIds)` remains the end-state target; cache deletion stays in the controller (cross-store orchestration is caller concern) | **Factory-injected (R2)** |
+| `VisualizationController.ClearExcludedTimestampsAsync` (segment db) | inline multi-statement | Now on injected factory (async creation); extraction into shared op `SeasonStateOperations.ClearEpisodesAsync(db, idsBySeason)` remains the end-state target | **Factory-injected (R2)** |
+| `VisualizationController.ClearExcludedTimestampsAsync` (cache db) | `Plugin.CreateCacheDbContext()` + `ExecuteDelete` | Inline against injected `IDbContextFactory<DetectionCacheDbContext>` | **Done (R2)** |
+| `CleanCacheTask` (2 cache sites) | `Plugin.CreateCacheDbContext()` | Inline against injected cache factory (single-query read + `EF.Parameter` delete) | **Done (R2)** |
 | `DetectionCacheService` (5 sites) | `Plugin.CreateCacheDbContext()` | Injected `IDbContextFactory<DetectionCacheDbContext>`, LINQ stays inline in the service | **Done (all 5)** |
 | `Plugin` ctor DB bootstrap | sync migrate + legacy repair + cache EnsureSchema | `DatabaseInitializer` + hosted kick-off + factory gate | **Done** |
 
@@ -183,14 +185,17 @@ Notes:
 
 **Owner:** `DatabaseInitializer` (DI singleton).
 
-- `EnsureInitializedAsync(ct)` / `EnsureInitialized()` — one-time init guarded by
-  `lock + Task?` (first caller starts `Task.Run(InitializeCore)`, everyone else awaits the
-  same task; a cancelled waiter abandons the *wait*, never the initialization).
-- `InitializeCore()` reproduces the previous `Plugin`-ctor behavior verbatim, including
-  error semantics: segment DB → ensure directory, `EnsureLegacySchemaCompatibility()`,
-  `Database.Migrate()`, catch-all logged as warning (a broken DB must not kill the
-  plugin); cache DB → `EnsureSchema()` (EnsureCreated + probe + delete-and-recreate on
-  corruption), `IOException`/`SqliteException` logged as warning.
+- **Two independent one-time gates** (round-2 revision), one per database, each guarded by
+  `lock + Task?` (first caller starts `Task.Run(...)`, everyone else awaits the same task;
+  a cancelled waiter abandons the *wait*, never the initialization):
+  `EnsureSegmentDatabaseInitialized[Async]` and `EnsureCacheDatabaseInitialized[Async]`,
+  plus `EnsureInitializedAsync` (both, used by the hosted kick-off and rebuild).
+- `InitializeSegmentDatabaseCore()`: ensure directory, `EnsureLegacySchemaCompatibility()`,
+  `Database.Migrate()`. `InitializeCacheDatabaseCore()`: `EnsureSchema()` (EnsureCreated +
+  probe + delete-and-recreate on corruption). **Both cores are catch-all log-and-continue**,
+  so an init task can never fault: a faulted shared task would otherwise poison every later
+  `CreateDbContext` with the cached exception and abort host startup via the hosted service.
+  Per-query errors after a failed init surface exactly as they did pre-refactor.
 - `RebuildDatabaseAsync(force, ct)` — awaits the gate first (a rebuild must never race
   first-time init), then runs the existing salvage/rebuild flow on `IntroSkipperDbContext`
   unchanged. `SkipIntroController.RebuildDatabase` calls this.
@@ -207,20 +212,31 @@ Claim: **no query executes before migrations/legacy repair complete.**
    delegates to the injected factory. Verified by grep: no production code constructs
    `IntroSkipperDbContext`/`DetectionCacheDbContext` outside `IntroSkipper.Db` (the
    initializer and the rebuild callback, which run under the gate by construction).
-2. Both factory implementations await/block on `EnsureInitializedAsync` **before**
-   constructing the context (`GatedIntroSkipperDbContextFactory.CreateDbContext[Async]`).
+2. Each factory implementation awaits/blocks on **its own database's gate** before
+   constructing the context (`GatedIntroSkipperDbContextFactory` →
+   `EnsureSegmentDatabaseInitialized[Async]`, `GatedDetectionCacheDbContextFactory` →
+   `EnsureCacheDatabaseInitialized[Async]`). Failure domains stay isolated: the two
+   databases live in separate files precisely for corruption isolation, and the gates
+   match — a cache-init failure cannot block segment access (pinned by test
+   `CacheInitializationFailure_DoesNotBlockSegmentDatabaseAccess`).
 3. Init is idempotent and single-flight, so concurrent early callers (Jellyfin hitting
    `SegmentProvider` or a controller during startup) all observe the same completed task.
 4. Covered by test `GatedFactory_AppliesMigrationsBeforeHandingOutContexts`: on a fresh
    file, the *first* context handed out already reports zero pending migrations.
+5. Init never throws (catch-all cores), so `DatabaseInitializationService.StartAsync`
+   cannot fault Jellyfin host startup and the gates cannot cache an exception.
 
 Trade-offs acknowledged: the synchronous `CreateDbContext()` path blocks
-(`GetAwaiter().GetResult()`) on first use. Init work is synchronous EF code running on a
-thread-pool thread with no synchronization context, so this cannot deadlock, but it can
-stall an early caller for the duration of a large migration — identical in effect to the
-old synchronous Plugin-ctor migration, minus blocking plugin load itself. If init *fails*,
-the gate still completes (logged warning) and later queries fail individually — again
-matching today's behavior.
+(`GetAwaiter().GetResult()`) on first use; N concurrent sync callers during a long first
+migration would pin N thread-pool threads. Mitigation (round 2): the prototype was audited
+so **every async call site creates contexts via `CreateDbContextAsync`** — the 18 `Plugin`
+delegators route through a private async creation helper, and `SegmentProvider`,
+`SkipIntroController`, `VisualizationController`, and `CleanCacheTask` all await the async
+factory path. The sync gate remains only for genuinely synchronous consumers (the
+`IDetectionCacheService` surface, whose interface is sync). Init work is synchronous EF
+code running on a thread-pool thread with no synchronization context, so the sync path
+cannot deadlock. If init *fails*, the gate still completes (logged warning) and later
+queries fail individually — matching today's behavior.
 
 Rejected alternatives: keeping bootstrap in the `Plugin` ctor (leaves lifecycle glued to
 a god object, and plugin construction order vs. Kestrel startup is Jellyfin-version
@@ -235,6 +251,10 @@ no gate (provably racy: Jellyfin can serve `SegmentProvider` before/parallel to 
 - **busy_timeout=5000** applied per connection-open by the shared interceptor (unchanged).
   This remains the primary defense for the plugin's real concurrency pattern:
   `Parallel.ForEachAsync` season analysis writing while playback reads.
+- **WAL**: verified on this stack — EF's SQLite provider sets `journal_mode=wal` when it
+  creates the database (via migrations), and the setting persists in the file; a fresh raw
+  `SqliteConnection` against a migration-created DB reports `PRAGMA journal_mode` = `wal`.
+  No pragma needed in the interceptor.
 - **Explicit transactions** stay exactly where multi-statement atomicity is required and
   nowhere else: `UpdateTimestampAsync` (read-check-replace of non-commercial segments) and
   `ResetSeasonForReanalysisAsync` (chunked deletes + episode-list clear must commit
@@ -284,7 +304,7 @@ How bypass is prevented without a repository interface:
 | Feature | Verdict | Why |
 |---|---|---|
 | `AddPooledDbContextFactory` | **Don't use** | Pooling requires a single public options-ctor; our contexts must keep the string-path ctor for the design-time factory-free test convention, `EnsureLegacySchemaCompatibility` tooling, and ~30 existing test files. Pooling also skips per-instance `OnConfiguring` (the string-path config path would silently die) and retains context state across leases. The measured win is ~µs per lease; every operation here does real SQLite I/O (≥100 µs). Interceptors themselves are pooling-compatible (they live on the singleton options), so this is revisitable if the string ctor is ever deleted — but it isn't worth breaking the ctor contract today. |
-| EF10 parameterized-collection translation (padding) vs `Chunk(500)` | **Keep chunking** | Measured on this repo (EF 10.0.7, SQLite, `ToQueryString`): default mode now emits **one scalar parameter per element** (`WHERE ItemId IN (@ids1…@idsN)`, padded buckets) — so the SQLite host-parameter limit (`SQLITE_MAX_VARIABLE_NUMBER` = 32766 since SQLite 3.32; e_sqlite3 3.50.x ships the default) applies again, and the existing 33k-episode regression test would fail unchunked. Chunking *could* go by forcing `EF.Parameter(ids)`, which we verified translates to a single JSON parameter + `json_each(@ids)` subquery (unbounded). Rejected for now: it pins correctness to a per-query translation-mode annotation that a future refactor can silently drop, whereas `Chunk(500)` is provider-agnostic, keeps per-statement work bounded, and costs one extra round-trip per 500 IDs on a maintenance path. The constant is documented with the real limit (500 is conservative, not load-bearing). |
+| EF10 parameterized-collection translation (padding) vs manual chunking | **Use `EF.Parameter` (JSON/`json_each`); chunking removed** (revised in round 2) | Measured on this repo (EF 10.0.7, SQLite, `ToQueryString`): the default mode emits one scalar parameter per element (`WHERE ItemId IN (@ids1…@idsN)`, padded buckets), so the SQLite host-parameter limit (`SQLITE_MAX_VARIABLE_NUMBER` = 32766 since SQLite 3.32; e_sqlite3 3.50.x ships the default) applies and 33k-ID sets throw 'too many SQL variables'. `EF.Parameter(ids)` forces the EF8/9-style translation: a single JSON parameter consumed via `json_each(@ids)` — no parameter limit at any collection size. Round-1 kept `Chunk(500)` as the provider-agnostic option; the round-2 coordinator benchmark on this exact stack flipped the call: 33k-ID `Contains` ×5 = 235 ms via `EF.Parameter` vs 1552 ms chunked (~6.6×), `ExecuteDelete` NOT-IN at 33k = 218 ms. All five unbounded-collection sites (`CleanTimestampsAsync` — now a single NOT-IN `ExecuteDelete`, dropping the extra read round-trip — `CleanStaleAutomaticSegmentsAsync`, `ResetSeasonForReanalysisAsync`, `GetSeasonQueueSnapshotAsync`, `CleanSeasonStateAsync`, plus `CleanCacheTask`'s cache delete) now use `EF.Parameter`, each pinned by a 33,000-ID test (> 32,766). Residual risk — the annotation is per-query and a refactor could silently drop it — is contained by the pin tests, which fail with 'too many SQL variables' the moment `EF.Parameter` disappears. Small enum/mode collections (≤6 elements) keep the default multi-parameter translation for index-friendly plans. |
 | `ExecuteUpdate` / `ExecuteDelete` | **Use (already in use)** | All bulk deletes go through `ExecuteDeleteAsync`. The EF10 non-expression `ExecuteUpdateAsync(setters => …)` overload was evaluated for the "clear `EpisodeIds`" writes; not adopted because those writes go through a value-converted property inside a transaction that also needs the loaded entities, so tracked updates are equally cheap and keep one code shape. Adopt where a standalone conditional bulk-update appears. |
 | Compiled queries (`EF.CompileAsyncQuery`) | **Use, narrowly** | Adopted for exactly one query: `GetSegmentsAsync`, the per-playback hot path (`SegmentProvider.GetMediaSegments`). It removes per-call expression-tree allocation + query-cache lookup. Benefit is honest-but-small (the SQLite read dominates); cost is near-zero since the query is trivial. A cross-model hazard (compiled delegate vs. contexts built from different options) was considered and is empirically pinned by test `GetSegmentsAsync_CompiledQuery_WorksAcrossPathAndOptionsBasedContexts`. Not worth extending to cold paths. |
 | Named query filters | **Don't use** | No global-filter use case: `IsUserProvided`/`ConfigHash` predicates vary per operation, and a filter default that silently hides rows is exactly how the user-precedence invariant would get corrupted. |
@@ -309,13 +329,13 @@ tests against real SQLite** (temp files / in-memory connections) and reflection-
   *seeding the database*, which is both easier and higher-fidelity than mocking a
   repository (unique indexes, converters, and transactions actually execute).
 - New coverage added in the spike (`TestDbOperations`): user-provided precedence (2
-  tests), credits/intro overlap guard (3 cases), chunked `CleanTimestampsAsync` above the
-  legacy 999-parameter limit, chunked `CleanStaleAutomaticSegmentsAsync` preserving
-  user-provided rows across chunks, compiled-query cross-context safety, and the
-  init-gate ordering proof.
-- All pre-existing DB tests (legacy repair, migration history, rebuild, 33k-episode
-  chunking) pass unchanged through the delegating `Plugin` methods, demonstrating
-  behavioral equivalence of the moved code.
+  tests), credits/intro overlap guard (3 cases), 33,000-ID pin tests (> `SQLITE_MAX_VARIABLE_NUMBER`)
+  for `CleanTimestampsAsync`, `CleanStaleAutomaticSegmentsAsync` (user rows preserved),
+  `ResetSeasonForReanalysisAsync`, and `GetSeasonQueueSnapshotAsync`, compiled-query
+  cross-context safety, the init-gate ordering proof, and cache-init fault isolation.
+- All pre-existing DB tests (legacy repair, migration history, rebuild, the original
+  33k-episode `CleanTimestampsAsync` test) pass unchanged through the delegating `Plugin`
+  methods, demonstrating behavioral equivalence of the moved code.
 
 What is genuinely harder: simulating *database failures* (e.g. "TryRead swallows
 `DbException`"). A repository mock can `Throw()`; here you corrupt a real file or use an
@@ -330,8 +350,10 @@ capability is lost — but pure-unit-test purists will not love it.
 |---|---|---|---|---|
 | 1 | **Invariant bypass**: a future call site does `db.DbSegment.Add(...)` directly, skipping user-precedence/overlap rules | Medium | High (silent data corruption of user edits) | Class-doc convention + review anchor; invariant tests pin behavior; documented upgrade path to BannedApiAnalyzers (`RS0030` already error-severity); schema-level unique indexes catch the duplicate class of mistakes regardless |
 | 2 | **Query-logic drift/duplication** across inline call sites (e.g. two subtly different "erase season" flows) | Medium | Medium | The inline/shared line (§1) forces multi-statement flows into ops; inventory table names the two end-state ops (`EraseSeasonDataAsync`, `ClearEpisodesAsync`) precisely to prevent the known duplication between `EraseSeasonAsync` and `ClearExcludedTimestampsAsync` |
-| 3 | Sync `CreateDbContext()` blocks on first call during a long migration | Low (migrations are small; hosted service usually wins the race) | Medium (one slow request at startup) | Eager hosted kick-off; async factory path used on all request paths in migrated code; no synchronization context in Jellyfin ⇒ no deadlock |
+| 3 | Sync `CreateDbContext()` blocks on first call during a long migration; N concurrent sync callers pin N thread-pool threads | Low (migrations are small; hosted service usually wins the race) | Medium (slow requests at startup) | Round 2: audited — every async call site (delegators included) now uses `CreateDbContextAsync`; sync gate remains only for the genuinely-sync `IDetectionCacheService` surface; eager hosted kick-off; no synchronization context in Jellyfin ⇒ no deadlock |
 | 4 | Compiled query executed against a context with a different model instance throws | Low (single context type ⇒ single cached model) | Medium | Pinned by dedicated test across both construction styles; fallback is deleting one `EF.CompileAsyncQuery` line |
+| 9 | A refactor drops an `EF.Parameter` annotation, silently reverting to per-element parameters and re-exposing the 32766 limit | Low | High at pathological library sizes | 33,000-ID pin tests on every unbounded-collection operation fail immediately ('too many SQL variables') if the annotation disappears |
+| 10 | Faulted init task poisoning all context creation (round-1 defect) | — (fixed) | High | Round 2: per-database gates + catch-all init cores; pinned by `CacheInitializationFailure_DoesNotBlockSegmentDatabaseAccess` |
 | 5 | Transitional state: `Plugin` delegators + `Plugin.Instance` fallback path (`new IntroSkipperDbContext(DbPath)`) bypasses the gate for reflection-created test plugins | Certain (by design) | Low (test-only path; prod always has the factory) | Fallback exists only when the ctor never ran; end state deletes delegators and fallback entirely |
 | 6 | `AddDbContextFactory` registers EF core services into Jellyfin's *global* container (options, scoped `TContext`) | Certain | Low | Registrations are generic over our context types only; no collision with Jellyfin's own EF registrations (verified: server boots these patterns for other plugins; nothing resolves a bare `DbContext`) |
 | 7 | Threading the factory through 5 manually-`new`-ed constructors (end state) touches many signatures at once | Certain | Medium (mechanical but wide diff) | Constructors already thread 6–8 dependencies this way; change is type-checked end-to-end; can land per-consumer since delegators keep old paths alive |
@@ -378,15 +400,81 @@ straight from the EF playbook rather than invented here.
 | File | Role |
 |---|---|
 | `IntroSkipper/Db/IntroSkipperDatabase.cs` | Paths + shared SQLite options config (single source of truth) |
-| `IntroSkipper/Db/DatabaseInitializer.cs` | Lifecycle owner: init gate, legacy repair + migrate, cache recovery, rebuild |
+| `IntroSkipper/Db/DatabaseInitializer.cs` | Lifecycle owner: two independent never-faulting init gates, legacy repair + migrate, cache recovery, rebuild |
 | `IntroSkipper/Db/DatabaseInitializationService.cs` | Hosted eager kick-off |
 | `IntroSkipper/Db/GatedIntroSkipperDbContextFactory.cs`, `GatedDetectionCacheDbContextFactory.cs` | `IDbContextFactory<T>` impls awaiting the gate |
-| `IntroSkipper/Db/SegmentOperations.cs` | Segment ops incl. invariant home + compiled hot-path query + chunked deletes |
-| `IntroSkipper/Db/SeasonStateOperations.cs` | Season-state ops incl. transactional reset + chunked snapshot |
+| `IntroSkipper/Db/SegmentOperations.cs` | Segment ops incl. invariant home + compiled hot-path query + `EF.Parameter` set-based deletes |
+| `IntroSkipper/Db/SeasonStateOperations.cs` | Season-state ops incl. transactional reset + `EF.Parameter` snapshot/cleanup |
 | `IntroSkipper/PluginServiceRegistrator.cs` | DI registrations (§3) |
 | `IntroSkipper/Plugin.cs` | Zero query logic; 18 thin delegators (transitional), bootstrap removed |
 | `IntroSkipper/Providers/SegmentProvider.cs` | Migrated: factory-injected reads/deletes |
 | `IntroSkipper/Controllers/SkipIntroController.cs` | Migrated: invariant write path, inline delete, initializer-owned rebuild |
-| `IntroSkipper/FFmpeg/DetectionCacheService.cs` | Migrated: all 5 sites off `Plugin.CreateCacheDbContext()` |
-| `IntroSkipper.Tests/TestDbOperations.cs` | New layer tests: invariants, chunking, compiled query, init-gate ordering |
+| `IntroSkipper/FFmpeg/DetectionCacheService.cs` | Migrated: all 5 sites off `Plugin.CreateCacheDbContext()` (sync factory path — sync interface) |
+| `IntroSkipper/Controllers/VisualizationController.cs` | Migrated (R2): both factories injected, async context creation |
+| `IntroSkipper/ScheduledTasks/CleanCacheTask.cs` | Migrated (R2): cache factory injected, `EF.Parameter` delete |
+| `IntroSkipper.Tests/TestDbOperations.cs` | New layer tests: invariants, 33k `EF.Parameter` pins, compiled query, init-gate ordering, fault isolation |
 | `IntroSkipper.Tests/EntrypointTestHelpers.cs` | Test factories (`FixedPathIntroSkipperDbContextFactory`, `PluginCacheDbContextFactory`, `CreateDatabaseInitializer`) |
+
+---
+
+## 12. Round 2 revisions
+
+Changes made in response to coordinator review (all verified by the full suite: 379
+passing, only the known environmental `TestSilenceDetection` failure remains).
+
+1. **Fault containment (high) — fixed with both suggested remedies.**
+   `DatabaseInitializer` now has **two independent gates**, one per database
+   (`EnsureSegmentDatabaseInitialized[Async]` / `EnsureCacheDatabaseInitialized[Async]`),
+   and each gated factory awaits only its own database's gate; additionally both init
+   cores are **catch-all log-and-continue**, so an init task can never fault and cache
+   an exception, and `DatabaseInitializationService.StartAsync` can never abort host
+   startup. The failure-domain split now matches the reason the databases are separate
+   files in the first place. Pinned by
+   `CacheInitializationFailure_DoesNotBlockSegmentDatabaseAccess`, which injects a cache
+   configuration that throws `InvalidOperationException` (outside the old
+   `IOException or SqliteException` filter) and asserts the combined gate completes and
+   the segment factory still hands out fully migrated contexts.
+
+2. **`EF.Parameter` adopted; `Chunk(500)` removed (major, verdict revised).**
+   The coordinator's benchmark on this exact stack (33k-ID `Contains` ×5: 235 ms vs
+   1552 ms chunked; NOT-IN `ExecuteDelete` at 33k: 218 ms; default translation throws)
+   outweighs round 1's provider-agnosticism argument. All unbounded-collection
+   operations now pass the collection as a single JSON parameter:
+   - `CleanTimestampsAsync` → one `ExecuteDelete` with `!EF.Parameter(ids).Contains(...)`
+     (also drops the previous read-then-delete round-trip entirely);
+   - `CleanStaleAutomaticSegmentsAsync`, `ResetSeasonForReanalysisAsync`,
+     `GetSeasonQueueSnapshotAsync`, `CleanSeasonStateAsync` → `EF.Parameter` IN/NOT-IN;
+   - `CleanCacheTask`'s stale-cache delete likewise; its stale-ID *read* was also fixed —
+     the old `Where(id => !enabledIds.Contains(id))` against the queryable would itself
+     have exceeded the parameter limit under EF10's default translation at 33k enabled
+     episodes, and is now a full distinct-ID fetch + client-side `ExceptWith`.
+   `SqliteParameterBatchSize` and all chunk loops are deleted. Each rewritten operation
+   is pinned by a 33,000-ID test (> `SQLITE_MAX_VARIABLE_NUMBER` = 32,766) that fails
+   with 'too many SQL variables' if the `EF.Parameter` annotation is ever dropped —
+   converting the round-1 "annotation can silently disappear" objection into a caught
+   regression. Small mode/enum collections (≤ 6 elements) intentionally keep the default
+   translation. The original 33k `Plugin.CleanTimestampsAsync` regression test passes
+   unchanged through the delegator.
+
+3. **Sync-over-async gate (documented + mitigated).** Audit result: the 18 `Plugin`
+   delegators now create contexts through a private async helper
+   (`await factory.CreateDbContextAsync(ct)`), and `VisualizationController` (3 sites)
+   and `CleanCacheTask` (2 sites) were migrated off `Plugin.Create*DbContext()` onto
+   injected factories with async creation — eliminating every sync-from-async context
+   creation in production code. The synchronous gate remains only behind the genuinely
+   synchronous `IDetectionCacheService` surface (`DetectionCacheService`), whose
+   interface is sync by contract. Risk register #3 updated. (Public transitional
+   `Plugin.CreateDbContextAsync` variants were deliberately *not* added: CA1849 would
+   then flag every remaining sync call in async test helpers, forcing unrelated test
+   churn for API that the end state deletes anyway.)
+
+4. **WAL (verified).** Round 1 made no WAL claim; §5 now records the verification: EF's
+   SQLite provider sets `journal_mode=wal` when migrations create the database and the
+   mode persists in the file (a fresh raw `SqliteConnection` on a migration-created DB
+   reports `wal`), so the interceptor correctly leaves journal mode alone.
+
+Net effect on the theory's standing: item 2 strengthens Theory C's core claim — staying
+on the raw EF surface let the fix land as a one-line-per-query annotation with no
+interface changes, and made the maintenance path measurably faster; item 1 was a real
+design defect in round 1 (a facade would have had the same bug, but honesty requires
+noting the gate design needed a second pass to get failure domains right).

--- a/docs/db-redesign/theory-c.md
+++ b/docs/db-redesign/theory-c.md
@@ -1,0 +1,392 @@
+# Theory C: No Repository — `DbContext` *is* the Repository
+
+**Status:** exploration spike (branch `12.0` derivative), competing with two rival designs
+(layered stores, facade). Prototype compiles StyleCop-clean and passes the full test suite
+(376 passing; only the known environmental `TestAudioFingerprinting.TestSilenceDetection`
+failure remains).
+
+---
+
+## 1. Architecture overview
+
+EF Core's `DbContext` already implements the Repository and Unit-of-Work patterns
+(`DbSet<T>` = repository, `SaveChanges` = unit of work). The EF team's own guidance is to
+not wrap it again. Theory C takes that position literally for this plugin:
+
+1. **Consumers inject `IDbContextFactory<IntroSkipperDbContext>` and/or
+   `IDbContextFactory<DetectionCacheDbContext>` directly.** There is no `ISegmentStore`,
+   no `IIntroSkipperRepository`, no facade. The factory interface *is* the data-access seam.
+2. **Shared multi-step operations become extension methods on the context**, grouped by
+   aggregate into static classes in `IntroSkipper.Db`:
+   - `SegmentOperations` — everything touching `DbSegment`
+   - `SeasonStateOperations` — everything touching `DbSeasonState`
+3. **Single-query call sites inline their LINQ** against a factory-created context
+   (e.g. `ResetIntroTimestamps`' one-line `ExecuteDelete`).
+4. **Lifecycle has one owner**: `DatabaseInitializer` (a plain DI singleton) owns
+   migrations, legacy schema repair, cache create-or-recover, and rebuild. Two thin
+   `IDbContextFactory<T>` implementations (`GatedIntroSkipperDbContextFactory`,
+   `GatedDetectionCacheDbContextFactory`) await the initializer before handing out any
+   context — this is the ordering proof (§5).
+
+```
+Consumers (controllers, SegmentProvider, tasks, analyzers, DetectionCacheService)
+        │  ctor-inject
+        ▼
+IDbContextFactory<TContext>  ──implemented by──►  Gated*DbContextFactory
+        │  CreateDbContext[Async]()                      │ awaits (once)
+        ▼                                                ▼
+   TContext (DbContext)                          DatabaseInitializer
+        │  extension methods                     (legacy repair → Migrate;
+        ▼                                         cache EnsureSchema/recover;
+SegmentOperations / SeasonStateOperations         RebuildDatabaseAsync)
+   (domain invariants live here)
+```
+
+### Extension methods vs. static operation classes — chosen convention
+
+Chosen: **extension methods on the context, grouped into per-aggregate static classes**
+(`db.UpdateTimestampAsync(...)`, `db.GetSeasonQueueSnapshotAsync(...)`).
+
+Why extensions rather than `SegmentOperations.UpdateTimestampAsync(db, ...)` static calls:
+
+- **Discoverability.** IntelliSense on `db.` surfaces the whole operation vocabulary to
+  anyone holding a context. This directly answers the "how do I find operations?"
+  objection — the context is the API surface, exactly as EF intends.
+- **Composability.** An operation works inside *whatever context the caller already has*,
+  so several operations can share one context/transaction. The prototype exploits this:
+  `SkipIntroController.UpdateTimestampsAsync` now writes all five segment types through a
+  single context instead of the five contexts the old `Plugin` methods opened.
+- The grouping into `SegmentOperations`/`SeasonStateOperations` keeps files reviewable and
+  gives the invariants a named home to cite in review comments.
+
+Why not extensions on `IDbContextFactory<T>` (one-liner call sites): it hides context
+lifetime, forbids sharing a context across operations, and reintroduces a de-facto
+repository with a different spelling.
+
+### The inline-vs-shared line
+
+- **Inline is fine:** single-site *reads* and single-site *deletes* expressed as one LINQ
+  statement (`ExecuteDelete`, `Any`, `FirstOrDefault`). Example: `ResetIntroTimestamps`.
+- **Must be a shared operation:** (a) anything that **inserts or replaces `DbSegment`
+  rows** — that is exclusively `SegmentOperations.UpdateTimestampAsync`, the invariant
+  home (§6); (b) any multi-statement flow used from ≥ 2 call sites; (c) anything needing
+  chunked batching (the batching policy must not be re-derived at call sites).
+- `DetectionCacheService` keeps its inline LINQ: it *is* the single consumer-facing owner
+  of the cache table plus its compression/config-hash logic; wrapping it again would be
+  the repository anti-pattern this theory rejects.
+
+---
+
+## 2. Complete migration inventory
+
+"Prototype" = migrated in this spike. "Delegating" = the `Plugin` method body is now a
+2-line delegation to the new home (zero query logic remains in `Plugin.cs`); the end state
+deletes the delegator and injects the factory at the listed consumers.
+
+### The 18 `Plugin` DB methods
+
+| # | Current `Plugin` member | New home | Consumers to rewire in end state | Status |
+|---|---|---|---|---|
+| 1 | `UpdateTimestampAsync` | `SegmentOperations.UpdateTimestampAsync` (ext) — invariant home | SkipIntroController (**done**), SegmentEditorController, ChapterAnalyzer, ChromaprintAnalyzer, BlackFrameAnalyzer, BaseItemAnalyzerTask | Prototype + delegating |
+| 2 | `GetTimestampsAsync` | `SegmentOperations.GetTimestampsAsync` (ext) | SkipIntroController (**done**), RecapDetectionHelper | Prototype + delegating |
+| 3 | `GetSegmentsAsync` | `SegmentOperations.GetSegmentsAsync` (ext, compiled query) | SegmentProvider (**done**), SegmentEditorController, BaseItemAnalyzerTask | Prototype + delegating |
+| 4 | `DeleteItemSegmentsAsync` | `SegmentOperations.DeleteItemSegmentsAsync` (ext) | SegmentProvider (**done**) | Prototype + delegating |
+| 5 | `DeleteTimestampAsync` | `SegmentOperations.DeleteTimestampAsync` (ext) | SegmentEditorController | Delegating |
+| 6 | `CleanTimestampsAsync` | `SegmentOperations.CleanTimestampsAsync` (ext, chunked) | CleanCacheTask | Prototype (op + tests) + delegating |
+| 7 | `CleanStaleAutomaticSegmentsAsync` | `SegmentOperations.CleanStaleAutomaticSegmentsAsync` (ext, chunked) | BaseItemAnalyzerTask | Prototype (op + tests) + delegating |
+| 8 | `SetAnalyzerActionAsync` | `SeasonStateOperations.SetAnalyzerActionAsync` (ext) | VisualizationController | Delegating |
+| 9 | `SetEpisodeIdsAsync` | `SeasonStateOperations.SetEpisodeIdsAsync` (ext) | BaseItemAnalyzerTask | Delegating |
+| 10 | `RemoveEpisodeIdAsync` | `SeasonStateOperations.RemoveEpisodeIdAsync` (ext) | SegmentEditorController | Delegating |
+| 11 | `GetEpisodeIdsAsync` | `SeasonStateOperations.GetEpisodeIdsAsync` (ext) | (currently unused externally) | Delegating |
+| 12 | `GetSettleReanalysisStatesAsync` | `SeasonStateOperations.GetSettleReanalysisStatesAsync` (ext) | BaseItemAnalyzerTask | Delegating |
+| 13 | `RecordSettleReanalysisAsync` | `SeasonStateOperations.RecordSettleReanalysisAsync` (ext) | BaseItemAnalyzerTask | Delegating |
+| 14 | `ResetSeasonForReanalysisAsync` | `SeasonStateOperations.ResetSeasonForReanalysisAsync` (ext, chunked + transaction) | BaseItemAnalyzerTask | Delegating |
+| 15 | `GetSeasonQueueSnapshotAsync` | `SeasonStateOperations.GetSeasonQueueSnapshotAsync` (ext, chunked) | QueueManager | Delegating |
+| 16 | `GetAllAnalyzerActionsAsync` | `SeasonStateOperations.GetAllAnalyzerActionsAsync` (ext) | VisualizationController | Delegating |
+| 17 | `GetAnalyzerActionAsync` | `SeasonStateOperations.GetAnalyzerActionAsync` (ext) | BaseItemAnalyzerTask | Delegating |
+| 18 | `CleanSeasonStateAsync` | `SeasonStateOperations.CleanSeasonStateAsync` (ext) | CleanCacheTask | Delegating |
+
+Non-DB members that merely live near them: `ShouldSettleReanalyze` (pure set comparison)
+and `MapSegmentTypeToMode` stay put (end state: move to `IntroSkipper.Data` helpers —
+they have no business on `Plugin` either, but they are not DB code).
+
+### Direct context call sites
+
+| Call site | Today | End-state home | Status |
+|---|---|---|---|
+| `SkipIntroController.ResetIntroTimestamps` | `Plugin.CreateDbContext()` + `ExecuteDelete` | **Inline** against injected factory (single-query delete) | **Done** |
+| `SkipIntroController.RebuildDatabase` | `db.RebuildDatabaseAsync(Plugin.CreateDbContext)` | `DatabaseInitializer.RebuildDatabaseAsync()` (lifecycle owner) | **Done** |
+| `VisualizationController.EraseSeasonAsync` | segment `ExecuteDelete` + season-state clear on one context | Shared op `SeasonStateOperations.EraseSeasonDataAsync(db, seasonId, episodeIds)` — multi-statement, also invoked by `ScanSeason`; cache deletion stays in the controller (cross-store orchestration is caller concern) | End state |
+| `VisualizationController.ClearExcludedTimestampsAsync` (segment db) | inline multi-statement | Shared op `SeasonStateOperations.ClearEpisodesAsync(db, idsBySeason)` (multi-statement, returns counts) | End state |
+| `VisualizationController.ClearExcludedTimestampsAsync` (cache db) | `Plugin.CreateCacheDbContext()` + `ExecuteDelete` | Inline against injected `IDbContextFactory<DetectionCacheDbContext>` | End state |
+| `CleanCacheTask` (2 cache sites) | `Plugin.CreateCacheDbContext()` | Inline against injected cache factory (single-query read + single-query delete) | End state |
+| `DetectionCacheService` (5 sites) | `Plugin.CreateCacheDbContext()` | Injected `IDbContextFactory<DetectionCacheDbContext>`, LINQ stays inline in the service | **Done (all 5)** |
+| `Plugin` ctor DB bootstrap | sync migrate + legacy repair + cache EnsureSchema | `DatabaseInitializer` + hosted kick-off + factory gate | **Done** |
+
+### Threading dependencies through manually-constructed objects (end state)
+
+`BaseItemAnalyzerTask`, `QueueManager`, and the analyzers are `new`-ed, not DI-resolved.
+The factory is a **singleton**, so threading it is mechanical — every constructor gains an
+`IDbContextFactory<IntroSkipperDbContext>` parameter supplied by the DI-resolved roots:
+
+- `Entrypoint`, `DetectSegmentsTask`, `CleanCacheTask`, `VisualizationController` (all
+  DI-resolved) inject the factory and pass it to `new BaseItemAnalyzerTask(..., dbFactory)`
+  and `new QueueManager(..., dbFactory)`.
+- `BaseItemAnalyzerTask` passes it to `new ChapterAnalyzer(..., dbFactory)`,
+  `ChromaprintAnalyzer`, `BlackFrameAnalyzer`, `CreditsBlackFrameAnalyzer`; a
+  `dbFactory` parameter is added to `RecapDetectionHelper.GetMaximumBoundaryAsync`.
+- Loggers already travel exactly this way in the current code (`_loggerFactory.CreateLogger<…>()`),
+  so this adds one parameter to constructors that already take six to eight.
+
+No `Plugin.Instance` DB access remains in the end state; `Plugin.CreateDbContext()` /
+`CreateCacheDbContext()` and all 18 delegators are deleted.
+
+---
+
+## 3. DI registration (as implemented)
+
+```csharp
+// PluginServiceRegistrator.RegisterServices
+serviceCollection.AddSingleton<DatabaseInitializer>();
+serviceCollection.AddHostedService<DatabaseInitializationService>();
+serviceCollection.AddDbContextFactory<IntroSkipperDbContext, GatedIntroSkipperDbContextFactory>(
+    (serviceProvider, options) => IntroSkipperDatabase.ConfigureSqlite(
+        options,
+        IntroSkipperDatabase.GetSegmentDatabasePath(serviceProvider.GetRequiredService<IApplicationPaths>())));
+serviceCollection.AddDbContextFactory<DetectionCacheDbContext, GatedDetectionCacheDbContextFactory>(
+    (serviceProvider, options) => IntroSkipperDatabase.ConfigureSqlite(
+        options,
+        IntroSkipperDatabase.GetCacheDatabasePath(serviceProvider.GetRequiredService<IApplicationPaths>())));
+```
+
+Notes:
+
+- `AddDbContextFactory<TContext, TFactory>` is the EF-sanctioned hook for a custom factory:
+  it registers `DbContextOptions<TContext>` (singleton) and our gated factory as
+  `IDbContextFactory<TContext>` in one idiomatic call. The gated factory constructs
+  contexts through the options-based constructor — no EF-internal types involved.
+- DB paths are computed lazily from `IApplicationPaths` (resolvable in Jellyfin's
+  container) the first time options are built; `IntroSkipperDatabase` is the single source
+  of truth for paths + connection config, shared with `Plugin` (which still exposes
+  `DbPath`/`CacheDbPath` for diagnostics and tests).
+- The shared `SqlitePragmaInterceptor` (busy_timeout=5000) is attached to the singleton
+  options in `ConfigureSqlite`; the string-path constructors' `OnConfiguring` keeps
+  attaching it for the design-time/test path, so both construction styles produce
+  identically-configured connections.
+- `DatabaseInitializer` takes the two `DbContextOptions<T>` singletons directly and news
+  contexts internally — it is *inside* the data layer and deliberately bypasses the gate
+  (it *is* the gate).
+
+---
+
+## 4. Initialization & lifecycle design
+
+**Owner:** `DatabaseInitializer` (DI singleton).
+
+- `EnsureInitializedAsync(ct)` / `EnsureInitialized()` — one-time init guarded by
+  `lock + Task?` (first caller starts `Task.Run(InitializeCore)`, everyone else awaits the
+  same task; a cancelled waiter abandons the *wait*, never the initialization).
+- `InitializeCore()` reproduces the previous `Plugin`-ctor behavior verbatim, including
+  error semantics: segment DB → ensure directory, `EnsureLegacySchemaCompatibility()`,
+  `Database.Migrate()`, catch-all logged as warning (a broken DB must not kill the
+  plugin); cache DB → `EnsureSchema()` (EnsureCreated + probe + delete-and-recreate on
+  corruption), `IOException`/`SqliteException` logged as warning.
+- `RebuildDatabaseAsync(force, ct)` — awaits the gate first (a rebuild must never race
+  first-time init), then runs the existing salvage/rebuild flow on `IntroSkipperDbContext`
+  unchanged. `SkipIntroController.RebuildDatabase` calls this.
+- `DatabaseInitializationService` (`IHostedService`) kicks the gate eagerly at server
+  start so the first playback query doesn't pay the migration cost. It is an optimization
+  only — correctness never depends on it.
+
+### Ordering proof
+
+Claim: **no query executes before migrations/legacy repair complete.**
+
+1. Every runtime code path obtains a context from `IDbContextFactory<T>` — either by
+   direct injection (migrated consumers) or via `Plugin.CreateDbContext()`, which now
+   delegates to the injected factory. Verified by grep: no production code constructs
+   `IntroSkipperDbContext`/`DetectionCacheDbContext` outside `IntroSkipper.Db` (the
+   initializer and the rebuild callback, which run under the gate by construction).
+2. Both factory implementations await/block on `EnsureInitializedAsync` **before**
+   constructing the context (`GatedIntroSkipperDbContextFactory.CreateDbContext[Async]`).
+3. Init is idempotent and single-flight, so concurrent early callers (Jellyfin hitting
+   `SegmentProvider` or a controller during startup) all observe the same completed task.
+4. Covered by test `GatedFactory_AppliesMigrationsBeforeHandingOutContexts`: on a fresh
+   file, the *first* context handed out already reports zero pending migrations.
+
+Trade-offs acknowledged: the synchronous `CreateDbContext()` path blocks
+(`GetAwaiter().GetResult()`) on first use. Init work is synchronous EF code running on a
+thread-pool thread with no synchronization context, so this cannot deadlock, but it can
+stall an early caller for the duration of a large migration — identical in effect to the
+old synchronous Plugin-ctor migration, minus blocking plugin load itself. If init *fails*,
+the gate still completes (logged warning) and later queries fail individually — again
+matching today's behavior.
+
+Rejected alternatives: keeping bootstrap in the `Plugin` ctor (leaves lifecycle glued to
+a god object, and plugin construction order vs. Kestrel startup is Jellyfin-version
+dependent — the gate holds under *any* ordering); a bare hosted-service initializer with
+no gate (provably racy: Jellyfin can serve `SegmentProvider` before/parallel to hosted
+`StartAsync`).
+
+---
+
+## 5. Transactions & SQLite concurrency
+
+- **busy_timeout=5000** applied per connection-open by the shared interceptor (unchanged).
+  This remains the primary defense for the plugin's real concurrency pattern:
+  `Parallel.ForEachAsync` season analysis writing while playback reads.
+- **Explicit transactions** stay exactly where multi-statement atomicity is required and
+  nowhere else: `UpdateTimestampAsync` (read-check-replace of non-commercial segments) and
+  `ResetSeasonForReanalysisAsync` (chunked deletes + episode-list clear must commit
+  together). Because operations are extensions on the *caller's* context, a future caller
+  can wrap several operations in one `db.Database.BeginTransactionAsync()` without any
+  layer changes — something the old one-context-per-Plugin-method shape made impossible.
+- Each logical operation still uses a short-lived context (create → operate → dispose);
+  connections return to Microsoft.Data.Sqlite's pool, keeping write locks brief.
+- Cross-database consistency (segment DB vs. cache DB) remains best-effort orchestration
+  at call sites, as today; the cache is reconstructable by design.
+
+---
+
+## 6. Domain invariants: single home + bypass prevention
+
+Both invariants live in exactly one place, `SegmentOperations.UpdateTimestampAsync`:
+
+1. user-provided segments are never overwritten by analysis results;
+2. auto-detected credits that overlap the stored intro are rejected (user-provided ones
+   are allowed).
+
+Multiplicity rules (commercial multi-row with filtered unique index, non-commercial
+unique per `(ItemId, Type)`) are enforced *structurally* by the schema's filtered unique
+indexes — they survive any bypass.
+
+How bypass is prevented without a repository interface:
+
+- **Stated convention with a named anchor:** the rule ("reads and deletes may be inline;
+  `DbSegment.Add`/`AddRange` only inside `SegmentOperations`") is written on the
+  `SegmentOperations` class doc, which is the thing reviewers link to.
+- **Greppability:** `DbSegment.Add` outside `Db/` is a one-line CI check away; the repo
+  already treats warnings as errors and has `RS0030` (banned APIs) pre-wired in
+  `.editorconfig` — the upgrade path is adding `Microsoft.CodeAnalysis.BannedApiAnalyzers`
+  with `P:IntroSkipper.Db.IntroSkipperDbContext.DbSegment` banned and a `#pragma`
+  allowance inside `SegmentOperations`. Deliberately not done in the spike (it also bans
+  legitimate inline reads unless the ban is scoped, which needs team buy-in).
+- **Honesty:** this is weaker than a compile-time seam. A layered-store design can make
+  the `DbSet` unreachable; Theory C cannot, because exposing the context *is the point*.
+  Ranked as the design's top risk (§9). Mitigation that keeps the theory intact: tests
+  pin both invariants (`TestDbOperations`), so a bypassing call site that corrupts
+  precedence semantics gets caught the moment anyone reproduces the flow in a test.
+
+---
+
+## 7. EF Core 10 feature verdicts
+
+| Feature | Verdict | Why |
+|---|---|---|
+| `AddPooledDbContextFactory` | **Don't use** | Pooling requires a single public options-ctor; our contexts must keep the string-path ctor for the design-time factory-free test convention, `EnsureLegacySchemaCompatibility` tooling, and ~30 existing test files. Pooling also skips per-instance `OnConfiguring` (the string-path config path would silently die) and retains context state across leases. The measured win is ~µs per lease; every operation here does real SQLite I/O (≥100 µs). Interceptors themselves are pooling-compatible (they live on the singleton options), so this is revisitable if the string ctor is ever deleted — but it isn't worth breaking the ctor contract today. |
+| EF10 parameterized-collection translation (padding) vs `Chunk(500)` | **Keep chunking** | Measured on this repo (EF 10.0.7, SQLite, `ToQueryString`): default mode now emits **one scalar parameter per element** (`WHERE ItemId IN (@ids1…@idsN)`, padded buckets) — so the SQLite host-parameter limit (`SQLITE_MAX_VARIABLE_NUMBER` = 32766 since SQLite 3.32; e_sqlite3 3.50.x ships the default) applies again, and the existing 33k-episode regression test would fail unchunked. Chunking *could* go by forcing `EF.Parameter(ids)`, which we verified translates to a single JSON parameter + `json_each(@ids)` subquery (unbounded). Rejected for now: it pins correctness to a per-query translation-mode annotation that a future refactor can silently drop, whereas `Chunk(500)` is provider-agnostic, keeps per-statement work bounded, and costs one extra round-trip per 500 IDs on a maintenance path. The constant is documented with the real limit (500 is conservative, not load-bearing). |
+| `ExecuteUpdate` / `ExecuteDelete` | **Use (already in use)** | All bulk deletes go through `ExecuteDeleteAsync`. The EF10 non-expression `ExecuteUpdateAsync(setters => …)` overload was evaluated for the "clear `EpisodeIds`" writes; not adopted because those writes go through a value-converted property inside a transaction that also needs the loaded entities, so tracked updates are equally cheap and keep one code shape. Adopt where a standalone conditional bulk-update appears. |
+| Compiled queries (`EF.CompileAsyncQuery`) | **Use, narrowly** | Adopted for exactly one query: `GetSegmentsAsync`, the per-playback hot path (`SegmentProvider.GetMediaSegments`). It removes per-call expression-tree allocation + query-cache lookup. Benefit is honest-but-small (the SQLite read dominates); cost is near-zero since the query is trivial. A cross-model hazard (compiled delegate vs. contexts built from different options) was considered and is empirically pinned by test `GetSegmentsAsync_CompiledQuery_WorksAcrossPathAndOptionsBasedContexts`. Not worth extending to cold paths. |
+| Named query filters | **Don't use** | No global-filter use case: `IsUserProvided`/`ConfigHash` predicates vary per operation, and a filter default that silently hides rows is exactly how the user-precedence invariant would get corrupted. |
+| `LeftJoin` operator | **Don't use** | Three entities, zero navigations, no joins anywhere in the workload; season-state + segments are fetched as two indexed lookups on purpose (snapshot shape). |
+| Compiled models | **Don't use** (per shared brief) | 3-entity model; model build is a one-time startup cost measured in ms, already hidden behind the async init gate. |
+
+---
+
+## 8. Testing strategy
+
+Answering the classic objection "no interface ⇒ nothing to mock": **this repo already
+tests against real SQLite** (temp files / in-memory connections) and reflection-patched
+`Plugin.Instance`. Theory C makes those tests *simpler*, not harder:
+
+- Operations are extensions on the context, so tests call them directly on a temp-file
+  context — no `Plugin.Instance`, no `FormatterServices.GetUninitializedObject`, no
+  private-field reflection. Compare `TestDbOperations.UpdateTimestampAsync_CreditsOverlapGuard`
+  (new, 0 reflection) with the equivalent in `TestDbSegmentStorage` (needs a fake plugin
+  scope + 2 reflected fields).
+- Consumers take `IDbContextFactory<T>`; tests hand them a 3-line fixed-path factory
+  (`EntrypointTestHelpers.FixedPathIntroSkipperDbContextFactory`). Faking data is done by
+  *seeding the database*, which is both easier and higher-fidelity than mocking a
+  repository (unique indexes, converters, and transactions actually execute).
+- New coverage added in the spike (`TestDbOperations`): user-provided precedence (2
+  tests), credits/intro overlap guard (3 cases), chunked `CleanTimestampsAsync` above the
+  legacy 999-parameter limit, chunked `CleanStaleAutomaticSegmentsAsync` preserving
+  user-provided rows across chunks, compiled-query cross-context safety, and the
+  init-gate ordering proof.
+- All pre-existing DB tests (legacy repair, migration history, rebuild, 33k-episode
+  chunking) pass unchanged through the delegating `Plugin` methods, demonstrating
+  behavioral equivalence of the moved code.
+
+What is genuinely harder: simulating *database failures* (e.g. "TryRead swallows
+`DbException`"). A repository mock can `Throw()`; here you corrupt a real file or use an
+interceptor. The existing suite already does the former for cache recovery, so no new
+capability is lost — but pure-unit-test purists will not love it.
+
+---
+
+## 9. Risk register
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| 1 | **Invariant bypass**: a future call site does `db.DbSegment.Add(...)` directly, skipping user-precedence/overlap rules | Medium | High (silent data corruption of user edits) | Class-doc convention + review anchor; invariant tests pin behavior; documented upgrade path to BannedApiAnalyzers (`RS0030` already error-severity); schema-level unique indexes catch the duplicate class of mistakes regardless |
+| 2 | **Query-logic drift/duplication** across inline call sites (e.g. two subtly different "erase season" flows) | Medium | Medium | The inline/shared line (§1) forces multi-statement flows into ops; inventory table names the two end-state ops (`EraseSeasonDataAsync`, `ClearEpisodesAsync`) precisely to prevent the known duplication between `EraseSeasonAsync` and `ClearExcludedTimestampsAsync` |
+| 3 | Sync `CreateDbContext()` blocks on first call during a long migration | Low (migrations are small; hosted service usually wins the race) | Medium (one slow request at startup) | Eager hosted kick-off; async factory path used on all request paths in migrated code; no synchronization context in Jellyfin ⇒ no deadlock |
+| 4 | Compiled query executed against a context with a different model instance throws | Low (single context type ⇒ single cached model) | Medium | Pinned by dedicated test across both construction styles; fallback is deleting one `EF.CompileAsyncQuery` line |
+| 5 | Transitional state: `Plugin` delegators + `Plugin.Instance` fallback path (`new IntroSkipperDbContext(DbPath)`) bypasses the gate for reflection-created test plugins | Certain (by design) | Low (test-only path; prod always has the factory) | Fallback exists only when the ctor never ran; end state deletes delegators and fallback entirely |
+| 6 | `AddDbContextFactory` registers EF core services into Jellyfin's *global* container (options, scoped `TContext`) | Certain | Low | Registrations are generic over our context types only; no collision with Jellyfin's own EF registrations (verified: server boots these patterns for other plugins; nothing resolves a bare `DbContext`) |
+| 7 | Threading the factory through 5 manually-`new`-ed constructors (end state) touches many signatures at once | Certain | Medium (mechanical but wide diff) | Constructors already thread 6–8 dependencies this way; change is type-checked end-to-end; can land per-consumer since delegators keep old paths alive |
+| 8 | Migration-history/legacy-repair behavior must stay byte-identical for existing user DBs | — | High | Deliberately did **not** move or edit `EnsureLegacySchemaCompatibility`, `ApplyMigrations`, `RebuildDatabaseAsync`, or the design-time factory; only their *invocation point* moved (Plugin ctor → initializer). All migration/legacy tests pass unchanged |
+
+---
+
+## 10. Honest cons vs. the rival designs
+
+Arguing against myself, ranked by how much they should worry the coordinator:
+
+1. **No compile-time write seam.** A layered store can make invariant bypass *impossible*
+   (private `DbSet` access, interface exposing only `UpdateTimestampAsync`). Theory C's
+   protection is convention + analyzer-optional + tests. In a plugin with drive-by
+   contributors, that's a real, recurring review burden — this is the strongest argument
+   for a facade.
+2. **The seam is EF-shaped forever.** Every consumer signature says
+   `IDbContextFactory<IntroSkipperDbContext>`. If the storage story ever changes (Jellyfin
+   shared DB, server-side segments API), the blast radius is every consumer, not one
+   store implementation. Mitigating honesty: this plugin's contexts have survived years
+   with the storage story only getting *more* SQLite, and the rival designs' abstraction
+   would still leak EF types (`DbSegment`, transactions) unless they invest heavily.
+3. **Extension-method ergonomics have warts.** Optional `ILogger?` parameters thread
+   through operations that log (`UpdateTimestampAsync`); a store would own its logger.
+   Discoverability via IntelliSense also means *everything* is discoverable — including
+   raw `DbSegment` access sitting right next to the safe operations.
+4. **Two-step call sites.** `create context → call operation` at every consumer vs. a
+   store's one-liner. Multiplied across ~15 consumers this is visible noise; it's the tax
+   for making context lifetime/transaction scope explicit and composable.
+5. **Testing double standard.** "Real SQLite everywhere" is a feature until someone needs
+   to unit-test a consumer's *error handling* without a real corrupt file. No seam to
+   inject failures cheaply.
+
+Where Theory C beats the rivals, for symmetry: zero new abstraction to maintain, the
+smallest possible diff from current code (the 18 methods moved nearly verbatim), full EF
+capability (transactions spanning operations, `ExecuteDelete`, compiled queries) with no
+interface lag, and DI/lifecycle mechanics (`AddDbContextFactory`, init gate) that are
+straight from the EF playbook rather than invented here.
+
+---
+
+## 11. Prototype map
+
+| File | Role |
+|---|---|
+| `IntroSkipper/Db/IntroSkipperDatabase.cs` | Paths + shared SQLite options config (single source of truth) |
+| `IntroSkipper/Db/DatabaseInitializer.cs` | Lifecycle owner: init gate, legacy repair + migrate, cache recovery, rebuild |
+| `IntroSkipper/Db/DatabaseInitializationService.cs` | Hosted eager kick-off |
+| `IntroSkipper/Db/GatedIntroSkipperDbContextFactory.cs`, `GatedDetectionCacheDbContextFactory.cs` | `IDbContextFactory<T>` impls awaiting the gate |
+| `IntroSkipper/Db/SegmentOperations.cs` | Segment ops incl. invariant home + compiled hot-path query + chunked deletes |
+| `IntroSkipper/Db/SeasonStateOperations.cs` | Season-state ops incl. transactional reset + chunked snapshot |
+| `IntroSkipper/PluginServiceRegistrator.cs` | DI registrations (§3) |
+| `IntroSkipper/Plugin.cs` | Zero query logic; 18 thin delegators (transitional), bootstrap removed |
+| `IntroSkipper/Providers/SegmentProvider.cs` | Migrated: factory-injected reads/deletes |
+| `IntroSkipper/Controllers/SkipIntroController.cs` | Migrated: invariant write path, inline delete, initializer-owned rebuild |
+| `IntroSkipper/FFmpeg/DetectionCacheService.cs` | Migrated: all 5 sites off `Plugin.CreateCacheDbContext()` |
+| `IntroSkipper.Tests/TestDbOperations.cs` | New layer tests: invariants, chunking, compiled query, init-gate ordering |
+| `IntroSkipper.Tests/EntrypointTestHelpers.cs` | Test factories (`FixedPathIntroSkipperDbContextFactory`, `PluginCacheDbContextFactory`, `CreateDatabaseInitializer`) |


### PR DESCRIPTION
This PR introduces Theory C’s no-repository, EF-idiomatic database architecture, moving logic out of `Plugin` into context extension operations and lifecycle-managed DB factories.

- **Data Layer**: Created `SegmentOperations` (invariant home, compiled queries, chunking) and `SeasonStateOperations` as context extensions. Added `DatabaseInitializer` for migrations/legacy repair and gated `IDbContextFactory<T>` implementations to ensure init ordering.
- **DI**: Registered `AddDbContextFactory` in `PluginServiceRegistrator` and centralized DB path/config in `IntroSkipperDatabase`.
- **Consumers**: Migrated `SegmentProvider`, `SkipIntroController`, and `DetectionCacheService` to injected factories. Reduced `Plugin` to thin delegators for the 18 existing DB methods.
- **Testing**: Added `TestDbOperations` covering user precedence, overlap guards, chunking (SQLite param limit safety), and init gate ordering.
- **Docs**: Added comprehensive design doc at `docs/db-redesign/theory-c.md` with migration inventory, EF10 verdicts, and risk register.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-064" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064"><img alt="INTRO-064" src="https://capy.ai/api/badge/thread.svg?label=INTRO-064"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Adopt an EF-idiomatic data layer backed by IDbContextFactory for both segment and cache databases, centralizing initialization and DB paths while keeping Plugin as a thin delegator during migration.

New Features:
- Introduce IntroSkipper.Db operations layer with SegmentOperations and SeasonStateOperations as context extension APIs for all segment and season-state workflows.
- Add DatabaseInitializer and hosted DatabaseInitializationService to own one-time migrations, legacy schema repair, cache recovery, and rebuild logic behind gated DbContext factories.
- Expose IntroSkipperDatabase as the single source of truth for database paths and SQLite configuration, including a pragma interceptor and options-based construction.

Enhancements:
- Refactor SkipIntroController and SegmentProvider to inject IntroSkipperDbContext factories, sharing contexts across operations and delegating segment writes to SegmentOperations.
- Switch DetectionCacheService to depend on an injected DetectionCacheDbContext factory instead of Plugin.CreateCacheDbContext, aligning cache access with the new DI-based DB layer.
- Provide test-only DbContextFactory implementations and helpers so consumers and cache services can be exercised against real SQLite in unit tests without Plugin reflection tricks.

Documentation:
- Add a comprehensive design document at docs/db-redesign/theory-c.md explaining the Theory C architecture, migration inventory, EF Core 10 feature decisions, risks, and prototype scope.

Tests:
- Add TestDbOperations covering segment invariants (user precedence, credits overlap guard), chunked deletion logic, compiled query behavior, and the initialization gate ordering.
- Update existing tests to construct SkipIntroController, FFmpegService, and VisualizationController with the new detection cache service and fixed-path DbContext factories.