### PR TITLE
refactor(db): introduce store-per-aggregate layer and domain service

### DIFF
--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
 using IntroSkipper.Services;
@@ -22,6 +23,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -29,6 +31,29 @@ using Xunit;
 internal static class EntrypointTestHelpers
 {
     internal static readonly byte[] EmptyJsonArray = Encoding.UTF8.GetBytes("[]");
+
+    /// <summary>
+    /// Creates a <see cref="DetectionCacheService"/> whose store resolves the cache database path
+    /// from <see cref="Plugin.Instance"/> at call time, mirroring the legacy
+    /// <c>Plugin.CreateCacheDbContext()</c> behavior that tests relied on.
+    /// </summary>
+    internal static DetectionCacheService CreateDetectionCacheService()
+        => new(NullLogger<DetectionCacheService>.Instance, CreatePluginBoundCacheStore());
+
+    internal static IDetectionCacheStore CreatePluginBoundCacheStore()
+        => new DetectionCacheStore(new PluginBoundCacheDbContextFactory());
+
+    internal static SegmentStore CreateSegmentStore(string dbPath)
+        => new(new SegmentDbContextFactory(dbPath));
+
+    internal static SegmentUpdateService CreateSegmentUpdateService(string dbPath)
+        => new(CreateSegmentStore(dbPath), NullLogger<SegmentUpdateService>.Instance);
+
+    internal static DatabaseInitializer CreateDatabaseInitializer(string dbPath, string cacheDbPath)
+        => new(
+            new SegmentDbContextFactory(dbPath),
+            new DetectionCacheDbContextFactory(cacheDbPath),
+            NullLogger<DatabaseInitializer>.Instance);
 
     internal static Entrypoint CreateEntrypoint(bool autoDetectIntros)
     {
@@ -43,7 +68,7 @@ internal static class EntrypointTestHelpers
             providerManager: null!,
             fileSystem: null!,
             taskManager: null!,
-            cacheService: new DetectionCacheService(NullLogger<DetectionCacheService>.Instance),
+            cacheService: CreateDetectionCacheService(),
             ffmpegService: null!,
             logger: logger,
             loggerFactory: loggerFactory,
@@ -51,6 +76,15 @@ internal static class EntrypointTestHelpers
 
         SetPrivateField(entrypoint, "_config", new PluginConfiguration { AutoDetectIntros = autoDetectIntros });
         return entrypoint;
+    }
+
+    private sealed class PluginBoundCacheDbContextFactory : IDbContextFactory<DetectionCacheDbContext>
+    {
+        public DetectionCacheDbContext CreateDbContext()
+        {
+            var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is required for cache database access.");
+            return new DetectionCacheDbContext(plugin.CacheDbPath);
+        }
     }
 
     private sealed class FakeMediaSegmentRefresher : IMediaSegmentRefresher

--- a/IntroSkipper.Tests/TestAudioFingerprinting.cs
+++ b/IntroSkipper.Tests/TestAudioFingerprinting.cs
@@ -162,7 +162,7 @@ public class TestAudioFingerprinting
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static ChromaprintAnalyzer CreateChromaprintAnalyzer()

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1801,7 +1801,7 @@ public class TestBlackFrames
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static BlackFrameAnalyzer CreateBlackFrameAnalyzer()

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -613,8 +613,7 @@ public sealed class TestCacheOperations
                     new PluginConfiguration { CacheFingerprints = true });
             }
 
-            CacheService = new DetectionCacheService(
-                NullLogger<DetectionCacheService>.Instance);
+            CacheService = EntrypointTestHelpers.CreateDetectionCacheService();
         }
 
         public DetectionCacheService CacheService { get; }

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -218,7 +218,7 @@ public class TestFFmpegService
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static QueuedEpisode QueueFile(string path)

--- a/IntroSkipper.Tests/TestSegmentStores.cs
+++ b/IntroSkipper.Tests/TestSegmentStores.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
@@ -251,6 +252,74 @@ public sealed class TestSegmentStores
         {
             DeleteSqliteFiles(cacheDbPath);
         }
+    }
+
+    [Fact]
+    public async Task DatabaseInitializer_GatesNeverThrow_WhenInitializationFails()
+    {
+        // The cache gate runs inside IHostedService.StartAsync; an escaped exception would abort
+        // Jellyfin host startup, and the Lazy gate would cache the fault forever. Use a factory that
+        // throws a type outside the old (IOException or SqliteException) filter to prove the
+        // catch-all containment.
+        var dbPath = CreateTempDbPath();
+
+        try
+        {
+            var initializer = new DatabaseInitializer(
+                new SegmentDbContextFactory(dbPath),
+                new ThrowingCacheDbContextFactory(),
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<DatabaseInitializer>.Instance);
+
+            // Must not throw, and repeated calls must not rethrow a cached fault.
+            initializer.EnsureCacheDbReady();
+            initializer.EnsureCacheDbReady();
+
+            // The hosted warm-up must complete without faulting host startup.
+            var startupService = new IntroSkipper.Services.DatabaseStartupService(initializer);
+            await startupService.StartAsync(CancellationToken.None);
+            await startupService.StopAsync(CancellationToken.None);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task DatabaseInitializer_EnforcesWalJournalMode_OnBothDatabases()
+    {
+        var dbPath = CreateTempDbPath();
+        var cacheDbPath = dbPath + "-cache.db";
+
+        try
+        {
+            var initializer = EntrypointTestHelpers.CreateDatabaseInitializer(dbPath, cacheDbPath);
+            await initializer.EnsureSegmentDbReadyAsync();
+            initializer.EnsureCacheDbReady();
+
+            Assert.Equal("wal", await ReadJournalModeAsync(dbPath));
+            Assert.Equal("wal", await ReadJournalModeAsync(cacheDbPath));
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    private static async Task<string?> ReadJournalModeAsync(string dbPath)
+    {
+        await using var connection = new SqliteConnection($"Data Source={dbPath}");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA journal_mode;";
+        return (await command.ExecuteScalarAsync())?.ToString();
+    }
+
+    private sealed class ThrowingCacheDbContextFactory : IDbContextFactory<DetectionCacheDbContext>
+    {
+        public DetectionCacheDbContext CreateDbContext()
+            => throw new InvalidOperationException("Simulated cache database initialization failure.");
     }
 
     private static async Task EnsureSchemaAsync(string dbPath)

--- a/IntroSkipper.Tests/TestSegmentStores.cs
+++ b/IntroSkipper.Tests/TestSegmentStores.cs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+/// <summary>
+/// Tests for the store layer (Theory A prototype): domain invariants enforced by
+/// <see cref="IntroSkipper.Services.SegmentUpdateService"/> over <see cref="SegmentStore"/>,
+/// the unchunked single-JSON-parameter delete path, and the initialization gate ordering.
+/// </summary>
+public sealed class TestSegmentStores
+{
+    [Fact]
+    public async Task SegmentUpdateService_DoesNotOverwriteUserProvidedSegment_WithAnalysisResult()
+    {
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            await EnsureSchemaAsync(dbPath);
+            var service = EntrypointTestHelpers.CreateSegmentUpdateService(dbPath);
+
+            // User provides an intro via the segment editor.
+            await service.UpdateTimestampAsync(
+                new Segment(itemId, new TimeRange(10, 60)),
+                AnalysisMode.Introduction,
+                isUserProvided: true);
+
+            // A later analysis run produces a different intro; it must be discarded.
+            await service.UpdateTimestampAsync(
+                new Segment(itemId, new TimeRange(100, 150)),
+                AnalysisMode.Introduction,
+                isUserProvided: false);
+
+            await using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var stored = await db.DbSegment.SingleAsync(s => s.ItemId == itemId && s.Type == AnalysisMode.Introduction);
+                Assert.True(stored.IsUserProvided);
+                Assert.Equal(10, stored.Start);
+                Assert.Equal(60, stored.End);
+            }
+
+            // A user-provided update replaces the user-provided segment.
+            await service.UpdateTimestampAsync(
+                new Segment(itemId, new TimeRange(20, 70)),
+                AnalysisMode.Introduction,
+                isUserProvided: true);
+
+            await using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var stored = await db.DbSegment.SingleAsync(s => s.ItemId == itemId && s.Type == AnalysisMode.Introduction);
+                Assert.True(stored.IsUserProvided);
+                Assert.Equal(20, stored.Start);
+                Assert.Equal(70, stored.End);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Theory]
+    [InlineData(60.0, 1440.0, false, 0)]   // overlapping, auto-detected → rejected
+    [InlineData(1200.0, 1440.0, false, 1)] // non-overlapping, auto-detected → accepted
+    [InlineData(60.0, 1440.0, true, 1)]    // overlapping, user-provided → accepted
+    public async Task SegmentUpdateService_CreditsOverlapGuard(
+        double creditsStart, double creditsEnd, bool isUserProvided, int expectedCount)
+    {
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            await EnsureSchemaAsync(dbPath);
+            await using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                // Store an intro: 0–90 s.
+                db.DbSegment.Add(new DbSegment(
+                    new Segment(itemId, new TimeRange(0, 90)),
+                    AnalysisMode.Introduction));
+                await db.SaveChangesAsync();
+            }
+
+            var service = EntrypointTestHelpers.CreateSegmentUpdateService(dbPath);
+            await service.UpdateTimestampAsync(
+                new Segment(itemId, new TimeRange(creditsStart, creditsEnd)),
+                AnalysisMode.Credits,
+                isUserProvided);
+
+            await using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var count = await db.DbSegment.CountAsync(s => s.ItemId == itemId && s.Type == AnalysisMode.Credits);
+                Assert.Equal(expectedCount, count);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task SegmentUpdateService_DeduplicatesCommercialSegments_WithinEpsilon()
+    {
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            await EnsureSchemaAsync(dbPath);
+            var service = EntrypointTestHelpers.CreateSegmentUpdateService(dbPath);
+
+            await service.UpdateTimestampAsync(new Segment(itemId, new TimeRange(0, 30)), AnalysisMode.Commercial);
+            await service.UpdateTimestampAsync(new Segment(itemId, new TimeRange(0.0005, 30.0005)), AnalysisMode.Commercial); // duplicate within epsilon
+            await service.UpdateTimestampAsync(new Segment(itemId, new TimeRange(600, 660)), AnalysisMode.Commercial); // distinct commercial
+
+            await using var db = new IntroSkipperDbContext(dbPath);
+            var count = await db.DbSegment.CountAsync(s => s.ItemId == itemId && s.Type == AnalysisMode.Commercial);
+            Assert.Equal(2, count);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task SegmentStore_CleanTimestampsAsync_HandlesCollectionsAboveSqliteVariableLimit_WithoutChunking()
+    {
+        // 33 000 > SQLITE_MAX_VARIABLE_NUMBER (32 766): proves the EF.Parameter single-JSON-parameter
+        // translation replaces the manual Chunk(500) batching safely.
+        const int LargeEpisodeCount = 33_000;
+
+        var dbPath = CreateTempDbPath();
+        var retainedItemId = Guid.NewGuid();
+        var staleItemId = Guid.NewGuid();
+        var enabledEpisodeIds = Enumerable.Range(0, LargeEpisodeCount - 1)
+            .Select(_ => Guid.NewGuid())
+            .Append(retainedItemId)
+            .ToHashSet();
+
+        try
+        {
+            await EnsureSchemaAsync(dbPath);
+            await using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                db.DbSegment.AddRange(
+                    new DbSegment(new Segment(retainedItemId, new TimeRange(0, 10)), AnalysisMode.Introduction),
+                    new DbSegment(new Segment(staleItemId, new TimeRange(20, 30)), AnalysisMode.Introduction));
+                await db.SaveChangesAsync();
+            }
+
+            var store = EntrypointTestHelpers.CreateSegmentStore(dbPath);
+            await store.CleanTimestampsAsync(enabledEpisodeIds);
+
+            await using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var itemId = Assert.Single(await db.DbSegment.Select(segment => segment.ItemId).ToListAsync());
+                Assert.Equal(retainedItemId, itemId);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task DatabaseInitializer_GatesStoreAccess_UntilMigrationsComplete()
+    {
+        // No schema is created up front: the store's first operation must trigger the initializer,
+        // which runs legacy repair + migrations before the query executes.
+        var dbPath = CreateTempDbPath();
+        var cacheDbPath = dbPath + "-cache.db";
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            var initializer = EntrypointTestHelpers.CreateDatabaseInitializer(dbPath, cacheDbPath);
+            var store = new SegmentStore(new SegmentDbContextFactory(dbPath), initializer);
+            var service = new IntroSkipper.Services.SegmentUpdateService(store, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            // Simulate racing consumers on a cold database: all must succeed, initialization runs once.
+            var tasks = Enumerable.Range(0, 8)
+                .Select(_ => store.GetSegmentsAsync(itemId))
+                .ToArray();
+            await Task.WhenAll(tasks);
+            Assert.All(tasks, t => Assert.Empty(t.Result));
+
+            await service.UpdateTimestampAsync(new Segment(itemId, new TimeRange(5, 25)), AnalysisMode.Introduction);
+            var segments = await store.GetSegmentsAsync(itemId);
+            Assert.Single(segments);
+
+            await using var db = new IntroSkipperDbContext(dbPath);
+            Assert.Empty(await db.Database.GetPendingMigrationsAsync());
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    [Fact]
+    public async Task DetectionCacheStore_DeleteForItemsAsync_HandlesCollectionsAboveSqliteVariableLimit()
+    {
+        const int LargeIdCount = 33_000;
+
+        var cacheDbPath = CreateTempDbPath();
+        var deletedItemId = Guid.NewGuid();
+        var retainedItemId = Guid.NewGuid();
+
+        try
+        {
+            var factory = new DetectionCacheDbContextFactory(cacheDbPath);
+            using (var db = factory.CreateDbContext())
+            {
+                db.EnsureSchema();
+                db.DetectionCache.AddRange(
+                    new DbDetectionCache(deletedItemId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, [1, 2], 0, 10, string.Empty),
+                    new DbDetectionCache(retainedItemId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, [3, 4], 0, 10, string.Empty));
+                await db.SaveChangesAsync();
+            }
+
+            var store = new DetectionCacheStore(factory);
+            var idsToDelete = Enumerable.Range(0, LargeIdCount - 1)
+                .Select(_ => Guid.NewGuid())
+                .Append(deletedItemId)
+                .ToArray();
+
+            var deleted = await store.DeleteForItemsAsync(idsToDelete);
+            Assert.Equal(1, deleted);
+
+            using var verifyDb = factory.CreateDbContext();
+            var remaining = Assert.Single(await verifyDb.DetectionCache.Select(e => e.ItemId).ToListAsync());
+            Assert.Equal(retainedItemId, remaining);
+        }
+        finally
+        {
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    private static async Task EnsureSchemaAsync(string dbPath)
+    {
+        await using var db = new IntroSkipperDbContext(dbPath);
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    private static string CreateTempDbPath()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests", "stores");
+        Directory.CreateDirectory(tempDir);
+        return Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+    }
+
+    private static void DeleteSqliteFiles(string dbPath)
+    {
+        SqliteConnection.ClearAllPools();
+
+        foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -32,7 +32,7 @@ public sealed class TestSkipIntroController
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+        var controller = CreateController(refresher, dbPath);
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -66,7 +66,7 @@ public sealed class TestSkipIntroController
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+        var controller = CreateController(refresher, dbPath);
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -76,6 +76,16 @@ public sealed class TestSkipIntroController
 
         Assert.IsType<NoContentResult>(result);
         Assert.Equal(0, refresher.ItemCallCount);
+    }
+
+    private static SkipIntroController CreateController(IMediaSegmentRefresher refresher, string dbPath)
+    {
+        return new SkipIntroController(
+            refresher,
+            EntrypointTestHelpers.CreateDetectionCacheService(),
+            EntrypointTestHelpers.CreateSegmentUpdateService(dbPath),
+            EntrypointTestHelpers.CreateSegmentStore(dbPath),
+            EntrypointTestHelpers.CreateDatabaseInitializer(dbPath, Plugin.Instance!.CacheDbPath));
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid itemId, bool updateMediaSegments, out Movie item)

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -130,7 +130,7 @@ public sealed class TestVisualizationController
             fileSystem: null!,
             loggerFactory,
             ffmpegService: null!,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            EntrypointTestHelpers.CreateDetectionCacheService());
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -9,14 +9,15 @@
 
 using System.Net.Mime;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
+using IntroSkipper.Services;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace IntroSkipper.Controllers;
 
@@ -26,10 +27,18 @@ namespace IntroSkipper.Controllers;
 [Authorize]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
-public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, IDetectionCacheService cacheService) : ControllerBase
+public class SkipIntroController(
+    IMediaSegmentRefresher mediaSegmentRefresher,
+    IDetectionCacheService cacheService,
+    ISegmentUpdateService segmentUpdateService,
+    ISegmentStore segmentStore,
+    IDatabaseInitializer databaseInitializer) : ControllerBase
 {
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly ISegmentUpdateService _segmentUpdateService = segmentUpdateService;
+    private readonly ISegmentStore _segmentStore = segmentStore;
+    private readonly IDatabaseInitializer _databaseInitializer = databaseInitializer;
 
     /// <summary>
     /// Updates the timestamps for the provided episode.
@@ -70,7 +79,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
             if (segment.Valid)
             {
                 segment.EpisodeId = id;
-                await Plugin.Instance!.UpdateTimestampAsync(segment, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await _segmentUpdateService.UpdateTimestampAsync(segment, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -102,7 +111,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
         }
 
         var times = new TimeStamps();
-        var segments = await Plugin.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
+        var segments = await _segmentStore.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (segments.TryGetValue(AnalysisMode.Introduction, out var introSegment))
         {
@@ -142,7 +151,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     [HttpGet("Episode/{id}/IntroSkipperSegments")]
     public async Task<ActionResult<Dictionary<AnalysisMode, Segment>>> GetSkippableSegments([FromRoute] Guid id, CancellationToken cancellationToken = default)
     {
-        var segments = await Plugin.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
+        var segments = await _segmentStore.GetTimestampsAsync(id, cancellationToken).ConfigureAwait(false);
         var result = new Dictionary<AnalysisMode, Segment>();
 
         if (segments.TryGetValue(AnalysisMode.Introduction, out var introSegment))
@@ -185,11 +194,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     [HttpPost("Intros/EraseTimestamps")]
     public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false, CancellationToken cancellationToken = default)
     {
-        using var db = Plugin.CreateDbContext();
-        await db.DbSegment
-            .Where(s => s.Type == mode)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        await _segmentStore.DeleteSegmentsByTypeAsync(mode, cancellationToken).ConfigureAwait(false);
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {
@@ -211,8 +216,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     public async Task<ActionResult> RebuildDatabase()
     {
         // Database rebuild is destructive and must run to completion — do not bind to HttpContext.RequestAborted.
-        using var db = Plugin.CreateDbContext();
-        await db.RebuildDatabaseAsync(Plugin.CreateDbContext).ConfigureAwait(false);
+        await _databaseInitializer.RebuildSegmentDatabaseAsync().ConfigureAwait(false);
         return NoContent();
     }
 }

--- a/IntroSkipper/Data/SeasonQueueSnapshot.cs
+++ b/IntroSkipper/Data/SeasonQueueSnapshot.cs
@@ -13,7 +13,7 @@ namespace IntroSkipper.Data;
 /// <param name="AnalyzerActionByMode">Analyzer actions grouped by analysis mode.</param>
 /// <param name="SegmentsByEpisodeId">Existing segments grouped by episode and analysis mode.</param>
 /// <param name="UserProvidedByMode">User-provided episode identifiers grouped by analysis mode.</param>
-internal sealed record SeasonQueueSnapshot(
+public sealed record SeasonQueueSnapshot(
     IReadOnlyDictionary<AnalysisMode, IReadOnlySet<Guid>> EpisodeIdsByMode,
     IReadOnlyDictionary<AnalysisMode, string> ConfigHashByMode,
     IReadOnlyDictionary<AnalysisMode, AnalyzerAction> AnalyzerActionByMode,

--- a/IntroSkipper/Db/DatabaseInitializer.cs
+++ b/IntroSkipper/Db/DatabaseInitializer.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
 // SPDX-License-Identifier: GPL-3.0-only
 
-using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -65,6 +64,11 @@ internal sealed partial class DatabaseInitializer : IDatabaseInitializer
             // Normalize those schemas first so recovery does not log a false initialization failure.
             db.EnsureLegacySchemaCompatibility();
             await db.ApplyMigrationsAsync().ConfigureAwait(false);
+
+            // EF's SQLite provider persists journal_mode=wal when *it* creates the database, but a
+            // database file created or vacuumed by external tooling may have reverted to rollback
+            // journaling. Enforce WAL once per startup; the pragma is idempotent and persistent.
+            await db.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;").ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -80,9 +84,15 @@ internal sealed partial class DatabaseInitializer : IDatabaseInitializer
         {
             using var cacheDb = _cacheContextFactory.CreateDbContext();
             cacheDb.EnsureSchema();
+            cacheDb.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");
         }
-        catch (Exception ex) when (ex is IOException or SqliteException)
+        catch (Exception ex)
         {
+            // Catch-all on purpose: this gate is invoked from IHostedService.StartAsync (host
+            // startup would abort on an escaped exception) and the Lazy gate would cache a fault
+            // forever, turning one transient failure into a permanently dead cache. Log and
+            // continue; individual cache operations then fail per-call and are handled by
+            // DetectionCacheService's existing exception policy.
             LogCacheDbInitializationError(_logger, ex);
         }
 

--- a/IntroSkipper/Db/DatabaseInitializer.cs
+++ b/IntroSkipper/Db/DatabaseInitializer.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Default <see cref="IDatabaseInitializer"/> implementation. Thread safety is provided by
+/// <see cref="Lazy{T}"/> gates with <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>,
+/// so each database is initialized exactly once regardless of how many stores race on first use.
+/// </summary>
+internal sealed partial class DatabaseInitializer : IDatabaseInitializer
+{
+    private readonly IDbContextFactory<IntroSkipperDbContext> _segmentContextFactory;
+    private readonly IDbContextFactory<DetectionCacheDbContext> _cacheContextFactory;
+    private readonly ILogger<DatabaseInitializer> _logger;
+    private readonly Lazy<Task> _segmentDbInitialization;
+    private readonly Lazy<bool> _cacheDbInitialization;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatabaseInitializer"/> class.
+    /// </summary>
+    /// <param name="segmentContextFactory">Factory for segment database contexts.</param>
+    /// <param name="cacheContextFactory">Factory for detection cache database contexts.</param>
+    /// <param name="logger">Logger.</param>
+    public DatabaseInitializer(
+        IDbContextFactory<IntroSkipperDbContext> segmentContextFactory,
+        IDbContextFactory<DetectionCacheDbContext> cacheContextFactory,
+        ILogger<DatabaseInitializer> logger)
+    {
+        _segmentContextFactory = segmentContextFactory;
+        _cacheContextFactory = cacheContextFactory;
+        _logger = logger;
+        _segmentDbInitialization = new Lazy<Task>(InitializeSegmentDbAsync, LazyThreadSafetyMode.ExecutionAndPublication);
+        _cacheDbInitialization = new Lazy<bool>(InitializeCacheDb, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <inheritdoc/>
+    public Task EnsureSegmentDbReadyAsync(CancellationToken cancellationToken = default)
+        => _segmentDbInitialization.Value.WaitAsync(cancellationToken);
+
+    /// <inheritdoc/>
+    public void EnsureCacheDbReady() => _ = _cacheDbInitialization.Value;
+
+    /// <inheritdoc/>
+    public async Task RebuildSegmentDatabaseAsync(bool forceCleanOnBackupFailure = false, CancellationToken cancellationToken = default)
+    {
+        // Never rebuild concurrently with (or before) first-time initialization.
+        await EnsureSegmentDbReadyAsync(cancellationToken).ConfigureAwait(false);
+
+        using var db = _segmentContextFactory.CreateDbContext();
+        await db.RebuildDatabaseAsync(_segmentContextFactory.CreateDbContext, forceCleanOnBackupFailure, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InitializeSegmentDbAsync()
+    {
+        try
+        {
+            using var db = _segmentContextFactory.CreateDbContext();
+
+            // Legacy databases may be missing migration history or columns that EF migrations expect.
+            // Normalize those schemas first so recovery does not log a false initialization failure.
+            db.EnsureLegacySchemaCompatibility();
+            await db.ApplyMigrationsAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Parity with the historical Plugin constructor: log and continue. Queries against a
+            // genuinely unusable database will fail with actionable errors at the call sites.
+            LogSegmentDbInitializationError(_logger, ex);
+        }
+    }
+
+    private bool InitializeCacheDb()
+    {
+        try
+        {
+            using var cacheDb = _cacheContextFactory.CreateDbContext();
+            cacheDb.EnsureSchema();
+        }
+        catch (Exception ex) when (ex is IOException or SqliteException)
+        {
+            LogCacheDbInitializationError(_logger, ex);
+        }
+
+        return true;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
+    private static partial void LogSegmentDbInitializationError(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
+    private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
+}

--- a/IntroSkipper/Db/DetectionCacheDbContextFactory.cs
+++ b/IntroSkipper/Db/DetectionCacheDbContextFactory.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Creates <see cref="DetectionCacheDbContext"/> instances bound to a fixed SQLite database path.
+/// The <see cref="DbContextOptions{TContext}"/> are built once so every context shares the same
+/// options instance (and therefore the same cached EF internal service provider).
+/// </summary>
+internal sealed class DetectionCacheDbContextFactory : IDbContextFactory<DetectionCacheDbContext>
+{
+    private readonly DbContextOptions<DetectionCacheDbContext> _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DetectionCacheDbContextFactory"/> class.
+    /// </summary>
+    /// <param name="dbPath">Path of the SQLite database file.</param>
+    public DetectionCacheDbContextFactory(string dbPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(dbPath);
+
+        var directory = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        _options = new DbContextOptionsBuilder<DetectionCacheDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .AddInterceptors(SqlitePragmaInterceptor.Instance)
+            .Options;
+    }
+
+    /// <inheritdoc/>
+    public DetectionCacheDbContext CreateDbContext() => new(_options);
+}

--- a/IntroSkipper/Db/DetectionCacheDbContextFactory.cs
+++ b/IntroSkipper/Db/DetectionCacheDbContextFactory.cs
@@ -25,7 +25,16 @@ internal sealed class DetectionCacheDbContextFactory : IDbContextFactory<Detecti
         var directory = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(directory))
         {
-            Directory.CreateDirectory(directory);
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Must not throw: factories are constructed during DI resolution at host startup.
+                // If the directory is truly unavailable, connection opens fail per operation and
+                // are logged by the initializer gate or the calling store.
+            }
         }
 
         _options = new DbContextOptionsBuilder<DetectionCacheDbContext>()

--- a/IntroSkipper/Db/DetectionCacheStore.cs
+++ b/IntroSkipper/Db/DetectionCacheStore.cs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Default <see cref="IDetectionCacheStore"/> implementation over <see cref="IDbContextFactory{TContext}"/>.
+/// Every operation runs the <see cref="IDatabaseInitializer"/> cache gate (when supplied) before
+/// opening a context, guaranteeing the schema exists before any query runs.
+/// </summary>
+internal sealed class DetectionCacheStore : IDetectionCacheStore
+{
+    private readonly IDbContextFactory<DetectionCacheDbContext> _contextFactory;
+    private readonly IDatabaseInitializer? _initializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DetectionCacheStore"/> class.
+    /// </summary>
+    /// <param name="contextFactory">Detection cache database context factory.</param>
+    /// <param name="initializer">Optional initialization gate. Pass <see langword="null"/> only when the schema is guaranteed to exist already.</param>
+    public DetectionCacheStore(IDbContextFactory<DetectionCacheDbContext> contextFactory, IDatabaseInitializer? initializer = null)
+    {
+        _contextFactory = contextFactory;
+        _initializer = initializer;
+    }
+
+    /// <inheritdoc/>
+    public DbDetectionCache? Find(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end)
+    {
+        using var db = CreateContext();
+        return db.DetectionCache
+            .AsNoTracking()
+            .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+    }
+
+    /// <inheritdoc/>
+    public bool Exists(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, string expectedConfigHash)
+    {
+        using var db = CreateContext();
+        return db.DetectionCache.Any(e =>
+            e.ItemId == itemId &&
+            e.Mode == mode &&
+            e.Type == type &&
+            e.Start == start &&
+            e.End == end &&
+            (e.ConfigHash == string.Empty || e.ConfigHash == expectedConfigHash));
+    }
+
+    /// <inheritdoc/>
+    public void Upsert(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, byte[] data, string configHash)
+    {
+        using var db = CreateContext();
+        var existing = db.DetectionCache
+            .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+
+        if (existing is not null)
+        {
+            existing.Data = data;
+            existing.ConfigHash = configHash;
+        }
+        else
+        {
+            db.DetectionCache.Add(new DbDetectionCache(itemId, mode, type, data, start, end, configHash));
+        }
+
+        db.SaveChanges();
+    }
+
+    /// <inheritdoc/>
+    public void DeleteForItem(Guid itemId)
+    {
+        using var db = CreateContext();
+        db.DetectionCache.Where(e => e.ItemId == itemId).ExecuteDelete();
+    }
+
+    /// <inheritdoc/>
+    public void DeleteByMode(AnalysisMode mode)
+    {
+        using var db = CreateContext();
+        db.DetectionCache.Where(e => e.Mode == mode).ExecuteDelete();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<Guid>> GetItemIdsAsync(CancellationToken cancellationToken = default)
+    {
+        using var db = CreateContext();
+        return await db.DetectionCache
+            .AsNoTracking()
+            .Select(e => e.ItemId)
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> DeleteForItemsAsync(IReadOnlyCollection<Guid> itemIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(itemIds);
+        if (itemIds.Count == 0)
+        {
+            return 0;
+        }
+
+        var ids = itemIds as Guid[] ?? [.. itemIds];
+
+        using var db = CreateContext();
+        return await db.DetectionCache
+            .Where(e => EF.Parameter(ids).Contains(e.ItemId))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private DetectionCacheDbContext CreateContext()
+    {
+        _initializer?.EnsureCacheDbReady();
+        return _contextFactory.CreateDbContext();
+    }
+}

--- a/IntroSkipper/Db/IDatabaseInitializer.cs
+++ b/IntroSkipper/Db/IDatabaseInitializer.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Owns the lifecycle of both plugin databases: applying EF migrations and legacy schema repair to
+/// the segment database, ensuring the detection cache schema exists (including delete-and-recreate
+/// corruption recovery), and rebuilding the segment database on demand.
+/// Initialization is idempotent and runs at most once per process; the <c>Ensure*</c> members act as
+/// gates that all stores await before touching a database, which guarantees no query can observe a
+/// database that has not been migrated yet.
+/// </summary>
+public interface IDatabaseInitializer
+{
+    /// <summary>
+    /// Ensures legacy schema repair and EF migrations have completed for the segment database.
+    /// The first caller triggers initialization; concurrent and subsequent callers await the same
+    /// task. Initialization failures are logged and swallowed (matching the historical behavior of
+    /// the <see cref="Plugin"/> constructor) so a broken database degrades to per-query errors
+    /// instead of poisoning every future call.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token. Cancels only this caller's wait, never the shared initialization work.</param>
+    /// <returns>A task that completes when initialization has finished.</returns>
+    Task EnsureSegmentDbReadyAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ensures the detection cache database schema exists, recreating the database when it is
+    /// corrupted. Synchronous because all detection cache store operations are synchronous.
+    /// </summary>
+    void EnsureCacheDbReady();
+
+    /// <summary>
+    /// Rebuilds the segment database while attempting to preserve valid segments and season state.
+    /// </summary>
+    /// <param name="forceCleanOnBackupFailure">
+    /// When <see langword="true"/>, the rebuild proceeds with an empty database if the backup read
+    /// fails; when <see langword="false"/>, the rebuild aborts to avoid data loss.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RebuildSegmentDatabaseAsync(bool forceCleanOnBackupFailure = false, CancellationToken cancellationToken = default);
+}

--- a/IntroSkipper/Db/IDatabaseInitializer.cs
+++ b/IntroSkipper/Db/IDatabaseInitializer.cs
@@ -27,6 +27,9 @@ public interface IDatabaseInitializer
     /// <summary>
     /// Ensures the detection cache database schema exists, recreating the database when it is
     /// corrupted. Synchronous because all detection cache store operations are synchronous.
+    /// Never throws: failures are logged and swallowed so a broken cache database can neither
+    /// abort host startup (this gate runs inside <c>IHostedService.StartAsync</c>) nor poison
+    /// subsequent cache operations with a cached fault.
     /// </summary>
     void EnsureCacheDbReady();
 

--- a/IntroSkipper/Db/IDetectionCacheStore.cs
+++ b/IntroSkipper/Db/IDetectionCacheStore.cs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Persistence operations for the FFmpeg detection cache (<see cref="DbDetectionCache"/>, stored in
+/// <c>introskipper-cache.db</c>). Pure storage: compression, configuration hashing and cache-miss
+/// policy live in <see cref="IntroSkipper.FFmpeg.DetectionCacheService"/>. The synchronous members
+/// mirror the synchronous <see cref="IntroSkipper.FFmpeg.IDetectionCacheService"/> surface.
+/// </summary>
+public interface IDetectionCacheStore
+{
+    /// <summary>
+    /// Finds the cache entry with the exact key (item, mode, type, start, end), or <see langword="null"/>.
+    /// Start/End are compared with equality, which is safe only because lookups reuse the exact
+    /// double values that were written.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="type">Cache entry type.</param>
+    /// <param name="start">Start time in seconds.</param>
+    /// <param name="end">End time in seconds.</param>
+    /// <returns>The matching entry, or <see langword="null"/>.</returns>
+    DbDetectionCache? Find(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end);
+
+    /// <summary>
+    /// Returns whether a cache entry with the exact key exists and its stored configuration hash is
+    /// either empty or equal to <paramref name="expectedConfigHash"/>.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="type">Cache entry type.</param>
+    /// <param name="start">Start time in seconds.</param>
+    /// <param name="end">End time in seconds.</param>
+    /// <param name="expectedConfigHash">Configuration hash the entry must match (empty stored hashes always match).</param>
+    /// <returns><see langword="true"/> when a valid entry exists.</returns>
+    bool Exists(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, string expectedConfigHash);
+
+    /// <summary>
+    /// Inserts or updates the cache entry with the exact key.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="type">Cache entry type.</param>
+    /// <param name="start">Start time in seconds.</param>
+    /// <param name="end">End time in seconds.</param>
+    /// <param name="data">Compressed payload.</param>
+    /// <param name="configHash">Configuration hash that produced the payload.</param>
+    void Upsert(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, byte[] data, string configHash);
+
+    /// <summary>
+    /// Deletes all cache entries for an item.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    void DeleteForItem(Guid itemId);
+
+    /// <summary>
+    /// Deletes all cache entries for an analysis mode.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    void DeleteByMode(AnalysisMode mode);
+
+    /// <summary>
+    /// Gets the distinct item IDs present in the cache.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Distinct item IDs.</returns>
+    Task<IReadOnlyList<Guid>> GetItemIdsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes all cache entries belonging to the supplied items. Safe for arbitrarily large ID
+    /// sets: the collection is sent as a single JSON parameter.
+    /// </summary>
+    /// <param name="itemIds">Item IDs whose entries should be deleted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of deleted rows.</returns>
+    Task<int> DeleteForItemsAsync(IReadOnlyCollection<Guid> itemIds, CancellationToken cancellationToken = default);
+}

--- a/IntroSkipper/Db/ISeasonStateStore.cs
+++ b/IntroSkipper/Db/ISeasonStateStore.cs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Persistence operations for per-season analysis state (<see cref="DbSeasonState"/>).
+/// The season is treated as the aggregate root for analysis bookkeeping, so the two operations that
+/// atomically touch segments and season state together (<see cref="ResetSeasonForReanalysisAsync"/>
+/// and <see cref="GetSeasonQueueSnapshotAsync"/>) live here rather than being split across stores,
+/// which would break their single-transaction / single-connection semantics.
+/// </summary>
+public interface ISeasonStateStore
+{
+    /// <summary>
+    /// Creates or updates the analyzer action for each supplied mode of a season.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="analyzerActions">Analyzer actions keyed by analysis mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task SetAnalyzerActionsAsync(Guid seasonId, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Replaces the analyzed-episode list and configuration hash for a season and mode.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="episodeIds">Episode IDs analyzed with the current configuration.</param>
+    /// <param name="configHash">Configuration hash used for the analysis.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task SetEpisodeIdsAsync(Guid seasonId, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a single episode ID from the season's analyzed-state list for the given mode.
+    /// The read and write share one context to keep the window for concurrent overwrites as small
+    /// as possible, and the write is skipped entirely when the ID is not present in the stored list.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="episodeId">Episode ID to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the analyzed-episode lists for a season, keyed by analysis mode.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Episode IDs keyed by analysis mode.</returns>
+    Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid seasonId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the settled-season reanalysis state for all modes in a season.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Settled reanalysis state keyed by analysis mode.</returns>
+    Task<IReadOnlyDictionary<AnalysisMode, (AnalyzerAction Action, IReadOnlySet<Guid> SettledReanalysisEpisodeIds)>> GetSettleReanalysisStatesAsync(Guid seasonId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records that season analysis modes have been re-analyzed for the given episode set so the
+    /// exact completed set is not repeated on subsequent scans or after a plugin restart. Call only
+    /// after the reset has committed.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="modes">Analysis modes that were re-analyzed.</param>
+    /// <param name="episodeIds">Episode IDs that were re-analyzed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RecordSettleReanalysisAsync(Guid seasonId, IReadOnlyCollection<AnalysisMode> modes, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears stored automatic analysis state for a season so it is re-analyzed from scratch on the
+    /// current pass. Automatic segments for the supplied modes are deleted and the season's analyzed
+    /// episode lists are cleared; user-provided segments are preserved. The deletes and the
+    /// episode-list clear run in a single transaction so a cancelled reset cannot leave segments
+    /// deleted while their episodes are still recorded as analyzed.
+    /// </summary>
+    /// <param name="seasonId">Season ID whose analyzed-state lists should be cleared.</param>
+    /// <param name="episodeIds">Episode IDs whose automatic segments should be removed.</param>
+    /// <param name="modes">Analysis modes to reset.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task ResetSeasonForReanalysisAsync(Guid seasonId, IEnumerable<Guid> episodeIds, IReadOnlyCollection<AnalysisMode> modes, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the season state rows and all segments for the supplied episodes in one round trip,
+    /// producing the queue verification snapshot.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="episodeIds">Episode IDs in the season.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The season queue snapshot.</returns>
+    Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the analyzer action for every analysis mode of a season, defaulting missing modes to
+    /// <see cref="AnalyzerAction.Default"/>.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Analyzer actions keyed by analysis mode.</returns>
+    Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the analyzer action for a season and mode, or <see cref="AnalyzerAction.Default"/> when none is stored.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The analyzer action.</returns>
+    Task<AnalyzerAction> GetAnalyzerActionAsync(Guid seasonId, AnalysisMode mode, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes season state rows whose season is not in <paramref name="validSeasonIds"/>.
+    /// Safe for arbitrarily large ID sets: the collection is sent as a single JSON parameter.
+    /// </summary>
+    /// <param name="validSeasonIds">Season IDs whose state should be kept.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task CleanSeasonStatesAsync(IReadOnlyCollection<Guid> validSeasonIds, CancellationToken cancellationToken = default);
+}

--- a/IntroSkipper/Db/ISegmentStore.cs
+++ b/IntroSkipper/Db/ISegmentStore.cs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Persistence operations for media segments (<see cref="DbSegment"/>). Pure storage: business
+/// rules such as user-provided precedence live in the domain layer
+/// (<see cref="IntroSkipper.Services.ISegmentUpdateService"/>), which passes decisions into
+/// <see cref="ReplaceNonCommercialAsync"/> so they execute inside the store's write transaction.
+/// </summary>
+public interface ISegmentStore
+{
+    /// <summary>
+    /// Gets all stored segments for an item.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Stored segments for the item.</returns>
+    Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the earliest stored segment per analysis mode for an item.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Segments keyed by analysis mode.</returns>
+    Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid itemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Inserts a commercial segment unless an equivalent one (same item, start and end within
+    /// <paramref name="epsilon"/>) already exists.
+    /// </summary>
+    /// <param name="segment">Commercial segment to insert.</param>
+    /// <param name="epsilon">Tolerance used when comparing start/end times.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> when the segment was inserted; <see langword="false"/> when an equivalent segment already existed.</returns>
+    Task<bool> TryAddCommercialAsync(DbSegment segment, double epsilon, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically replaces the stored segments for the candidate's item and mode with the candidate,
+    /// but only when <paramref name="shouldPersist"/> approves the write. The callback runs inside
+    /// the write transaction with a snapshot of the existing rows, keeping the domain decision and
+    /// the write atomic.
+    /// </summary>
+    /// <param name="segment">Candidate segment (non-commercial).</param>
+    /// <param name="shouldPersist">Domain decision invoked with the stored state; return <see langword="false"/> to skip the write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> when the segment was persisted; <see langword="false"/> when the write was skipped.</returns>
+    Task<bool> ReplaceNonCommercialAsync(DbSegment segment, Func<NonCommercialSegmentContext, bool> shouldPersist, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes all segments for an item.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes the segments for an item and analysis mode, optionally restricted to entries whose
+    /// start/end match <paramref name="match"/> within <paramref name="epsilon"/>.
+    /// </summary>
+    /// <param name="itemId">Item ID.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="match">Optional segment whose start/end restrict the delete.</param>
+    /// <param name="epsilon">Tolerance used when comparing start/end times.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task DeleteSegmentsAsync(Guid itemId, AnalysisMode mode, Segment? match, double epsilon, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes all segments of the given analysis mode.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task DeleteSegmentsByTypeAsync(AnalysisMode mode, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes segments belonging to items that are not in <paramref name="enabledItemIds"/>.
+    /// Safe for arbitrarily large ID sets: the collection is sent as a single JSON parameter.
+    /// </summary>
+    /// <param name="enabledItemIds">Item IDs whose segments should be kept.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task CleanTimestampsAsync(IReadOnlyCollection<Guid> enabledItemIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes stale automatic segments (config hash mismatch) for the supplied items and mode.
+    /// User-provided segments are intentionally preserved. Safe for arbitrarily large ID sets.
+    /// </summary>
+    /// <param name="itemIds">Item IDs to inspect.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="configHash">Current configuration hash.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task CleanStaleAutomaticSegmentsAsync(IReadOnlyCollection<Guid> itemIds, AnalysisMode mode, string configHash, CancellationToken cancellationToken = default);
+}

--- a/IntroSkipper/Db/NonCommercialSegmentContext.cs
+++ b/IntroSkipper/Db/NonCommercialSegmentContext.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Snapshot of the stored segments relevant to a non-commercial segment write, loaded inside the
+/// store's write transaction and handed to the domain layer so persistence decisions (user-provided
+/// precedence, credits/intro overlap) stay atomic with the write itself.
+/// </summary>
+/// <param name="ExistingSegments">Stored segments with the same item ID and analysis mode as the candidate segment.</param>
+/// <param name="StoredIntroduction">The stored introduction segment for the item, or <see langword="null"/> when none exists or the candidate itself is an introduction.</param>
+public sealed record NonCommercialSegmentContext(
+    IReadOnlyList<DbSegment> ExistingSegments,
+    DbSegment? StoredIntroduction);

--- a/IntroSkipper/Db/PluginDatabasePaths.cs
+++ b/IntroSkipper/Db/PluginDatabasePaths.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using MediaBrowser.Common.Configuration;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Computes the on-disk locations of the plugin databases from the Jellyfin application paths.
+/// Kept in one place so the DI registrations and the <see cref="Plugin"/> constructor can never diverge.
+/// </summary>
+public static class PluginDatabasePaths
+{
+    private const string PluginDirectoryName = "introskipper";
+    private const string SegmentDbFileName = "introskipper.db";
+    private const string CacheDbFileName = "introskipper-cache.db";
+
+    /// <summary>
+    /// Gets the plugin data directory that contains both database files.
+    /// </summary>
+    /// <param name="applicationPaths">Jellyfin application paths.</param>
+    /// <returns>Absolute path of the plugin data directory.</returns>
+    public static string GetPluginDataDirectory(IApplicationPaths applicationPaths)
+    {
+        ArgumentNullException.ThrowIfNull(applicationPaths);
+        return Path.Join(applicationPaths.DataPath, PluginDirectoryName);
+    }
+
+    /// <summary>
+    /// Gets the path of the segment/season-state database (<c>introskipper.db</c>).
+    /// </summary>
+    /// <param name="applicationPaths">Jellyfin application paths.</param>
+    /// <returns>Absolute path of the segment database file.</returns>
+    public static string GetSegmentDbPath(IApplicationPaths applicationPaths)
+        => Path.Join(GetPluginDataDirectory(applicationPaths), SegmentDbFileName);
+
+    /// <summary>
+    /// Gets the path of the detection cache database (<c>introskipper-cache.db</c>).
+    /// </summary>
+    /// <param name="applicationPaths">Jellyfin application paths.</param>
+    /// <returns>Absolute path of the detection cache database file.</returns>
+    public static string GetCacheDbPath(IApplicationPaths applicationPaths)
+        => Path.Join(GetPluginDataDirectory(applicationPaths), CacheDbFileName);
+}

--- a/IntroSkipper/Db/SeasonStateStore.cs
+++ b/IntroSkipper/Db/SeasonStateStore.cs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Default <see cref="ISeasonStateStore"/> implementation over <see cref="IDbContextFactory{TContext}"/>.
+/// Every operation awaits the <see cref="IDatabaseInitializer"/> gate (when supplied) before opening
+/// a context, guaranteeing migrations have completed before any query runs.
+/// </summary>
+internal sealed class SeasonStateStore : ISeasonStateStore
+{
+    private readonly IDbContextFactory<IntroSkipperDbContext> _contextFactory;
+    private readonly IDatabaseInitializer? _initializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeasonStateStore"/> class.
+    /// </summary>
+    /// <param name="contextFactory">Segment database context factory.</param>
+    /// <param name="initializer">Optional initialization gate. Pass <see langword="null"/> only when the schema is guaranteed to exist already.</param>
+    public SeasonStateStore(IDbContextFactory<IntroSkipperDbContext> contextFactory, IDatabaseInitializer? initializer = null)
+    {
+        _contextFactory = contextFactory;
+        _initializer = initializer;
+    }
+
+    /// <inheritdoc/>
+    public async Task SetAnalyzerActionsAsync(Guid seasonId, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(analyzerActions);
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var existingEntries = await db.DbSeasonState
+            .Where(s => s.SeasonId == seasonId)
+            .ToDictionaryAsync(s => s.Type, cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var (mode, action) in analyzerActions)
+        {
+            if (existingEntries.TryGetValue(mode, out var existing))
+            {
+                db.Entry(existing).Property(s => s.Action).CurrentValue = action;
+            }
+            else
+            {
+                db.DbSeasonState.Add(new DbSeasonState(seasonId, mode, action));
+            }
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task SetEpisodeIdsAsync(Guid seasonId, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var seasonState = await db.DbSeasonState
+            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (seasonState is null)
+        {
+            seasonState = new DbSeasonState(seasonId, mode, AnalyzerAction.Default, episodeIds, configHash);
+            db.DbSeasonState.Add(seasonState);
+        }
+        else
+        {
+            db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
+            db.Entry(seasonState).Property(s => s.ConfigHash).CurrentValue = configHash;
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var seasonState = await db.DbSeasonState
+            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (seasonState is null)
+        {
+            return;
+        }
+
+        var currentIds = seasonState.EpisodeIds.ToList();
+        if (!currentIds.Remove(episodeId))
+        {
+            return; // Episode was not in the list — no write needed.
+        }
+
+        db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = currentIds;
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        return await db.DbSeasonState.Where(s => s.SeasonId == seasonId)
+            .ToDictionaryAsync(s => s.Type, s => s.EpisodeIds, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<AnalysisMode, (AnalyzerAction Action, IReadOnlySet<Guid> SettledReanalysisEpisodeIds)>> GetSettleReanalysisStatesAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var states = await db.DbSeasonState
+            .AsNoTracking()
+            .Where(s => s.SeasonId == seasonId)
+            .Select(s => new
+            {
+                s.Type,
+                s.Action,
+                s.SettledReanalysisEpisodeIds
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return states.ToDictionary(
+            s => s.Type,
+            s => (s.Action, (IReadOnlySet<Guid>)s.SettledReanalysisEpisodeIds.ToHashSet()));
+    }
+
+    /// <inheritdoc/>
+    public async Task RecordSettleReanalysisAsync(Guid seasonId, IReadOnlyCollection<AnalysisMode> modes, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(modes);
+        ArgumentNullException.ThrowIfNull(episodeIds);
+        if (modes.Count == 0)
+        {
+            return;
+        }
+
+        var settledEpisodeIds = DbSeasonState.SerializeEpisodeIds(episodeIds);
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var mode in modes)
+        {
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"""
+                INSERT INTO "DbSeasonState" ("SeasonId", "Type", "Action", "EpisodeIds", "ConfigHash", "SettledReanalysisEpisodeIds")
+                VALUES ({seasonId}, {(int)mode}, {(int)AnalyzerAction.Default}, {"[]"}, {string.Empty}, {settledEpisodeIds})
+                ON CONFLICT("SeasonId", "Type") DO UPDATE SET
+                    "SettledReanalysisEpisodeIds" = excluded."SettledReanalysisEpisodeIds"
+                """,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task ResetSeasonForReanalysisAsync(Guid seasonId, IEnumerable<Guid> episodeIds, IReadOnlyCollection<AnalysisMode> modes, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(episodeIds);
+        ArgumentNullException.ThrowIfNull(modes);
+
+        var ids = episodeIds.Distinct().ToArray();
+        var modeArray = modes.ToArray();
+        if (ids.Length == 0 || modeArray.Length == 0)
+        {
+            return;
+        }
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+
+        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await db.DbSegment
+                .Where(s => EF.Parameter(ids).Contains(s.ItemId) && modeArray.Contains(s.Type) && !s.IsUserProvided)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            // Clear the analyzed-episode lists so VerifyQueueAsync treats every episode as NotAnalyzed.
+            // Committing this together with the deletes guarantees the episodes are re-analyzed (either
+            // on this pass or a later one) instead of being stranded as NoSegments.
+            var seasonStates = await db.DbSeasonState
+                .Where(s => s.SeasonId == seasonId && modeArray.Contains(s.Type))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var state in seasonStates)
+            {
+                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
+            }
+
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await transaction.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(episodeIds);
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var episodeIdArray = (Guid[])[.. episodeIds.Distinct()];
+
+        var seasonStates = await db.DbSeasonState
+            .AsNoTracking()
+            .Where(s => s.SeasonId == seasonId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var segments = await db.DbSegment
+            .AsNoTracking()
+            .Where(s => EF.Parameter(episodeIdArray).Contains(s.ItemId))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new SeasonQueueSnapshot(
+            seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
+            seasonStates.ToDictionary(s => s.Type, s => s.ConfigHash),
+            seasonStates.ToDictionary(s => s.Type, s => s.Action),
+            segments
+                .GroupBy(s => s.ItemId)
+                .ToDictionary(
+                    group => group.Key,
+                    group => (IReadOnlyDictionary<AnalysisMode, Segment>)group
+                        .GroupBy(segment => segment.Type)
+                        .ToDictionary(
+                            segmentGroup => segmentGroup.Key,
+                            segmentGroup => segmentGroup.OrderBy(segment => segment.Start).First().ToSegment())),
+            segments
+                .Where(s => s.IsUserProvided)
+                .GroupBy(s => s.Type)
+                .ToDictionary(
+                    group => group.Key,
+                    group => (IReadOnlySet<Guid>)group.Select(s => s.ItemId).ToHashSet()));
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var states = await db.DbSeasonState
+            .Where(s => s.SeasonId == seasonId)
+            .ToDictionaryAsync(s => s.Type, s => s.Action, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Fill in defaults for any missing modes
+        var result = new Dictionary<AnalysisMode, AnalyzerAction>();
+        foreach (var mode in Enum.GetValues<AnalysisMode>())
+        {
+            result[mode] = states.TryGetValue(mode, out var action) ? action : AnalyzerAction.Default;
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<AnalyzerAction> GetAnalyzerActionAsync(Guid seasonId, AnalysisMode mode, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var state = await db.DbSeasonState
+            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
+            .ConfigureAwait(false);
+        return state?.Action ?? AnalyzerAction.Default;
+    }
+
+    /// <inheritdoc/>
+    public async Task CleanSeasonStatesAsync(IReadOnlyCollection<Guid> validSeasonIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(validSeasonIds);
+        var ids = validSeasonIds as Guid[] ?? [.. validSeasonIds];
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        await db.DbSeasonState
+            .Where(s => !EF.Parameter(ids).Contains(s.SeasonId))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<IntroSkipperDbContext> CreateContextAsync(CancellationToken cancellationToken)
+    {
+        if (_initializer is not null)
+        {
+            await _initializer.EnsureSegmentDbReadyAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return _contextFactory.CreateDbContext();
+    }
+}

--- a/IntroSkipper/Db/SegmentDbContextFactory.cs
+++ b/IntroSkipper/Db/SegmentDbContextFactory.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Creates <see cref="IntroSkipperDbContext"/> instances bound to a fixed SQLite database path.
+/// The <see cref="DbContextOptions{TContext}"/> are built once so every context shares the same
+/// options instance (and therefore the same cached EF internal service provider).
+/// </summary>
+internal sealed class SegmentDbContextFactory : IDbContextFactory<IntroSkipperDbContext>
+{
+    private readonly DbContextOptions<IntroSkipperDbContext> _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SegmentDbContextFactory"/> class.
+    /// </summary>
+    /// <param name="dbPath">Path of the SQLite database file.</param>
+    public SegmentDbContextFactory(string dbPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(dbPath);
+
+        var directory = Path.GetDirectoryName(dbPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        _options = new DbContextOptionsBuilder<IntroSkipperDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .AddInterceptors(SqlitePragmaInterceptor.Instance)
+            .Options;
+    }
+
+    /// <inheritdoc/>
+    public IntroSkipperDbContext CreateDbContext() => new(_options);
+}

--- a/IntroSkipper/Db/SegmentDbContextFactory.cs
+++ b/IntroSkipper/Db/SegmentDbContextFactory.cs
@@ -25,7 +25,16 @@ internal sealed class SegmentDbContextFactory : IDbContextFactory<IntroSkipperDb
         var directory = Path.GetDirectoryName(dbPath);
         if (!string.IsNullOrEmpty(directory))
         {
-            Directory.CreateDirectory(directory);
+            try
+            {
+                Directory.CreateDirectory(directory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Must not throw: factories are constructed during DI resolution at host startup.
+                // If the directory is truly unavailable, connection opens fail per operation and
+                // are logged by the initializer gate or the calling store.
+            }
         }
 
         _options = new DbContextOptionsBuilder<IntroSkipperDbContext>()

--- a/IntroSkipper/Db/SegmentStore.cs
+++ b/IntroSkipper/Db/SegmentStore.cs
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Default <see cref="ISegmentStore"/> implementation over <see cref="IDbContextFactory{TContext}"/>.
+/// Every operation awaits the <see cref="IDatabaseInitializer"/> gate (when supplied) before opening
+/// a context, guaranteeing migrations have completed before any query runs.
+/// </summary>
+internal sealed class SegmentStore : ISegmentStore
+{
+    // Hot path: runs on every playback via SegmentProvider.GetMediaSegments. Compiling once skips
+    // per-call LINQ expression construction and query-cache lookups.
+    private static readonly Func<IntroSkipperDbContext, Guid, IAsyncEnumerable<DbSegment>> _segmentsByItemQuery =
+        EF.CompileAsyncQuery((IntroSkipperDbContext db, Guid itemId) =>
+            db.DbSegment.AsNoTracking().Where(s => s.ItemId == itemId));
+
+    private readonly IDbContextFactory<IntroSkipperDbContext> _contextFactory;
+    private readonly IDatabaseInitializer? _initializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SegmentStore"/> class.
+    /// </summary>
+    /// <param name="contextFactory">Segment database context factory.</param>
+    /// <param name="initializer">Optional initialization gate. Pass <see langword="null"/> only when the schema is guaranteed to exist already.</param>
+    public SegmentStore(IDbContextFactory<IntroSkipperDbContext> contextFactory, IDatabaseInitializer? initializer = null)
+    {
+        _contextFactory = contextFactory;
+        _initializer = initializer;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var segments = new List<DbSegment>();
+        await foreach (var segment in _segmentsByItemQuery(db, itemId).WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            segments.Add(segment);
+        }
+
+        return segments;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        var segments = await GetSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
+
+        return segments
+            .GroupBy(segment => segment.Type)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(segment => segment.Start).First().ToSegment());
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> TryAddCommercialAsync(DbSegment segment, double epsilon, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var exists = await db.DbSegment
+            .AnyAsync(
+                s => s.ItemId == segment.ItemId
+                     && s.Type == segment.Type
+                     && Math.Abs(s.Start - segment.Start) <= epsilon
+                     && Math.Abs(s.End - segment.End) <= epsilon,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (exists)
+        {
+            return false;
+        }
+
+        db.DbSegment.Add(segment);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> ReplaceNonCommercialAsync(DbSegment segment, Func<NonCommercialSegmentContext, bool> shouldPersist, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+        ArgumentNullException.ThrowIfNull(shouldPersist);
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var existingSegments = await db.DbSegment
+                .Where(s => s.ItemId == segment.ItemId && s.Type == segment.Type)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            DbSegment? storedIntroduction = null;
+            if (segment.Type != AnalysisMode.Introduction)
+            {
+                storedIntroduction = await db.DbSegment
+                    .AsNoTracking()
+                    .Where(s => s.ItemId == segment.ItemId && s.Type == AnalysisMode.Introduction)
+                    .FirstOrDefaultAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (!shouldPersist(new NonCommercialSegmentContext(existingSegments, storedIntroduction)))
+            {
+                return false;
+            }
+
+            if (existingSegments.Count > 0)
+            {
+                db.DbSegment.RemoveRange(existingSegments);
+            }
+
+            db.DbSegment.Add(segment);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        finally
+        {
+            await transaction.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        await db.DbSegment
+            .Where(s => s.ItemId == itemId)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteSegmentsAsync(Guid itemId, AnalysisMode mode, Segment? match, double epsilon, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        var query = db.DbSegment.Where(s => s.ItemId == itemId && s.Type == mode);
+
+        if (match is not null)
+        {
+            query = query.Where(s =>
+                Math.Abs(s.Start - match.Start) <= epsilon
+                && Math.Abs(s.End - match.End) <= epsilon);
+        }
+
+        var entries = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
+        if (entries.Count > 0)
+        {
+            db.DbSegment.RemoveRange(entries);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteSegmentsByTypeAsync(AnalysisMode mode, CancellationToken cancellationToken = default)
+    {
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        await db.DbSegment
+            .Where(s => s.Type == mode)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task CleanTimestampsAsync(IReadOnlyCollection<Guid> enabledItemIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(enabledItemIds);
+        var enabledIds = enabledItemIds as Guid[] ?? [.. enabledItemIds];
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // EF.Parameter forces the single-JSON-parameter translation (json_each) instead of EF 10's
+        // default one-parameter-per-value expansion, which would exceed SQLite's 32766-variable
+        // limit for large libraries. See docs/db-redesign/theory-a.md for the measured proof.
+        await db.DbSegment
+            .Where(s => !EF.Parameter(enabledIds).Contains(s.ItemId))
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task CleanStaleAutomaticSegmentsAsync(IReadOnlyCollection<Guid> itemIds, AnalysisMode mode, string configHash, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(itemIds);
+        var ids = itemIds.Distinct().ToArray();
+        if (ids.Length == 0)
+        {
+            return;
+        }
+
+        using var db = await CreateContextAsync(cancellationToken).ConfigureAwait(false);
+        await db.DbSegment
+            .Where(s => EF.Parameter(ids).Contains(s.ItemId)
+                && s.Type == mode
+                && !s.IsUserProvided
+                && s.ConfigHash != configHash)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<IntroSkipperDbContext> CreateContextAsync(CancellationToken cancellationToken)
+    {
+        if (_initializer is not null)
+        {
+            await _initializer.EnsureSegmentDbReadyAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return _contextFactory.CreateDbContext();
+    }
+}

--- a/IntroSkipper/Db/SqlitePragmaInterceptor.cs
+++ b/IntroSkipper/Db/SqlitePragmaInterceptor.cs
@@ -17,6 +17,12 @@ namespace IntroSkipper.Db;
 /// </summary>
 internal sealed class SqlitePragmaInterceptor : DbConnectionInterceptor
 {
+    /// <summary>
+    /// Gets a shared interceptor instance. The interceptor is stateless; sharing one instance keeps
+    /// the EF options cache key stable so all contexts reuse a single internal service provider.
+    /// </summary>
+    public static SqlitePragmaInterceptor Instance { get; } = new();
+
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
     {
         using var cmd = connection.CreateCommand();

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -19,9 +19,11 @@ namespace IntroSkipper.FFmpeg;
 /// Initializes a new instance of the <see cref="DetectionCacheService"/> class.
 /// </remarks>
 /// <param name="logger">The logger instance.</param>
-public sealed partial class DetectionCacheService(ILogger<DetectionCacheService> logger) : IDetectionCacheService
+/// <param name="cacheStore">The detection cache store.</param>
+public sealed partial class DetectionCacheService(ILogger<DetectionCacheService> logger, IDetectionCacheStore cacheStore) : IDetectionCacheService
 {
     private readonly ILogger<DetectionCacheService> _logger = logger;
+    private readonly IDetectionCacheStore _cacheStore = cacheStore;
 
     /// <inheritdoc/>
     public bool IsEnabled => Plugin.Instance?.Configuration.CacheFingerprints ?? false;
@@ -38,13 +40,10 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
         try
         {
-            using var db = Plugin.CreateCacheDbContext();
-
             // NOTE: Start/End are compared with == which is safe only because the exact same
             // double values that were written are used for lookup (no intermediate arithmetic).
             // If a future caller computes start/end differently, the lookup will silently miss.
-            var entry = db.DetectionCache
-                .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+            var entry = _cacheStore.Find(itemId, mode, type, start, end);
 
             if (entry is null)
             {
@@ -89,10 +88,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
         try
         {
-            using var db = Plugin.CreateCacheDbContext();
-
-            UpsertEntry(db, itemId, mode, type, start, end, data, configHash);
-            db.SaveChanges();
+            _cacheStore.Upsert(itemId, mode, type, start, end, data, configHash);
             return true;
         }
         catch (Exception ex) when (ex is DbUpdateException or DbException)
@@ -115,8 +111,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         try
         {
             // Delete from the SQLite cache database.
-            using var db = Plugin.CreateCacheDbContext();
-            db.DetectionCache.Where(e => e.ItemId == itemId).ExecuteDelete();
+            _cacheStore.DeleteForItem(itemId);
         }
         catch (Exception ex) when (ex is DbUpdateException or DbException)
         {
@@ -134,8 +129,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         try
         {
             // Delete from the SQLite cache database.
-            using var db = Plugin.CreateCacheDbContext();
-            db.DetectionCache.Where(e => e.Mode == mode).ExecuteDelete();
+            _cacheStore.DeleteByMode(mode);
         }
         catch (Exception ex) when (ex is DbUpdateException or DbException)
         {
@@ -159,15 +153,8 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
         try
         {
-            using var db = Plugin.CreateCacheDbContext();
             var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), CacheEntryType.Chromaprint, mode);
-            if (db.DetectionCache.Any(e =>
-                e.ItemId == episode.EpisodeId &&
-                e.Mode == mode &&
-                e.Type == CacheEntryType.Chromaprint &&
-                e.Start == start &&
-                e.End == end &&
-                (e.ConfigHash == string.Empty || e.ConfigHash == expectedHash)))
+            if (_cacheStore.Exists(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, expectedHash))
             {
                 return true;
             }
@@ -209,32 +196,6 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         using var input = new MemoryStream(compressed);
         using var brotli = new BrotliStream(input, CompressionMode.Decompress);
         return JsonSerializer.Deserialize<T>(brotli);
-    }
-
-    private static void UpsertEntry(
-        DetectionCacheDbContext db,
-        Guid itemId,
-        AnalysisMode mode,
-        CacheEntryType type,
-        double start,
-        double end,
-        byte[] data,
-        string configHash)
-    {
-        // NOTE: Start/End are compared with == which is safe only because the exact same
-        // double values that were written are used for lookup (no intermediate arithmetic).
-        var existing = db.DetectionCache
-            .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
-
-        if (existing is not null)
-        {
-            existing.Data = data;
-            existing.ConfigHash = configHash;
-        }
-        else
-        {
-            db.DetectionCache.Add(new DbDetectionCache(itemId, mode, type, data, start, end, configHash));
-        }
     }
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Detection cache hit for {CacheKey}")]

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -12,6 +12,7 @@ using System.Collections.Concurrent;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
+using IntroSkipper.Services;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -23,18 +24,23 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IntroSkipper;
 
 /// <summary>
 /// Intro skipper plugin. Uses audio analysis to find common sequences of audio shared between episodes.
 /// </summary>
+/// <remarks>
+/// The database methods on this type are transitional delegates to the store layer
+/// (<see cref="ISegmentStore"/>, <see cref="ISeasonStateStore"/>, <see cref="ISegmentUpdateService"/>)
+/// kept only for call sites that are still constructed manually (analyzers, QueueManager,
+/// BaseItemAnalyzerTask). New code must inject the stores via DI instead; see
+/// docs/db-redesign/theory-a.md for the target end state with zero database code in this class.
+/// </remarks>
 public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
-    private const double SegmentComparisonEpsilon = 0.001;
-    private const int SqliteParameterBatchSize = 500;
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
     private readonly IPluginManager _pluginManager;
@@ -73,14 +79,13 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         ArgumentNullException.ThrowIfNull(applicationPaths);
 
-        var pluginDirName = "introskipper";
         var pluginCachePath = "chromaprints";
 
-        var introsDirectory = Path.Join(applicationPaths.DataPath, pluginDirName);
+        var introsDirectory = PluginDatabasePaths.GetPluginDataDirectory(applicationPaths);
         FingerprintCachePath = Path.Join(introsDirectory, pluginCachePath);
 
-        _dbPath = Path.Join(introsDirectory, "introskipper.db");
-        _cacheDbPath = Path.Join(introsDirectory, "introskipper-cache.db");
+        _dbPath = PluginDatabasePaths.GetSegmentDbPath(applicationPaths);
+        _cacheDbPath = PluginDatabasePaths.GetCacheDbPath(applicationPaths);
 
         // Create the base directories (if needed).
         // Directory.CreateDirectory is already a no-op when the directory exists, so we can call it unconditionally without checking first.
@@ -223,225 +228,64 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? Array.Empty<ChapterInfo>();
 
-    internal async Task UpdateTimestampAsync(
+    internal Task UpdateTimestampAsync(
         Segment segment,
         AnalysisMode mode,
         bool isUserProvided = false,
         string configHash = "",
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-
-        try
-        {
-            var dbSegment = new DbSegment(segment, mode, isUserProvided, configHash);
-
-            if (mode == AnalysisMode.Commercial)
-            {
-                var exists = await db.DbSegment
-                    .AnyAsync(
-                        s => s.ItemId == segment.EpisodeId
-                             && s.Type == mode
-                             && Math.Abs(s.Start - dbSegment.Start) <= SegmentComparisonEpsilon
-                             && Math.Abs(s.End - dbSegment.End) <= SegmentComparisonEpsilon,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (!exists)
-                {
-                    db.DbSegment.Add(dbSegment);
-                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-                try
-                {
-                    var existingSegments = await db.DbSegment
-                        .Where(s => s.ItemId == segment.EpisodeId && s.Type == mode)
-                        .ToListAsync(cancellationToken)
-                        .ConfigureAwait(false);
-
-                    // Do not overwrite a user-provided segment with an analysis result.
-                    if (!isUserProvided && existingSegments.Any(s => s.IsUserProvided))
-                    {
-                        return;
-                    }
-
-                    // Guard: prevent auto-detected credits from overlapping with the introduction.
-                    if (mode == AnalysisMode.Credits && !isUserProvided)
-                    {
-                        var intro = await db.DbSegment
-                            .AsNoTracking()
-                            .Where(s => s.ItemId == segment.EpisodeId && s.Type == AnalysisMode.Introduction)
-                            .FirstOrDefaultAsync(cancellationToken)
-                            .ConfigureAwait(false);
-
-                        if (intro is not null && segment.Start < intro.End && intro.Start < segment.End)
-                        {
-                            LogCreditsOverlapWithIntro(_logger, segment.EpisodeId);
-                            return;
-                        }
-                    }
-
-                    if (existingSegments.Count > 0)
-                    {
-                        db.DbSegment.RemoveRange(existingSegments);
-                    }
-
-                    db.DbSegment.Add(dbSegment);
-                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-                }
-                finally
-                {
-                    await transaction.DisposeAsync().ConfigureAwait(false);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            LogFailedToUpdateTimestamp(_logger, ex, segment.EpisodeId);
-            throw;
-        }
+        return CreateSegmentUpdateService().UpdateTimestampAsync(segment, mode, isUserProvided, configHash, cancellationToken);
     }
 
-    internal static async Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)
+    internal static Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var segments = await db.DbSegment
-            .AsNoTracking()
-            .Where(s => s.ItemId == id)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return segments
-            .GroupBy(segment => segment.Type)
-            .ToDictionary(
-                group => group.Key,
-                group => group.OrderBy(segment => segment.Start).First().ToSegment());
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSegmentStore().GetTimestampsAsync(id, cancellationToken);
     }
 
-    internal static async Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
+    internal static Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        return await db.DbSegment
-            .AsNoTracking()
-            .Where(s => s.ItemId == id)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSegmentStore().GetSegmentsAsync(id, cancellationToken);
     }
 
-    internal static async Task DeleteItemSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
+    internal static Task DeleteItemSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        await db.DbSegment
-            .Where(s => s.ItemId == itemId)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSegmentStore().DeleteSegmentsAsync(itemId, cancellationToken);
     }
 
-    internal static async Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
+    internal static Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        var enabledEpisodeIds = episodeIds.ToHashSet();
-
-        using var db = CreateDbContext();
-        var segmentEpisodeIds = await db.DbSegment
-            .AsNoTracking()
-            .Select(s => s.ItemId)
-            .Distinct()
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        var staleEpisodeIds = segmentEpisodeIds
-            .Where(id => !enabledEpisodeIds.Contains(id))
-            .ToArray();
-
-        foreach (var staleEpisodeIdBatch in staleEpisodeIds.Chunk(SqliteParameterBatchSize))
-        {
-            await db.DbSegment
-                .Where(s => staleEpisodeIdBatch.Contains(s.ItemId))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSegmentStore().CleanTimestampsAsync(episodeIds as IReadOnlyCollection<Guid> ?? [.. episodeIds], cancellationToken);
     }
 
-    internal static async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
+    internal static Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var existingEntries = await db.DbSeasonState
-            .Where(s => s.SeasonId == id)
-            .ToDictionaryAsync(s => s.Type, cancellationToken)
-            .ConfigureAwait(false);
-
-        foreach (var (mode, action) in analyzerActions)
-        {
-            if (existingEntries.TryGetValue(mode, out var existing))
-            {
-                db.Entry(existing).Property(s => s.Action).CurrentValue = action;
-            }
-            else
-            {
-                db.DbSeasonState.Add(new DbSeasonState(id, mode, action));
-            }
-        }
-
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().SetAnalyzerActionsAsync(id, analyzerActions, cancellationToken);
     }
 
-    internal static async Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
+    internal static Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var seasonState = await db.DbSeasonState
-            .FirstOrDefaultAsync(s => s.SeasonId == id && s.Type == mode, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (seasonState is null)
-        {
-            seasonState = new DbSeasonState(id, mode, AnalyzerAction.Default, episodeIds, configHash);
-            db.DbSeasonState.Add(seasonState);
-        }
-        else
-        {
-            db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
-            db.Entry(seasonState).Property(s => s.ConfigHash).CurrentValue = configHash;
-        }
-
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().SetEpisodeIdsAsync(id, mode, episodeIds, configHash, cancellationToken);
     }
 
     /// <summary>
     /// Removes a single episode ID from the season's analyzed-state list for the given mode.
-    /// The read and write share one <see cref="IntroSkipperDbContext"/> to keep the window for
-    /// concurrent overwrites as small as possible, and the write is skipped entirely when the
-    /// ID is not present in the stored list.
     /// </summary>
     /// <param name="seasonId">Season ID.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="episodeId">Episode ID to remove.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    internal static async Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
+    internal static Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var seasonState = await db.DbSeasonState
-            .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (seasonState is null)
-        {
-            return;
-        }
-
-        var currentIds = seasonState.EpisodeIds.ToList();
-        if (!currentIds.Remove(episodeId))
-        {
-            return; // Episode was not in the list — no write needed.
-        }
-
-        db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = currentIds;
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().RemoveEpisodeIdAsync(seasonId, mode, episodeId, cancellationToken);
     }
 
     /// <summary>
@@ -453,37 +297,20 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="configHash">Current configuration hash.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    internal static async Task CleanStaleAutomaticSegmentsAsync(
+    internal static Task CleanStaleAutomaticSegmentsAsync(
         IEnumerable<Guid> itemIds,
         AnalysisMode mode,
         string configHash,
         CancellationToken cancellationToken = default)
     {
-        var ids = itemIds.Distinct().ToArray();
-        if (ids.Length == 0)
-        {
-            return;
-        }
-
-        using var db = CreateDbContext();
-        foreach (var batch in ids.Chunk(SqliteParameterBatchSize))
-        {
-            await db.DbSegment
-                .Where(s => batch.Contains(s.ItemId)
-                    && s.Type == mode
-                    && !s.IsUserProvided
-                    && s.ConfigHash != configHash)
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSegmentStore().CleanStaleAutomaticSegmentsAsync(itemIds as IReadOnlyCollection<Guid> ?? [.. itemIds], mode, configHash, cancellationToken);
     }
 
-    internal static async Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid id, CancellationToken cancellationToken = default)
+    internal static Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        return await db.DbSeasonState.Where(s => s.SeasonId == id)
-            .ToDictionaryAsync(s => s.Type, s => s.EpisodeIds, cancellationToken)
-            .ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().GetEpisodeIdsAsync(id, cancellationToken);
     }
 
     /// <summary>
@@ -492,26 +319,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="seasonId">Season ID.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Settled reanalysis state keyed by analysis mode.</returns>
-    internal static async Task<IReadOnlyDictionary<AnalysisMode, (AnalyzerAction Action, IReadOnlySet<Guid> SettledReanalysisEpisodeIds)>> GetSettleReanalysisStatesAsync(
+    internal static Task<IReadOnlyDictionary<AnalysisMode, (AnalyzerAction Action, IReadOnlySet<Guid> SettledReanalysisEpisodeIds)>> GetSettleReanalysisStatesAsync(
         Guid seasonId,
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var states = await db.DbSeasonState
-            .AsNoTracking()
-            .Where(s => s.SeasonId == seasonId)
-            .Select(s => new
-            {
-                s.Type,
-                s.Action,
-                s.SettledReanalysisEpisodeIds
-            })
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return states.ToDictionary(
-            s => s.Type,
-            s => (s.Action, (IReadOnlySet<Guid>)s.SettledReanalysisEpisodeIds.ToHashSet()));
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().GetSettleReanalysisStatesAsync(seasonId, cancellationToken);
     }
 
     /// <summary>
@@ -538,171 +351,58 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="episodeIds">Episode IDs that were re-analyzed.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    internal static async Task RecordSettleReanalysisAsync(
+    internal static Task RecordSettleReanalysisAsync(
         Guid seasonId,
         IReadOnlyCollection<AnalysisMode> modes,
         IReadOnlyCollection<Guid> episodeIds,
         CancellationToken cancellationToken = default)
     {
-        if (modes.Count == 0)
-        {
-            return;
-        }
-
-        var settledEpisodeIds = DbSeasonState.SerializeEpisodeIds(episodeIds);
-
-        using var db = CreateDbContext();
-        foreach (var mode in modes)
-        {
-            await db.Database.ExecuteSqlInterpolatedAsync(
-                $"""
-                INSERT INTO "DbSeasonState" ("SeasonId", "Type", "Action", "EpisodeIds", "ConfigHash", "SettledReanalysisEpisodeIds")
-                VALUES ({seasonId}, {(int)mode}, {(int)AnalyzerAction.Default}, {"[]"}, {string.Empty}, {settledEpisodeIds})
-                ON CONFLICT("SeasonId", "Type") DO UPDATE SET
-                    "SettledReanalysisEpisodeIds" = excluded."SettledReanalysisEpisodeIds"
-                """,
-                cancellationToken).ConfigureAwait(false);
-        }
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().RecordSettleReanalysisAsync(seasonId, modes, episodeIds, cancellationToken);
     }
 
     /// <summary>
     /// Clears stored automatic analysis state for a season so it is re-analyzed from scratch on the
     /// current pass. Automatic segments for the supplied modes are deleted and the season's analyzed
     /// episode lists are cleared; user-provided segments and the fingerprint cache are preserved.
-    /// The deletes and the episode-list clear run in a single transaction so a cancelled reset cannot
-    /// leave segments deleted while their episodes are still recorded as analyzed.
     /// </summary>
     /// <param name="seasonId">Season ID whose analyzed-state lists should be cleared.</param>
     /// <param name="episodeIds">Episode IDs whose automatic segments should be removed.</param>
     /// <param name="modes">Analysis modes to reset.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    internal static async Task ResetSeasonForReanalysisAsync(
+    internal static Task ResetSeasonForReanalysisAsync(
         Guid seasonId,
         IEnumerable<Guid> episodeIds,
         IReadOnlyCollection<AnalysisMode> modes,
         CancellationToken cancellationToken = default)
     {
-        var ids = episodeIds.Distinct().ToArray();
-        var modeArray = modes.ToArray();
-        if (ids.Length == 0 || modeArray.Length == 0)
-        {
-            return;
-        }
-
-        using var db = CreateDbContext();
-
-        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            foreach (var batch in ids.Chunk(SqliteParameterBatchSize))
-            {
-                await db.DbSegment
-                    .Where(s => batch.Contains(s.ItemId) && modeArray.Contains(s.Type) && !s.IsUserProvided)
-                    .ExecuteDeleteAsync(cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            // Clear the analyzed-episode lists so VerifyQueueAsync treats every episode as NotAnalyzed.
-            // Committing this together with the deletes guarantees the episodes are re-analyzed (either
-            // on this pass or a later one) instead of being stranded as NoSegments.
-            var seasonStates = await db.DbSeasonState
-                .Where(s => s.SeasonId == seasonId && modeArray.Contains(s.Type))
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            foreach (var state in seasonStates)
-            {
-                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
-            }
-
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            await transaction.DisposeAsync().ConfigureAwait(false);
-        }
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().ResetSeasonForReanalysisAsync(seasonId, episodeIds, modes, cancellationToken);
     }
 
-    internal static async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
+    internal static Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var episodeIdArray = (Guid[])[.. episodeIds.Distinct()];
-
-        var seasonStates = await db.DbSeasonState
-            .AsNoTracking()
-            .Where(s => s.SeasonId == seasonId)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        var allSegments = new List<DbSegment>();
-        foreach (var batch in episodeIdArray.Chunk(SqliteParameterBatchSize))
-        {
-            allSegments.AddRange(await db.DbSegment
-                .AsNoTracking()
-                .Where(s => batch.Contains(s.ItemId))
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false));
-        }
-
-        var segments = allSegments;
-
-        return new SeasonQueueSnapshot(
-            seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
-            seasonStates.ToDictionary(s => s.Type, s => s.ConfigHash),
-            seasonStates.ToDictionary(s => s.Type, s => s.Action),
-            segments
-                .GroupBy(s => s.ItemId)
-                .ToDictionary(
-                    group => group.Key,
-                    group => (IReadOnlyDictionary<AnalysisMode, Segment>)group
-                        .GroupBy(segment => segment.Type)
-                        .ToDictionary(
-                            segmentGroup => segmentGroup.Key,
-                            segmentGroup => segmentGroup.OrderBy(segment => segment.Start).First().ToSegment())),
-            segments
-                .Where(s => s.IsUserProvided)
-                .GroupBy(s => s.Type)
-                .ToDictionary(
-                    group => group.Key,
-                    group => (IReadOnlySet<Guid>)group.Select(s => s.ItemId).ToHashSet()));
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().GetSeasonQueueSnapshotAsync(seasonId, episodeIds, cancellationToken);
     }
 
-    internal static async Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
+    internal static Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var states = await db.DbSeasonState
-            .Where(s => s.SeasonId == seasonId)
-            .ToDictionaryAsync(s => s.Type, s => s.Action, cancellationToken)
-            .ConfigureAwait(false);
-
-        // Fill in defaults for any missing modes
-        var result = new Dictionary<AnalysisMode, AnalyzerAction>();
-        foreach (var mode in Enum.GetValues<AnalysisMode>())
-        {
-            result[mode] = states.TryGetValue(mode, out var action) ? action : AnalyzerAction.Default;
-        }
-
-        return result;
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().GetAllAnalyzerActionsAsync(seasonId, cancellationToken);
     }
 
-    internal static async Task<AnalyzerAction> GetAnalyzerActionAsync(Guid id, AnalysisMode mode, CancellationToken cancellationToken = default)
+    internal static Task<AnalyzerAction> GetAnalyzerActionAsync(Guid id, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        var state = await db.DbSeasonState
-            .FirstOrDefaultAsync(s => s.SeasonId == id && s.Type == mode, cancellationToken)
-            .ConfigureAwait(false);
-        return state?.Action ?? AnalyzerAction.Default;
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().GetAnalyzerActionAsync(id, mode, cancellationToken);
     }
 
-    internal static async Task CleanSeasonStateAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
+    internal static Task CleanSeasonStateAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        await db.DbSeasonState
-            .Where(s => !ids.Contains(s.SeasonId))
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSeasonStateStore().CleanSeasonStatesAsync(ids as IReadOnlyCollection<Guid> ?? [.. ids], cancellationToken);
     }
 
     internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
@@ -726,34 +426,21 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="segment">Optional segment details used to remove a specific entry.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    internal static async Task DeleteTimestampAsync(
+    internal static Task DeleteTimestampAsync(
         Guid itemId,
         AnalysisMode mode,
         Segment? segment = null,
         CancellationToken cancellationToken = default)
     {
-        using var db = CreateDbContext();
-        if (segment is null && mode == AnalysisMode.Commercial)
-        {
-            return;
-        }
-
-        var query = db.DbSegment.Where(s => s.ItemId == itemId && s.Type == mode);
-
-        if (segment is not null)
-        {
-            query = query.Where(s =>
-                Math.Abs(s.Start - segment.Start) <= SegmentComparisonEpsilon
-                && Math.Abs(s.End - segment.End) <= SegmentComparisonEpsilon);
-        }
-
-        var entries = await query.ToListAsync(cancellationToken).ConfigureAwait(false);
-        if (entries.Count > 0)
-        {
-            db.DbSegment.RemoveRange(entries);
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
+        ArgumentNullException.ThrowIfNull(Instance);
+        return Instance.CreateSegmentUpdateService().DeleteTimestampAsync(itemId, mode, segment, cancellationToken);
     }
+
+    private SegmentStore CreateSegmentStore() => new(new SegmentDbContextFactory(_dbPath));
+
+    private SeasonStateStore CreateSeasonStateStore() => new(new SegmentDbContextFactory(_dbPath));
+
+    private SegmentUpdateService CreateSegmentUpdateService() => new(CreateSegmentStore(), (ILogger?)_logger ?? NullLogger.Instance);
 
     private void MigrateLegacyExcludeSeries()
     {
@@ -780,10 +467,4 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
     private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping credits for episode {EpisodeId}: detected segment overlaps with introduction")]
-    private static partial void LogCreditsOverlapWithIntro(ILogger logger, Guid episodeId);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update timestamp for episode {EpisodeId}")]
-    private static partial void LogFailedToUpdateTimestamp(ILogger logger, Exception ex, Guid episodeId);
 }

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -3,16 +3,20 @@
 // SPDX-FileCopyrightText: 2024-2026 AbandonedCart
 // SPDX-License-Identifier: GPL-3.0-only
 
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Filters;
 using IntroSkipper.Manager;
 using IntroSkipper.Providers;
 using IntroSkipper.Services;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper
 {
@@ -24,6 +28,30 @@ namespace IntroSkipper
         /// <inheritdoc />
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
+            // Database layer. Hand-rolled IDbContextFactory implementations are registered instead
+            // of EF's AddDbContextFactory so no EF internal services leak into the shared Jellyfin
+            // service collection (see docs/db-redesign/theory-a.md for the trade-off discussion).
+            serviceCollection.AddSingleton<IDbContextFactory<IntroSkipperDbContext>>(serviceProvider =>
+                new SegmentDbContextFactory(PluginDatabasePaths.GetSegmentDbPath(serviceProvider.GetRequiredService<IApplicationPaths>())));
+            serviceCollection.AddSingleton<IDbContextFactory<DetectionCacheDbContext>>(serviceProvider =>
+                new DetectionCacheDbContextFactory(PluginDatabasePaths.GetCacheDbPath(serviceProvider.GetRequiredService<IApplicationPaths>())));
+            serviceCollection.AddSingleton<IDatabaseInitializer, DatabaseInitializer>();
+            serviceCollection.AddSingleton<ISegmentStore>(serviceProvider => new SegmentStore(
+                serviceProvider.GetRequiredService<IDbContextFactory<IntroSkipperDbContext>>(),
+                serviceProvider.GetRequiredService<IDatabaseInitializer>()));
+            serviceCollection.AddSingleton<ISeasonStateStore>(serviceProvider => new SeasonStateStore(
+                serviceProvider.GetRequiredService<IDbContextFactory<IntroSkipperDbContext>>(),
+                serviceProvider.GetRequiredService<IDatabaseInitializer>()));
+            serviceCollection.AddSingleton<IDetectionCacheStore>(serviceProvider => new DetectionCacheStore(
+                serviceProvider.GetRequiredService<IDbContextFactory<DetectionCacheDbContext>>(),
+                serviceProvider.GetRequiredService<IDatabaseInitializer>()));
+            serviceCollection.AddSingleton<ISegmentUpdateService>(serviceProvider => new SegmentUpdateService(
+                serviceProvider.GetRequiredService<ISegmentStore>(),
+                serviceProvider.GetRequiredService<ILogger<SegmentUpdateService>>()));
+
+            // Registered before Entrypoint so database initialization starts first.
+            serviceCollection.AddHostedService<DatabaseStartupService>();
+
             serviceCollection.AddHostedService<Entrypoint>();
             serviceCollection.AddSingleton<IDetectionCacheService, DetectionCacheService>();
             serviceCollection.AddSingleton<IFFmpegService, FFmpegService>();

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -17,8 +18,14 @@ namespace IntroSkipper.Providers
     /// <summary>
     /// Introskipper media segment provider.
     /// </summary>
-    public class SegmentProvider : IMediaSegmentProvider
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="SegmentProvider"/> class.
+    /// </remarks>
+    /// <param name="segmentStore">Segment store.</param>
+    public class SegmentProvider(ISegmentStore segmentStore) : IMediaSegmentProvider
     {
+        private readonly ISegmentStore _segmentStore = segmentStore;
+
         /// <summary>
         /// Mappings between AnalysisMode and MediaSegmentType.
         /// </summary>
@@ -38,10 +45,9 @@ namespace IntroSkipper.Providers
         public async Task<IReadOnlyList<MediaSegmentDto>> GetMediaSegments(MediaSegmentGenerationRequest request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
-            ArgumentNullException.ThrowIfNull(Plugin.Instance);
 
             var segments = new List<MediaSegmentDto>();
-            var itemSegments = await Plugin.GetSegmentsAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
+            var itemSegments = await _segmentStore.GetSegmentsAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
             var dedupedModes = new HashSet<AnalysisMode>();
 
             foreach (var segment in itemSegments.OrderBy(segment => segment.Start))
@@ -79,8 +85,7 @@ namespace IntroSkipper.Providers
         /// <inheritdoc/>
         public async Task CleanupExtractedData(Guid itemId, CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(Plugin.Instance);
-            await Plugin.DeleteItemSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
+            await _segmentStore.DeleteSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Data.Common;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
 using MediaBrowser.Controller.Library;
@@ -25,13 +26,19 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="providerManager">Provider manager.</param>
 /// <param name="fileSystem">File system.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
+/// <param name="segmentStore">Segment store.</param>
+/// <param name="seasonStateStore">Season state store.</param>
+/// <param name="detectionCacheStore">Detection cache store.</param>
 public partial class CleanCacheTask(
     ILogger<CleanCacheTask> logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
     IProviderManager providerManager,
     IFileSystem fileSystem,
-    IFFmpegService ffmpegService) : IScheduledTask
+    IFFmpegService ffmpegService,
+    ISegmentStore segmentStore,
+    ISeasonStateStore seasonStateStore,
+    IDetectionCacheStore detectionCacheStore) : IScheduledTask
 {
     private readonly ILogger<CleanCacheTask> _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
@@ -39,6 +46,9 @@ public partial class CleanCacheTask(
     private readonly IProviderManager _providerManager = providerManager;
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly ISegmentStore _segmentStore = segmentStore;
+    private readonly ISeasonStateStore _seasonStateStore = seasonStateStore;
+    private readonly IDetectionCacheStore _detectionCacheStore = detectionCacheStore;
 
     /// <summary>
     /// Gets the task name.
@@ -93,18 +103,13 @@ public partial class CleanCacheTask(
             .Select(e => e.EpisodeId)
             .ToHashSet();
 
-        await Plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
+        await _segmentStore.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
 
         // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
-        HashSet<Guid> invalidEpisodeIds;
-        using (var cacheDb = Plugin.CreateCacheDbContext())
-        {
-            invalidEpisodeIds = cacheDb.DetectionCache
-                .Select(e => e.ItemId)
-                .Distinct()
-                .Where(id => !enabledLibraryEpisodeIds.Contains(id))
-                .ToHashSet();
-        }
+        var cachedItemIds = await _detectionCacheStore.GetItemIdsAsync(cancellationToken).ConfigureAwait(false);
+        var invalidEpisodeIds = cachedItemIds
+            .Where(id => !enabledLibraryEpisodeIds.Contains(id))
+            .ToHashSet();
 
         // Log and batch-delete all invalid episode DB rows in a single round-trip.
         foreach (var episodeId in invalidEpisodeIds)
@@ -116,10 +121,8 @@ public partial class CleanCacheTask(
         {
             try
             {
-                using var deleteDb = Plugin.CreateCacheDbContext();
-                await deleteDb.DetectionCache
-                    .Where(e => invalidEpisodeIds.Contains(e.ItemId))
-                    .ExecuteDeleteAsync(cancellationToken)
+                await _detectionCacheStore
+                    .DeleteForItemsAsync(invalidEpisodeIds, cancellationToken)
                     .ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is DbUpdateException or DbException)
@@ -129,7 +132,7 @@ public partial class CleanCacheTask(
         }
 
         // Clean up season state by removing items that no longer exist.
-        await Plugin.CleanSeasonStateAsync(queue.Keys, cancellationToken).ConfigureAwait(false);
+        await _seasonStateStore.CleanSeasonStatesAsync([.. queue.Keys], cancellationToken).ConfigureAwait(false);
 
         plugin.AnalyzeAgain = true;
 

--- a/IntroSkipper/Services/DatabaseStartupService.cs
+++ b/IntroSkipper/Services/DatabaseStartupService.cs
@@ -11,6 +11,9 @@ namespace IntroSkipper.Services;
 /// serves any request. This is an optimization, not the correctness guarantee: every store
 /// operation independently awaits the <see cref="IDatabaseInitializer"/> gate, so even a request
 /// that races server startup cannot query an unmigrated database.
+/// Both gates swallow initialization failures (log-and-continue), so <see cref="StartAsync"/>
+/// cannot fault host startup; the only exception it may surface is cooperative cancellation of
+/// the startup token itself.
 /// Registered before <see cref="Entrypoint"/> so it starts first.
 /// </summary>
 internal sealed class DatabaseStartupService : IHostedService

--- a/IntroSkipper/Services/DatabaseStartupService.cs
+++ b/IntroSkipper/Services/DatabaseStartupService.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Db;
+using Microsoft.Extensions.Hosting;
+
+namespace IntroSkipper.Services;
+
+/// <summary>
+/// Hosted service that eagerly triggers database initialization at server startup, before Jellyfin
+/// serves any request. This is an optimization, not the correctness guarantee: every store
+/// operation independently awaits the <see cref="IDatabaseInitializer"/> gate, so even a request
+/// that races server startup cannot query an unmigrated database.
+/// Registered before <see cref="Entrypoint"/> so it starts first.
+/// </summary>
+internal sealed class DatabaseStartupService : IHostedService
+{
+    private readonly IDatabaseInitializer _databaseInitializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatabaseStartupService"/> class.
+    /// </summary>
+    /// <param name="databaseInitializer">Database initializer.</param>
+    public DatabaseStartupService(IDatabaseInitializer databaseInitializer)
+    {
+        _databaseInitializer = databaseInitializer;
+    }
+
+    /// <inheritdoc/>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await _databaseInitializer.EnsureSegmentDbReadyAsync(cancellationToken).ConfigureAwait(false);
+        _databaseInitializer.EnsureCacheDbReady();
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/IntroSkipper/Services/ISegmentUpdateService.cs
+++ b/IntroSkipper/Services/ISegmentUpdateService.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Services;
+
+/// <summary>
+/// Domain service owning the business rules for writing and deleting media segments:
+/// user-provided segments take precedence over analysis results, auto-detected credits must not
+/// overlap the stored introduction, and commercial segments are deduplicated within a tolerance.
+/// Persistence is delegated to <see cref="IntroSkipper.Db.ISegmentStore"/>.
+/// </summary>
+public interface ISegmentUpdateService
+{
+    /// <summary>
+    /// Stores a segment for an item, enforcing the domain rules above.
+    /// </summary>
+    /// <param name="segment">Segment to store.</param>
+    /// <param name="mode">Analysis mode that produced the segment.</param>
+    /// <param name="isUserProvided">Whether the segment was provided by the user via the segment editor.</param>
+    /// <param name="configHash">Configuration hash that produced the segment.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task UpdateTimestampAsync(Segment segment, AnalysisMode mode, bool isUserProvided = false, string configHash = "", CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a stored timestamp for the specified item and analysis mode. Commercial deletions
+    /// require an explicit <paramref name="segment"/> because multiple commercials may exist per item.
+    /// </summary>
+    /// <param name="itemId">The item ID whose timestamp should be removed.</param>
+    /// <param name="mode">The analysis mode representing the segment type.</param>
+    /// <param name="segment">Optional segment details used to remove a specific entry.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task DeleteTimestampAsync(Guid itemId, AnalysisMode mode, Segment? segment = null, CancellationToken cancellationToken = default);
+}

--- a/IntroSkipper/Services/SegmentUpdateService.cs
+++ b/IntroSkipper/Services/SegmentUpdateService.cs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Services;
+
+/// <summary>
+/// Default <see cref="ISegmentUpdateService"/> implementation. The decision logic runs inside the
+/// store's write transaction (via the <see cref="ISegmentStore.ReplaceNonCommercialAsync"/>
+/// callback), so rule evaluation and the write are atomic exactly as they were in the original
+/// <c>Plugin.UpdateTimestampAsync</c> implementation.
+/// </summary>
+internal sealed partial class SegmentUpdateService : ISegmentUpdateService
+{
+    /// <summary>
+    /// Tolerance used when comparing segment start/end times.
+    /// </summary>
+    internal const double SegmentComparisonEpsilon = 0.001;
+
+    private readonly ISegmentStore _segmentStore;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SegmentUpdateService"/> class.
+    /// </summary>
+    /// <param name="segmentStore">Segment store.</param>
+    /// <param name="logger">Logger.</param>
+    public SegmentUpdateService(ISegmentStore segmentStore, ILogger logger)
+    {
+        _segmentStore = segmentStore;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateTimestampAsync(Segment segment, AnalysisMode mode, bool isUserProvided = false, string configHash = "", CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+
+        try
+        {
+            var dbSegment = new DbSegment(segment, mode, isUserProvided, configHash);
+
+            if (mode == AnalysisMode.Commercial)
+            {
+                await _segmentStore.TryAddCommercialAsync(dbSegment, SegmentComparisonEpsilon, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            await _segmentStore
+                .ReplaceNonCommercialAsync(dbSegment, context => ShouldPersist(context, segment, mode, isUserProvided), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogFailedToUpdateTimestamp(_logger, ex, segment.EpisodeId);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteTimestampAsync(Guid itemId, AnalysisMode mode, Segment? segment = null, CancellationToken cancellationToken = default)
+    {
+        // Multiple commercial segments may exist per item; deleting them all without an explicit
+        // match would discard more than the caller intended.
+        if (segment is null && mode == AnalysisMode.Commercial)
+        {
+            return;
+        }
+
+        await _segmentStore.DeleteSegmentsAsync(itemId, mode, segment, SegmentComparisonEpsilon, cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool ShouldPersist(NonCommercialSegmentContext context, Segment segment, AnalysisMode mode, bool isUserProvided)
+    {
+        // Do not overwrite a user-provided segment with an analysis result.
+        if (!isUserProvided && context.ExistingSegments.Any(s => s.IsUserProvided))
+        {
+            return false;
+        }
+
+        // Guard: prevent auto-detected credits from overlapping with the introduction.
+        if (mode == AnalysisMode.Credits && !isUserProvided && context.StoredIntroduction is { } intro
+            && segment.Start < intro.End && intro.Start < segment.End)
+        {
+            LogCreditsOverlapWithIntro(_logger, segment.EpisodeId);
+            return false;
+        }
+
+        return true;
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping credits for episode {EpisodeId}: detected segment overlaps with introduction")]
+    private static partial void LogCreditsOverlapWithIntro(ILogger logger, Guid episodeId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update timestamp for episode {EpisodeId}")]
+    private static partial void LogFailedToUpdateTimestamp(ILogger logger, Exception ex, Guid episodeId);
+}

--- a/docs/db-redesign/theory-a.md
+++ b/docs/db-redesign/theory-a.md
@@ -1,0 +1,459 @@
+# Theory A — Repository/Store-per-Aggregate + Domain Service
+
+Exploration spike for the intro-skipper database-layer rewrite (branch `12.0`, net10.0, EF Core 10.0.7).
+This document describes the architecture, proves the prototype's key claims empirically, and — because
+this is a comparison spike — documents the weaknesses honestly instead of hiding them.
+
+**Prototype status:** compiling, StyleCop/analyzer-clean (`TreatWarningsAsErrors`), full test suite green
+(375 passed / 1 known environmental failure `TestAudioFingerprinting.TestSilenceDetection`).
+
+---
+
+## 1. Architecture overview
+
+```
+                 ┌──────────────────────────────────────────────────────────────┐
+                 │                     PluginServiceRegistrator                  │
+                 │  (all singletons; hand-rolled IDbContextFactory<T> per DB)    │
+                 └──────────────────────────────────────────────────────────────┘
+   consumers                          domain                    persistence               lifecycle
+┌────────────────┐        ┌───────────────────────┐      ┌──────────────────────┐   ┌──────────────────────┐
+│ SegmentProvider│──────▶ │                       │      │ ISegmentStore        │   │ IDatabaseInitializer │
+│ SkipIntroCtrl  │──────▶ │ ISegmentUpdateService │─────▶│  (DbSegment)         │──▶│  · segment gate      │
+│ Analyzers*     │        │  · user-provided      │      ├──────────────────────┤   │    (Lazy<Task>)      │
+│ BaseItemTask*  │──────▶ │    precedence         │      │ ISeasonStateStore    │──▶│  · cache gate        │
+│ QueueManager*  │        │  · credits/intro      │      │  (DbSeasonState +    │   │    (Lazy<bool>)      │
+│ CleanCacheTask │──────▶ │    overlap guard      │      │   2 cross-agg. ops)  │   │  · RebuildDatabase   │
+│ SegmentEditor* │        │  · commercial dedupe  │      ├──────────────────────┤   │  · legacy repair     │
+│ DetectionCache-│        └───────────────────────┘      │ IDetectionCacheStore │──▶│  · EnsureSchema      │
+│ Service        │──────────────────────────────────────▶│  (DbDetectionCache,  │   └──────────┬───────────┘
+└────────────────┘                                       │   introskipper-      │              │ warmed by
+  * = still on transitional Plugin delegates, see §3     │   cache.db)          │   ┌──────────▼───────────┐
+                                                         └──────────────────────┘   │ DatabaseStartupService│
+                                                                                    │ (IHostedService)      │
+                                                                                    └───────────────────────┘
+```
+
+### Components
+
+| Component | Kind | Responsibility |
+|---|---|---|
+| `ISegmentStore` / `SegmentStore` | store (singleton) | All `DbSegment` persistence. Compiled query on the playback hot path. No business rules. |
+| `ISeasonStateStore` / `SeasonStateStore` | store (singleton) | All `DbSeasonState` persistence **plus** the two operations that atomically span segments + season state (`ResetSeasonForReanalysisAsync`, `GetSeasonQueueSnapshotAsync`). See §8 for why. |
+| `IDetectionCacheStore` / `DetectionCacheStore` | store (singleton) | All `introskipper-cache.db` persistence. Synchronous surface mirroring `IDetectionCacheService`. |
+| `ISegmentUpdateService` / `SegmentUpdateService` | domain service | Business rules formerly inside `Plugin.UpdateTimestampAsync` / `DeleteTimestampAsync`: user-provided precedence, credits/intro overlap guard, commercial epsilon-dedupe, "no blind commercial delete". |
+| `IDatabaseInitializer` / `DatabaseInitializer` | lifecycle | Legacy schema repair + EF migrations (segment DB), `EnsureSchema` with delete-and-recreate recovery (cache DB), `RebuildDatabaseAsync`. Exposes the async init **gate** every store awaits. |
+| `DatabaseStartupService` | `IHostedService` | Eagerly warms both gates at server startup. Optimization only — correctness never depends on it (§5). |
+| `SegmentDbContextFactory` / `DetectionCacheDbContextFactory` | infrastructure | Hand-rolled `IDbContextFactory<T>` singletons; options built once per factory; shared static `SqlitePragmaInterceptor.Instance`. |
+| `PluginDatabasePaths` | infrastructure | Single source of truth for DB paths, computed from `IApplicationPaths`; used by both DI registrations and the `Plugin` constructor so they cannot diverge. |
+
+### Rationale for this shape
+
+- **Stores are pure persistence.** Every store method is "open context → query/mutate → dispose". The single
+  place where a domain decision must be *transactionally atomic* with a write
+  (`UpdateTimestampAsync`'s read-check-write) is handled by a callback primitive:
+  `ISegmentStore.ReplaceNonCommercialAsync(segment, Func<NonCommercialSegmentContext, bool> shouldPersist)`.
+  The store owns the transaction and loads the snapshot (existing rows + stored intro); the domain service
+  owns the decision. This preserves the exact atomicity of the original implementation (BEGIN → read →
+  decide → delete+insert → COMMIT) without moving rules into the store or a context factory into the service.
+- **The domain service is deliberately small.** Only rules that currently live in `Plugin` moved into it.
+  No speculative "domain model" was invented — `DbSegment`/`Segment` stay as they are.
+- **Interface granularity — considered and consolidated.** An earlier sketch had five interfaces
+  (`ISegmentReader`/`ISegmentWriter` splits, a separate `ISeasonSnapshotReader`). That is over-engineering
+  for a 3-entity plugin; it was collapsed to exactly one store per aggregate (segment, season-state, cache)
+  plus one domain service. I did **not** collapse further into a single facade because the two databases have
+  different lifecycles (migrations vs. ensure-created) and different consumers, and because the store-per-aggregate
+  seam is the point of Theory A — but §9 states plainly what a facade would have saved.
+
+---
+
+## 2. Complete migration inventory
+
+### 2.1 The 18 `Plugin` DB methods
+
+"Prototype" column: **migrated** = implementation lives in the new layer, `Plugin` method is a one-line
+delegate kept only for manually-constructed callers; end state deletes the `Plugin` method entirely.
+
+| # | Current `Plugin` member | New home | Notes | Prototype |
+|---|---|---|---|---|
+| 1 | `UpdateTimestampAsync` | `SegmentUpdateService.UpdateTimestampAsync` → `SegmentStore.TryAddCommercialAsync` / `SegmentStore.ReplaceNonCommercialAsync` | Rules in service; decision runs inside store transaction via callback | migrated |
+| 2 | `GetTimestampsAsync` | `SegmentStore.GetTimestampsAsync` | Groups over the compiled segment query | migrated |
+| 3 | `GetSegmentsAsync` | `SegmentStore.GetSegmentsAsync` | `EF.CompileAsyncQuery` hot path (playback) | migrated |
+| 4 | `DeleteItemSegmentsAsync` | `SegmentStore.DeleteSegmentsAsync(Guid)` | `ExecuteDeleteAsync` | migrated |
+| 5 | `CleanTimestampsAsync` | `SegmentStore.CleanTimestampsAsync` | **Chunk(500) removed**: single server-side `DELETE … WHERE ItemId NOT IN (json_each(@ids))` via `EF.Parameter` (§6.2). Replaces read-all-distinct + client diff + batched deletes | migrated |
+| 6 | `SetAnalyzerActionAsync` | `SeasonStateStore.SetAnalyzerActionsAsync` | body ported verbatim | migrated |
+| 7 | `SetEpisodeIdsAsync` | `SeasonStateStore.SetEpisodeIdsAsync` | body ported verbatim | migrated |
+| 8 | `RemoveEpisodeIdAsync` | `SeasonStateStore.RemoveEpisodeIdAsync` | read+write share one context (unchanged) | migrated |
+| 9 | `CleanStaleAutomaticSegmentsAsync` | `SegmentStore.CleanStaleAutomaticSegmentsAsync` | Chunk(500) removed via `EF.Parameter` | migrated |
+| 10 | `GetEpisodeIdsAsync` | `SeasonStateStore.GetEpisodeIdsAsync` | | migrated |
+| 11 | `GetSettleReanalysisStatesAsync` | `SeasonStateStore.GetSettleReanalysisStatesAsync` | | migrated |
+| 12 | `RecordSettleReanalysisAsync` | `SeasonStateStore.RecordSettleReanalysisAsync` | raw upsert SQL unchanged | migrated |
+| 13 | `ResetSeasonForReanalysisAsync` | `SeasonStateStore.ResetSeasonForReanalysisAsync` | cross-aggregate transaction (segments + season state); Chunk removed via `EF.Parameter` inside the transaction | migrated |
+| 14 | `GetSeasonQueueSnapshotAsync` | `SeasonStateStore.GetSeasonQueueSnapshotAsync` | cross-aggregate read; episode batching removed via `EF.Parameter`; `SeasonQueueSnapshot` made public | migrated |
+| 15 | `GetAllAnalyzerActionsAsync` | `SeasonStateStore.GetAllAnalyzerActionsAsync` | | migrated |
+| 16 | `GetAnalyzerActionAsync` | `SeasonStateStore.GetAnalyzerActionAsync` | | migrated |
+| 17 | `CleanSeasonStateAsync` | `SeasonStateStore.CleanSeasonStatesAsync` | `EF.Parameter` (the old inline `!ids.Contains(...)` would break at >32 766 seasons under EF 10's default translation) | migrated |
+| 18 | `DeleteTimestampAsync` | `SegmentUpdateService.DeleteTimestampAsync` → `SegmentStore.DeleteSegmentsAsync(Guid, AnalysisMode, Segment?, double)` | "commercial requires explicit match" rule stays in service | migrated |
+
+Also removed from `Plugin` in the end state: `CreateDbContext()` / `CreateCacheDbContext()` statics,
+`SegmentComparisonEpsilon` (now `SegmentUpdateService.SegmentComparisonEpsilon`), `SqliteParameterBatchSize`
+(obsolete). `ShouldSettleReanalyze` (pure function, no DB) and `MapSegmentTypeToMode` stay.
+
+### 2.2 Direct-context call sites
+
+| Site | Current | New | Prototype |
+|---|---|---|---|
+| `SkipIntroController.ResetIntroTimestamps` | `Plugin.CreateDbContext()` + `ExecuteDeleteAsync` | `ISegmentStore.DeleteSegmentsByTypeAsync(mode)` (injected) | **migrated** |
+| `SkipIntroController.RebuildDatabase` | `Plugin.CreateDbContext()` + `db.RebuildDatabaseAsync(Plugin.CreateDbContext)` | `IDatabaseInitializer.RebuildSegmentDatabaseAsync()` (injected) | **migrated** |
+| `VisualizationController.EraseSeasonAsync` | `Plugin.CreateDbContext()` (segment delete + season-state clear) | end state: `ISeasonStateStore.EraseSeasonAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds)` — new composite method so the segment delete and episode-list clear stay on one connection | table-documented, not yet migrated |
+| `VisualizationController.ClearExcludedTimestampsAsync` (segment DB) | `Plugin.CreateDbContext()` | end state: `ISegmentStore.DeleteSegmentsForItemsAsync(IReadOnlyCollection<Guid>) : Task<int>` + `ISeasonStateStore.RemoveEpisodesFromSeasonsAsync(IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>)` | table-documented, not yet migrated |
+| `VisualizationController.ClearExcludedTimestampsAsync` (cache DB) | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.DeleteForItemsAsync(ids)` (already exists) | table-documented, not yet migrated |
+| `CleanCacheTask` (cache read of distinct IDs) | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.GetItemIdsAsync()` | **migrated** |
+| `CleanCacheTask` (cache batched delete) | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.DeleteForItemsAsync(ids)` | **migrated** |
+| `DetectionCacheService.TryRead` | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.Find(...)` | **migrated** |
+| `DetectionCacheService.Write` | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.Upsert(...)` | **migrated** |
+| `DetectionCacheService.DeleteForItem` | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.DeleteForItem(...)` | **migrated** |
+| `DetectionCacheService.DeleteByMode` | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.DeleteByMode(...)` | **migrated** |
+| `DetectionCacheService.HasCachedFingerprint` | `Plugin.CreateCacheDbContext()` | `IDetectionCacheStore.Exists(...)` | **migrated** |
+| `Plugin` ctor (migrations + legacy repair + cache `EnsureSchema`) | inline in ctor | `IDatabaseInitializer` + `DatabaseStartupService` | **implemented**; ctor init retained transitionally (§5) |
+
+`DetectionCacheService` no longer references `Plugin.CreateCacheDbContext()` anywhere — the required
+slice item is complete. Its remaining `Plugin.Instance` reads are **configuration** access
+(`CacheFingerprints`, compression level, config hashing), which is out of scope for the DB rewrite.
+
+### 2.3 Threading dependencies through manually-constructed types (end state)
+
+These types are `new`-ed, not DI-resolved, so the end state passes stores down explicitly (no
+`Plugin.Instance` for DB work):
+
+| Type | Constructed by | New ctor parameters |
+|---|---|---|
+| `BaseItemAnalyzerTask` | `Entrypoint`, `VisualizationController.ScanSeason`, `DetectSegmentsTask` (all DI contexts) | `ISegmentUpdateService`, `ISegmentStore`, `ISeasonStateStore` |
+| `QueueManager` | `CleanCacheTask`, `VisualizationController`, `BaseItemAnalyzerTask` (all DI contexts or already-threaded) | `ISeasonStateStore` (for `GetSeasonQueueSnapshotAsync`) |
+| `ChromaprintAnalyzer`, `ChapterAnalyzer`, `BlackFrameAnalyzer`, `CreditsBlackFrameAnalyzer` | `BaseItemAnalyzerTask` | `ISegmentUpdateService` |
+| `RecapDetectionHelper` | analyzers | `ISegmentStore` (for `GetTimestampsAsync`) |
+| `SegmentEditorController` | DI (controller) | inject `ISegmentStore`, `ISegmentUpdateService`, `ISeasonStateStore` |
+
+Every root of these object graphs is DI-resolved, so the dependencies flow down without any service
+locator. The prototype keeps them on the one-line `Plugin` delegates to bound the diff; the delegates
+already forward into the exact same store code paths, so switching a caller is mechanical.
+
+---
+
+## 3. DI registration (as implemented)
+
+```csharp
+// PluginServiceRegistrator.RegisterServices
+serviceCollection.AddSingleton<IDbContextFactory<IntroSkipperDbContext>>(sp =>
+    new SegmentDbContextFactory(PluginDatabasePaths.GetSegmentDbPath(sp.GetRequiredService<IApplicationPaths>())));
+serviceCollection.AddSingleton<IDbContextFactory<DetectionCacheDbContext>>(sp =>
+    new DetectionCacheDbContextFactory(PluginDatabasePaths.GetCacheDbPath(sp.GetRequiredService<IApplicationPaths>())));
+serviceCollection.AddSingleton<IDatabaseInitializer, DatabaseInitializer>();
+serviceCollection.AddSingleton<ISegmentStore>(sp => new SegmentStore(
+    sp.GetRequiredService<IDbContextFactory<IntroSkipperDbContext>>(),
+    sp.GetRequiredService<IDatabaseInitializer>()));
+serviceCollection.AddSingleton<ISeasonStateStore>(sp => new SeasonStateStore(
+    sp.GetRequiredService<IDbContextFactory<IntroSkipperDbContext>>(),
+    sp.GetRequiredService<IDatabaseInitializer>()));
+serviceCollection.AddSingleton<IDetectionCacheStore>(sp => new DetectionCacheStore(
+    sp.GetRequiredService<IDbContextFactory<DetectionCacheDbContext>>(),
+    sp.GetRequiredService<IDatabaseInitializer>()));
+serviceCollection.AddSingleton<ISegmentUpdateService>(sp => new SegmentUpdateService(
+    sp.GetRequiredService<ISegmentStore>(),
+    sp.GetRequiredService<ILogger<SegmentUpdateService>>()));
+
+// Registered before Entrypoint so database initialization starts first.
+serviceCollection.AddHostedService<DatabaseStartupService>();
+serviceCollection.AddHostedService<Entrypoint>();
+```
+
+Paths come from `IApplicationPaths` (DI-resolvable at registration time), **not** `Plugin.Instance`, so the
+data layer has zero dependency on plugin construction order. `PluginDatabasePaths` is also used by the
+`Plugin` constructor, so the transitional delegates and the DI singletons always agree on the same files.
+
+---
+
+## 4. Why hand-rolled `IDbContextFactory<T>` instead of `AddDbContextFactory` (the pooling verdict)
+
+This is the first EF-10-checklist verdict because it shapes everything else; see §6 for the rest.
+
+`AddDbContextFactory`/`AddPooledDbContextFactory` call EF's `AddCoreServices`, which `TryAdd`s ~60 EF
+internal service registrations **into Jellyfin's shared service collection**. Jellyfin server registers its
+own EF Core services for `jellyfin.db`, and plugin assemblies load in a separate `AssemblyLoadContext` — so
+whether the plugin's `TryAdd`s win or lose depends on registration order and on whether the server's EF
+assembly identity matches the plugin's EF 10.0.7. That is exactly the kind of cross-version fragility a
+plugin must not introduce. The hand-rolled factories:
+
+```csharp
+internal sealed class SegmentDbContextFactory : IDbContextFactory<IntroSkipperDbContext>
+{
+    private readonly DbContextOptions<IntroSkipperDbContext> _options; // built once
+    public IntroSkipperDbContext CreateDbContext() => new(_options);
+}
+```
+
+keep every EF service private to the contexts, while still exposing the *standard* `IDbContextFactory<T>`
+abstraction — swapping to EF's factory later is a one-line DI change, invisible to the stores.
+
+**Pooling (`AddPooledDbContextFactory`) — rejected**, for three independent reasons:
+
+1. **Constructor constraint.** Pooling requires the context to expose a single public
+   `DbContextOptions`-based constructor. `IntroSkipperDbContext` deliberately keeps the legacy
+   string-path constructor: it is used by `RebuildDatabaseAsync`'s `DeleteDatabaseFiles` fallback
+   (`_dbPath` field), by the design-time flow, and by ~30 existing tests. Reconciling it means either
+   deleting that ctor (large test churn, riskier rebuild path relying purely on connection-string parsing)
+   or maintaining two context types.
+2. **`OnConfiguring` semantics.** Pooled instances are created once and reset on return; per-instance
+   `OnConfiguring`-based configuration (what the string-path ctor relies on) does not participate per
+   rental. With non-pooled factory-created contexts, options are baked into the factory and
+   `OnConfiguring` short-circuits on `IsConfigured` — the current behavior, preserved.
+3. **No measurable benefit at this workload.** The hottest path is one small indexed query per playback
+   start; analysis is a batch job dominated by FFmpeg. `DbContext` construction is microseconds against
+   SQLite I/O milliseconds. Pooling's win (avoiding context+service scope allocation at thousands of
+   req/s) simply does not apply. Interceptor interplay is a non-issue either way because
+   `SqlitePragmaInterceptor` is registered in options (singleton, stateless) — but with pooling one must
+   additionally verify connection-state resets between rentals; not worth the audit for zero gain.
+
+One subtlety the prototype handles: EF caches its internal service provider keyed by options fingerprints.
+All factories share the single static `SqlitePragmaInterceptor.Instance` and build options once, so the
+whole plugin still resolves to **one** cached EF internal provider (same as today), avoiding
+`ManyServiceProvidersCreatedWarning` even while the transitional `Plugin` delegates construct short-lived
+factories.
+
+---
+
+## 5. Initialization & lifecycle design (with ordering proof)
+
+**Chosen option:** async init gate *inside the data layer* + eager `IHostedService` warm-up.
+(Rejected: "keep bootstrap in Plugin ctor delegating to the new layer" — it would force sync-over-async
+into the ctor and keeps `Plugin` in the lifecycle business; "hosted-service-only initialization" — unsafe
+alone, because `IMediaSegmentProvider`/controllers can theoretically be hit while startup is racing.)
+
+Mechanism (`DatabaseInitializer`):
+
+- Segment DB: `Lazy<Task>` (`ExecutionAndPublication`) running `EnsureLegacySchemaCompatibility()` then
+  `Database.MigrateAsync()`. `EnsureSegmentDbReadyAsync(ct)` returns `_lazy.Value.WaitAsync(ct)` — a
+  cancelled caller abandons its *wait*, never the shared initialization, so one impatient request can't
+  poison the gate.
+- Cache DB: `Lazy<bool>` running `EnsureSchema()` (EnsureCreated + probe + delete-and-recreate recovery),
+  synchronous because the whole cache surface is synchronous.
+- Failure policy: parity with the current `Plugin` ctor — log and continue (a genuinely broken DB then
+  fails per-query with actionable errors). Caching a *faulted* task instead would turn one transient init
+  failure into a permanently dead plugin, which is worse than today's behavior.
+- `RebuildSegmentDatabaseAsync` first awaits the gate (a rebuild must never interleave with first-time
+  migration), then runs the existing `IntroSkipperDbContext.RebuildDatabaseAsync` salvage flow with the
+  factory as the sibling-context source. The salvage/`forceCleanOnBackupFailure` logic itself is untouched.
+
+**Ordering proof.** Claim: no query observes an unmigrated database.
+
+1. In the end state, *every* database access is inside a store method (inventory §2 is exhaustive; the
+   context types stop being constructible outside `Db/` once the `Plugin` statics are deleted).
+2. Every store method's first awaited action is `EnsureSegmentDbReadyAsync` (or `EnsureCacheDbReady` for
+   the cache store) — checked structurally: the private `CreateContextAsync`/`CreateContext` helpers are
+   the only way store code obtains a context.
+3. `Lazy<T>` with `ExecutionAndPublication` guarantees the init body runs at most once and that every
+   caller's continuation runs only after the shared task completes. Therefore any store call either
+   triggers initialization and waits, or waits on the already-running/completed task. ∎
+4. `DatabaseStartupService` merely *warms* the gate before Jellyfin serves traffic (ASP.NET Core starts
+   hosted services before the server accepts requests; it is registered before `Entrypoint`). If that
+   assumption ever breaks, correctness is unaffected — only first-call latency.
+5. Concurrency corner: two concurrent cold-start callers → one migration run (proven by the
+   `DatabaseInitializer_GatesStoreAccess_UntilMigrationsComplete` test, which fires 8 parallel store calls
+   at a nonexistent database file and asserts success + zero pending migrations).
+
+**Transitional note (prototype):** the `Plugin` ctor still performs its synchronous init because
+`VisualizationController` still uses `Plugin.CreateDbContext()` and tests construct contexts by path.
+Double initialization is safe — `EnsureLegacySchemaCompatibility` and `Migrate` are idempotent, and the
+plugin is constructed before hosted services start, so the two never race in practice. The end state
+deletes the ctor block; the gate then becomes the *only* initialization path.
+
+**Migration-history compatibility (invariant g):** untouched. `EnsureLegacySchemaCompatibility`,
+`ApplyMigrations`, the `Migrations/` folder and `IntroSkipperDbContextFactory` (design-time) are all
+byte-for-byte unchanged — only the *call site* moved from the `Plugin` ctor into `DatabaseInitializer`
+(and the ctor retains it transitionally). Existing user DBs upgrade exactly as before;
+`dotnet ef migrations` still uses the untouched design-time factory.
+
+---
+
+## 6. EF Core 10 feature verdicts
+
+All verdicts were verified against EF Core 10.0.7 + `SQLitePCLRaw.lib.e_sqlite3` 3.50.3 (SQLite 3.50.3)
+with a scratch probe project on this VM; the load-bearing ones are additionally locked in by unit tests.
+
+### 6.1 `AddPooledDbContextFactory` vs `AddDbContextFactory`
+**Verdict: neither — hand-rolled `IDbContextFactory<T>` singletons.** Full reasoning in §4.
+
+### 6.2 EF 10 parameterized-collection translation vs manual `Chunk(500)`
+**Verdict: manual chunking is removed, but only because every unbounded collection predicate is pinned to
+`EF.Parameter(...)`; EF 10's *default* translation is NOT safe on SQLite for large sets.**
+
+Measured on this repo's exact package versions:
+
+| Translation | 8 elements | 33 000 elements |
+|---|---|---|
+| default (EF 10 = one scalar parameter per value, padded — e.g. 8 values → 10 params) | `WHERE "ItemId" IN (@p1..@p10)` ✅ | ❌ `SQLite Error 1: 'too many SQL variables'` |
+| `EF.Parameter(ids).Contains(...)` (single JSON array parameter) | `IN (SELECT value FROM json_each(@ids))` ✅ | ✅ incl. `ExecuteDelete` with `NOT IN` |
+
+Facts: e_sqlite3 3.50 has `SQLITE_MAX_VARIABLE_NUMBER = 32766` (999 only for SQLite < 3.32, which
+`Microsoft.Data.Sqlite`'s bundled engine never is), so the historical `Chunk(500)` was ~65× more
+conservative than needed — but under EF 10's new default it protects against a *real* failure mode again.
+Policy adopted:
+
+- **Unbounded ID sets** (`CleanTimestampsAsync`, `CleanStaleAutomaticSegmentsAsync`,
+  `CleanSeasonStatesAsync`, `ResetSeasonForReanalysisAsync`, `GetSeasonQueueSnapshotAsync`,
+  `DetectionCacheStore.DeleteForItemsAsync`): `EF.Parameter` → single JSON parameter, no limit, one
+  round-trip. `CleanTimestampsAsync` collapsed from *read all distinct IDs + client-side diff + N batched
+  deletes* into one server-side `DELETE … WHERE ItemId NOT IN (…)`.
+- **Small bounded sets** (`modeArray.Contains(s.Type)`, ≤ 5 analysis modes): keep the EF 10 default
+  multi-parameter translation — it gives the planner real cardinality and pads to stable bucket sizes.
+- Locked in by tests at 33 000 IDs (> 32 766) against both databases, plus the pre-existing 33k
+  `Plugin.CleanTimestampsAsync` test which now routes through the store.
+- Residual risk & mitigation in §10 (R1).
+
+### 6.3 `ExecuteUpdate` / `ExecuteDelete` (incl. EF 10 non-expression overload)
+**Verdict: `ExecuteDeleteAsync` everywhere it applies (kept and extended); `ExecuteUpdate` — no use.**
+Every bulk delete in the layer is a set-based `ExecuteDelete`. The only bulk-update candidates
+(`SetEpisodeIdsAsync`, `RemoveEpisodeIdAsync`, `ResetSeasonForReanalysisAsync`'s list clear) mutate
+`EpisodeIds`, a JSON-serialized value-converted collection that requires read-modify-write in memory —
+`ExecuteUpdate` cannot express "remove one element from a JSON list" portably, and the row counts (a
+handful of season rows) make tracked updates the simpler, equally-fast choice. The EF 10 non-expression
+lambda overload would only matter for conditionally-composed `SetProperty` chains, which do not occur here.
+
+### 6.4 Compiled queries (`EF.CompileAsyncQuery`)
+**Verdict: use exactly once — the playback hot path.** `SegmentStore.GetSegmentsAsync` (called by
+`SegmentProvider.GetMediaSegments` on every playback and reused by `GetTimestampsAsync`) uses a static
+compiled query. It skips per-call expression-tree construction and query-cache lookup; with factory-created
+contexts sharing one options/model instance the compiled plan is reused across contexts. Gains are real but
+small (µs); spreading compiled queries over cold paths (scan-time, admin endpoints) would add boilerplate
+for nothing, so we don't.
+
+### 6.5 Named query filters
+**Verdict: don't use.** The model has no soft-delete/tenant axis. The tempting candidate —
+a global `IsUserProvided` filter — would *hide* the precedence rule inside model configuration where the
+domain service can't reason about it (the rule needs to *see* user rows, not filter them out).
+
+### 6.6 `LeftJoin` operator
+**Verdict: don't use.** The three tables are deliberately unrelated (no navigations, no FKs); correlation
+(`GetSeasonQueueSnapshotAsync`) happens in memory over two indexed reads, which is both simpler and avoids
+a fan-out join over the JSON-converted columns. Nothing in the inventory becomes clearer as a `LeftJoin`.
+
+### 6.7 Compiled models
+**Verdict: don't use** (per shared guidance): 3 entities / 2 contexts; model building is sub-millisecond at
+startup and happens once. Compiled models would add a generation step to the build for unmeasurable gain.
+
+---
+
+## 7. Transaction & SQLite concurrency strategy
+
+- **Connections:** every store operation is a short-lived context → one pooled `Microsoft.Data.Sqlite`
+  connection per operation, `busy_timeout=5000` applied on every open by the shared
+  `SqlitePragmaInterceptor` (unchanged). WAL is EF's SQLite default (unchanged). Both stores over
+  `introskipper.db` share the same factory, hence the same connection pool and pragmas.
+- **Explicit transactions only where multi-statement atomicity is required**, exactly mirroring today:
+  `ReplaceNonCommercialAsync` (read snapshot → domain decision → delete+insert) and
+  `ResetSeasonForReanalysisAsync` (segment delete + episode-list clear). Everything else is a single
+  statement (`ExecuteDelete`, single `SaveChanges`) riding SQLite's implicit transaction.
+- **Write races:** SQLite serializes writers; `busy_timeout` absorbs contention between the analysis task,
+  controllers and the cache. The domain-decision-inside-transaction design means the user-provided
+  precedence check cannot be defeated by a concurrent analyzer write (same guarantee as the current code,
+  now structurally enforced by the store primitive instead of by discipline inside one 80-line method).
+- **Cross-database consistency** (e.g. erase segments then cache): not transactional today, not made
+  transactional — the cache is derived data and self-heals; keeping the DBs in separate files (corruption
+  isolation) is the higher-value property.
+- **Rebuild:** `RebuildSegmentDatabaseAsync` awaits the init gate, then reuses the existing salvage flow
+  including `SqliteConnection.ClearAllPools()` before file deletion.
+
+## 8. Where the theory bent: cross-aggregate operations
+
+`ResetSeasonForReanalysisAsync` (transactional) and `GetSeasonQueueSnapshotAsync` (consistent read) touch
+both `DbSegment` and `DbSeasonState`. Splitting them across two stores would require either distributed
+coordination between stores sharing a context (a unit-of-work abstraction — heavy) or losing atomicity
+(a real invariant regression). Decision: the **season is the aggregate root** for analysis bookkeeping and
+owns these two operations, at the acknowledged cost of `SeasonStateStore` querying `DbSegment`. The same
+reasoning will apply to `VisualizationController.EraseSeasonAsync` when it migrates (§2.2). This is a
+known, honest dent in repository purity — a facade design wouldn't even notice the problem, which is a
+point in the facade's favor (§9).
+
+## 9. Honest cons vs a simpler facade / no-repository design
+
+- **File and interface count.** ~10 new types for 3 entities. A single `IIntroSkipperData` facade (one
+  interface, one implementation, same initializer) would deliver the identical testability and DI story
+  with a third of the surface. Theory A's extra seams only pay off if the persistence of one aggregate is
+  ever swapped or decorated independently — there is no current roadmap item that needs that.
+- **The abstraction is mostly 1:1 with use cases.** Nearly every store method has exactly one production
+  caller. That's a facade wearing repository clothes; the "reusable persistence vocabulary" argument for
+  repositories is weak here.
+- **Purity broke immediately** (§8): two cross-aggregate operations and a callback-in-transaction
+  primitive were needed on day one. `ReplaceNonCommercialAsync(segment, shouldPersist)` keeps the layering
+  honest but is subtle — a contributor could add I/O inside the callback and unknowingly extend a write
+  transaction. (Mitigated by doc contract + the callback receiving an immutable record, but it's a trap a
+  facade doesn't have: the facade would just keep the 30-line method intact in one place.)
+- **Transitional double surface.** Until analyzers/QueueManager/BaseItemAnalyzerTask are re-threaded, the
+  18 `Plugin` delegates coexist with the stores. The delegates are one-liners into the same code, but a
+  reviewer must still know which layer to call. A facade migration could have moved `Plugin` callers and
+  implementation in a single step per method with less indirection.
+- **Interface evolution tax.** Each future DB feature now costs interface + implementation + (often)
+  domain-service touch, and the store interfaces are `public` (Jellyfin controllers must be public and
+  their ctor parameter types with them), so their surface is effectively semi-API.
+- Where Theory A genuinely wins: the domain rules are now unit-tested in isolation at two levels, the
+  initializer is an explicit, testable component instead of ctor side effects, `SegmentProvider` and
+  `SkipIntroController` are constructible in tests without reflection-based `Plugin` scopes, and the
+  concurrency contract of the segment-write rules is enforced by construction.
+
+## 10. Risk register
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | A future EF release changes `EF.Parameter` collection translation on SQLite (e.g. away from `json_each`), reintroducing parameter limits | low | high (silent until a big library hits it) | Three tests pin the behavior at 33 000 IDs (> 32 766) across both DBs; any regression fails CI loudly. Fallback is reintroducing `Chunk` inside the affected store methods only — call sites don't change. |
+| R2 | DI-computed DB path diverges from the `Plugin` ctor path during the transition (two data directories) | very low | high | Single source of truth `PluginDatabasePaths` used by both; no string literals remain at either site. |
+| R3 | EF internal service-provider cache bloat (`ManyServiceProvidersCreated`) from transitional per-call factories in `Plugin` delegates | low | medium | Shared static interceptor + identical options per path ⇒ one cached provider; removed entirely with the delegates in the end state. |
+| R4 | Hosted-service start order changes in a future Jellyfin release (warm-up runs late) | low | none (perf only) | Correctness never depends on the warm-up — every store call awaits the gate itself (§5 proof). |
+| R5 | Init failure semantics: gate swallows the error (parity with today), so a broken DB surfaces as per-query failures rather than one startup error | medium (unchanged from today) | medium | Same warning logs as today; `RebuildDatabase` endpoint remains the documented recovery path and now flows through the initializer, which serializes it against first-time init. |
+| R6 | Copy-paste drift while porting 18 method bodies into stores | medium | high | Bodies ported verbatim (diff-reviewable); the untouched pre-existing test suite (367 tests incl. legacy-schema, salvage, 33k-parameter and overlap-guard tests) passed unmodified against the delegating layer before any new tests were added. |
+| R7 | `shouldPersist` callback misuse (I/O inside the write transaction) | medium | medium | Contract documented on the interface; callback receives an immutable `NonCommercialSegmentContext`; only one implementer (`SegmentUpdateService`). If misuse recurs, replace with a closed enum-decision API at the cost of rule locality. |
+| R8 | Public store interfaces become de-facto API for other plugins | low | low | Implementations stay `internal sealed`; interfaces documented as unstable spike surface. |
+| R9 | Tests constructing `Plugin` via `GetUninitializedObject` bypass ctor init; transitional delegates must build stores from `_dbPath` per call | certain (test-only) | low | Handled: delegates resolve `_dbPath` lazily per call; disappears with the delegates. |
+
+## 11. Testing strategy
+
+- **Regression net first:** the entire pre-existing suite (including `UpdateTimestampAsync_CreditsOverlapGuard`,
+  the 33k `CleanTimestampsAsync`/`GetSeasonQueueSnapshotAsync` parameter-limit tests, legacy-schema upgrade
+  and salvage tests) ran **unmodified** against the delegating layer and passed — proving behavior parity of
+  the ported implementations before any new tests were written.
+- **New layer tests** (`TestSegmentStores.cs`, temp-file SQLite like the existing suite):
+  - user-provided precedence end-to-end through `SegmentUpdateService` (auto never overwrites user; user
+    overwrites user);
+  - credits/intro overlap guard (same 3-case theory as the legacy test, now against the service);
+  - commercial epsilon-dedupe (invariant c, multiples allowed);
+  - `CleanTimestampsAsync` at 33 000 IDs directly against `SegmentStore` — the chunk-removal proof;
+  - `DetectionCacheStore.DeleteForItemsAsync` at 33 000 IDs — same proof on the cache DB;
+  - initializer gate: 8 concurrent store calls against a nonexistent DB file → all succeed, migrations
+    applied exactly once, zero pending migrations (ordering proof, executable form).
+- **Test seams gained:** `SkipIntroController` and `DetectionCacheService` are now constructed in tests
+  from explicit stores/factories; the reflection-based `PluginInstanceScope` remains only for the
+  transitional `Plugin` delegates and configuration access.
+- Result: 375 passed / 1 failed — the known environmental `TestAudioFingerprinting.TestSilenceDetection`.
+
+## 12. Invariant checklist (a–g)
+
+| Invariant | Status |
+|---|---|
+| (a) user-provided segments never overwritten | Enforced in `SegmentUpdateService.ShouldPersist`, executed inside the store write transaction; tested at service level and via legacy tests. |
+| (b) credits/intro overlap guard | Same mechanism; 3-case theory tests at both levels. |
+| (c) commercial multiples + filtered unique indexes | Model config untouched; epsilon-dedupe in `TryAddCommercialAsync`; legacy index tests pass. |
+| (d) `RebuildDatabaseAsync` salvage + `EnsureLegacySchemaCompatibility` | Code untouched; now invoked via `IDatabaseInitializer` (rebuild serialized behind the init gate); legacy tests pass. |
+| (e) SQLite parameter-limit safety | Strengthened: `EF.Parameter` single-JSON-parameter, proven at 33k (> new-default failure threshold); old `Chunk(500)` removed. |
+| (f) design-time factory / `dotnet ef migrations` | `IntroSkipperDbContextFactory` byte-for-byte untouched. |
+| (g) migration history behavior | `Migrations/`, `_currentMigrationIds`, history-repair SQL all untouched; only the invocation site moved. |
+
+## 13. Verdict summary
+
+**Strongest argument for:** the two safety-critical rules (user precedence, overlap guard) moved from the
+middle of an 80-line `Plugin` method into a 15-line, independently unit-tested domain service — while
+*keeping* their transactional atomicity via the callback-in-transaction store primitive — and the
+initialization/ordering problem became a provable, testable gate instead of constructor side effects.
+
+**Strongest argument against:** for a plugin with 3 entities and ~20 call sites, store-per-aggregate is
+near the over-engineering line — purity bent on day one (cross-aggregate season ops, callback primitive),
+and a single facade would have bought ~80 % of the benefit (DI, gate, testability, EF10 wins) for ~35 % of
+the surface area and none of the interface-evolution tax.

--- a/docs/db-redesign/theory-a.md
+++ b/docs/db-redesign/theory-a.md
@@ -5,7 +5,8 @@ This document describes the architecture, proves the prototype's key claims empi
 this is a comparison spike — documents the weaknesses honestly instead of hiding them.
 
 **Prototype status:** compiling, StyleCop/analyzer-clean (`TreatWarningsAsErrors`), full test suite green
-(375 passed / 1 known environmental failure `TestAudioFingerprinting.TestSilenceDetection`).
+(377 passed / 1 known environmental failure `TestAudioFingerprinting.TestSilenceDetection`). Round-2
+coordinator feedback addressed in §14.
 
 ---
 
@@ -308,6 +309,10 @@ Policy adopted:
   multi-parameter translation — it gives the planner real cardinality and pads to stable bucket sizes.
 - Locked in by tests at 33 000 IDs (> 32 766) against both databases, plus the pre-existing 33k
   `Plugin.CleanTimestampsAsync` test which now routes through the store.
+- Independently cross-checked by the round-2 coordinator benchmark (EF 10.0.7 + `Microsoft.Data.Sqlite`,
+  40k-row table, 33k-ID set): default translation throws `too many SQL variables`; `EF.Parameter`
+  json_each `Contains` ×5 = 235 ms vs `Chunk(500)` = 1552 ms (~6.6× faster); `ExecuteDelete` `NOT IN`
+  at 33k = 218 ms. The chunk removal is therefore a performance win as well as a simplification.
 - Residual risk & mitigation in §10 (R1).
 
 ### 6.3 `ExecuteUpdate` / `ExecuteDelete` (incl. EF 10 non-expression overload)
@@ -347,8 +352,12 @@ startup and happens once. Compiled models would add a generation step to the bui
 
 - **Connections:** every store operation is a short-lived context → one pooled `Microsoft.Data.Sqlite`
   connection per operation, `busy_timeout=5000` applied on every open by the shared
-  `SqlitePragmaInterceptor` (unchanged). WAL is EF's SQLite default (unchanged). Both stores over
-  `introskipper.db` share the same factory, hence the same connection pool and pragmas.
+  `SqlitePragmaInterceptor` (unchanged). **WAL journaling is enforced by the initializer**: EF's SQLite
+  provider persists `journal_mode=wal` when *it* creates the database, but a file created or vacuumed by
+  external tooling may have reverted — so `DatabaseInitializer` issues an idempotent
+  `PRAGMA journal_mode=WAL` once per startup on both databases (regression-tested:
+  `DatabaseInitializer_EnforcesWalJournalMode_OnBothDatabases`). Both stores over `introskipper.db`
+  share the same factory, hence the same connection pool and pragmas.
 - **Explicit transactions only where multi-statement atomicity is required**, exactly mirroring today:
   `ReplaceNonCommercialAsync` (read snapshot → domain decision → delete+insert) and
   `ResetSeasonForReanalysisAsync` (segment delete + episode-list clear). Everything else is a single
@@ -408,7 +417,7 @@ point in the facade's favor (§9).
 | R2 | DI-computed DB path diverges from the `Plugin` ctor path during the transition (two data directories) | very low | high | Single source of truth `PluginDatabasePaths` used by both; no string literals remain at either site. |
 | R3 | EF internal service-provider cache bloat (`ManyServiceProvidersCreated`) from transitional per-call factories in `Plugin` delegates | low | medium | Shared static interceptor + identical options per path ⇒ one cached provider; removed entirely with the delegates in the end state. |
 | R4 | Hosted-service start order changes in a future Jellyfin release (warm-up runs late) | low | none (perf only) | Correctness never depends on the warm-up — every store call awaits the gate itself (§5 proof). |
-| R5 | Init failure semantics: gate swallows the error (parity with today), so a broken DB surfaces as per-query failures rather than one startup error | medium (unchanged from today) | medium | Same warning logs as today; `RebuildDatabase` endpoint remains the documented recovery path and now flows through the initializer, which serializes it against first-time init. |
+| R5 | Init failure semantics: gate swallows the error (parity with today), so a broken DB surfaces as per-query failures rather than one startup error | medium (unchanged from today) | medium | Same warning logs as today; `RebuildDatabase` endpoint remains the documented recovery path and now flows through the initializer, which serializes it against first-time init. Round 2 hardened both gates to full catch-all so no init failure can escape `IHostedService.StartAsync` (see §14). |
 | R6 | Copy-paste drift while porting 18 method bodies into stores | medium | high | Bodies ported verbatim (diff-reviewable); the untouched pre-existing test suite (367 tests incl. legacy-schema, salvage, 33k-parameter and overlap-guard tests) passed unmodified against the delegating layer before any new tests were added. |
 | R7 | `shouldPersist` callback misuse (I/O inside the write transaction) | medium | medium | Contract documented on the interface; callback receives an immutable `NonCommercialSegmentContext`; only one implementer (`SegmentUpdateService`). If misuse recurs, replace with a closed enum-decision API at the cost of rule locality. |
 | R8 | Public store interfaces become de-facto API for other plugins | low | low | Implementations stay `internal sealed`; interfaces documented as unstable spike surface. |
@@ -432,7 +441,8 @@ point in the facade's favor (§9).
 - **Test seams gained:** `SkipIntroController` and `DetectionCacheService` are now constructed in tests
   from explicit stores/factories; the reflection-based `PluginInstanceScope` remains only for the
   transitional `Plugin` delegates and configuration access.
-- Result: 375 passed / 1 failed — the known environmental `TestAudioFingerprinting.TestSilenceDetection`.
+- Result: 377 passed / 1 failed — the known environmental `TestAudioFingerprinting.TestSilenceDetection`.
+  (Round 2 added the gate fault-containment and WAL-enforcement tests; see §14.)
 
 ## 12. Invariant checklist (a–g)
 
@@ -457,3 +467,49 @@ initialization/ordering problem became a provable, testable gate instead of cons
 near the over-engineering line — purity bent on day one (cross-aggregate season ops, callback primitive),
 and a single facade would have bought ~80 % of the benefit (DI, gate, testability, EF10 wins) for ~35 % of
 the surface area and none of the interface-evolution tax.
+
+## 14. Round 2 revisions
+
+Changes made in response to round-2 coordinator feedback (automated review + cross-theory arbitration).
+Suite after revisions: **377 passed / 1 failed** (the known environmental `TestSilenceDetection`).
+
+1. **Cache-init fault containment (high, fixed).** `DatabaseInitializer.InitializeCacheDb` previously
+   caught only `IOException or SqliteException` (blind parity with the old `Plugin` ctor filter). That
+   was strictly worse than today in the new architecture: the gate runs inside
+   `DatabaseStartupService.StartAsync`, so an escaped `UnauthorizedAccessException` (e.g. from
+   `EnsureDeleted` during corruption recovery) or `InvalidOperationException` would abort Jellyfin host
+   startup — and the `Lazy` gate would cache the fault, rethrowing it on every subsequent cache operation
+   forever. Fixed: the cache gate is now catch-all log-and-continue, matching the segment-DB gate;
+   `IDatabaseInitializer.EnsureCacheDbReady` is documented as never-throwing. Regression test
+   `DatabaseInitializer_GatesNeverThrow_WhenInitializationFails` uses a factory that throws
+   `InvalidOperationException` (deliberately outside the old filter) and asserts: the gate does not
+   throw, repeated calls do not rethrow a cached fault, and `DatabaseStartupService.StartAsync`
+   completes.
+2. **WAL claim hardened (verified → enforced).** Chose the *enforce* option over the doc-note option:
+   `DatabaseInitializer` now issues an idempotent `PRAGMA journal_mode=WAL` after segment-DB migration
+   and after cache `EnsureSchema`. Rationale: EF persists WAL only for databases *it* creates; a user
+   database vacuumed/recreated by external SQLite tooling could silently revert to rollback journaling
+   and regress write concurrency. One pragma per startup is free; the property is persistent in the
+   file. Regression test asserts `PRAGMA journal_mode == 'wal'` on both freshly initialized databases.
+3. **Independent benchmark cross-check** of the `EF.Parameter` verdict incorporated into §6.2
+   (json_each ≈ 6.6× faster than `Chunk(500)` at 33k IDs, in addition to being correct where the EF 10
+   default translation throws).
+4. **Startup throw-path audit** (per item 4). Paths that execute during Jellyfin host startup or DI
+   resolution were re-checked:
+   - *Factory constructors* (`SegmentDbContextFactory`, `DetectionCacheDbContextFactory`) ran
+     `Directory.CreateDirectory` unguarded; they are constructed during DI resolution of
+     `DatabaseStartupService`, so an `IO/UnauthorizedAccessException` there could fault host startup
+     (today the equivalent failure is contained to plugin creation). Fixed: directory creation is now
+     guarded; a truly unavailable directory surfaces later as per-operation connection failures, which
+     the gates log and the stores' callers already handle. `ArgumentException.ThrowIfNullOrEmpty(dbPath)`
+     is retained — it can only fire on a programming error (`IApplicationPaths.DataPath` is always
+     non-empty and Jellyfin always registers `IApplicationPaths`).
+   - *`DatabaseStartupService.StartAsync`*: `EnsureSegmentDbReadyAsync` wraps a catch-all async gate
+     (async method semantics capture even synchronous throws into the task, and the entire body is
+     inside `try`); `EnsureCacheDbReady` is catch-all after fix 1. The only exception `StartAsync` can
+     surface is cooperative cancellation of the startup token via `Task.WaitAsync(ct)` — standard hosted
+     service semantics during host shutdown, and it cancels only the wait, never the shared init.
+   - *DI registration lambdas* resolve only `IApplicationPaths` and `ILogger<>`, both unconditionally
+     provided by Jellyfin.
+   - *`SqlitePragmaInterceptor`* still catches only `SqliteException` — unchanged and out of scope: it
+     runs per connection-open (never during startup DI), and its failure mode today is identical.


### PR DESCRIPTION
This PR introduces a new layered architecture (Theory A) to evaluate replacing the static `Plugin` database methods with a store-per-aggregate approach and a dedicated domain service.

*   **Persistence Layer**: Adds `ISegmentStore`, `ISeasonStateStore`, and `IDetectionCacheStore` over hand-rolled `IDbContextFactory` implementations to isolate EF internals from the Jellyfin container. Uses `EF.Parameter` translation to replace manual `Chunk(500)` batching, safely handling deletes with over 32,000 IDs.
*   **Domain Service**: Adds `ISegmentUpdateService` to own business rules (user-provided segment precedence, credits/intro overlap), executing decisions inside the store's transaction via a callback to preserve atomicity.
*   **Lifecycle**: Adds `IDatabaseInitializer` with an async gate to ensure migrations complete before any query, warmed by `DatabaseStartupService`. Manages legacy schema repair and `RebuildDatabaseAsync`.
*   **Consumer Migration**: Updates `SegmentProvider`, `SkipIntroController`, `DetectionCacheService`, and `CleanCacheTask` to inject and use the new layer.
*   **Cleanup**: Reduces all `Plugin` DB methods to transitional one-line delegates.
*   **Documentation & Testing**: Adds `docs/db-redesign/theory-a.md` (migration inventory, EF10 verdicts, risks) and `TestSegmentStores.cs` (domain invariants, initialization ordering, large-set deletes).

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-064" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064"><img alt="INTRO-064" src="https://capy.ai/api/badge/thread.svg?label=INTRO-064"></picture></a>
<!-- capy-pr-badge:end -->