### PR TITLE
refactor(db): remove Plugin DB delegators via constructor threading

### DIFF
--- a/IntroSkipper.Tests/DatabaseTestHelpers.cs
+++ b/IntroSkipper.Tests/DatabaseTestHelpers.cs
@@ -10,10 +10,10 @@ using IntroSkipper.FFmpeg;
 using Microsoft.Extensions.Logging.Abstractions;
 
 /// <summary>
-/// Helpers for constructing the database facades in tests. The plugin-bound variants
-/// resolve the database path from <see cref="Plugin.Instance"/> lazily on every
-/// operation, matching the way tests swap plugin instances and paths via
-/// <see cref="EntrypointTestHelpers.PluginInstanceScope"/>.
+/// Helpers for constructing the database facades in tests over explicit temp-file
+/// SQLite paths. Tests that scope <see cref="Plugin.Instance"/> via
+/// <see cref="EntrypointTestHelpers.PluginInstanceScope"/> pass the scope's cache
+/// database path (<c>scope.CacheDbPath</c>) explicitly.
 /// </summary>
 internal static class DatabaseTestHelpers
 {
@@ -27,20 +27,41 @@ internal static class DatabaseTestHelpers
     /// </summary>
     /// <returns>The segment database facade.</returns>
     internal static IntroSkipperDatabase CreateTempSegmentDatabase()
-        => CreateSegmentDatabase(Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + ".db"));
+        => CreateSegmentDatabase(CreateTempDbPath(Guid.NewGuid().ToString("N") + ".db"));
 
     internal static DetectionCacheDatabase CreateCacheDatabase(string dbPath)
         => new(new DetectionCacheDbContextPathFactory(() => dbPath), NullLogger.Instance);
 
-    internal static IntroSkipperDatabase CreatePluginBoundSegmentDatabase()
-        => new(new IntroSkipperDbContextPathFactory(() => RequirePlugin().DbPath), NullLogger.Instance);
+    internal static DetectionCacheService CreateCacheService(string dbPath)
+        => new(NullLogger<DetectionCacheService>.Instance, CreateCacheDatabase(dbPath));
 
-    internal static DetectionCacheDatabase CreatePluginBoundCacheDatabase()
-        => new(new DetectionCacheDbContextPathFactory(() => RequirePlugin().CacheDbPath), NullLogger.Instance);
+    /// <summary>
+    /// Creates a fresh temp-file cache database path. The file is only created when a
+    /// context or facade actually operates on it.
+    /// </summary>
+    /// <returns>The cache database path.</returns>
+    internal static string CreateTempCacheDbPath()
+        => CreateTempDbPath(Guid.NewGuid().ToString("N") + "-cache.db");
 
-    internal static DetectionCacheService CreatePluginBoundCacheService()
-        => new(NullLogger<DetectionCacheService>.Instance, CreatePluginBoundCacheDatabase());
+    /// <summary>
+    /// Creates a detection cache service over a fresh temp-file path, for consumers
+    /// whose tests never reach the cache database (e.g. fingerprint caching disabled).
+    /// The file is only created if a cache operation is actually performed.
+    /// </summary>
+    /// <returns>The detection cache service.</returns>
+    internal static DetectionCacheService CreateTempCacheService()
+        => CreateCacheService(CreateTempCacheDbPath());
 
-    private static Plugin RequirePlugin()
-        => Plugin.Instance ?? throw new InvalidOperationException("Plugin.Instance is not set.");
+    /// <summary>
+    /// Returns a database path under the shared test temp directory, creating the
+    /// directory so SQLite can open the file regardless of which test runs first.
+    /// </summary>
+    /// <param name="fileName">Database file name.</param>
+    /// <returns>The database path.</returns>
+    private static string CreateTempDbPath(string fileName)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
 }

--- a/IntroSkipper.Tests/DatabaseTestHelpers.cs
+++ b/IntroSkipper.Tests/DatabaseTestHelpers.cs
@@ -4,6 +4,7 @@
 namespace IntroSkipper.Tests;
 
 using System;
+using System.IO;
 using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,6 +19,15 @@ internal static class DatabaseTestHelpers
 {
     internal static IntroSkipperDatabase CreateSegmentDatabase(string dbPath)
         => new(new IntroSkipperDbContextPathFactory(() => dbPath), NullLogger.Instance);
+
+    /// <summary>
+    /// Creates a segment database facade over a fresh temp-file path, for consumers
+    /// (e.g. analyzers) whose tests never reach the database. The file is only created
+    /// if an operation is actually performed.
+    /// </summary>
+    /// <returns>The segment database facade.</returns>
+    internal static IntroSkipperDatabase CreateTempSegmentDatabase()
+        => CreateSegmentDatabase(Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + ".db"));
 
     internal static DetectionCacheDatabase CreateCacheDatabase(string dbPath)
         => new(new DetectionCacheDbContextPathFactory(() => dbPath), NullLogger.Instance);

--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -47,7 +47,8 @@ internal static class EntrypointTestHelpers
             ffmpegService: null!,
             logger: logger,
             loggerFactory: loggerFactory,
-            mediaSegmentRefresher: new FakeMediaSegmentRefresher());
+            mediaSegmentRefresher: new FakeMediaSegmentRefresher(),
+            database: DatabaseTestHelpers.CreatePluginBoundSegmentDatabase());
 
         SetPrivateField(entrypoint, "_config", new PluginConfiguration { AutoDetectIntros = autoDetectIntros });
         return entrypoint;

--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -30,7 +30,7 @@ internal static class EntrypointTestHelpers
 {
     internal static readonly byte[] EmptyJsonArray = Encoding.UTF8.GetBytes("[]");
 
-    internal static Entrypoint CreateEntrypoint(bool autoDetectIntros)
+    internal static Entrypoint CreateEntrypoint(bool autoDetectIntros, string? cacheDbPath = null)
     {
         // Entrypoint's ctor reads Plugin.Instance?.Configuration. Ensure Plugin.Instance is null during construction.
         using var _ = new PluginInstanceNullScope();
@@ -43,12 +43,14 @@ internal static class EntrypointTestHelpers
             providerManager: null!,
             fileSystem: null!,
             taskManager: null!,
-            cacheService: DatabaseTestHelpers.CreatePluginBoundCacheService(),
+            cacheService: cacheDbPath is null
+                ? DatabaseTestHelpers.CreateTempCacheService()
+                : DatabaseTestHelpers.CreateCacheService(cacheDbPath),
             ffmpegService: null!,
             logger: logger,
             loggerFactory: loggerFactory,
             mediaSegmentRefresher: new FakeMediaSegmentRefresher(),
-            database: DatabaseTestHelpers.CreatePluginBoundSegmentDatabase());
+            database: DatabaseTestHelpers.CreateTempSegmentDatabase());
 
         SetPrivateField(entrypoint, "_config", new PluginConfiguration { AutoDetectIntros = autoDetectIntros });
         return entrypoint;
@@ -237,14 +239,15 @@ internal static class EntrypointTestHelpers
 #pragma warning restore SYSLIB0050
 
             SetPropertyOrField(plugin, "FingerprintCachePath", CacheDir);
-            SetPropertyOrField(plugin, "_cacheDbPath", CacheDbPath);
 
             // Plugin.Instance has a private setter; invoke it via reflection.
             var setter = instanceProp.SetMethod ?? instanceProp.GetSetMethod(nonPublic: true);
             Assert.NotNull(setter);
             setter!.Invoke(null, [plugin]);
 
-            // Ensure the schema exists so tests can write to the cache DB.
+            // Ensure the schema exists so tests can write to the cache DB. Create the
+            // containing directory first so this scope works regardless of test order.
+            Directory.CreateDirectory(Path.GetDirectoryName(CacheDbPath)!);
             using var cacheDb = new IntroSkipper.Db.DetectionCacheDbContext(CacheDbPath);
             cacheDb.EnsureSchema();
         }

--- a/IntroSkipper.Tests/TestAudioFingerprinting.cs
+++ b/IntroSkipper.Tests/TestAudioFingerprinting.cs
@@ -167,7 +167,7 @@ public class TestAudioFingerprinting
 
     private static ChromaprintAnalyzer CreateChromaprintAnalyzer()
     {
-        return new(NullLogger<ChromaprintAnalyzer>.Instance, null!, null!);
+        return new(NullLogger<ChromaprintAnalyzer>.Instance, null!, null!, DatabaseTestHelpers.CreateTempSegmentDatabase());
     }
 }
 

--- a/IntroSkipper.Tests/TestAudioFingerprinting.cs
+++ b/IntroSkipper.Tests/TestAudioFingerprinting.cs
@@ -162,7 +162,7 @@ public class TestAudioFingerprinting
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            DatabaseTestHelpers.CreatePluginBoundCacheService());
+            DatabaseTestHelpers.CreateTempCacheService());
     }
 
     private static ChromaprintAnalyzer CreateChromaprintAnalyzer()

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1704,7 +1704,7 @@ public class TestBlackFrames
 
     private static CreditsBlackFrameAnalyzer CreateCreditsBlackFrameAnalyzer(IFFmpegService ffmpegService)
     {
-        return new(NullLogger<CreditsBlackFrameAnalyzer>.Instance, ffmpegService);
+        return new(NullLogger<CreditsBlackFrameAnalyzer>.Instance, ffmpegService, DatabaseTestHelpers.CreateTempSegmentDatabase());
     }
 
     private static void SetRefineCreditsBoundary(CreditsBlackFrameAnalyzer analyzer, bool value)
@@ -1806,7 +1806,7 @@ public class TestBlackFrames
 
     private static BlackFrameAnalyzer CreateBlackFrameAnalyzer()
     {
-        return new(NullLogger<BlackFrameAnalyzer>.Instance, CreateFFmpegService());
+        return new(NullLogger<BlackFrameAnalyzer>.Instance, CreateFFmpegService(), DatabaseTestHelpers.CreateTempSegmentDatabase());
     }
 
     private sealed class FakeFFmpegService(

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1801,7 +1801,7 @@ public class TestBlackFrames
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            DatabaseTestHelpers.CreatePluginBoundCacheService());
+            DatabaseTestHelpers.CreateTempCacheService());
     }
 
     private static BlackFrameAnalyzer CreateBlackFrameAnalyzer()

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -45,7 +45,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.AddRange(shouldKeep);
             db.DetectionCache.AddRange(shouldDelete);
@@ -57,7 +57,7 @@ public sealed class TestCacheOperations
             cachingScope.CacheService.DeleteByMode(AnalysisMode.Introduction);
         }
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             // Introduction entries should be gone
             Assert.False(
@@ -95,7 +95,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.AddRange(shouldKeep);
             db.DetectionCache.AddRange(shouldDelete);
@@ -107,7 +107,7 @@ public sealed class TestCacheOperations
             cachingScope.CacheService.DeleteByMode(AnalysisMode.Credits);
         }
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             // Credits entries should be gone
             Assert.False(
@@ -129,7 +129,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));
@@ -173,7 +173,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
@@ -346,7 +346,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Credits,
@@ -386,7 +386,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Introduction,
@@ -423,7 +423,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Introduction,
@@ -461,7 +461,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Introduction,
@@ -493,7 +493,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             // Stale entry: cached with old end=600
             db.DetectionCache.Add(new DbDetectionCache(
@@ -520,7 +520,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, 0, 600));
@@ -546,7 +546,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId, AnalysisMode.Credits, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, 1560, 1800));
@@ -613,9 +613,7 @@ public sealed class TestCacheOperations
                     new PluginConfiguration { CacheFingerprints = true });
             }
 
-            CacheService = new DetectionCacheService(
-                NullLogger<DetectionCacheService>.Instance,
-                DatabaseTestHelpers.CreatePluginBoundCacheDatabase());
+            CacheService = DatabaseTestHelpers.CreateCacheService(_inner.CacheDbPath);
         }
 
         public DetectionCacheService CacheService { get; }

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -253,7 +253,7 @@ public class TestChapterAnalyzer
         string? expressionOverride = null,
         bool enableSponsorBlockChapterDetection = true)
     {
-        var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, null!);
+        var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, null!, DatabaseTestHelpers.CreateTempSegmentDatabase());
         var chapters = CreateChapters(chapterName, mode);
 
         var config = new Configuration.PluginConfiguration();

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -181,7 +181,7 @@ public sealed class TestDbSegmentStorage
                 var plugin = Plugin.Instance!;
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
 
-                await Plugin.CleanTimestampsAsync(enabledEpisodeIds);
+                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).CleanTimestampsAsync(enabledEpisodeIds);
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -657,7 +657,7 @@ public sealed class TestDbSegmentStorage
                 ConfigurePluginLogger(plugin);
 
                 var credits = new Segment(itemId, new TimeRange(creditsStart, creditsEnd));
-                await plugin.UpdateTimestampAsync(credits, AnalysisMode.Credits, isUserProvided);
+                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).UpdateTimestampAsync(credits, AnalysisMode.Credits, isUserProvided);
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -176,13 +176,7 @@ public sealed class TestDbSegmentStorage
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).CleanTimestampsAsync(enabledEpisodeIds);
-            }
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).CleanTimestampsAsync(enabledEpisodeIds);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -229,24 +223,17 @@ public sealed class TestDbSegmentStorage
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+            // Should not throw even with 1001 episode IDs (above the SQLite 999-parameter limit).
+            var snapshot = await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).GetSeasonQueueSnapshotAsync(seasonId, episodeIds);
+            Assert.True(snapshot.EpisodeIdsByMode.TryGetValue(AnalysisMode.Introduction, out var analyzedIds));
+            Assert.Contains(episodeWithSegmentId, analyzedIds!);
+            Assert.True(snapshot.ConfigHashByMode.TryGetValue(AnalysisMode.Introduction, out var configHash));
+            Assert.Equal("snapshot-config", configHash);
+            Assert.True(snapshot.AnalyzerActionByMode.TryGetValue(AnalysisMode.Introduction, out var analyzerAction));
+            Assert.Equal(AnalyzerAction.Chromaprint, analyzerAction);
 
-                // Should not throw even with 1001 episode IDs (above the SQLite 999-parameter limit).
-                var snapshot = await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).GetSeasonQueueSnapshotAsync(seasonId, episodeIds);
-                Assert.True(snapshot.EpisodeIdsByMode.TryGetValue(AnalysisMode.Introduction, out var analyzedIds));
-                Assert.Contains(episodeWithSegmentId, analyzedIds!);
-                Assert.True(snapshot.ConfigHashByMode.TryGetValue(AnalysisMode.Introduction, out var configHash));
-                Assert.Equal("snapshot-config", configHash);
-                Assert.True(snapshot.AnalyzerActionByMode.TryGetValue(AnalysisMode.Introduction, out var analyzerAction));
-                Assert.Equal(AnalyzerAction.Chromaprint, analyzerAction);
-
-
-                Assert.True(snapshot.SegmentsByEpisodeId.TryGetValue(episodeWithSegmentId, out var segmentsByAnalysisMode));
-                Assert.True(segmentsByAnalysisMode!.TryGetValue(AnalysisMode.Introduction, out _));
-            }
+            Assert.True(snapshot.SegmentsByEpisodeId.TryGetValue(episodeWithSegmentId, out var segmentsByAnalysisMode));
+            Assert.True(segmentsByAnalysisMode!.TryGetValue(AnalysisMode.Introduction, out _));
         }
         finally
         {
@@ -650,15 +637,8 @@ public sealed class TestDbSegmentStorage
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                ConfigurePluginLogger(plugin);
-
-                var credits = new Segment(itemId, new TimeRange(creditsStart, creditsEnd));
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).UpdateTimestampAsync(credits, AnalysisMode.Credits, isUserProvided);
-            }
+            var credits = new Segment(itemId, new TimeRange(creditsStart, creditsEnd));
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).UpdateTimestampAsync(credits, AnalysisMode.Credits, isUserProvided);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -698,12 +678,6 @@ public sealed class TestDbSegmentStorage
                 await db.Database.CloseConnectionAsync();
             }
         }
-    }
-
-    private static void ConfigurePluginLogger(Plugin plugin)
-    {
-        using var loggerFactory = LoggerFactory.Create(_ => { });
-        EntrypointTestHelpers.SetPrivateField(plugin, "_logger", loggerFactory.CreateLogger<Plugin>());
     }
 
     private static void DeleteSqliteFiles(string dbPath)

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -235,7 +235,7 @@ public sealed class TestDbSegmentStorage
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
 
                 // Should not throw even with 1001 episode IDs (above the SQLite 999-parameter limit).
-                var snapshot = await Plugin.GetSeasonQueueSnapshotAsync(seasonId, episodeIds);
+                var snapshot = await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).GetSeasonQueueSnapshotAsync(seasonId, episodeIds);
                 Assert.True(snapshot.EpisodeIdsByMode.TryGetValue(AnalysisMode.Introduction, out var analyzedIds));
                 Assert.Contains(episodeWithSegmentId, analyzedIds!);
                 Assert.True(snapshot.ConfigHashByMode.TryGetValue(AnalysisMode.Introduction, out var configHash));

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -74,19 +74,20 @@ public sealed class TestEntrypointEvents
     public void OnItemRemoved_DeletesCache_ForEpisode()
     {
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
         var episodeId = Guid.NewGuid();
         var otherId = Guid.NewGuid();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true, cacheDbPath);
 
         var episode = new Episode();
         EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
         EntrypointTestHelpers.EnsureNonVirtual(episode);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: episode, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     episodeId,
@@ -110,7 +111,7 @@ public sealed class TestEntrypointEvents
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.False(verificationDb.DetectionCache.Any(e => e.ItemId == episodeId));
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == otherId));
         }
@@ -172,8 +173,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         var otherId = Guid.NewGuid();
 
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true, cacheDbPath);
 
         var movie = new Movie();
         EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
@@ -182,9 +184,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         Assert.Equal(removedId, movie.Id);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     removedId,
@@ -208,7 +210,7 @@ public sealed class TestFingerprintCacheDeletionOnRemove
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.False(verificationDb.DetectionCache.Any(e => e.ItemId == removedId));
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == otherId));
         }
@@ -219,8 +221,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
     {
         var removedId = Guid.NewGuid();
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false, cacheDbPath);
 
         var movie = new Movie();
         EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
@@ -229,9 +232,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         Assert.Equal(removedId, movie.Id);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     removedId,
@@ -243,7 +246,7 @@ public sealed class TestFingerprintCacheDeletionOnRemove
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == removedId));
         }
     }
@@ -254,8 +257,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         var removedId = Guid.Empty;
 
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true, cacheDbPath);
 
         var movie = new Movie();
         EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
@@ -264,9 +268,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         Assert.Equal(removedId, movie.Id);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     removedId,
@@ -278,7 +282,7 @@ public sealed class TestFingerprintCacheDeletionOnRemove
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == removedId));
         }
     }

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -218,7 +218,7 @@ public class TestFFmpegService
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            DatabaseTestHelpers.CreatePluginBoundCacheService());
+            DatabaseTestHelpers.CreateTempCacheService());
     }
 
     private static QueuedEpisode QueueFile(string path)

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -318,59 +318,51 @@ public sealed class TestSeasonReanalysisReset
                 await db.Database.EnsureCreatedAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
 
-                // Stays eligible until the work is explicitly recorded, so a failed reset is retried.
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+            // Stays eligible until the work is explicitly recorded, so a failed reset is retried.
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // already done for this set
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive.Reverse().ToArray())); // order-insensitive set match
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix)); // grew → eligible again
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive)); // same count, different membership
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive)); // unrecorded mode stays eligible
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // already done for this set
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, [.. firstFive.Reverse()])); // order-insensitive set match
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix)); // grew → eligible again
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive)); // same count, different membership
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive)); // unrecorded mode stays eligible
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], replacementFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], replacementFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstSix);
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrank → eligible again
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstSix);
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrank → eligible again
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrink was recorded
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrink was recorded
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstSix);
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
-            }
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstSix);
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            // A fresh facade over the same file simulates a plugin restart: the recorded
+            // episode sets must be read back from the database.
+            var reopenedDatabase = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
 
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
-            }
+            Assert.False(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Introduction, firstFive));
+            Assert.True(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Introduction, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Introduction, firstSeven));
+            Assert.False(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Credits, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Credits, firstSeven));
         }
         finally
         {
@@ -430,30 +422,26 @@ public sealed class TestSeasonReanalysisReset
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
+            using (var cacheDb = new DetectionCacheDbContext(cacheDbPath))
             {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                cacheDb.EnsureSchema();
+                cacheDb.DetectionCache.Add(new DbDetectionCache(
+                    autoEpisode,
+                    AnalysisMode.Introduction,
+                    CacheEntryType.Chromaprint,
+                    EntrypointTestHelpers.EmptyJsonArray));
+                await cacheDb.SaveChangesAsync();
+            }
 
-                using (var cacheDb = Plugin.CreateCacheDbContext())
-                {
-                    cacheDb.DetectionCache.Add(new DbDetectionCache(
-                        autoEpisode,
-                        AnalysisMode.Introduction,
-                        CacheEntryType.Chromaprint,
-                        EntrypointTestHelpers.EmptyJsonArray));
-                    await cacheDb.SaveChangesAsync();
-                }
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
+                seasonId,
+                new[] { autoEpisode, userEpisode },
+                new[] { AnalysisMode.Introduction });
 
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
-                    seasonId,
-                    new[] { autoEpisode, userEpisode },
-                    new[] { AnalysisMode.Introduction });
-
-                using (var cacheDb = Plugin.CreateCacheDbContext())
-                {
-                    Assert.True(cacheDb.DetectionCache.Any(e => e.ItemId == autoEpisode && e.Mode == AnalysisMode.Introduction));
-                }
+            using (var cacheDb = new DetectionCacheDbContext(cacheDbPath))
+            {
+                Assert.True(cacheDb.DetectionCache.Any(e => e.ItemId == autoEpisode && e.Mode == AnalysisMode.Introduction));
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))
@@ -523,17 +511,12 @@ public sealed class TestSeasonReanalysisReset
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                var resetModes = BaseItemAnalyzerTask.ExpandSettledResetModesForDerivedSegments([AnalysisMode.Credits], true);
+            var resetModes = BaseItemAnalyzerTask.ExpandSettledResetModesForDerivedSegments([AnalysisMode.Credits], true);
 
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
-                    seasonId,
-                    new[] { autoEpisode, userPreviewEpisode },
-                    resetModes);
-            }
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
+                seasonId,
+                new[] { autoEpisode, userPreviewEpisode },
+                resetModes);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -573,24 +556,18 @@ public sealed class TestSeasonReanalysisReset
                 await db.Database.EnsureCreatedAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-
-                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
-                await database.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeA, episodeB], "hash-a");
-                await database.SetAnalyzerActionAsync(
-                    seasonId,
-                    new Dictionary<AnalysisMode, AnalyzerAction>
-                    {
-                        [AnalysisMode.Introduction] = AnalyzerAction.Chromaprint,
-                    });
-                await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], completedEpisodeIds);
-                await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], lowerEpisodeIds);
-                await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, episodeA);
-                await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, Guid.NewGuid());
-            }
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeA, episodeB], "hash-a");
+            await database.SetAnalyzerActionAsync(
+                seasonId,
+                new Dictionary<AnalysisMode, AnalyzerAction>
+                {
+                    [AnalysisMode.Introduction] = AnalyzerAction.Chromaprint,
+                });
+            await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], completedEpisodeIds);
+            await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], lowerEpisodeIds);
+            await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, episodeA);
+            await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, Guid.NewGuid());
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -645,7 +622,6 @@ public sealed class TestSeasonReanalysisReset
             using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
             {
                 var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
                 EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
 
                 var episode = new Episode();
@@ -746,7 +722,7 @@ public sealed class TestSeasonReanalysisReset
     {
         var states = await database.GetSettleReanalysisStatesAsync(seasonId);
         return !states.TryGetValue(mode, out var state)
-            || Plugin.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds);
+            || AnalysisHelpers.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds);
     }
 
     private static void DeleteSqliteFiles(string dbPath)

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -322,52 +322,54 @@ public sealed class TestSeasonReanalysisReset
             {
                 var plugin = Plugin.Instance!;
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
 
                 // Stays eligible until the work is explicitly recorded, so a failed reset is retried.
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstFive));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
 
-                await Plugin.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstFive)); // already done for this set
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstFive.Reverse().ToArray())); // order-insensitive set match
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstSix)); // grew → eligible again
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, replacementFive)); // same count, different membership
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstFive)); // unrecorded mode stays eligible
+                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // already done for this set
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive.Reverse().ToArray())); // order-insensitive set match
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix)); // grew → eligible again
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive)); // same count, different membership
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive)); // unrecorded mode stays eligible
 
-                await Plugin.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], replacementFive);
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, replacementFive));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstFive));
+                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], replacementFive);
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
 
-                await Plugin.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstSix);
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstFive)); // shrank → eligible again
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstSeven));
+                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstSix);
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrank → eligible again
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
 
-                await Plugin.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstFive)); // shrink was recorded
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstSeven));
+                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrink was recorded
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
 
-                await Plugin.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstSix));
+                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstFive);
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
 
-                await Plugin.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstSix);
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstFive));
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstSeven));
+                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstSix);
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
             }
 
             using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
             {
                 var plugin = Plugin.Instance!;
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
 
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Introduction, firstSeven));
-                Assert.False(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(season, AnalysisMode.Credits, firstSeven));
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
+                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
+                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
             }
         }
         finally
@@ -443,7 +445,7 @@ public sealed class TestSeasonReanalysisReset
                     await cacheDb.SaveChangesAsync();
                 }
 
-                await Plugin.ResetSeasonForReanalysisAsync(
+                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
                     seasonId,
                     new[] { autoEpisode, userEpisode },
                     new[] { AnalysisMode.Introduction });
@@ -527,7 +529,7 @@ public sealed class TestSeasonReanalysisReset
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
                 var resetModes = BaseItemAnalyzerTask.ExpandSettledResetModesForDerivedSegments([AnalysisMode.Credits], true);
 
-                await Plugin.ResetSeasonForReanalysisAsync(
+                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
                     seasonId,
                     new[] { autoEpisode, userPreviewEpisode },
                     resetModes);
@@ -576,17 +578,18 @@ public sealed class TestSeasonReanalysisReset
                 var plugin = Plugin.Instance!;
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
 
-                await Plugin.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeA, episodeB], "hash-a");
-                await Plugin.SetAnalyzerActionAsync(
+                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+                await database.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeA, episodeB], "hash-a");
+                await database.SetAnalyzerActionAsync(
                     seasonId,
                     new Dictionary<AnalysisMode, AnalyzerAction>
                     {
                         [AnalysisMode.Introduction] = AnalyzerAction.Chromaprint,
                     });
-                await Plugin.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], completedEpisodeIds);
-                await Plugin.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], lowerEpisodeIds);
-                await Plugin.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, episodeA);
-                await Plugin.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, Guid.NewGuid());
+                await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], completedEpisodeIds);
+                await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], lowerEpisodeIds);
+                await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, episodeA);
+                await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, Guid.NewGuid());
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))
@@ -734,11 +737,12 @@ public sealed class TestSeasonReanalysisReset
     // Mirrors the production eligibility decision in BaseItemAnalyzerTask.GetSettleReanalysisModesAsync,
     // exercising the same batch read (GetSettleReanalysisStatesAsync) and set comparison the analyzer uses.
     private static async Task<bool> ShouldReanalyzeAsync(
+        IntroSkipperDatabase database,
         Guid seasonId,
         AnalysisMode mode,
         IReadOnlyCollection<Guid> episodeIds)
     {
-        var states = await Plugin.GetSettleReanalysisStatesAsync(seasonId);
+        var states = await database.GetSettleReanalysisStatesAsync(seasonId);
         return !states.TryGetValue(mode, out var state)
             || Plugin.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds);
     }

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -659,7 +659,8 @@ public sealed class TestSeasonReanalysisReset
                     libraryManager,
                     providerManager: null!,
                     fileSystem: null!,
-                    ffmpegService: new FakeFfmpegService(ffmpegValid: false));
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: false),
+                    database: DatabaseTestHelpers.CreateSegmentDatabase(dbPath));
                 var stillUnavailable = await unavailableQueueManager.VerifyQueueAsync(
                     [CreateQueuedEpisode(episodeId, seasonId)],
                     [AnalysisMode.Introduction]);
@@ -670,7 +671,8 @@ public sealed class TestSeasonReanalysisReset
                     libraryManager,
                     providerManager: null!,
                     fileSystem: null!,
-                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true),
+                    database: DatabaseTestHelpers.CreateSegmentDatabase(dbPath));
                 var reopened = await availableQueueManager.VerifyQueueAsync(
                     [CreateQueuedEpisode(episodeId, seasonId)],
                     [AnalysisMode.Introduction]);

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -26,13 +26,13 @@ public sealed class TestSkipIntroController
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, itemId, updateMediaSegments: true, out var item);
+        using var pluginScope = CreatePluginScope(itemId, updateMediaSegments: true, out var item);
         await EnsureDatabaseAsync(dbPath);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreatePluginBoundCacheService(), DatabaseTestHelpers.CreatePluginBoundSegmentDatabase());
+        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreateCacheService(pluginScope.CacheDbPath), DatabaseTestHelpers.CreateSegmentDatabase(dbPath));
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -60,13 +60,13 @@ public sealed class TestSkipIntroController
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, itemId, updateMediaSegments: false, out _);
+        using var pluginScope = CreatePluginScope(itemId, updateMediaSegments: false, out _);
         await EnsureDatabaseAsync(dbPath);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreatePluginBoundCacheService(), DatabaseTestHelpers.CreatePluginBoundSegmentDatabase());
+        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreateCacheService(pluginScope.CacheDbPath), DatabaseTestHelpers.CreateSegmentDatabase(dbPath));
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -78,7 +78,7 @@ public sealed class TestSkipIntroController
         Assert.Equal(0, refresher.ItemCallCount);
     }
 
-    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid itemId, bool updateMediaSegments, out Movie item)
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(Guid itemId, bool updateMediaSegments, out Movie item)
     {
         var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         item = new Movie();
@@ -87,7 +87,6 @@ public sealed class TestSkipIntroController
 
         var libraryManager = EntrypointTestHelpers.CreateLibraryManager(item);
         var plugin = Plugin.Instance!;
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
         EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
         return scope;

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -29,14 +29,14 @@ public sealed class TestVisualizationController
         var seasonId = Guid.NewGuid();
         var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: true);
+        using var pluginScope = CreatePluginScope(seriesId, seasonId, episodeIds, updateMediaSegments: true);
         await SeedSeasonAsync(dbPath, seasonId, episodeIds);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath, pluginScope.CacheDbPath);
 
         var actionTask = controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
 
@@ -60,14 +60,14 @@ public sealed class TestVisualizationController
         var seasonId = Guid.NewGuid();
         var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: false);
+        using var pluginScope = CreatePluginScope(seriesId, seasonId, episodeIds, updateMediaSegments: false);
         await SeedSeasonAsync(dbPath, seasonId, episodeIds);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath, pluginScope.CacheDbPath);
 
         var result = await controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
 
@@ -89,16 +89,15 @@ public sealed class TestVisualizationController
             SeriesExclusions = { "Excluded Show" }
         };
         using var pluginScope = CreatePluginScope(
-            dbPath,
             seriesId,
             seasonId,
             [excludedId, includedId],
             config);
         await SeedSeasonAsync(dbPath, seasonId, [excludedId, includedId]);
-        await SeedCacheAsync(excludedId, includedId);
+        await SeedCacheAsync(pluginScope.CacheDbPath, excludedId, includedId);
         var refresher = new RecordingMediaSegmentRefresher();
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath, pluginScope.CacheDbPath);
 
         var result = await controller.ClearExcludedTimestampsAsync(CancellationToken.None);
 
@@ -115,12 +114,12 @@ public sealed class TestVisualizationController
         var seasonStates = await db.DbSeasonState.Where(s => s.SeasonId == seasonId).ToListAsync();
         Assert.All(seasonStates, state => Assert.Equal([includedId], state.EpisodeIds));
 
-        using var cacheDb = Plugin.CreateCacheDbContext();
+        using var cacheDb = new DetectionCacheDbContext(pluginScope.CacheDbPath);
         Assert.False(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == excludedId));
         Assert.True(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == includedId));
     }
 
-    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory)
+    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory, string dbPath, string cacheDbPath)
     {
         return new VisualizationController(
             NullLogger<VisualizationController>.Instance,
@@ -130,24 +129,22 @@ public sealed class TestVisualizationController
             fileSystem: null!,
             loggerFactory,
             ffmpegService: null!,
-            DatabaseTestHelpers.CreatePluginBoundCacheService(),
-            DatabaseTestHelpers.CreatePluginBoundSegmentDatabase(),
-            DatabaseTestHelpers.CreatePluginBoundCacheDatabase());
+            DatabaseTestHelpers.CreateCacheService(cacheDbPath),
+            DatabaseTestHelpers.CreateSegmentDatabase(dbPath),
+            DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath));
     }
 
-    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
         => CreatePluginScope(
-            dbPath,
             seriesId,
             seasonId,
             episodeIds,
             new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
 
-    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, PluginConfiguration config)
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, PluginConfiguration config)
     {
         var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var plugin = Plugin.Instance!;
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
         plugin.QueuedMediaItems[seasonId] =
@@ -171,9 +168,9 @@ public sealed class TestVisualizationController
         await db.SaveChangesAsync();
     }
 
-    private static async Task SeedCacheAsync(Guid excludedId, Guid includedId)
+    private static async Task SeedCacheAsync(string cacheDbPath, Guid excludedId, Guid includedId)
     {
-        using var cacheDb = Plugin.CreateCacheDbContext();
+        using var cacheDb = new DetectionCacheDbContext(cacheDbPath);
         cacheDb.DetectionCache.AddRange(
             new DbDetectionCache(excludedId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray),
             new DbDetectionCache(includedId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -6,6 +6,7 @@
 
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using Microsoft.Extensions.Logging;
 
@@ -20,12 +21,14 @@ namespace IntroSkipper.Analyzers;
 /// </remarks>
 /// <param name="logger">Logger for the analyzer.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
-public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger, IFFmpegService ffmpegService) : IMediaFileAnalyzer
+/// <param name="database">Segment database facade.</param>
+public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logger, IFFmpegService ffmpegService, IIntroSkipperDatabase database) : IMediaFileAnalyzer
 {
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly TimeSpan _maximumError = TimeSpan.FromSeconds(4);
     private readonly ILogger<BlackFrameAnalyzer> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly IIntroSkipperDatabase _database = database;
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<QueuedEpisode>> AnalyzeMediaFiles(
@@ -99,7 +102,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
                 LogFoundCredits(_logger, episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await Plugin.Instance!.UpdateTimestampAsync(credit, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await _database.UpdateTimestampAsync(credit, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 // Update search start for next episode based on this result
                 searchStart = episode.Duration - credit.Start + _config.MinimumCreditsDuration;

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
@@ -23,10 +24,12 @@ namespace IntroSkipper.Analyzers;
 /// </remarks>
 /// <param name="logger">Logger.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
-public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegService ffmpegService) : IMediaFileAnalyzer
+/// <param name="database">Segment database facade.</param>
+public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegService ffmpegService, IIntroSkipperDatabase database) : IMediaFileAnalyzer
 {
     private readonly ILogger<ChapterAnalyzer> _logger = logger;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly IIntroSkipperDatabase _database = database;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private static readonly ImmutableHashSet<string> _ambiguousSponsorBlockChapterLabels =
         ImmutableHashSet.Create(
@@ -123,7 +126,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
             skipRange = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, skipRange, false, cancellationToken).ConfigureAwait(false);
 
             episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-            await Plugin.Instance!.UpdateTimestampAsync(skipRange, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _database.UpdateTimestampAsync(skipRange, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         return analysisQueue;
@@ -221,7 +224,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
     internal async Task<Segment?> DetectRecapUsingBlackFramesAsync(QueuedEpisode episode, CancellationToken cancellationToken)
     {
         var maxRecapBoundary = await RecapDetectionHelper.GetMaximumBoundaryAsync(
-            Plugin.Instance!.SegmentDatabase,
+            _database,
             episode,
             _config,
             cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -221,6 +221,7 @@ public partial class ChapterAnalyzer(ILogger<ChapterAnalyzer> logger, IFFmpegSer
     internal async Task<Segment?> DetectRecapUsingBlackFramesAsync(QueuedEpisode episode, CancellationToken cancellationToken)
     {
         var maxRecapBoundary = await RecapDetectionHelper.GetMaximumBoundaryAsync(
+            Plugin.Instance!.SegmentDatabase,
             episode,
             _config,
             cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -263,6 +263,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
         }
 
         var maximumBoundary = await RecapDetectionHelper.GetMaximumBoundaryAsync(
+            Plugin.Instance!.SegmentDatabase,
             episode,
             _config,
             cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -7,6 +7,7 @@
 using System.Numerics;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using Microsoft.Extensions.Logging;
 
@@ -18,7 +19,8 @@ namespace IntroSkipper.Analyzers;
 /// <param name="logger">Logger.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="cacheService">Detection cache service.</param>
-public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IFFmpegService ffmpegService, IDetectionCacheService cacheService) : IMediaFileAnalyzer
+/// <param name="database">Segment database facade.</param>
+public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IFFmpegService ffmpegService, IDetectionCacheService cacheService, IIntroSkipperDatabase database) : IMediaFileAnalyzer
 {
     /// <summary>
     /// Minimum duration (seconds) for a shared recap card/sting to count as a candidate.
@@ -29,6 +31,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
     private readonly ILogger<ChromaprintAnalyzer> _logger = logger;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly IIntroSkipperDatabase _database = database;
     private readonly Dictionary<Guid, Dictionary<uint, int>> _invertedIndexCache = [];
     private readonly Dictionary<Guid, IReadOnlyList<BlackFrame>> _recapBlackFrameCache = [];
     private AnalysisMode _analysisMode;
@@ -175,7 +178,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             {
                 var adjustedIntro = await timeAdjustmentHelper.AdjustIntroTimesAsync(currentEpisode, intro, cancellationToken: cancellationToken).ConfigureAwait(false);
                 currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await Plugin.Instance!.UpdateTimestampAsync(adjustedIntro, mode, configHash: currentEpisode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await _database.UpdateTimestampAsync(adjustedIntro, mode, configHash: currentEpisode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -263,7 +266,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
         }
 
         var maximumBoundary = await RecapDetectionHelper.GetMaximumBoundaryAsync(
-            Plugin.Instance!.SegmentDatabase,
+            _database,
             episode,
             _config,
             cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -6,6 +6,7 @@
 using IntroSkipper.Analyzers.Credits;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using Microsoft.Extensions.Logging;
 
@@ -20,11 +21,13 @@ namespace IntroSkipper.Analyzers;
 /// </remarks>
 /// <param name="logger">Logger for the analyzer.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
-public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameAnalyzer> logger, IFFmpegService ffmpegService) : IMediaFileAnalyzer
+/// <param name="database">Segment database facade.</param>
+public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameAnalyzer> logger, IFFmpegService ffmpegService, IIntroSkipperDatabase database) : IMediaFileAnalyzer
 {
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
     private readonly ILogger<CreditsBlackFrameAnalyzer> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly IIntroSkipperDatabase _database = database;
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<QueuedEpisode>> AnalyzeMediaFiles(
@@ -53,7 +56,6 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
         var minimumPercentage = _config.BlackFrameMinimumPercentage;
         var threshold = _config.BlackFrameThreshold;
         var minimumDuration = _config.MinimumCreditsDuration;
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
 
         foreach (var episode in unanalyzedEpisodes)
         {
@@ -73,7 +75,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
                 LogFoundCredits(episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);
-                await plugin.UpdateTimestampAsync(credit, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await _database.UpdateTimestampAsync(credit, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/IntroSkipper/Analyzers/RecapDetectionHelper.cs
+++ b/IntroSkipper/Analyzers/RecapDetectionHelper.cs
@@ -3,6 +3,7 @@
 
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 
 namespace IntroSkipper.Analyzers;
 
@@ -14,17 +15,19 @@ internal static class RecapDetectionHelper
     /// <summary>
     /// Gets the latest timestamp that recap boundary detection should scan.
     /// </summary>
+    /// <param name="database">Segment database facade.</param>
     /// <param name="episode">Queued episode.</param>
     /// <param name="config">Plugin configuration.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The maximum recap boundary in seconds.</returns>
     internal static async Task<double> GetMaximumBoundaryAsync(
+        IIntroSkipperDatabase database,
         QueuedEpisode episode,
         PluginConfiguration config,
         CancellationToken cancellationToken)
     {
         var maximumBoundary = Math.Min(episode.Duration, config.MaximumRecapDetectionDuration);
-        var timestamps = await Plugin.GetTimestampsAsync(
+        var timestamps = await database.GetTimestampsAsync(
             episode.EpisodeId,
             cancellationToken).ConfigureAwait(false);
         if (timestamps.TryGetValue(AnalysisMode.Introduction, out var intro) && intro.Valid)

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -6,6 +6,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Net.Mime;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities.TV;
@@ -24,16 +25,18 @@ namespace IntroSkipper.Controllers;
 /// Initializes a new instance of the <see cref="SegmentEditorController"/> class.
 /// </remarks>
 /// <param name="mediaSegmentEditorService">Media segment editor service.</param>
+/// <param name="database">Segment database facade.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("MediaSegmentsApi")]
-public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEditorService) : ControllerBase
+public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEditorService, IIntroSkipperDatabase database) : ControllerBase
 {
     // Maximum difference in seconds between two time values to be considered equal.
     private const double TimeComparisonToleranceSeconds = 0.01;
 
     private readonly MediaSegmentEditorService _mediaSegmentEditorService = mediaSegmentEditorService;
+    private readonly IIntroSkipperDatabase _database = database;
 
     /// <summary>
     /// Plugin meta endpoint.
@@ -77,7 +80,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         var seg = new Segment(itemId, new TimeRange(TimeSpan.FromTicks(segment.StartTicks).TotalSeconds, TimeSpan.FromTicks(segment.EndTicks).TotalSeconds));
         var mode = Plugin.MapSegmentTypeToMode(segment.Type);
 
-        await Plugin.Instance!.UpdateTimestampAsync(seg, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await _database.UpdateTimestampAsync(seg, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await _mediaSegmentEditorService.CreateOrReplaceSegmentAsync(item, segment, cancellationToken).ConfigureAwait(false);
 
@@ -132,7 +135,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         // Match on type AND start/end times so that when multiple segments of the same mode exist
         // (e.g. Commercial) we identify the exact one being deleted rather than an arbitrary first match.
         var wasUserProvided = false;
-        var pluginSegments = await Plugin.GetSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
+        var pluginSegments = await _database.GetSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
         var matchingSegment = pluginSegments.FirstOrDefault(s =>
             s.Type == mode &&
             (dbSegment is null || (Math.Abs(s.Start - dbSegment.Start) < TimeComparisonToleranceSeconds && Math.Abs(s.End - dbSegment.End) < TimeComparisonToleranceSeconds)));
@@ -142,7 +145,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         }
 
         // Delete from the plugin DB first so it is consistent even if the Jellyfin delete fails.
-        await Plugin.DeleteTimestampAsync(itemId, mode, dbSegment, cancellationToken).ConfigureAwait(false);
+        await _database.DeleteTimestampAsync(itemId, mode, dbSegment, cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -153,7 +156,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             // Jellyfin delete failed — restore the plugin DB entry to avoid an orphaned Jellyfin segment.
             if (dbSegment is not null)
             {
-                await Plugin.Instance!.UpdateTimestampAsync(dbSegment, mode, isUserProvided: wasUserProvided, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                await _database.UpdateTimestampAsync(dbSegment, mode, isUserProvided: wasUserProvided, cancellationToken: CancellationToken.None).ConfigureAwait(false);
             }
 
             throw;
@@ -165,7 +168,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         if (deletedItem is not null)
         {
             var seasonId = deletedItem is Episode ep ? ep.SeasonId : deletedItem.Id;
-            await Plugin.RemoveEpisodeIdAsync(seasonId, mode, itemId, cancellationToken).ConfigureAwait(false);
+            await _database.RemoveEpisodeIdAsync(seasonId, mode, itemId, cancellationToken).ConfigureAwait(false);
         }
 
         return Ok();

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -78,7 +78,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         }
 
         var seg = new Segment(itemId, new TimeRange(TimeSpan.FromTicks(segment.StartTicks).TotalSeconds, TimeSpan.FromTicks(segment.EndTicks).TotalSeconds));
-        var mode = Plugin.MapSegmentTypeToMode(segment.Type);
+        var mode = AnalysisHelpers.MapSegmentTypeToMode(segment.Type);
 
         await _database.UpdateTimestampAsync(seg, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -319,7 +319,8 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
                             _fileSystem,
                             _mediaSegmentRefresher,
                             _ffmpegService,
-                            _cacheService);
+                            _cacheService,
+                            _database);
 
                         await baseIntroAnalyzer.AnalyzeItemsAsync(new Progress<double>(), CancellationToken.None, [seasonId]).ConfigureAwait(false);
                     }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -244,7 +244,8 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
                 _libraryManager,
                 _providerManager,
                 _fileSystem,
-                _ffmpegService);
+                _ffmpegService,
+                _database);
             var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
             return [.. queue.Values.SelectMany(static episodes => episodes).Where(static episode => episode.IsExcluded)];
         }

--- a/IntroSkipper/Data/AnalysisHelpers.cs
+++ b/IntroSkipper/Data/AnalysisHelpers.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Pure analysis helper functions with no database or plugin state access.
+/// </summary>
+internal static class AnalysisHelpers
+{
+    /// <summary>
+    /// Returns whether a settled-season analysis mode still needs re-analysis for its current episode
+    /// set. Pure set comparison: the decision is committed separately via
+    /// <see cref="Db.IIntroSkipperDatabase.RecordSettleReanalysisAsync(Guid, IReadOnlyCollection{AnalysisMode}, IReadOnlyCollection{Guid}, CancellationToken)"/>
+    /// once the reset has succeeded, so the completed episode set survives plugin restarts.
+    /// </summary>
+    /// <param name="settledEpisodeIds">Episode IDs recorded when the season was last settle-reanalyzed for this mode.</param>
+    /// <param name="episodeIds">Current episode IDs in the season.</param>
+    /// <returns><see langword="true"/> when a re-analysis should be performed; otherwise <see langword="false"/>.</returns>
+    internal static bool ShouldSettleReanalyze(
+        IReadOnlySet<Guid> settledEpisodeIds,
+        IReadOnlyCollection<Guid> episodeIds)
+        => settledEpisodeIds.Count != episodeIds.Count || episodeIds.Any(id => !settledEpisodeIds.Contains(id));
+
+    /// <summary>
+    /// Maps a Jellyfin media segment type to the corresponding analysis mode.
+    /// </summary>
+    /// <param name="type">Media segment type.</param>
+    /// <returns>The corresponding <see cref="AnalysisMode"/>.</returns>
+    internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
+    {
+        return type switch
+        {
+            MediaSegmentType.Intro => AnalysisMode.Introduction,
+            MediaSegmentType.Recap => AnalysisMode.Recap,
+            MediaSegmentType.Preview => AnalysisMode.Preview,
+            MediaSegmentType.Outro => AnalysisMode.Credits,
+            MediaSegmentType.Commercial => AnalysisMode.Commercial,
+            _ => throw new NotImplementedException(),
+        };
+    }
+}

--- a/IntroSkipper/Data/SeasonQueueSnapshot.cs
+++ b/IntroSkipper/Data/SeasonQueueSnapshot.cs
@@ -13,7 +13,7 @@ namespace IntroSkipper.Data;
 /// <param name="AnalyzerActionByMode">Analyzer actions grouped by analysis mode.</param>
 /// <param name="SegmentsByEpisodeId">Existing segments grouped by episode and analysis mode.</param>
 /// <param name="UserProvidedByMode">User-provided episode identifiers grouped by analysis mode.</param>
-internal sealed record SeasonQueueSnapshot(
+public sealed record SeasonQueueSnapshot(
     IReadOnlyDictionary<AnalysisMode, IReadOnlySet<Guid>> EpisodeIdsByMode,
     IReadOnlyDictionary<AnalysisMode, string> ConfigHashByMode,
     IReadOnlyDictionary<AnalysisMode, AnalyzerAction> AnalyzerActionByMode,

--- a/IntroSkipper/Db/IIntroSkipperDatabase.cs
+++ b/IntroSkipper/Db/IIntroSkipperDatabase.cs
@@ -196,6 +196,17 @@ public interface IIntroSkipperDatabase
     Task<AnalyzerAction> GetAnalyzerActionAsync(Guid seasonId, AnalysisMode mode, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns a consistent snapshot of the season state and stored segments used by
+    /// queue verification, avoiding per-episode database lookups. The episode ID set is
+    /// bound as one JSON parameter, so the episode count is unbounded.
+    /// </summary>
+    /// <param name="seasonId">Season ID.</param>
+    /// <param name="episodeIds">Episode IDs in the season.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The season queue snapshot.</returns>
+    Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Clears the analyzed-episode lists of every mode for a season.
     /// </summary>
     /// <param name="seasonId">Season ID.</param>

--- a/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
@@ -236,16 +236,8 @@ public sealed partial class IntroSkipperDatabase
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Returns a consistent snapshot of the season state and stored segments used by
-    /// queue verification. Internal because <see cref="Data.SeasonQueueSnapshot"/> is an
-    /// internal type; end-state consumers receive this facade via constructor injection.
-    /// </summary>
-    /// <param name="seasonId">Season ID.</param>
-    /// <param name="episodeIds">Episode IDs in the season.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The season queue snapshot.</returns>
-    internal async Task<Data.SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
+    /// <inheritdoc/>
+    public async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
@@ -263,7 +255,7 @@ public sealed partial class IntroSkipperDatabase
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        return new Data.SeasonQueueSnapshot(
+        return new SeasonQueueSnapshot(
             seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
             seasonStates.ToDictionary(s => s.Type, s => s.ConfigHash),
             seasonStates.ToDictionary(s => s.Type, s => s.Action),

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -6,6 +6,7 @@
 
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using Jellyfin.Data.Enums;
@@ -32,13 +33,15 @@ namespace IntroSkipper.Manager;
 /// <param name="providerManager">Provider manager.</param>
 /// <param name="fileSystem">File system.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
-public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem, IFFmpegService ffmpegService)
+/// <param name="database">Segment database facade.</param>
+public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem, IFFmpegService ffmpegService, IIntroSkipperDatabase database)
 {
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IProviderManager _providerManager = providerManager;
     private readonly ILogger<QueueManager> _logger = logger;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly IIntroSkipperDatabase _database = database;
     private readonly Dictionary<Guid, List<QueuedEpisode>> _queuedEpisodes = [];
     private readonly HashSet<Guid> _refreshedEpisodes = [];
     private bool? _ffmpegValid;
@@ -445,7 +448,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var policy = ExclusionPolicy.FromConfiguration(plugin.Configuration);
         var ffmpegValid = await GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
-        var snapshot = await Plugin.GetSeasonQueueSnapshotAsync(candidates[0].SeasonId, [.. candidates.Select(c => c.EpisodeId)], cancellationToken).ConfigureAwait(false);
+        var snapshot = await _database.GetSeasonQueueSnapshotAsync(candidates[0].SeasonId, [.. candidates.Select(c => c.EpisodeId)], cancellationToken).ConfigureAwait(false);
 
         // The expected config hash depends on the season-level analyzer action and mode, not on the
         // individual episode, so compute it once per mode instead of once per episode and mode.

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -24,7 +24,6 @@ using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IntroSkipper;
 
@@ -33,11 +32,11 @@ namespace IntroSkipper;
 /// </summary>
 /// <remarks>
 /// All database access lives in <see cref="IIntroSkipperDatabase"/> and
-/// <see cref="IDetectionCacheDatabase"/>. The members below that touch the database are
-/// transitional delegating wrappers kept only for call sites that are still constructed
-/// manually (analyzers, <c>QueueManager</c>, <c>BaseItemAnalyzerTask</c>); they forward to
-/// a bridge facade instance and will be removed once those constructors take the facade
-/// directly.
+/// <see cref="IDetectionCacheDatabase"/>; every consumer receives the facades by
+/// constructor injection. The only database-related members left here are the
+/// transitional constructor bootstrap and the <see cref="CreateDbContext"/>/
+/// <see cref="CreateCacheDbContext"/> statics still used by tests; both are removed in
+/// the final transition phase.
 /// </remarks>
 public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
@@ -47,7 +46,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     private readonly ILogger<Plugin> _logger;
     private readonly string _dbPath;
     private readonly string _cacheDbPath;
-    private IntroSkipperDatabase? _segmentDatabase;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -173,14 +171,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public static Plugin? Instance { get; private set; }
 
     /// <summary>
-    /// Gets the transitional segment database bridge used by call sites that are not yet
-    /// constructor-injected. Resolves <see cref="DbPath"/> lazily on every operation, so
-    /// it always follows the current plugin instance.
-    /// </summary>
-    internal IntroSkipperDatabase SegmentDatabase =>
-        LazyInitializer.EnsureInitialized(ref _segmentDatabase, CreateSegmentDatabaseBridge);
-
-    /// <summary>
     /// Creates a new <see cref="IntroSkipperDbContext"/> instance configured for the plugin database.
     /// </summary>
     /// <returns>A new <see cref="IntroSkipperDbContext"/>.</returns>
@@ -234,20 +224,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? Array.Empty<ChapterInfo>();
 
-    internal Task UpdateTimestampAsync(
-        Segment segment,
-        AnalysisMode mode,
-        bool isUserProvided = false,
-        string configHash = "",
-        CancellationToken cancellationToken = default)
-        => SegmentDatabase.UpdateTimestampAsync(segment, mode, isUserProvided, configHash, cancellationToken);
-
-    internal static Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().GetSegmentsAsync(id, cancellationToken);
-
-    internal static Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().RemoveEpisodeIdAsync(seasonId, mode, episodeId, cancellationToken);
-
     /// <summary>
     /// Returns whether a settled-season analysis mode still needs re-analysis for its current episode
     /// set. Pure set comparison: the decision is committed separately via
@@ -274,22 +250,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             _ => throw new NotImplementedException(),
         };
     }
-
-    internal static Task DeleteTimestampAsync(
-        Guid itemId,
-        AnalysisMode mode,
-        Segment? segment = null,
-        CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().DeleteTimestampAsync(itemId, mode, segment, cancellationToken);
-
-    private static IntroSkipperDatabase RequireSegmentDatabase()
-    {
-        ArgumentNullException.ThrowIfNull(Instance);
-        return Instance.SegmentDatabase;
-    }
-
-    private IntroSkipperDatabase CreateSegmentDatabaseBridge()
-        => new(new IntroSkipperDbContextPathFactory(() => DbPath), (ILogger?)_logger ?? NullLogger.Instance);
 
     private void MigrateLegacyExcludeSeries()
     {

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -48,7 +48,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     private readonly string _dbPath;
     private readonly string _cacheDbPath;
     private IntroSkipperDatabase? _segmentDatabase;
-    private DetectionCacheDatabase? _cacheDatabase;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -182,14 +181,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         LazyInitializer.EnsureInitialized(ref _segmentDatabase, CreateSegmentDatabaseBridge);
 
     /// <summary>
-    /// Gets the transitional detection cache database bridge used by call sites that are
-    /// not yet constructor-injected. Resolves <see cref="CacheDbPath"/> lazily on every
-    /// operation, so it always follows the current plugin instance.
-    /// </summary>
-    internal DetectionCacheDatabase CacheDatabase =>
-        LazyInitializer.EnsureInitialized(ref _cacheDatabase, CreateCacheDatabaseBridge);
-
-    /// <summary>
     /// Creates a new <see cref="IntroSkipperDbContext"/> instance configured for the plugin database.
     /// </summary>
     /// <returns>A new <see cref="IntroSkipperDbContext"/>.</returns>
@@ -257,40 +248,13 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     internal static Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
         => RequireSegmentDatabase().GetSegmentsAsync(id, cancellationToken);
 
-    internal static Task DeleteItemSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().DeleteItemSegmentsAsync(itemId, cancellationToken);
-
-    internal static Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().CleanTimestampsAsync(episodeIds, cancellationToken);
-
-    internal static Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().SetAnalyzerActionAsync(id, analyzerActions, cancellationToken);
-
-    internal static Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().SetEpisodeIdsAsync(id, mode, episodeIds, configHash, cancellationToken);
-
     internal static Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
         => RequireSegmentDatabase().RemoveEpisodeIdAsync(seasonId, mode, episodeId, cancellationToken);
-
-    internal static Task CleanStaleAutomaticSegmentsAsync(
-        IEnumerable<Guid> itemIds,
-        AnalysisMode mode,
-        string configHash,
-        CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().CleanStaleAutomaticSegmentsAsync(itemIds, mode, configHash, cancellationToken);
-
-    internal static Task<IReadOnlyDictionary<AnalysisMode, IEnumerable<Guid>>> GetEpisodeIdsAsync(Guid id, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().GetEpisodeIdsAsync(id, cancellationToken);
-
-    internal static Task<IReadOnlyDictionary<AnalysisMode, (AnalyzerAction Action, IReadOnlySet<Guid> SettledReanalysisEpisodeIds)>> GetSettleReanalysisStatesAsync(
-        Guid seasonId,
-        CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().GetSettleReanalysisStatesAsync(seasonId, cancellationToken);
 
     /// <summary>
     /// Returns whether a settled-season analysis mode still needs re-analysis for its current episode
     /// set. Pure set comparison: the decision is committed separately via
-    /// <see cref="RecordSettleReanalysisAsync(Guid, IReadOnlyCollection{AnalysisMode}, IReadOnlyCollection{Guid}, CancellationToken)"/>
+    /// <see cref="IIntroSkipperDatabase.RecordSettleReanalysisAsync(Guid, IReadOnlyCollection{AnalysisMode}, IReadOnlyCollection{Guid}, CancellationToken)"/>
     /// once the reset has succeeded, so the completed episode set survives plugin restarts.
     /// </summary>
     /// <param name="settledEpisodeIds">Episode IDs recorded when the season was last settle-reanalyzed for this mode.</param>
@@ -301,31 +265,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         IReadOnlyCollection<Guid> episodeIds)
         => settledEpisodeIds.Count != episodeIds.Count || episodeIds.Any(id => !settledEpisodeIds.Contains(id));
 
-    internal static Task RecordSettleReanalysisAsync(
-        Guid seasonId,
-        IReadOnlyCollection<AnalysisMode> modes,
-        IReadOnlyCollection<Guid> episodeIds,
-        CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().RecordSettleReanalysisAsync(seasonId, modes, episodeIds, cancellationToken);
-
-    internal static Task ResetSeasonForReanalysisAsync(
-        Guid seasonId,
-        IEnumerable<Guid> episodeIds,
-        IReadOnlyCollection<AnalysisMode> modes,
-        CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().ResetSeasonForReanalysisAsync(seasonId, episodeIds, modes, cancellationToken);
-
     internal static Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
         => RequireSegmentDatabase().GetSeasonQueueSnapshotAsync(seasonId, episodeIds, cancellationToken);
-
-    internal static Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().GetAllAnalyzerActionsAsync(seasonId, cancellationToken);
-
-    internal static Task<AnalyzerAction> GetAnalyzerActionAsync(Guid id, AnalysisMode mode, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().GetAnalyzerActionAsync(id, mode, cancellationToken);
-
-    internal static Task CleanSeasonStateAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().CleanSeasonStateAsync(ids, cancellationToken);
 
     internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
     {
@@ -355,9 +296,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     private IntroSkipperDatabase CreateSegmentDatabaseBridge()
         => new(new IntroSkipperDbContextPathFactory(() => DbPath), (ILogger?)_logger ?? NullLogger.Instance);
-
-    private DetectionCacheDatabase CreateCacheDatabaseBridge()
-        => new(new DetectionCacheDbContextPathFactory(() => CacheDbPath), (ILogger?)_logger ?? NullLogger.Instance);
 
     private void MigrateLegacyExcludeSeries()
     {

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -12,7 +12,6 @@ using System.Collections.Concurrent;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
-using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller.Chapters;
@@ -22,8 +21,6 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
-using Microsoft.Data.Sqlite;
-using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper;
 
@@ -31,21 +28,16 @@ namespace IntroSkipper;
 /// Intro skipper plugin. Uses audio analysis to find common sequences of audio shared between episodes.
 /// </summary>
 /// <remarks>
-/// All database access lives in <see cref="IIntroSkipperDatabase"/> and
-/// <see cref="IDetectionCacheDatabase"/>; every consumer receives the facades by
-/// constructor injection. The only database-related members left here are the
-/// transitional constructor bootstrap and the <see cref="CreateDbContext"/>/
-/// <see cref="CreateCacheDbContext"/> statics still used by tests; both are removed in
-/// the final transition phase.
+/// This class contains no database code. All database access lives in
+/// <see cref="IIntroSkipperDatabase"/> and <see cref="IDetectionCacheDatabase"/>;
+/// every consumer receives the facades by constructor injection, and their
+/// initialization gates own the database lifecycle.
 /// </remarks>
-public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
+public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
     private readonly IPluginManager _pluginManager;
-    private readonly ILogger<Plugin> _logger;
-    private readonly string _dbPath;
-    private readonly string _cacheDbPath;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -56,15 +48,13 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="chapterRepository">Chapter repository.</param>
     /// <param name="pluginManager">Plugin manager.</param>
-    /// <param name="logger">Logger.</param>
     public Plugin(
         IApplicationPaths applicationPaths,
         IXmlSerializer xmlSerializer,
         IServerConfigurationManager serverConfiguration,
         ILibraryManager libraryManager,
         IChapterManager chapterRepository,
-        IPluginManager pluginManager,
-        ILogger<Plugin> logger)
+        IPluginManager pluginManager)
         : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
@@ -72,7 +62,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         _libraryManager = libraryManager;
         _chapterRepository = chapterRepository;
         _pluginManager = pluginManager;
-        _logger = logger;
 
         FFmpegPath = serverConfiguration.GetEncodingOptions().EncoderAppPathDisplay;
 
@@ -84,50 +73,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         var introsDirectory = IntroSkipperDatabasePaths.GetPluginDirectory(applicationPaths);
         FingerprintCachePath = Path.Join(introsDirectory, pluginCachePath);
 
-        _dbPath = Path.Join(introsDirectory, IntroSkipperDatabasePaths.SegmentDatabaseFileName);
-        _cacheDbPath = Path.Join(introsDirectory, IntroSkipperDatabasePaths.DetectionCacheDatabaseFileName);
-
-        // Initialize segment database.
-        try
-        {
-            using var db = CreateDbContext();
-            // Legacy databases may be missing migration history or columns that EF migrations expect.
-            // Normalize those schemas first so recovery does not log a false initialization failure.
-            db.EnsureLegacySchemaCompatibility();
-            db.ApplyMigrations();
-        }
-        catch (Exception ex)
-        {
-            LogDatabaseInitializationError(_logger, ex);
-        }
-
-        // Initialize detection cache database.
-        try
-        {
-            using var cacheDb = CreateCacheDbContext();
-            cacheDb.EnsureSchema();
-        }
-        catch (Exception ex) when (ex is IOException or SqliteException)
-        {
-            LogCacheDbInitializationError(_logger, ex);
-        }
-
         MigrateLegacyExcludeSeries();
 
         Configuration.FileTransformationPluginEnabled = _pluginManager
             .Plugins
             .Any(p => p.Id == Guid.Parse("5e87cc92-571a-4d8d-8d98-d2d4147f9f90")); // File Transformation plugin ID
     }
-
-    /// <summary>
-    /// Gets the path to the segment database.
-    /// </summary>
-    public string DbPath => _dbPath;
-
-    /// <summary>
-    /// Gets the path to the detection cache database.
-    /// </summary>
-    public string CacheDbPath => _cacheDbPath;
 
     /// <summary>
     /// Gets or sets a value indicating whether to analyze again.
@@ -170,28 +121,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public static Plugin? Instance { get; private set; }
 
-    /// <summary>
-    /// Creates a new <see cref="IntroSkipperDbContext"/> instance configured for the plugin database.
-    /// </summary>
-    /// <returns>A new <see cref="IntroSkipperDbContext"/>.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
-    public static IntroSkipperDbContext CreateDbContext()
-    {
-        ArgumentNullException.ThrowIfNull(Instance);
-        return new IntroSkipperDbContext(Instance.DbPath);
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="DetectionCacheDbContext"/> instance configured for the plugin cache database.
-    /// </summary>
-    /// <returns>A new <see cref="DetectionCacheDbContext"/>.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
-    public static DetectionCacheDbContext CreateCacheDbContext()
-    {
-        ArgumentNullException.ThrowIfNull(Instance);
-        return new DetectionCacheDbContext(Instance.CacheDbPath);
-    }
-
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {
@@ -224,33 +153,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? Array.Empty<ChapterInfo>();
 
-    /// <summary>
-    /// Returns whether a settled-season analysis mode still needs re-analysis for its current episode
-    /// set. Pure set comparison: the decision is committed separately via
-    /// <see cref="IIntroSkipperDatabase.RecordSettleReanalysisAsync(Guid, IReadOnlyCollection{AnalysisMode}, IReadOnlyCollection{Guid}, CancellationToken)"/>
-    /// once the reset has succeeded, so the completed episode set survives plugin restarts.
-    /// </summary>
-    /// <param name="settledEpisodeIds">Episode IDs recorded when the season was last settle-reanalyzed for this mode.</param>
-    /// <param name="episodeIds">Current episode IDs in the season.</param>
-    /// <returns><see langword="true"/> when a re-analysis should be performed; otherwise <see langword="false"/>.</returns>
-    internal static bool ShouldSettleReanalyze(
-        IReadOnlySet<Guid> settledEpisodeIds,
-        IReadOnlyCollection<Guid> episodeIds)
-        => settledEpisodeIds.Count != episodeIds.Count || episodeIds.Any(id => !settledEpisodeIds.Contains(id));
-
-    internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
-    {
-        return type switch
-        {
-            MediaSegmentType.Intro => AnalysisMode.Introduction,
-            MediaSegmentType.Recap => AnalysisMode.Recap,
-            MediaSegmentType.Preview => AnalysisMode.Preview,
-            MediaSegmentType.Outro => AnalysisMode.Credits,
-            MediaSegmentType.Commercial => AnalysisMode.Commercial,
-            _ => throw new NotImplementedException(),
-        };
-    }
-
     private void MigrateLegacyExcludeSeries()
     {
         var legacy = Configuration.ExcludeSeries;
@@ -270,10 +172,4 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         Configuration.ExcludeSeries = string.Empty;
         SaveConfiguration();
     }
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
-    private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
-    private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -242,9 +242,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         CancellationToken cancellationToken = default)
         => SegmentDatabase.UpdateTimestampAsync(segment, mode, isUserProvided, configHash, cancellationToken);
 
-    internal static Task<IReadOnlyDictionary<AnalysisMode, Segment>> GetTimestampsAsync(Guid id, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().GetTimestampsAsync(id, cancellationToken);
-
     internal static Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
         => RequireSegmentDatabase().GetSegmentsAsync(id, cancellationToken);
 
@@ -264,9 +261,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         IReadOnlySet<Guid> settledEpisodeIds,
         IReadOnlyCollection<Guid> episodeIds)
         => settledEpisodeIds.Count != episodeIds.Count || episodeIds.Any(id => !settledEpisodeIds.Contains(id));
-
-    internal static Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
-        => RequireSegmentDatabase().GetSeasonQueueSnapshotAsync(seasonId, episodeIds, cancellationToken);
 
     internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
     {

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -342,7 +342,7 @@ public partial class BaseItemAnalyzerTask(
         var analyzers = new List<IMediaFileAnalyzer>
         {
             // ChapterAnalyzer: supports all modes and content types
-            new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>(), _ffmpegService)
+            new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>(), _ffmpegService, _database)
         };
 
         if (mode is AnalysisMode.Credits)
@@ -352,7 +352,7 @@ public partial class BaseItemAnalyzerTask(
                 // Anime credits: Chromaprint before BlackFrame (fingerprint matching preferred)
                 if (ffmpegValid)
                 {
-                    analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService));
+                    analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService, _database));
                 }
 
                 analyzers.Add(CreateBlackFrameAnalyzer());
@@ -364,7 +364,7 @@ public partial class BaseItemAnalyzerTask(
 
                 if (!isMovie && ffmpegValid)
                 {
-                    analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService));
+                    analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService, _database));
                 }
             }
         }
@@ -373,13 +373,13 @@ public partial class BaseItemAnalyzerTask(
             // Introduction: Chromaprint is the only non-chapter analyzer
             if (!isMovie && ffmpegValid)
             {
-                analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService));
+                analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService, _database));
             }
         }
         else if (mode is AnalysisMode.Recap && !isMovie && ffmpegValid)
         {
             // Recap: Chromaprint can match the repeated "previously on" card/sting near the start.
-            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService));
+            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>(), _ffmpegService, _cacheService, _database));
         }
 
         // Preview, Commercial: only ChapterAnalyzer (already added above)
@@ -475,8 +475,8 @@ public partial class BaseItemAnalyzerTask(
     /// </summary>
     /// <returns>A <see cref="BlackFrameAnalyzer"/> or <see cref="CreditsBlackFrameAnalyzer"/> based on configuration.</returns>
     private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => _config.UseAlternativeBlackFrameAnalyzer
-        ? new CreditsBlackFrameAnalyzer(_loggerFactory.CreateLogger<CreditsBlackFrameAnalyzer>(), _ffmpegService)
-        : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>(), _ffmpegService);
+        ? new CreditsBlackFrameAnalyzer(_loggerFactory.CreateLogger<CreditsBlackFrameAnalyzer>(), _ffmpegService, _database)
+        : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>(), _ffmpegService, _database);
 
     /// <summary>
     /// Moves the first analyzer matching <paramref name="predicate"/> to the front of the list,

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -88,7 +88,8 @@ public partial class BaseItemAnalyzerTask(
             _libraryManager,
             _providerManager,
             _fileSystem,
-            _ffmpegService);
+            _ffmpegService,
+            _database);
 
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var ffmpegValid = await queueManager.GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -235,7 +235,7 @@ public partial class BaseItemAnalyzerTask(
             var action = stateExists ? state.Action : AnalyzerAction.Default;
             if (action != AnalyzerAction.None &&
                 CanSettleReanalysisRun(mode, action, ffmpegValid) &&
-                (!stateExists || Plugin.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds)))
+                (!stateExists || AnalysisHelpers.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds)))
             {
                 resetModes.Add(mode);
             }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -8,6 +8,7 @@
 using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
@@ -32,6 +33,7 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="cacheService">Detection cache service.</param>
+/// <param name="database">Segment database facade.</param>
 public partial class BaseItemAnalyzerTask(
     ILogger logger,
     ILoggerFactory loggerFactory,
@@ -40,7 +42,8 @@ public partial class BaseItemAnalyzerTask(
     IFileSystem fileSystem,
     IMediaSegmentRefresher mediaSegmentRefresher,
     IFFmpegService ffmpegService,
-    IDetectionCacheService cacheService)
+    IDetectionCacheService cacheService,
+    IIntroSkipperDatabase database)
 {
     /// <summary>
     /// Tolerance (seconds) when comparing an existing anime Preview's start to a newly-computed
@@ -57,6 +60,7 @@ public partial class BaseItemAnalyzerTask(
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly IIntroSkipperDatabase _database = database;
     private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
 
     /// <summary>
@@ -143,7 +147,7 @@ public partial class BaseItemAnalyzerTask(
                 {
                     var resetModes = ExpandSettledResetModesForDerivedSegments(settledResetModes, _config.AnimePreviewFromCreditsEnd);
                     LogReanalyzingSettledSeason(_logger, first.SeasonNumber, first.SeriesName, episodes.Count);
-                    await Plugin.ResetSeasonForReanalysisAsync(first.SeasonId, episodeIds, resetModes, ct).ConfigureAwait(false);
+                    await _database.ResetSeasonForReanalysisAsync(first.SeasonId, episodeIds, resetModes, ct).ConfigureAwait(false);
                     foreach (var episode in episodes)
                     {
                         foreach (var resetMode in resetModes)
@@ -168,7 +172,6 @@ public partial class BaseItemAnalyzerTask(
                 {
                     ct.ThrowIfCancellationRequested();
                     int analyzed = await AnalyzeItemsAsync(
-                        plugin,
                         episodes,
                         mode,
                         ffmpegValid,
@@ -210,20 +213,20 @@ public partial class BaseItemAnalyzerTask(
 
             if (completedSettledModes.Count > 0)
             {
-                await Plugin.RecordSettleReanalysisAsync(first.SeasonId, completedSettledModes, episodeIds, ct).ConfigureAwait(false);
+                await _database.RecordSettleReanalysisAsync(first.SeasonId, completedSettledModes, episodeIds, ct).ConfigureAwait(false);
             }
         }).ConfigureAwait(false);
         plugin.AnalyzeAgain = false;
     }
 
-    private static async Task<IReadOnlyList<AnalysisMode>> GetSettleReanalysisModesAsync(
+    private async Task<IReadOnlyList<AnalysisMode>> GetSettleReanalysisModesAsync(
         Guid seasonId,
         IReadOnlyCollection<Guid> episodeIds,
         IReadOnlyCollection<AnalysisMode> modes,
         bool ffmpegValid,
         CancellationToken cancellationToken)
     {
-        var settleReanalysisStates = await Plugin.GetSettleReanalysisStatesAsync(seasonId, cancellationToken).ConfigureAwait(false);
+        var settleReanalysisStates = await _database.GetSettleReanalysisStatesAsync(seasonId, cancellationToken).ConfigureAwait(false);
         var resetModes = new List<AnalysisMode>(modes.Count);
         foreach (var mode in modes)
         {
@@ -283,14 +286,12 @@ public partial class BaseItemAnalyzerTask(
     /// <summary>
     /// Analyze a group of media items for skippable segments.
     /// </summary>
-    /// <param name="plugin">Plugin instance.</param>
     /// <param name="items">Media items to analyze.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="ffmpegValid">Whether FFmpeg supports the required Chromaprint features.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Number of items successfully analyzed.</returns>
     private async Task<int> AnalyzeItemsAsync(
-        Plugin plugin,
         IReadOnlyList<QueuedEpisode> items,
         AnalysisMode mode,
         bool ffmpegValid,
@@ -312,7 +313,7 @@ public partial class BaseItemAnalyzerTask(
         }
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
-        var action = await Plugin.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
+        var action = await _database.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
         var configHash = ConfigHasher.Analysis(_config, mode, action, ffmpegValid);
 
         if (action == AnalyzerAction.None)
@@ -326,7 +327,7 @@ public partial class BaseItemAnalyzerTask(
             item.AnalysisConfigHash = configHash;
         }
 
-        await Plugin.CleanStaleAutomaticSegmentsAsync(
+        await _database.CleanStaleAutomaticSegmentsAsync(
             items.Where(e => e.GetAnalyzed(mode) != EpisodeState.UserProvided).Select(e => e.EpisodeId),
             mode,
             configHash,
@@ -416,11 +417,11 @@ public partial class BaseItemAnalyzerTask(
         // For anime, optionally create a Preview segment from the end of credits to the end of the episode.
         if (mode == AnalysisMode.Credits && isAnime && _config.AnimePreviewFromCreditsEnd)
         {
-            await CreateAnimePreviewFromCreditsAsync(plugin, items, cancellationToken).ConfigureAwait(false);
+            await CreateAnimePreviewFromCreditsAsync(items, cancellationToken).ConfigureAwait(false);
         }
 
         // Set the episode IDs for the analyzed items
-        await Plugin.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), configHash, cancellationToken).ConfigureAwait(false);
+        await _database.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), configHash, cancellationToken).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
     }
@@ -496,11 +497,9 @@ public partial class BaseItemAnalyzerTask(
     /// <summary>
     /// For anime episodes, creates or refreshes a Preview segment covering the remaining content after the credits end.
     /// </summary>
-    /// <param name="plugin">Plugin instance.</param>
     /// <param name="items">Media items to process.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     private async Task CreateAnimePreviewFromCreditsAsync(
-        Plugin plugin,
         IReadOnlyList<QueuedEpisode> items,
         CancellationToken cancellationToken)
     {
@@ -514,7 +513,7 @@ public partial class BaseItemAnalyzerTask(
             // Use GetSegmentsAsync (not GetTimestampsAsync) so we can see IsUserProvided.
             // UpdateTimestampAsync silently no-ops when a user-provided Preview exists, which would
             // otherwise leave us emitting a misleading "Created anime preview" log + Analyzed state.
-            var dbSegments = await Plugin.GetSegmentsAsync(episode.EpisodeId, cancellationToken).ConfigureAwait(false);
+            var dbSegments = await _database.GetSegmentsAsync(episode.EpisodeId, cancellationToken).ConfigureAwait(false);
 
             if (dbSegments.Any(s => s.Type == AnalysisMode.Preview && s.IsUserProvided))
             {
@@ -532,7 +531,7 @@ public partial class BaseItemAnalyzerTask(
                 continue;
             }
 
-            await plugin.UpdateTimestampAsync(preview, AnalysisMode.Preview, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _database.UpdateTimestampAsync(preview, AnalysisMode.Preview, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
             episode.SetAnalyzed(AnalysisMode.Preview, EpisodeState.Analyzed);
 
             LogCreatedAnimePreview(_logger, episode.Name, preview.Start, preview.End);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -89,7 +89,8 @@ public partial class CleanCacheTask(
             _libraryManager,
             _providerManager,
             _fileSystem,
-            _ffmpegService);
+            _ffmpegService,
+            _database);
 
         // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders.

--- a/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
+++ b/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
@@ -4,6 +4,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Kilian von Pflugk
 // SPDX-License-Identifier: GPL-3.0-only
 
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
 using IntroSkipper.Services;
@@ -29,6 +30,7 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="cacheService">Detection cache service.</param>
+/// <param name="database">Segment database facade.</param>
 public partial class DetectSegmentsTask(
     ILogger<DetectSegmentsTask> logger,
     ILoggerFactory loggerFactory,
@@ -37,7 +39,8 @@ public partial class DetectSegmentsTask(
     IFileSystem fileSystem,
     IMediaSegmentRefresher mediaSegmentRefresher,
     IFFmpegService ffmpegService,
-    IDetectionCacheService cacheService) : IScheduledTask
+    IDetectionCacheService cacheService,
+    IIntroSkipperDatabase database) : IScheduledTask
 {
     private readonly ILogger<DetectSegmentsTask> _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
@@ -47,6 +50,7 @@ public partial class DetectSegmentsTask(
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly IIntroSkipperDatabase _database = database;
 
     /// <summary>
     /// Gets the task name.
@@ -100,7 +104,8 @@ public partial class DetectSegmentsTask(
                 _fileSystem,
                 _mediaSegmentRefresher,
                 _ffmpegService,
-                _cacheService);
+                _cacheService,
+                _database);
 
             await baseIntroAnalyzer.AnalyzeItemsAsync(progress, cancellationToken).ConfigureAwait(false);
         }

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Loader;
 using IntroSkipper.Configuration;
+using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
@@ -41,6 +42,7 @@ namespace IntroSkipper.Services
         private readonly ILogger<Entrypoint> _logger;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IMediaSegmentRefresher _mediaSegmentRefresher;
+        private readonly IIntroSkipperDatabase _database;
         private readonly HashSet<Guid> _seasonsToAnalyze = [];
         private readonly object _seasonsLock = new();
         private readonly Timer _queueTimer;
@@ -61,6 +63,7 @@ namespace IntroSkipper.Services
         /// <param name="logger">Logger.</param>
         /// <param name="loggerFactory">Logger factory.</param>
         /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
+        /// <param name="database">Segment database facade.</param>
         public Entrypoint(
             ILibraryManager libraryManager,
             IProviderManager providerManager,
@@ -70,7 +73,8 @@ namespace IntroSkipper.Services
             IFFmpegService ffmpegService,
             ILogger<Entrypoint> logger,
             ILoggerFactory loggerFactory,
-            IMediaSegmentRefresher mediaSegmentRefresher)
+            IMediaSegmentRefresher mediaSegmentRefresher,
+            IIntroSkipperDatabase database)
         {
             _libraryManager = libraryManager;
             _providerManager = providerManager;
@@ -81,6 +85,7 @@ namespace IntroSkipper.Services
             _logger = logger;
             _loggerFactory = loggerFactory;
             _mediaSegmentRefresher = mediaSegmentRefresher;
+            _database = database;
 
             _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
             _queueTimer = new Timer(
@@ -353,7 +358,7 @@ namespace IntroSkipper.Services
 
                         _analyzeAgain = false;
 
-                        var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentRefresher, _ffmpegService, _cacheService);
+                        var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentRefresher, _ffmpegService, _cacheService, _database);
                         await analyzer.AnalyzeItemsAsync(new Progress<double>(), cts.Token, seasonIds).ConfigureAwait(false);
 
                         if (_analyzeAgain && !cts.IsCancellationRequested)

--- a/docs/db-redesign/theory-b.md
+++ b/docs/db-redesign/theory-b.md
@@ -655,3 +655,50 @@ made per-instance, see §12.3), `Db/IntroSkipperDatabase.cs` +
 no existing test modified).
 Verification: `dotnet build IntroSkipper.sln` 0 warnings/errors; full suite 411/412 —
 sole failure remains the known environmental `TestSilenceDetection`.
+
+---
+
+## 13. Phase 3 — constructor threading (final-plan Plan 1, Phase 3)
+
+Purely mechanical: every manually-constructed consumer now receives
+`IIntroSkipperDatabase` by constructor threading from DI-resolved roots, and the
+transitional `Plugin` delegators are gone. Landed as three commits, each deleting the
+delegators it made call-less (grep-verified per commit).
+
+**Threaded constructors** (parameter `IIntroSkipperDatabase database` appended):
+
+- `BaseItemAnalyzerTask` — forwarded by its three DI-resolved creators
+  (`DetectSegmentsTask`, `Entrypoint`, `VisualizationController.ScanSeason`).
+- `QueueManager` — forwarded by `BaseItemAnalyzerTask`, `CleanCacheTask`,
+  `VisualizationController`. `SeasonQueueSnapshot` promoted to `public` and
+  `GetSeasonQueueSnapshotAsync` lifted onto `IIntroSkipperDatabase` (resolves R9;
+  the §2a inventory is now fully represented on the interface).
+- Analyzers `ChromaprintAnalyzer`, `ChapterAnalyzer`, `BlackFrameAnalyzer`,
+  `CreditsBlackFrameAnalyzer` — created by `BaseItemAnalyzerTask`, facade parameter
+  alongside the existing `IFFmpegService`/`IDetectionCacheService` parameters.
+- `SegmentEditorController` — DI-resolved, injected directly.
+- `RecapDetectionHelper` (static) — receives the facade as a method argument from its
+  analyzer callers.
+
+**Deleted from `Plugin`**: all remaining DB delegators — `UpdateTimestampAsync`,
+`GetTimestampsAsync`, `GetSegmentsAsync`, `DeleteItemSegmentsAsync`,
+`CleanTimestampsAsync`, `SetAnalyzerActionAsync`, `SetEpisodeIdsAsync`,
+`RemoveEpisodeIdAsync`, `CleanStaleAutomaticSegmentsAsync`, `GetEpisodeIdsAsync`,
+`GetSettleReanalysisStatesAsync`, `RecordSettleReanalysisAsync`,
+`ResetSeasonForReanalysisAsync`, `GetSeasonQueueSnapshotAsync`,
+`GetAllAnalyzerActionsAsync`, `GetAnalyzerActionAsync`, `CleanSeasonStateAsync`,
+`DeleteTimestampAsync` — plus the now-unreferenced bridge surface
+(`SegmentDatabase`/`CacheDatabase` properties, `RequireSegmentDatabase`, the bridge
+factory methods and their lazy fields). Still present for Phase 4: the ctor bootstrap
+and the `CreateDbContext`/`CreateCacheDbContext` statics (referenced by the bootstrap
+and by tests), and the pure functions `ShouldSettleReanalyze`/`MapSegmentTypeToMode`.
+
+Tests that previously exercised the delegators now construct facades over the same
+temp-file SQLite databases (`DatabaseTestHelpers.CreateSegmentDatabase`, new
+`CreateTempSegmentDatabase` for analyzer constructions that never reach the DB); no
+test was weakened.
+
+Verification per commit and at the end: `dotnet build IntroSkipper.sln` 0
+warnings/errors; full suite 411/412 — sole failure remains the known environmental
+`TestSilenceDetection`; `git grep "Plugin\.\(Get\|Set\|Update\|Delete\|Clean\|Record\|Reset\|Remove\)" IntroSkipper/`
+returns no DB-delegator call sites.

--- a/docs/db-redesign/theory-b.md
+++ b/docs/db-redesign/theory-b.md
@@ -26,9 +26,10 @@ Principles:
    user-provided segments are never overwritten by analysis results, and auto-detected
    credits must not overlap the stored intro — live inside
    `IntroSkipperDatabase.UpdateTimestampAsync`, exactly where they lived in `Plugin`.
-   No caller can reach a `DbContext` and bypass them (in the end state; see §3).
+   No caller can reach a `DbContext` and bypass them (end state reached in Phase 4;
+   see §14).
 3. **Stateless services.** Each operation creates a fresh short-lived context from the
-   injected factory — identical to the current `using var db = Plugin.CreateDbContext()`
+   injected factory — identical to the pre-redesign `using var db = Plugin.CreateDbContext()`
    discipline, so the concurrency model is unchanged. The only state is a one-shot
    initialization gate (§5).
 4. **Lifecycle is part of the facade.** Migrations, legacy schema repair,
@@ -55,8 +56,8 @@ Db/
   IDetectionCacheDatabase.cs
   DetectionCacheDatabase.cs               single file; the cache is 8 methods
   IntroSkipperDatabasePaths.cs            single source of truth for DB file paths
-  IntroSkipperDbContextPathFactory.cs     transitional/test factory (path resolved lazily)
-  DetectionCacheDbContextPathFactory.cs   transitional/test factory
+  IntroSkipperDbContextPathFactory.cs     test factory (path resolved lazily; test-only since Phase 4)
+  DetectionCacheDbContextPathFactory.cs   test factory (test-only since Phase 4)
 ```
 
 Conventions that keep a ~23-method interface maintainable:
@@ -124,7 +125,7 @@ through the constructor chain (§3).
 | `GetAnalyzerActionAsync` | `IIntroSkipperDatabase.GetAnalyzerActionAsync` | bridge (`BaseItemAnalyzerTask`) |
 | `CleanSeasonStateAsync` | `IIntroSkipperDatabase.CleanSeasonStateAsync` | `CleanCacheTask` injected |
 | `DeleteTimestampAsync` | `IIntroSkipperDatabase.DeleteTimestampAsync` | bridge (`SegmentEditorController`) |
-| `ShouldSettleReanalyze`, `MapSegmentTypeToMode` | stay on `Plugin` — pure functions, no DB access | n/a |
+| `ShouldSettleReanalyze`, `MapSegmentTypeToMode` | pure functions, no DB access — stayed on `Plugin` through Phase 3, moved to `IntroSkipper.Data.AnalysisHelpers` in Phase 4 | done (§14) |
 
 ### 2b. Direct `CreateDbContext()` / `CreateCacheDbContext()` call sites
 
@@ -148,7 +149,7 @@ through the constructor chain (§3).
 `Plugin.CreateCacheDbContext()` references remain in it. Serialization/compression and
 config-hash policy stay in the service; the facade is purely the DB boundary.
 
-### 2c. End state (zero DB code in `Plugin`)
+### 2c. End state (zero DB code in `Plugin`) — **reached in Phase 4 (§14)**
 
 Delete from `Plugin`: all wrappers in §2a, `SegmentDatabase`/`CacheDatabase` bridge
 properties, `CreateDbContext`/`CreateCacheDbContext`, the ctor DB bootstrap, and the
@@ -216,11 +217,12 @@ Notes:
   `IDbContextFactory<TContext>`) are keyed by our context types, so registering them in
   Jellyfin's host container cannot collide with Jellyfin's own EF registrations.
 
-Transitional bridge: `Plugin.SegmentDatabase` / `Plugin.CacheDatabase` are lazily
+Transitional bridge (**deleted**: bridge in Phase 3, remaining `Plugin` DB surface in
+Phase 4, §14): `Plugin.SegmentDatabase` / `Plugin.CacheDatabase` were lazily
 created facade instances over `IntroSkipperDbContextPathFactory(() => DbPath)`. The
-facades are stateless, so the DI instance and the bridge instance coexist safely (same
-file, same pragmas, same short-lived contexts as today). The bridge disappears in the
-end state.
+facades are stateless, so the DI instance and the bridge instance coexisted safely
+(same file, same pragmas, same short-lived contexts). The DI-registered facades are now
+the only production instances.
 
 ---
 
@@ -262,7 +264,9 @@ deliberate parity decision, recorded as risk R4.
 `Database.Migrate()` which is idempotent, and `EnsureLegacySchemaCompatibility` is
 written to be re-runnable). Tests prove the gate alone is sufficient
 (`InitializationGate_CreatesSchemaBeforeFirstQuery` runs the facade against a virgin
-file with no ctor bootstrap at all). The end state deletes the ctor bootstrap.
+file with no ctor bootstrap at all). The end state deletes the ctor bootstrap —
+**done in Phase 4 (§14)**; the facade gates (plus the gated factories of §12.3) are now
+the sole initialization path.
 
 **Rebuild and legacy repair** keep working unchanged: `RebuildDatabaseAsync(bool, ct)`
 wraps the existing context-level salvage flow, passing `_contextFactory.CreateDbContext`
@@ -702,3 +706,75 @@ Verification per commit and at the end: `dotnet build IntroSkipper.sln` 0
 warnings/errors; full suite 411/412 — sole failure remains the known environmental
 `TestSilenceDetection`; `git grep "Plugin\.\(Get\|Set\|Update\|Delete\|Clean\|Record\|Reset\|Remove\)" IntroSkipper/`
 returns no DB-delegator call sites.
+
+---
+
+## 14. Phase 4 — kill the transitional surface (final-plan Plan 1, Phase 4)
+
+The end state of §2c is reached: `Plugin.cs` contains **zero database code** — no
+contexts, no statics, no bootstrap, no paths. Verified by
+`grep -nE "DbContext|DbSegment|DbSeasonState|CreateCacheDb" IntroSkipper/Plugin.cs`
+(zero matches) and `git grep "Plugin\.CreateDbContext\|Plugin\.CreateCacheDbContext"`
+(zero code matches, tests included).
+
+**Deleted from `Plugin`:**
+
+- The constructor DB bootstrap (both try/catch init blocks) and its two
+  `LoggerMessage` definitions (`LogDatabaseInitializationError`,
+  `LogCacheDbInitializationError`). With them gone, the `ILogger<Plugin>` constructor
+  parameter and `_logger` field had no remaining readers and were removed too; the
+  class is no longer `partial` (the partial existed only for the LoggerMessage source
+  generator). The facade init gates — eagerly driven by
+  `IntroSkipperDatabaseInitializer` and structurally enforced by the gated factories
+  (§12.3) — are the sole initialization path; `InitializationGate_CreatesSchemaBeforeFirstQuery`
+  and `TestGatedContextFactories` already pin that the gates alone are sufficient, so
+  no bootstrap-equivalent test was needed.
+- `CreateDbContext()` / `CreateCacheDbContext()` statics, and the `_dbPath` /
+  `_cacheDbPath` fields with their `DbPath` / `CacheDbPath` properties. No production
+  code read the paths (DI resolves them via `IntroSkipperDatabasePaths` +
+  `IApplicationPaths`); the only consumers were tests (below). The
+  `IntroSkipperDatabasePaths.GetPluginDirectory` call stays in the ctor because
+  `FingerprintCachePath` (a non-DB concern) still lives under the plugin data
+  directory; the facades' initialization independently ensures the directory for the
+  database files.
+
+**Helper move (zero behavior change):** the pure functions `MapSegmentTypeToMode` and
+`ShouldSettleReanalyze` moved verbatim to the new internal static class
+`IntroSkipper.Data.AnalysisHelpers` (naming per `TimeRangeHelpers`). Callers updated:
+`SegmentEditorController`, `BaseItemAnalyzerTask`, and the season-reanalysis tests.
+
+**Test migration** (no assertion weakened; test count unchanged at 412):
+
+- `DatabaseTestHelpers` lost the `CreatePluginBound*` lazy-`Plugin.Instance`-path
+  variants and gained explicit-path equivalents: `CreateCacheService(dbPath)`,
+  `CreateTempCacheService()`, `CreateTempCacheDbPath()`. Facades/services in tests are
+  now always bound to explicit temp-file paths — the same pattern the facade tests
+  used since Phase 1.
+- `EntrypointTestHelpers.PluginInstanceScope` no longer reflects `_cacheDbPath` onto
+  the uninitialized `Plugin`; it still owns/creates the cache DB file and exposes
+  `CacheDbPath`, and still sets `FingerprintCachePath`/configuration (the
+  configuration-scoped reflection use, which stays by design). `CreateEntrypoint`
+  takes an optional `cacheDbPath` so entrypoint tests bind the cache service to the
+  scope's database explicitly.
+- Every test-side `Plugin.CreateCacheDbContext()` became
+  `new DetectionCacheDbContext(<explicit path>)`
+  (`TestCacheOperations`, `TestEntrypointEvents`, `TestVisualizationController`,
+  `TestSeasonReanalysis`), and controller tests
+  (`TestSkipIntroController`, `TestVisualizationController`) construct their facades
+  over the test's `dbPath`/`scope.CacheDbPath` directly instead of routing through
+  `Plugin.Instance`.
+- Reflection writes of `_dbPath`/`_logger` onto `Plugin` (vestigial from the
+  delegator era — the facades under test already receive their paths explicitly) were
+  removed, along with `PluginInstanceScope` wrappers that existed *only* to carry
+  `_dbPath`. Scopes that provide configuration/`FingerprintCachePath`/library-manager
+  state (e.g. the `QueueManager` and controller tests) remain.
+
+**End-state confirmation:** the §2c checklist is complete — facades own all DB access
+and lifecycle; manually-constructed consumers receive `IIntroSkipperDatabase` by
+constructor threading (§13); `Plugin.Instance` survives only for configuration/paths
+(separate follow-up per the final plan). The transition-state notes in §2c, §3, and §4
+are updated above.
+
+Verification: `dotnet build IntroSkipper.sln` 0 warnings/errors; full suite 411/412 —
+sole failure remains the known environmental `TestSilenceDetection`; acceptance greps
+above return zero matches.


### PR DESCRIPTION
This PR threads `IIntroSkipperDatabase` into every manually-constructed consumer (BaseItemAnalyzerTask, QueueManager, analyzers, SegmentEditorController) and replaces their `Plugin.*` database calls with direct facade calls, removing all transitional delegators from production code.

- **BaseItemAnalyzerTask group**: Adds `IIntroSkipperDatabase` constructor parameter forwarded by DetectSegmentsTask, Entrypoint, and VisualizationController; replaces calls to `ResetSeasonForReanalysisAsync`, `RecordSettleReanalysisAsync`, `GetSettleReanalysisStatesAsync`, `GetAnalyzerActionAsync`, `CleanStaleAutomaticSegmentsAsync`, and `SetEpisodeIdsAsync` with facade calls; deletes the six now-call-less delegators plus six unused ones and the `CacheDatabase` bridge.

- **QueueManager group**: Adds `IIntroSkipperDatabase` constructor parameter forwarded by BaseItemAnalyzerTask, CleanCacheTask, and VisualizationController; promotes `SeasonQueueSnapshot` to public and lifts `GetSeasonQueueSnapshotAsync` onto `IIntroSkipperDatabase`; wires `RecapDetectionHelper` via method argument; deletes `GetTimestampsAsync` and `GetSeasonQueueSnapshotAsync` delegators.

- **Analyzers + SegmentEditorController**: Adds `IIntroSkipperDatabase` parameter to ChromaprintAnalyzer, ChapterAnalyzer, BlackFrameAnalyzer, and CreditsBlackFrameAnalyzer (created by BaseItemAnalyzerTask); injects facade directly into DI-resolved SegmentEditorController; replaces all remaining delegator calls (`UpdateTimestampAsync`, `GetSegmentsAsync`, `DeleteTimestampAsync`, `RemoveEpisodeIdAsync`); deletes the delegators and the segment DB bridge.

Tests updated to use real facades over temp-file databases rather than Plugin delegators. Acceptance checks: 0 build warnings/errors; 411/412 tests passing (known environmental failure); no delegator calls remain in production code.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-064" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064"><img alt="INTRO-064" src="https://capy.ai/api/badge/thread.svg?label=INTRO-064"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Thread IIntroSkipperDatabase into all manually constructed consumers and remove remaining Plugin database delegator methods in favor of direct facade usage.

Enhancements:
- Inject IIntroSkipperDatabase into BaseItemAnalyzerTask, QueueManager, analyzers, SegmentEditorController, Entrypoint, DetectSegmentsTask, CleanCacheTask, and RecapDetectionHelper to centralize DB access behind the facade.
- Promote SeasonQueueSnapshot to a public record and expose GetSeasonQueueSnapshotAsync via IIntroSkipperDatabase for queue verification.
- Adjust tests to construct IntroSkipperDatabase facades (including temp-file variants) instead of relying on Plugin DB delegators, keeping coverage intact.

Documentation:
- Document Phase 3 of the DB redesign plan, describing constructor threading of IIntroSkipperDatabase and removal of Plugin delegators.