### PR TITLE
Add auto-skip and visibility controls

### DIFF
--- a/IntroSkipper.Tests/TestInjector.cs
+++ b/IntroSkipper.Tests/TestInjector.cs
@@ -8,9 +8,8 @@ namespace IntroSkipper.Tests;
 public sealed class TestInjector
 {
     private const string CurrentJellyfinBundleSnippet =
-        "t.prototype.showSkipButton=function(e){var t=this;e.keep||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),8e3))}" +
+        "t.prototype.showSkipButton=function(e){var t=this,n=this.skipElement;if(n){var r=document.activeElement&&ye.A.isCurrentlyFocusable(document.activeElement);e.keep||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),8e3))}}" +
         "function onOsdClose(){return this.visible?this.show():this.hideTimeout||this.hideSkipButton()}" +
-        "function focusCheck(t){var r=document.activeElement&&ye.A.isCurrentlyFocusable(document.activeElement);return r}" +
         "var a=((r={})[i.w.Intro]=o.M.AskToSkip,r[i.w.Outro]=o.M.AskToSkip,r)" +
         "function timeUpdate(){if(this.currentSegment){var e=100;H(this.currentSegment,e)||(this.currentSegment=null,this.hideSkipButton())}}";
 
@@ -28,13 +27,25 @@ public sealed class TestInjector
     }
 
     [Fact]
+    public void FileTransformer_UsesMatchedPlaybackReceiver_ForFocusabilityCheck()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 5);
+        const string bundle = "x.prototype.showSkipButton=function(o){var s=this,n=this.skipElement;if(n){var a=document.activeElement&&fm.A.isCurrentlyFocusable(document.activeElement);return a}}";
+
+        var transformed = Transform(bundle);
+
+        Assert.Contains("var a=document.activeElement&&fm.A.isCurrentlyFocusable(document.activeElement)&&s.playbackManager.currentTime()>1000", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("t.playbackManager", transformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FileTransformer_MakesCurrentJellyfinBundleShapePersistent_ForZeroHideDelay()
     {
         using var scope = CreatePluginScope(skipbuttonHideDelay: 0);
 
         var transformed = Transform(CurrentJellyfinBundleSnippet);
 
-        Assert.Contains("showSkipButton=function(e){var t=this;true}", transformed, StringComparison.Ordinal);
+        Assert.Contains("var r=document.activeElement&&ye.A.isCurrentlyFocusable(document.activeElement)&&t.playbackManager.currentTime()>1000;true", transformed, StringComparison.Ordinal);
         Assert.DoesNotContain("setTimeout(", transformed, StringComparison.Ordinal);
         Assert.DoesNotContain("hideTimeout||this.hideSkipButton()", transformed, StringComparison.Ordinal);
         Assert.Contains("return this.visible?this.show():true}", transformed, StringComparison.Ordinal);

--- a/IntroSkipper.Tests/TestInjector.cs
+++ b/IntroSkipper.Tests/TestInjector.cs
@@ -1,0 +1,118 @@
+using System;
+using IntroSkipper.Configuration;
+using IntroSkipper.Helper;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestInjector
+{
+    private const string CurrentJellyfinBundleSnippet =
+        "t.prototype.showSkipButton=function(e){var t=this;e.keep||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),8e3))}" +
+        "function onOsdClose(){return this.visible?this.show():this.hideTimeout||this.hideSkipButton()}" +
+        "function focusCheck(t){var r=document.activeElement&&ye.A.isCurrentlyFocusable(document.activeElement);return r}" +
+        "var a=((r={})[i.w.Intro]=o.M.AskToSkip,r[i.w.Outro]=o.M.AskToSkip,r)" +
+        "function timeUpdate(){if(this.currentSegment){var e=100;H(this.currentSegment,e)||(this.currentSegment=null,this.hideSkipButton())}}";
+
+    [Fact]
+    public void FileTransformer_UpdatesCurrentJellyfinBundleShape_ForConfiguredHideDelay()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 5);
+
+        var transformed = Transform(CurrentJellyfinBundleSnippet);
+
+        Assert.Contains("e.keep||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),5000))", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("8e3", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("e.keep||false||", transformed, StringComparison.Ordinal);
+        Assert.Contains("var r=document.activeElement&&ye.A.isCurrentlyFocusable(document.activeElement)&&t.playbackManager.currentTime()>1000", transformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileTransformer_MakesCurrentJellyfinBundleShapePersistent_ForZeroHideDelay()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 0);
+
+        var transformed = Transform(CurrentJellyfinBundleSnippet);
+
+        Assert.Contains("showSkipButton=function(e){var t=this;true}", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("setTimeout(", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("hideTimeout||this.hideSkipButton()", transformed, StringComparison.Ordinal);
+        Assert.Contains("return this.visible?this.show():true}", transformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileTransformer_AutoSkipsIntro_WhenConfigured()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 8, autoSkipIntro: true);
+
+        var transformed = Transform(CurrentJellyfinBundleSnippet);
+
+        Assert.Contains("[i.w.Intro]=o.M.Skip", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("[i.w.Intro]=o.M.AskToSkip", transformed, StringComparison.Ordinal);
+        // Outro should remain unchanged
+        Assert.Contains("[i.w.Outro]=o.M.AskToSkip", transformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileTransformer_AutoSkipsCredits_WhenConfigured()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 8, autoSkipCredits: true);
+
+        var transformed = Transform(CurrentJellyfinBundleSnippet);
+
+        Assert.Contains("[i.w.Outro]=o.M.Skip", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("[i.w.Outro]=o.M.AskToSkip", transformed, StringComparison.Ordinal);
+        // Intro should remain unchanged
+        Assert.Contains("[i.w.Intro]=o.M.AskToSkip", transformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileTransformer_LimitsButtonVisibility_WhenSecondsConfigured()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 8, skipButtonVisibleSeconds: 10);
+
+        var transformed = Transform(CurrentJellyfinBundleSnippet);
+
+        // threshold=10s=100000000 ticks, floor=hideDelay 8s=80000000 ticks
+        var cutoff = "Math.max(this.currentSegment.StartTicks+80000000,this.currentSegment.EndTicks-100000000)";
+        Assert.Contains($"H(this.currentSegment,e)?(e>={cutoff}&&this.hideSkipButton()):(this.currentSegment=null,this.hideSkipButton())", transformed, StringComparison.Ordinal);
+        Assert.Contains($"showSkipButton=function(e){{if(this.currentSegment&&this.playbackManager.currentTime(this.player)*1e4>={cutoff})return;", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("H(this.currentSegment,e)||(this.currentSegment=null", transformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileTransformer_LeavesDefaultsUntouched_WhenFeaturesDisabled()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 8);
+
+        var transformed = Transform(CurrentJellyfinBundleSnippet);
+
+        Assert.Contains("[i.w.Intro]=o.M.AskToSkip", transformed, StringComparison.Ordinal);
+        Assert.Contains("[i.w.Outro]=o.M.AskToSkip", transformed, StringComparison.Ordinal);
+        Assert.Contains("H(this.currentSegment,e)||(this.currentSegment=null", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("if(this.currentSegment&&this.playbackManager.currentTime", transformed, StringComparison.Ordinal);
+    }
+
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(
+        int skipbuttonHideDelay,
+        bool autoSkipIntro = false,
+        bool autoSkipCredits = false,
+        int skipButtonVisibleSeconds = 0)
+    {
+        var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(
+            Plugin.Instance!,
+            "Configuration",
+            new PluginConfiguration
+            {
+                UseFileTransformationPlugin = true,
+                SkipbuttonHideDelay = skipbuttonHideDelay,
+                AutoSkipIntro = autoSkipIntro,
+                AutoSkipCredits = autoSkipCredits,
+                SkipButtonVisibleSeconds = skipButtonVisibleSeconds,
+            });
+        return scope;
+    }
+
+    private static string Transform(string contents) => Injector.FileTransformer(new PayloadRequest { Contents = contents });
+}

--- a/IntroSkipper.Tests/TestInjector.cs
+++ b/IntroSkipper.Tests/TestInjector.cs
@@ -39,6 +39,19 @@ public sealed class TestInjector
     }
 
     [Fact]
+    public void FileTransformer_DoesNotCrossShowSkipButtonBoundary_ForFocusabilityCheck()
+    {
+        using var scope = CreatePluginScope(skipbuttonHideDelay: 5);
+        const string bundle = "x.prototype.showSkipButton=function(o){var s=this;return o}" +
+            "function later(){var a=document.activeElement&&fm.A.isCurrentlyFocusable(document.activeElement);return a}";
+
+        var transformed = Transform(bundle);
+
+        Assert.Contains("var a=document.activeElement&&fm.A.isCurrentlyFocusable(document.activeElement);return a", transformed, StringComparison.Ordinal);
+        Assert.DoesNotContain("playbackManager.currentTime()", transformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FileTransformer_MakesCurrentJellyfinBundleShapePersistent_ForZeroHideDelay()
     {
         using var scope = CreatePluginScope(skipbuttonHideDelay: 0);

--- a/IntroSkipper.Tests/TestInjector.cs
+++ b/IntroSkipper.Tests/TestInjector.cs
@@ -99,7 +99,7 @@ public sealed class TestInjector
 
         // threshold=10s=100000000 ticks, floor=hideDelay 8s=80000000 ticks
         var cutoff = "Math.max(this.currentSegment.StartTicks+80000000,this.currentSegment.EndTicks-100000000)";
-        Assert.Contains($"H(this.currentSegment,e)?(e>={cutoff}&&this.hideSkipButton()):(this.currentSegment=null,this.hideSkipButton())", transformed, StringComparison.Ordinal);
+        Assert.Contains($"H(this.currentSegment,e)?(e>={cutoff}&&this.skipElement&&!this.skipElement.classList.contains(\"skip-button-hidden\")&&this.hideSkipButton()):(this.currentSegment=null,this.hideSkipButton())", transformed, StringComparison.Ordinal);
         Assert.Contains($"showSkipButton=function(e){{if(this.currentSegment&&this.playbackManager.currentTime(this.player)*1e4>={cutoff})return;", transformed, StringComparison.Ordinal);
         Assert.DoesNotContain("H(this.currentSegment,e)||(this.currentSegment=null", transformed, StringComparison.Ordinal);
     }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -452,6 +452,22 @@ public class PluginConfiguration : BasePluginConfiguration
     public int SkipbuttonHideDelay { get; set; } = 8;
 
     /// <summary>
+    /// Gets or sets a value indicating whether intros are auto-skipped without prompting.
+    /// </summary>
+    public bool AutoSkipIntro { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether credits/outros are auto-skipped without prompting.
+    /// </summary>
+    public bool AutoSkipCredits { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of seconds before the segment ends at which the skip button hides.
+    /// 0 means the button stays visible for the entire segment (default).
+    /// </summary>
+    public int SkipButtonVisibleSeconds { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to enable the main menu entry for the plugin.
     /// </summary>
     public bool EnableMainMenu { get; set; } = true;

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -26,7 +26,7 @@ namespace IntroSkipper.Helper
         /// Pattern to match the focusability check in the showSkipButton method.
         /// </summary>
         private const string FocusabilityAssignmentPattern =
-            @"(?:(?:var)\s+)?[A-Za-z_$][\w$]*\s*=\s*document\.activeElement\s*&&\s*[A-Za-z_$][\w$]*\.A\.isCurrentlyFocusable\(document\.activeElement\)";
+            @"showSkipButton=function\([A-Za-z_$][\w$]*\)\{var\s+(?<receiver>[A-Za-z_$][\w$]*)\s*=\s*this[\s\S]*?(?:(?:var)\s+)?[A-Za-z_$][\w$]*\s*=\s*document\.activeElement\s*&&\s*[A-Za-z_$][\w$]*\.A\.isCurrentlyFocusable\(document\.activeElement\)";
 
         /// <summary>
         /// Pattern to match the default Intro segment action (AskToSkip) in the action map.
@@ -168,7 +168,7 @@ namespace IntroSkipper.Helper
         /// </summary>
         /// <param name="contents">The JavaScript content to modify.</param>
         /// <returns>The modified content.</returns>
-        private static string ReplaceFocusabilityCheck(string contents) => FocusabilityAssignmentRegex().Replace(contents, m => m.Value + $"&&t.playbackManager.currentTime()>{MillisecondsPerSecond}");
+        private static string ReplaceFocusabilityCheck(string contents) => FocusabilityAssignmentRegex().Replace(contents, m => m.Value + $"&&{m.Groups["receiver"].Value}.playbackManager.currentTime()>{MillisecondsPerSecond}");
 
         /// <summary>
         /// Changes the default Intro segment action from AskToSkip to Skip (auto-skip).

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -137,7 +137,7 @@ namespace IntroSkipper.Helper
             if (config.SkipButtonVisibleSeconds > 0)
             {
                 var thresholdTicks = ((long)config.SkipButtonVisibleSeconds * TicksPerSecond).ToString(CultureInfo.InvariantCulture);
-                var floorTicks = ((long)config.SkipbuttonHideDelay * TicksPerSecond).ToString(CultureInfo.InvariantCulture);
+                var floorTicks = ((long)hideDelayMs * TicksPerSecond / MillisecondsPerSecond).ToString(CultureInfo.InvariantCulture);
                 updated = ReplaceSegmentBoundsCheck(updated, thresholdTicks, floorTicks);
                 updated = InjectShowSkipButtonGuard(updated, thresholdTicks, floorTicks);
             }

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -29,16 +29,10 @@ namespace IntroSkipper.Helper
             @"showSkipButton=function\([A-Za-z_$][\w$]*\)\{var\s+(?<receiver>[A-Za-z_$][\w$]*)\s*=\s*this(?<depth>)(?:(?(depth)(?:[^{}]|\{(?<depth>)|\}(?<-depth>))|(?!)))*?(?:(?:var)\s+)?[A-Za-z_$][\w$]*\s*=\s*document\.activeElement\s*&&\s*[A-Za-z_$][\w$]*\.A\.isCurrentlyFocusable\(document\.activeElement\)";
 
         /// <summary>
-        /// Pattern to match the default Intro segment action (AskToSkip) in the action map.
+        /// Pattern to match default Intro and Outro segment actions in the action map.
         /// </summary>
-        private const string IntroActionDefaultPattern =
-            @"\[(?<mod>[A-Za-z_$][\w$]*)\.w\.Intro\]=(?<act>[A-Za-z_$][\w$]*)\.M\.AskToSkip";
-
-        /// <summary>
-        /// Pattern to match the default Outro/Credits segment action (AskToSkip) in the action map.
-        /// </summary>
-        private const string OutroActionDefaultPattern =
-            @"\[(?<mod>[A-Za-z_$][\w$]*)\.w\.Outro\]=(?<act>[A-Za-z_$][\w$]*)\.M\.AskToSkip";
+        private const string SegmentActionDefaultPattern =
+            @"\[(?<mod>[A-Za-z_$][\w$]*)\.w\.(?<segment>Intro|Outro)\]=(?<act>[A-Za-z_$][\w$]*)\.M\.AskToSkip";
 
         /// <summary>
         /// Pattern to match the segment bounds check in onPlayerTimeUpdate that controls skip button visibility.
@@ -50,7 +44,7 @@ namespace IntroSkipper.Helper
         /// Pattern to match the showSkipButton function opening to inject an early-return guard.
         /// </summary>
         private const string ShowSkipButtonPattern =
-            @"showSkipButton=function\((?<arg>[A-Za-z_$][\w$]*)\)\{";
+            @"showSkipButton=function\([A-Za-z_$][\w$]*\)\{";
 
         /// <summary>
         /// Number of milliseconds per second.
@@ -76,11 +70,8 @@ namespace IntroSkipper.Helper
         [GeneratedRegex(FocusabilityAssignmentPattern, RegexOptions.CultureInvariant)]
         private static partial Regex FocusabilityAssignmentRegex();
 
-        [GeneratedRegex(IntroActionDefaultPattern)]
-        private static partial Regex IntroActionDefaultRegex();
-
-        [GeneratedRegex(OutroActionDefaultPattern)]
-        private static partial Regex OutroActionDefaultRegex();
+        [GeneratedRegex(SegmentActionDefaultPattern)]
+        private static partial Regex SegmentActionDefaultRegex();
 
         [GeneratedRegex(SegmentBoundsCheckPattern)]
         private static partial Regex SegmentBoundsCheckRegex();
@@ -123,14 +114,9 @@ namespace IntroSkipper.Helper
             updated = ReplaceFocusabilityCheck(updated);
 
             // Override default segment actions from AskToSkip to Skip when configured
-            if (config.AutoSkipIntro)
+            if (config.AutoSkipIntro || config.AutoSkipCredits)
             {
-                updated = ReplaceIntroActionDefault(updated);
-            }
-
-            if (config.AutoSkipCredits)
-            {
-                updated = ReplaceOutroActionDefault(updated);
+                updated = ReplaceActionDefaults(updated, config.AutoSkipIntro, config.AutoSkipCredits);
             }
 
             // Hide skip button N seconds before segment end and block all re-show paths
@@ -138,8 +124,9 @@ namespace IntroSkipper.Helper
             {
                 var thresholdTicks = ((long)config.SkipButtonVisibleSeconds * TicksPerSecond).ToString(CultureInfo.InvariantCulture);
                 var floorTicks = ((long)hideDelayMs * TicksPerSecond / MillisecondsPerSecond).ToString(CultureInfo.InvariantCulture);
-                updated = ReplaceSegmentBoundsCheck(updated, thresholdTicks, floorTicks);
-                updated = InjectShowSkipButtonGuard(updated, thresholdTicks, floorTicks);
+                var cutoff = $"Math.max(this.currentSegment.StartTicks+{floorTicks},this.currentSegment.EndTicks-{thresholdTicks})";
+                updated = ReplaceSegmentBoundsCheck(updated, cutoff);
+                updated = InjectShowSkipButtonGuard(updated, cutoff);
             }
 
             return updated;
@@ -171,32 +158,32 @@ namespace IntroSkipper.Helper
         private static string ReplaceFocusabilityCheck(string contents) => FocusabilityAssignmentRegex().Replace(contents, m => m.Value + $"&&{m.Groups["receiver"].Value}.playbackManager.currentTime()>{MillisecondsPerSecond}");
 
         /// <summary>
-        /// Changes the default Intro segment action from AskToSkip to Skip (auto-skip).
+        /// Changes configured segment actions from AskToSkip to Skip (auto-skip).
         /// </summary>
         /// <param name="contents">The JavaScript content to modify.</param>
+        /// <param name="autoSkipIntro">Whether to auto-skip Intro segments.</param>
+        /// <param name="autoSkipCredits">Whether to auto-skip Outro segments.</param>
         /// <returns>The modified content.</returns>
-        private static string ReplaceIntroActionDefault(string contents) =>
-            IntroActionDefaultRegex().Replace(contents, m => $"[{m.Groups["mod"].Value}.w.Intro]={m.Groups["act"].Value}.M.Skip");
-
-        /// <summary>
-        /// Changes the default Outro/Credits segment action from AskToSkip to Skip (auto-skip).
-        /// </summary>
-        /// <param name="contents">The JavaScript content to modify.</param>
-        /// <returns>The modified content.</returns>
-        private static string ReplaceOutroActionDefault(string contents) =>
-            OutroActionDefaultRegex().Replace(contents, m => $"[{m.Groups["mod"].Value}.w.Outro]={m.Groups["act"].Value}.M.Skip");
+        private static string ReplaceActionDefaults(string contents, bool autoSkipIntro, bool autoSkipCredits) =>
+            SegmentActionDefaultRegex().Replace(contents, m =>
+            {
+                var segment = m.Groups["segment"].Value;
+                var autoSkip = segment == "Intro" ? autoSkipIntro : autoSkipCredits;
+                return autoSkip
+                    ? $"[{m.Groups["mod"].Value}.w.{segment}]={m.Groups["act"].Value}.M.Skip"
+                    : m.Value;
+            });
 
         /// <summary>
         /// Modifies onPlayerTimeUpdate to actively hide the skip button N seconds before segment end.
         /// Uses Math.max(StartTicks+floor, EndTicks-threshold) so the button always shows for at least the hide delay duration.
         /// Keeps currentSegment set to prevent onPromptSkip from re-triggering.
         /// </summary>
-        private static string ReplaceSegmentBoundsCheck(string contents, string thresholdTicks, string floorTicks) =>
+        private static string ReplaceSegmentBoundsCheck(string contents, string cutoff) =>
             SegmentBoundsCheckRegex().Replace(contents, m =>
             {
                 var chk = m.Groups["check"].Value;
                 var pos = m.Groups["pos"].Value;
-                var cutoff = $"Math.max(this.currentSegment.StartTicks+{floorTicks},this.currentSegment.EndTicks-{thresholdTicks})";
                 return $"{chk}(this.currentSegment,{pos})" +
                     $"?({pos}>={cutoff}&&this.hideSkipButton())" +
                     $":(this.currentSegment=null,this.hideSkipButton())";
@@ -206,15 +193,10 @@ namespace IntroSkipper.Helper
         /// Injects an early-return guard into showSkipButton so the button cannot be re-shown
         /// (by OSD changes or any other caller) once the visibility threshold has been reached.
         /// </summary>
-        private static string InjectShowSkipButtonGuard(string contents, string thresholdTicks, string floorTicks) =>
-            ShowSkipButtonRegex().Replace(contents, m =>
-            {
-                var arg = m.Groups["arg"].Value;
-                var pos = "this.playbackManager.currentTime(this.player)*1e4";
-                var cutoff = $"Math.max(this.currentSegment.StartTicks+{floorTicks},this.currentSegment.EndTicks-{thresholdTicks})";
-                return $"showSkipButton=function({arg}){{" +
-                    $"if(this.currentSegment&&{pos}>={cutoff})return;";
-            });
+        private static string InjectShowSkipButtonGuard(string contents, string cutoff) =>
+            ShowSkipButtonRegex().Replace(
+                contents,
+                m => m.Value + $"if(this.currentSegment&&this.playbackManager.currentTime(this.player)*1e4>={cutoff})return;");
 
         /// <summary>
         /// Attempts to convert seconds to milliseconds with validation and overflow protection.

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -26,7 +26,7 @@ namespace IntroSkipper.Helper
         /// Pattern to match the focusability check in the showSkipButton method.
         /// </summary>
         private const string FocusabilityAssignmentPattern =
-            @"showSkipButton=function\([A-Za-z_$][\w$]*\)\{var\s+(?<receiver>[A-Za-z_$][\w$]*)\s*=\s*this[\s\S]*?(?:(?:var)\s+)?[A-Za-z_$][\w$]*\s*=\s*document\.activeElement\s*&&\s*[A-Za-z_$][\w$]*\.A\.isCurrentlyFocusable\(document\.activeElement\)";
+            @"showSkipButton=function\([A-Za-z_$][\w$]*\)\{var\s+(?<receiver>[A-Za-z_$][\w$]*)\s*=\s*this(?<depth>)(?:(?(depth)(?:[^{}]|\{(?<depth>)|\}(?<-depth>))|(?!)))*?(?:(?:var)\s+)?[A-Za-z_$][\w$]*\s*=\s*document\.activeElement\s*&&\s*[A-Za-z_$][\w$]*\.A\.isCurrentlyFocusable\(document\.activeElement\)";
 
         /// <summary>
         /// Pattern to match the default Intro segment action (AskToSkip) in the action map.

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -177,7 +177,8 @@ namespace IntroSkipper.Helper
         /// <summary>
         /// Modifies onPlayerTimeUpdate to actively hide the skip button N seconds before segment end.
         /// Uses Math.max(StartTicks+floor, EndTicks-threshold) so the button always shows for at least the hide delay duration.
-        /// Keeps currentSegment set to prevent onPromptSkip from re-triggering.
+        /// Keeps currentSegment set to prevent onPromptSkip from re-triggering, while the hidden-class
+        /// check prevents later time updates from restarting the hide transition.
         /// </summary>
         private static string ReplaceSegmentBoundsCheck(string contents, string cutoff) =>
             SegmentBoundsCheckRegex().Replace(contents, m =>
@@ -185,7 +186,7 @@ namespace IntroSkipper.Helper
                 var chk = m.Groups["check"].Value;
                 var pos = m.Groups["pos"].Value;
                 return $"{chk}(this.currentSegment,{pos})" +
-                    $"?({pos}>={cutoff}&&this.hideSkipButton())" +
+                    $"?({pos}>={cutoff}&&this.skipElement&&!this.skipElement.classList.contains(\"skip-button-hidden\")&&this.hideSkipButton())" +
                     $":(this.currentSegment=null,this.hideSkipButton())";
             });
 

--- a/IntroSkipper/Helper/Injector.cs
+++ b/IntroSkipper/Helper/Injector.cs
@@ -15,7 +15,7 @@ namespace IntroSkipper.Helper
         /// <summary>
         /// Pattern to match the timeout assignment in the showSkipButton method.
         /// </summary>
-        private const string TimeoutAssignmentPattern = @"\(t\.hideTimeout=setTimeout\(t\.hideSkipButton\.bind\(t\)\,8e3\)\)";
+        private const string TimeoutAssignmentPattern = @"(?<keep>[A-Za-z_$][\w$]*\.keep\|\|)?\((?<button>[A-Za-z_$][\w$]*)\.hideTimeout=setTimeout\(\k<button>\.hideSkipButton\.bind\(\k<button>\),8e3\)\)";
 
         /// <summary>
         /// Pattern to match the timeout check in the hideSkipButton method.
@@ -23,15 +23,44 @@ namespace IntroSkipper.Helper
         private const string TimeoutOsdChangePattern = @"\:this\.hideTimeout\|\|this\.hideSkipButton\(\)";
 
         /// <summary>
-        /// Regex to match the focusability check.
+        /// Pattern to match the focusability check in the showSkipButton method.
         /// </summary>
         private const string FocusabilityAssignmentPattern =
-            @"(?:(?:var)\s+)?r\s*=\s*document\.activeElement\s*&&\s*[A-Za-z_$][\w$]*\.A\.isCurrentlyFocusable\(document\.activeElement\)";
+            @"(?:(?:var)\s+)?[A-Za-z_$][\w$]*\s*=\s*document\.activeElement\s*&&\s*[A-Za-z_$][\w$]*\.A\.isCurrentlyFocusable\(document\.activeElement\)";
+
+        /// <summary>
+        /// Pattern to match the default Intro segment action (AskToSkip) in the action map.
+        /// </summary>
+        private const string IntroActionDefaultPattern =
+            @"\[(?<mod>[A-Za-z_$][\w$]*)\.w\.Intro\]=(?<act>[A-Za-z_$][\w$]*)\.M\.AskToSkip";
+
+        /// <summary>
+        /// Pattern to match the default Outro/Credits segment action (AskToSkip) in the action map.
+        /// </summary>
+        private const string OutroActionDefaultPattern =
+            @"\[(?<mod>[A-Za-z_$][\w$]*)\.w\.Outro\]=(?<act>[A-Za-z_$][\w$]*)\.M\.AskToSkip";
+
+        /// <summary>
+        /// Pattern to match the segment bounds check in onPlayerTimeUpdate that controls skip button visibility.
+        /// </summary>
+        private const string SegmentBoundsCheckPattern =
+            @"(?<check>[A-Za-z_$][\w$]*)\(this\.currentSegment,(?<pos>[A-Za-z_$][\w$]*)\)\|\|\(this\.currentSegment=null,this\.hideSkipButton\(\)\)";
+
+        /// <summary>
+        /// Pattern to match the showSkipButton function opening to inject an early-return guard.
+        /// </summary>
+        private const string ShowSkipButtonPattern =
+            @"showSkipButton=function\((?<arg>[A-Za-z_$][\w$]*)\)\{";
 
         /// <summary>
         /// Number of milliseconds per second.
         /// </summary>
         private const int MillisecondsPerSecond = 1000;
+
+        /// <summary>
+        /// Ticks per second (Jellyfin uses 100-nanosecond tick intervals).
+        /// </summary>
+        private const long TicksPerSecond = 10_000_000L;
 
         /// <summary>
         /// Maximum safe number of seconds that can be converted to milliseconds without overflow.
@@ -47,11 +76,23 @@ namespace IntroSkipper.Helper
         [GeneratedRegex(FocusabilityAssignmentPattern, RegexOptions.CultureInvariant)]
         private static partial Regex FocusabilityAssignmentRegex();
 
+        [GeneratedRegex(IntroActionDefaultPattern)]
+        private static partial Regex IntroActionDefaultRegex();
+
+        [GeneratedRegex(OutroActionDefaultPattern)]
+        private static partial Regex OutroActionDefaultRegex();
+
+        [GeneratedRegex(SegmentBoundsCheckPattern)]
+        private static partial Regex SegmentBoundsCheckRegex();
+
+        [GeneratedRegex(ShowSkipButtonPattern)]
+        private static partial Regex ShowSkipButtonRegex();
+
         /// <summary>
-        /// Transforms the file contents by modifying JavaScript timeout values.
+        /// Transforms the file contents by modifying skip button behavior, segment actions, and visibility timing.
         /// </summary>
         /// <param name="payload">The payload containing the file contents to transform.</param>
-        /// <returns>The transformed file contents with modified timeout values.</returns>
+        /// <returns>The transformed file contents.</returns>
         /// <exception cref="ArgumentNullException">Thrown when payload is null.</exception>
         public static string FileTransformer(PayloadRequest payload)
         {
@@ -70,44 +111,110 @@ namespace IntroSkipper.Helper
             }
 
             // Validate and get the timeout value
-            bool persist = !TryGetValidTimeoutMs(config.SkipbuttonHideDelay, out var hideDelayMs);
-            string persistStr = persist ? "true" : "false";
+            var persist = !TryGetValidTimeoutMs(config.SkipbuttonHideDelay, out var hideDelayMs);
 
             // Replace the hardcoded 8e3 (8000 ms) timeout with our configurable value
-            var updated = ReplaceTimeoutAssignment(contents, persistStr, hideDelayMs.ToString(CultureInfo.InvariantCulture));
+            var updated = ReplaceTimeoutAssignment(contents, persist, hideDelayMs.ToString(CultureInfo.InvariantCulture));
 
             // Replace the timeout check in hideSkipButton to respect the persist setting
-            updated = ReplaceTimeoutOsdChange(updated, persistStr);
+            updated = ReplaceTimeoutOsdChange(updated, persist);
 
-            // Add playback time condition to focusability check to gate skip button behavior
+            // Force skip button focus during early playback for TV remotes
             updated = ReplaceFocusabilityCheck(updated);
+
+            // Override default segment actions from AskToSkip to Skip when configured
+            if (config.AutoSkipIntro)
+            {
+                updated = ReplaceIntroActionDefault(updated);
+            }
+
+            if (config.AutoSkipCredits)
+            {
+                updated = ReplaceOutroActionDefault(updated);
+            }
+
+            // Hide skip button N seconds before segment end and block all re-show paths
+            if (config.SkipButtonVisibleSeconds > 0)
+            {
+                var thresholdTicks = ((long)config.SkipButtonVisibleSeconds * TicksPerSecond).ToString(CultureInfo.InvariantCulture);
+                var floorTicks = ((long)config.SkipbuttonHideDelay * TicksPerSecond).ToString(CultureInfo.InvariantCulture);
+                updated = ReplaceSegmentBoundsCheck(updated, thresholdTicks, floorTicks);
+                updated = InjectShowSkipButtonGuard(updated, thresholdTicks, floorTicks);
+            }
 
             return updated;
         }
 
         /// <summary>
-        /// Makes the skip button persistent by removing the setTimeout call that auto-hides it.
+        /// Replaces the hardcoded 8-second auto-hide timeout with a configurable delay,
+        /// or removes it entirely to make the skip button persistent.
         /// </summary>
         /// <param name="contents">The JavaScript content to modify.</param>
         /// <param name="persist">true if the skip button should be persistent; otherwise, false.</param>
         /// <param name="hideDelayMs">The delay in milliseconds before hiding the skip button.</param>
-        /// <returns>The modified content with persistent skip button behavior.</returns>
-        private static string ReplaceTimeoutAssignment(string contents, string persist, string hideDelayMs) => TimeoutAssignmentRegex().Replace(contents, $"{persist}||(t.hideTimeout=setTimeout(t.hideSkipButton.bind(t),{hideDelayMs}))");
+        /// <returns>The modified content.</returns>
+        private static string ReplaceTimeoutAssignment(string contents, bool persist, string hideDelayMs) => TimeoutAssignmentRegex().Replace(contents, m => persist ? "true" : $"{m.Groups["keep"].Value}({m.Groups["button"].Value}.hideTimeout=setTimeout({m.Groups["button"].Value}.hideSkipButton.bind({m.Groups["button"].Value}),{hideDelayMs}))");
 
         /// <summary>
-        /// Makes the skip button persistent by removing the setTimeout call that auto-hides it.
+        /// Suppresses the immediate-hide on OSD close when the skip button is persistent.
         /// </summary>
         /// <param name="contents">The JavaScript content to modify.</param>
         /// <param name="persist">true if the skip button should be persistent; otherwise, false.</param>
         /// <returns>The modified content.</returns>
-        private static string ReplaceTimeoutOsdChange(string contents, string persist) => TimeoutOsdChangeRegex().Replace(contents, $":{persist}||this.hideTimeout||this.hideSkipButton()");
+        private static string ReplaceTimeoutOsdChange(string contents, bool persist) => persist ? TimeoutOsdChangeRegex().Replace(contents, ":true") : contents;
 
         /// <summary>
-        /// Adds a current time check to the focusability condition.
+        /// Forces focus onto the skip button during the first second of playback for TV remote UX.
         /// </summary>
         /// <param name="contents">The JavaScript content to modify.</param>
         /// <returns>The modified content.</returns>
         private static string ReplaceFocusabilityCheck(string contents) => FocusabilityAssignmentRegex().Replace(contents, m => m.Value + $"&&t.playbackManager.currentTime()>{MillisecondsPerSecond}");
+
+        /// <summary>
+        /// Changes the default Intro segment action from AskToSkip to Skip (auto-skip).
+        /// </summary>
+        /// <param name="contents">The JavaScript content to modify.</param>
+        /// <returns>The modified content.</returns>
+        private static string ReplaceIntroActionDefault(string contents) =>
+            IntroActionDefaultRegex().Replace(contents, m => $"[{m.Groups["mod"].Value}.w.Intro]={m.Groups["act"].Value}.M.Skip");
+
+        /// <summary>
+        /// Changes the default Outro/Credits segment action from AskToSkip to Skip (auto-skip).
+        /// </summary>
+        /// <param name="contents">The JavaScript content to modify.</param>
+        /// <returns>The modified content.</returns>
+        private static string ReplaceOutroActionDefault(string contents) =>
+            OutroActionDefaultRegex().Replace(contents, m => $"[{m.Groups["mod"].Value}.w.Outro]={m.Groups["act"].Value}.M.Skip");
+
+        /// <summary>
+        /// Modifies onPlayerTimeUpdate to actively hide the skip button N seconds before segment end.
+        /// Uses Math.max(StartTicks+floor, EndTicks-threshold) so the button always shows for at least the hide delay duration.
+        /// Keeps currentSegment set to prevent onPromptSkip from re-triggering.
+        /// </summary>
+        private static string ReplaceSegmentBoundsCheck(string contents, string thresholdTicks, string floorTicks) =>
+            SegmentBoundsCheckRegex().Replace(contents, m =>
+            {
+                var chk = m.Groups["check"].Value;
+                var pos = m.Groups["pos"].Value;
+                var cutoff = $"Math.max(this.currentSegment.StartTicks+{floorTicks},this.currentSegment.EndTicks-{thresholdTicks})";
+                return $"{chk}(this.currentSegment,{pos})" +
+                    $"?({pos}>={cutoff}&&this.hideSkipButton())" +
+                    $":(this.currentSegment=null,this.hideSkipButton())";
+            });
+
+        /// <summary>
+        /// Injects an early-return guard into showSkipButton so the button cannot be re-shown
+        /// (by OSD changes or any other caller) once the visibility threshold has been reached.
+        /// </summary>
+        private static string InjectShowSkipButtonGuard(string contents, string thresholdTicks, string floorTicks) =>
+            ShowSkipButtonRegex().Replace(contents, m =>
+            {
+                var arg = m.Groups["arg"].Value;
+                var pos = "this.playbackManager.currentTime(this.player)*1e4";
+                var cutoff = $"Math.max(this.currentSegment.StartTicks+{floorTicks},this.currentSegment.EndTicks-{thresholdTicks})";
+                return $"showSkipButton=function({arg}){{" +
+                    $"if(this.currentSegment&&{pos}>={cutoff})return;";
+            });
 
         /// <summary>
         /// Attempts to convert seconds to milliseconds with validation and overflow protection.

--- a/web/src/tabs/general.ts
+++ b/web/src/tabs/general.ts
@@ -289,7 +289,7 @@ export const generalTab: Tab = {
                 max: 600,
                 step: 1,
                 description:
-                    "Hide the skip button this many seconds before the segment ends. 0 keeps it visible for the entire segment. Example: 10 on a 90-second intro hides the button at 80 seconds.",
+                    "Hide the skip button this many seconds before the segment ends. Set to 0 to disable this end-relative limit. The normal skip button hide delay still applies.",
                 visible: () => configStore.get("UseFileTransformationPlugin") === true,
             }),
             injectSection,

--- a/web/src/tabs/general.ts
+++ b/web/src/tabs/general.ts
@@ -268,6 +268,30 @@ export const generalTab: Tab = {
                 warning:
                     "Note: This setting only applies to the web client (browsers, LG webOS, Android with web player enabled, etc). May require a refresh or clearing cache to see changes.",
             }),
+            checkboxField({
+                id: "AutoSkipIntro",
+                label: "Auto-skip intros",
+                description:
+                    "Automatically skip intro segments without showing the skip button. Users who have explicitly set a preference in their Jellyfin settings will keep it.",
+                visible: () => configStore.get("UseFileTransformationPlugin") === true,
+            }),
+            checkboxField({
+                id: "AutoSkipCredits",
+                label: "Auto-skip credits/outros",
+                description:
+                    "Automatically skip credits/outro segments without showing the skip button. Users who have explicitly set a preference in their Jellyfin settings will keep it.",
+                visible: () => configStore.get("UseFileTransformationPlugin") === true,
+            }),
+            numberField({
+                id: "SkipButtonVisibleSeconds",
+                label: "Hide skip button before segment end (seconds)",
+                min: 0,
+                max: 600,
+                step: 1,
+                description:
+                    "Hide the skip button this many seconds before the segment ends. 0 keeps it visible for the entire segment. Example: 10 on a 90-second intro hides the button at 80 seconds.",
+                visible: () => configStore.get("UseFileTransformationPlugin") === true,
+            }),
             injectSection,
             checkboxField({
                 id: "EnableMainMenu",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -22,6 +22,7 @@ export interface PluginConfig {
     IntroEndOffset: number;
     IntroStartOffset: number;
     SkipbuttonHideDelay: number;
+    SkipButtonVisibleSeconds: number;
     SilenceDetectionMaximumNoise: number;
     SilenceDetectionMinimumDuration: number;
     BlackFrameMinimumPercentage: number;
@@ -70,6 +71,8 @@ export interface PluginConfig {
     AdjustIntroBasedOnSilence: boolean;
     AdjustIntroBasedOnChapters: boolean;
     UseFileTransformationPlugin: boolean;
+    AutoSkipIntro: boolean;
+    AutoSkipCredits: boolean;
 
     // Server-managed flag exposed to the dashboard.
     readonly FileTransformationPluginEnabled: boolean;

--- a/web/src/validation/rules.ts
+++ b/web/src/validation/rules.ts
@@ -48,6 +48,7 @@ export const validationRules: Partial<Record<keyof PluginConfig, ValidationRule<
     MaxParallelism: [minValue(1)],
     ProcessThreads: [range(0, 16)],
     SkipbuttonHideDelay: [range(0, 1000)],
+    SkipButtonVisibleSeconds: [range(0, 600)],
     SilenceDetectionMaximumNoise: [range(-90, 0)],
     SilenceDetectionMinimumDuration: [minValue(0)],
     ChapterAnalyzerIntroductionPattern: [validRegex()],


### PR DESCRIPTION
Add configuration and UI options to auto-skip intros/credits and control how long the skip button stays visible. Update the file injector to rewrite Jellyfin's bundle for the new behaviors, including configurable hide timing and tighter skip-button visibility handling.

## Summary by Sourcery

Add configurable controls for skip button visibility and auto-skipping of intro/credits segments, and update the Jellyfin bundle injector accordingly.

New Features:
- Introduce configuration options to auto-skip intro segments and credits/outros without showing the skip button.
- Add a setting to hide the skip button a configurable number of seconds before the segment ends while allowing full-segment visibility when set to zero.

Enhancements:
- Refine the file transformation injector to respect new visibility timing, segment action overrides, and improved skip button focus behavior for TV remotes.

Tests:
- Add injector unit tests to validate bundle rewriting for configurable hide delays, auto-skip behavior, and limited button visibility timing.