### PR TITLE
refactor(plugin): delete DB bootstrap and helpers

### DIFF
--- a/IntroSkipper.Tests/DatabaseTestHelpers.cs
+++ b/IntroSkipper.Tests/DatabaseTestHelpers.cs
@@ -27,7 +27,7 @@ internal static class DatabaseTestHelpers
     /// </summary>
     /// <returns>The segment database facade.</returns>
     internal static IntroSkipperDatabase CreateTempSegmentDatabase()
-        => CreateSegmentDatabase(Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + ".db"));
+        => CreateSegmentDatabase(CreateTempDbPath(Guid.NewGuid().ToString("N") + ".db"));
 
     internal static DetectionCacheDatabase CreateCacheDatabase(string dbPath)
         => new(new DetectionCacheDbContextPathFactory(() => dbPath), NullLogger.Instance);
@@ -41,7 +41,7 @@ internal static class DatabaseTestHelpers
     /// </summary>
     /// <returns>The cache database path.</returns>
     internal static string CreateTempCacheDbPath()
-        => Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + "-cache.db");
+        => CreateTempDbPath(Guid.NewGuid().ToString("N") + "-cache.db");
 
     /// <summary>
     /// Creates a detection cache service over a fresh temp-file path, for consumers
@@ -51,4 +51,17 @@ internal static class DatabaseTestHelpers
     /// <returns>The detection cache service.</returns>
     internal static DetectionCacheService CreateTempCacheService()
         => CreateCacheService(CreateTempCacheDbPath());
+
+    /// <summary>
+    /// Returns a database path under the shared test temp directory, creating the
+    /// directory so SQLite can open the file regardless of which test runs first.
+    /// </summary>
+    /// <param name="fileName">Database file name.</param>
+    /// <returns>The database path.</returns>
+    private static string CreateTempDbPath(string fileName)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, fileName);
+    }
 }

--- a/IntroSkipper.Tests/DatabaseTestHelpers.cs
+++ b/IntroSkipper.Tests/DatabaseTestHelpers.cs
@@ -10,10 +10,10 @@ using IntroSkipper.FFmpeg;
 using Microsoft.Extensions.Logging.Abstractions;
 
 /// <summary>
-/// Helpers for constructing the database facades in tests. The plugin-bound variants
-/// resolve the database path from <see cref="Plugin.Instance"/> lazily on every
-/// operation, matching the way tests swap plugin instances and paths via
-/// <see cref="EntrypointTestHelpers.PluginInstanceScope"/>.
+/// Helpers for constructing the database facades in tests over explicit temp-file
+/// SQLite paths. Tests that scope <see cref="Plugin.Instance"/> via
+/// <see cref="EntrypointTestHelpers.PluginInstanceScope"/> pass the scope's cache
+/// database path (<c>scope.CacheDbPath</c>) explicitly.
 /// </summary>
 internal static class DatabaseTestHelpers
 {
@@ -32,15 +32,23 @@ internal static class DatabaseTestHelpers
     internal static DetectionCacheDatabase CreateCacheDatabase(string dbPath)
         => new(new DetectionCacheDbContextPathFactory(() => dbPath), NullLogger.Instance);
 
-    internal static IntroSkipperDatabase CreatePluginBoundSegmentDatabase()
-        => new(new IntroSkipperDbContextPathFactory(() => RequirePlugin().DbPath), NullLogger.Instance);
+    internal static DetectionCacheService CreateCacheService(string dbPath)
+        => new(NullLogger<DetectionCacheService>.Instance, CreateCacheDatabase(dbPath));
 
-    internal static DetectionCacheDatabase CreatePluginBoundCacheDatabase()
-        => new(new DetectionCacheDbContextPathFactory(() => RequirePlugin().CacheDbPath), NullLogger.Instance);
+    /// <summary>
+    /// Creates a fresh temp-file cache database path. The file is only created when a
+    /// context or facade actually operates on it.
+    /// </summary>
+    /// <returns>The cache database path.</returns>
+    internal static string CreateTempCacheDbPath()
+        => Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid().ToString("N") + "-cache.db");
 
-    internal static DetectionCacheService CreatePluginBoundCacheService()
-        => new(NullLogger<DetectionCacheService>.Instance, CreatePluginBoundCacheDatabase());
-
-    private static Plugin RequirePlugin()
-        => Plugin.Instance ?? throw new InvalidOperationException("Plugin.Instance is not set.");
+    /// <summary>
+    /// Creates a detection cache service over a fresh temp-file path, for consumers
+    /// whose tests never reach the cache database (e.g. fingerprint caching disabled).
+    /// The file is only created if a cache operation is actually performed.
+    /// </summary>
+    /// <returns>The detection cache service.</returns>
+    internal static DetectionCacheService CreateTempCacheService()
+        => CreateCacheService(CreateTempCacheDbPath());
 }

--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -30,7 +30,7 @@ internal static class EntrypointTestHelpers
 {
     internal static readonly byte[] EmptyJsonArray = Encoding.UTF8.GetBytes("[]");
 
-    internal static Entrypoint CreateEntrypoint(bool autoDetectIntros)
+    internal static Entrypoint CreateEntrypoint(bool autoDetectIntros, string? cacheDbPath = null)
     {
         // Entrypoint's ctor reads Plugin.Instance?.Configuration. Ensure Plugin.Instance is null during construction.
         using var _ = new PluginInstanceNullScope();
@@ -43,12 +43,14 @@ internal static class EntrypointTestHelpers
             providerManager: null!,
             fileSystem: null!,
             taskManager: null!,
-            cacheService: DatabaseTestHelpers.CreatePluginBoundCacheService(),
+            cacheService: cacheDbPath is null
+                ? DatabaseTestHelpers.CreateTempCacheService()
+                : DatabaseTestHelpers.CreateCacheService(cacheDbPath),
             ffmpegService: null!,
             logger: logger,
             loggerFactory: loggerFactory,
             mediaSegmentRefresher: new FakeMediaSegmentRefresher(),
-            database: DatabaseTestHelpers.CreatePluginBoundSegmentDatabase());
+            database: DatabaseTestHelpers.CreateTempSegmentDatabase());
 
         SetPrivateField(entrypoint, "_config", new PluginConfiguration { AutoDetectIntros = autoDetectIntros });
         return entrypoint;
@@ -237,7 +239,6 @@ internal static class EntrypointTestHelpers
 #pragma warning restore SYSLIB0050
 
             SetPropertyOrField(plugin, "FingerprintCachePath", CacheDir);
-            SetPropertyOrField(plugin, "_cacheDbPath", CacheDbPath);
 
             // Plugin.Instance has a private setter; invoke it via reflection.
             var setter = instanceProp.SetMethod ?? instanceProp.GetSetMethod(nonPublic: true);

--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -245,7 +245,9 @@ internal static class EntrypointTestHelpers
             Assert.NotNull(setter);
             setter!.Invoke(null, [plugin]);
 
-            // Ensure the schema exists so tests can write to the cache DB.
+            // Ensure the schema exists so tests can write to the cache DB. Create the
+            // containing directory first so this scope works regardless of test order.
+            Directory.CreateDirectory(Path.GetDirectoryName(CacheDbPath)!);
             using var cacheDb = new IntroSkipper.Db.DetectionCacheDbContext(CacheDbPath);
             cacheDb.EnsureSchema();
         }

--- a/IntroSkipper.Tests/TestAudioFingerprinting.cs
+++ b/IntroSkipper.Tests/TestAudioFingerprinting.cs
@@ -162,7 +162,7 @@ public class TestAudioFingerprinting
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            DatabaseTestHelpers.CreatePluginBoundCacheService());
+            DatabaseTestHelpers.CreateTempCacheService());
     }
 
     private static ChromaprintAnalyzer CreateChromaprintAnalyzer()

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1801,7 +1801,7 @@ public class TestBlackFrames
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            DatabaseTestHelpers.CreatePluginBoundCacheService());
+            DatabaseTestHelpers.CreateTempCacheService());
     }
 
     private static BlackFrameAnalyzer CreateBlackFrameAnalyzer()

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -45,7 +45,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.AddRange(shouldKeep);
             db.DetectionCache.AddRange(shouldDelete);
@@ -57,7 +57,7 @@ public sealed class TestCacheOperations
             cachingScope.CacheService.DeleteByMode(AnalysisMode.Introduction);
         }
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             // Introduction entries should be gone
             Assert.False(
@@ -95,7 +95,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.AddRange(shouldKeep);
             db.DetectionCache.AddRange(shouldDelete);
@@ -107,7 +107,7 @@ public sealed class TestCacheOperations
             cachingScope.CacheService.DeleteByMode(AnalysisMode.Credits);
         }
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             // Credits entries should be gone
             Assert.False(
@@ -129,7 +129,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));
@@ -173,7 +173,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
@@ -346,7 +346,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Credits,
@@ -386,7 +386,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Introduction,
@@ -423,7 +423,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Introduction,
@@ -461,7 +461,7 @@ public sealed class TestCacheOperations
         using (var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
         {
             cacheDbPath = scope.CacheDbPath;
-            using var db = Plugin.CreateCacheDbContext();
+            using var db = new DetectionCacheDbContext(scope.CacheDbPath);
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId,
                 AnalysisMode.Introduction,
@@ -493,7 +493,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             // Stale entry: cached with old end=600
             db.DetectionCache.Add(new DbDetectionCache(
@@ -520,7 +520,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, 0, 600));
@@ -546,7 +546,7 @@ public sealed class TestCacheOperations
 
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
 
-        using (var db = Plugin.CreateCacheDbContext())
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
         {
             db.DetectionCache.Add(new DbDetectionCache(
                 episode.EpisodeId, AnalysisMode.Credits, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, 1560, 1800));
@@ -613,9 +613,7 @@ public sealed class TestCacheOperations
                     new PluginConfiguration { CacheFingerprints = true });
             }
 
-            CacheService = new DetectionCacheService(
-                NullLogger<DetectionCacheService>.Instance,
-                DatabaseTestHelpers.CreatePluginBoundCacheDatabase());
+            CacheService = DatabaseTestHelpers.CreateCacheService(_inner.CacheDbPath);
         }
 
         public DetectionCacheService CacheService { get; }

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -176,13 +176,7 @@ public sealed class TestDbSegmentStorage
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).CleanTimestampsAsync(enabledEpisodeIds);
-            }
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).CleanTimestampsAsync(enabledEpisodeIds);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -229,24 +223,17 @@ public sealed class TestDbSegmentStorage
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+            // Should not throw even with 1001 episode IDs (above the SQLite 999-parameter limit).
+            var snapshot = await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).GetSeasonQueueSnapshotAsync(seasonId, episodeIds);
+            Assert.True(snapshot.EpisodeIdsByMode.TryGetValue(AnalysisMode.Introduction, out var analyzedIds));
+            Assert.Contains(episodeWithSegmentId, analyzedIds!);
+            Assert.True(snapshot.ConfigHashByMode.TryGetValue(AnalysisMode.Introduction, out var configHash));
+            Assert.Equal("snapshot-config", configHash);
+            Assert.True(snapshot.AnalyzerActionByMode.TryGetValue(AnalysisMode.Introduction, out var analyzerAction));
+            Assert.Equal(AnalyzerAction.Chromaprint, analyzerAction);
 
-                // Should not throw even with 1001 episode IDs (above the SQLite 999-parameter limit).
-                var snapshot = await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).GetSeasonQueueSnapshotAsync(seasonId, episodeIds);
-                Assert.True(snapshot.EpisodeIdsByMode.TryGetValue(AnalysisMode.Introduction, out var analyzedIds));
-                Assert.Contains(episodeWithSegmentId, analyzedIds!);
-                Assert.True(snapshot.ConfigHashByMode.TryGetValue(AnalysisMode.Introduction, out var configHash));
-                Assert.Equal("snapshot-config", configHash);
-                Assert.True(snapshot.AnalyzerActionByMode.TryGetValue(AnalysisMode.Introduction, out var analyzerAction));
-                Assert.Equal(AnalyzerAction.Chromaprint, analyzerAction);
-
-
-                Assert.True(snapshot.SegmentsByEpisodeId.TryGetValue(episodeWithSegmentId, out var segmentsByAnalysisMode));
-                Assert.True(segmentsByAnalysisMode!.TryGetValue(AnalysisMode.Introduction, out _));
-            }
+            Assert.True(snapshot.SegmentsByEpisodeId.TryGetValue(episodeWithSegmentId, out var segmentsByAnalysisMode));
+            Assert.True(segmentsByAnalysisMode!.TryGetValue(AnalysisMode.Introduction, out _));
         }
         finally
         {
@@ -650,15 +637,8 @@ public sealed class TestDbSegmentStorage
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                ConfigurePluginLogger(plugin);
-
-                var credits = new Segment(itemId, new TimeRange(creditsStart, creditsEnd));
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).UpdateTimestampAsync(credits, AnalysisMode.Credits, isUserProvided);
-            }
+            var credits = new Segment(itemId, new TimeRange(creditsStart, creditsEnd));
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).UpdateTimestampAsync(credits, AnalysisMode.Credits, isUserProvided);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -698,12 +678,6 @@ public sealed class TestDbSegmentStorage
                 await db.Database.CloseConnectionAsync();
             }
         }
-    }
-
-    private static void ConfigurePluginLogger(Plugin plugin)
-    {
-        using var loggerFactory = LoggerFactory.Create(_ => { });
-        EntrypointTestHelpers.SetPrivateField(plugin, "_logger", loggerFactory.CreateLogger<Plugin>());
     }
 
     private static void DeleteSqliteFiles(string dbPath)

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -74,19 +74,20 @@ public sealed class TestEntrypointEvents
     public void OnItemRemoved_DeletesCache_ForEpisode()
     {
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
         var episodeId = Guid.NewGuid();
         var otherId = Guid.NewGuid();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true, cacheDbPath);
 
         var episode = new Episode();
         EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
         EntrypointTestHelpers.EnsureNonVirtual(episode);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: episode, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     episodeId,
@@ -110,7 +111,7 @@ public sealed class TestEntrypointEvents
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.False(verificationDb.DetectionCache.Any(e => e.ItemId == episodeId));
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == otherId));
         }
@@ -172,8 +173,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         var otherId = Guid.NewGuid();
 
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true, cacheDbPath);
 
         var movie = new Movie();
         EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
@@ -182,9 +184,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         Assert.Equal(removedId, movie.Id);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     removedId,
@@ -208,7 +210,7 @@ public sealed class TestFingerprintCacheDeletionOnRemove
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.False(verificationDb.DetectionCache.Any(e => e.ItemId == removedId));
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == otherId));
         }
@@ -219,8 +221,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
     {
         var removedId = Guid.NewGuid();
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false, cacheDbPath);
 
         var movie = new Movie();
         EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
@@ -229,9 +232,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         Assert.Equal(removedId, movie.Id);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     removedId,
@@ -243,7 +246,7 @@ public sealed class TestFingerprintCacheDeletionOnRemove
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == removedId));
         }
     }
@@ -254,8 +257,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         var removedId = Guid.Empty;
 
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
 
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true, cacheDbPath);
 
         var movie = new Movie();
         EntrypointTestHelpers.SetPropertyOrField(movie, "Id", removedId);
@@ -264,9 +268,9 @@ public sealed class TestFingerprintCacheDeletionOnRemove
         Assert.Equal(removedId, movie.Id);
 
         var args = EntrypointTestHelpers.CreateItemChangeEventArgs(item: movie, updateReason: 0);
-        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+        using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir, cacheDbPath))
         {
-            using (var db = Plugin.CreateCacheDbContext())
+            using (var db = new DetectionCacheDbContext(cacheDbPath))
             {
                 db.DetectionCache.Add(new DbDetectionCache(
                     removedId,
@@ -278,7 +282,7 @@ public sealed class TestFingerprintCacheDeletionOnRemove
 
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemRemoved", args);
 
-            using var verificationDb = Plugin.CreateCacheDbContext();
+            using var verificationDb = new DetectionCacheDbContext(cacheDbPath);
             Assert.True(verificationDb.DetectionCache.Any(e => e.ItemId == removedId));
         }
     }

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -218,7 +218,7 @@ public class TestFFmpegService
     {
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
-            DatabaseTestHelpers.CreatePluginBoundCacheService());
+            DatabaseTestHelpers.CreateTempCacheService());
     }
 
     private static QueuedEpisode QueueFile(string path)

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -326,7 +326,7 @@ public sealed class TestSeasonReanalysisReset
 
             await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
             Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // already done for this set
-            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive.Reverse().ToArray())); // order-insensitive set match
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, [.. firstFive.Reverse()])); // order-insensitive set match
             Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix)); // grew → eligible again
             Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive)); // same count, different membership
             Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive)); // unrecorded mode stays eligible

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -318,59 +318,51 @@ public sealed class TestSeasonReanalysisReset
                 await db.Database.EnsureCreatedAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
 
-                // Stays eligible until the work is explicitly recorded, so a failed reset is retried.
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+            // Stays eligible until the work is explicitly recorded, so a failed reset is retried.
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // already done for this set
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive.Reverse().ToArray())); // order-insensitive set match
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix)); // grew → eligible again
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive)); // same count, different membership
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive)); // unrecorded mode stays eligible
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // already done for this set
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive.Reverse().ToArray())); // order-insensitive set match
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix)); // grew → eligible again
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive)); // same count, different membership
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive)); // unrecorded mode stays eligible
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], replacementFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], replacementFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, replacementFive));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstSix);
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrank → eligible again
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstSix);
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrank → eligible again
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrink was recorded
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Introduction], firstFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive)); // shrink was recorded
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstFive);
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstFive);
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
 
-                await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstSix);
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
-            }
+            await database.RecordSettleReanalysisAsync(season, [AnalysisMode.Credits], firstSix);
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstFive));
+            Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            // A fresh facade over the same file simulates a plugin restart: the recorded
+            // episode sets must be read back from the database.
+            var reopenedDatabase = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
 
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstFive));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Introduction, firstSeven));
-                Assert.False(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSix));
-                Assert.True(await ShouldReanalyzeAsync(database, season, AnalysisMode.Credits, firstSeven));
-            }
+            Assert.False(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Introduction, firstFive));
+            Assert.True(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Introduction, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Introduction, firstSeven));
+            Assert.False(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Credits, firstSix));
+            Assert.True(await ShouldReanalyzeAsync(reopenedDatabase, season, AnalysisMode.Credits, firstSeven));
         }
         finally
         {
@@ -430,30 +422,26 @@ public sealed class TestSeasonReanalysisReset
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            var cacheDbPath = DatabaseTestHelpers.CreateTempCacheDbPath();
+            using (var cacheDb = new DetectionCacheDbContext(cacheDbPath))
             {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                cacheDb.EnsureSchema();
+                cacheDb.DetectionCache.Add(new DbDetectionCache(
+                    autoEpisode,
+                    AnalysisMode.Introduction,
+                    CacheEntryType.Chromaprint,
+                    EntrypointTestHelpers.EmptyJsonArray));
+                await cacheDb.SaveChangesAsync();
+            }
 
-                using (var cacheDb = Plugin.CreateCacheDbContext())
-                {
-                    cacheDb.DetectionCache.Add(new DbDetectionCache(
-                        autoEpisode,
-                        AnalysisMode.Introduction,
-                        CacheEntryType.Chromaprint,
-                        EntrypointTestHelpers.EmptyJsonArray));
-                    await cacheDb.SaveChangesAsync();
-                }
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
+                seasonId,
+                new[] { autoEpisode, userEpisode },
+                new[] { AnalysisMode.Introduction });
 
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
-                    seasonId,
-                    new[] { autoEpisode, userEpisode },
-                    new[] { AnalysisMode.Introduction });
-
-                using (var cacheDb = Plugin.CreateCacheDbContext())
-                {
-                    Assert.True(cacheDb.DetectionCache.Any(e => e.ItemId == autoEpisode && e.Mode == AnalysisMode.Introduction));
-                }
+            using (var cacheDb = new DetectionCacheDbContext(cacheDbPath))
+            {
+                Assert.True(cacheDb.DetectionCache.Any(e => e.ItemId == autoEpisode && e.Mode == AnalysisMode.Introduction));
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))
@@ -523,17 +511,12 @@ public sealed class TestSeasonReanalysisReset
                 await db.SaveChangesAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-                var resetModes = BaseItemAnalyzerTask.ExpandSettledResetModesForDerivedSegments([AnalysisMode.Credits], true);
+            var resetModes = BaseItemAnalyzerTask.ExpandSettledResetModesForDerivedSegments([AnalysisMode.Credits], true);
 
-                await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
-                    seasonId,
-                    new[] { autoEpisode, userPreviewEpisode },
-                    resetModes);
-            }
+            await DatabaseTestHelpers.CreateSegmentDatabase(dbPath).ResetSeasonForReanalysisAsync(
+                seasonId,
+                new[] { autoEpisode, userPreviewEpisode },
+                resetModes);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -573,24 +556,18 @@ public sealed class TestSeasonReanalysisReset
                 await db.Database.EnsureCreatedAsync();
             }
 
-            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
-
-                var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
-                await database.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeA, episodeB], "hash-a");
-                await database.SetAnalyzerActionAsync(
-                    seasonId,
-                    new Dictionary<AnalysisMode, AnalyzerAction>
-                    {
-                        [AnalysisMode.Introduction] = AnalyzerAction.Chromaprint,
-                    });
-                await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], completedEpisodeIds);
-                await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], lowerEpisodeIds);
-                await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, episodeA);
-                await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, Guid.NewGuid());
-            }
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeA, episodeB], "hash-a");
+            await database.SetAnalyzerActionAsync(
+                seasonId,
+                new Dictionary<AnalysisMode, AnalyzerAction>
+                {
+                    [AnalysisMode.Introduction] = AnalyzerAction.Chromaprint,
+                });
+            await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], completedEpisodeIds);
+            await database.RecordSettleReanalysisAsync(seasonId, [AnalysisMode.Introduction], lowerEpisodeIds);
+            await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, episodeA);
+            await database.RemoveEpisodeIdAsync(seasonId, AnalysisMode.Introduction, Guid.NewGuid());
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -645,7 +622,6 @@ public sealed class TestSeasonReanalysisReset
             using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
             {
                 var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
                 EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
 
                 var episode = new Episode();
@@ -746,7 +722,7 @@ public sealed class TestSeasonReanalysisReset
     {
         var states = await database.GetSettleReanalysisStatesAsync(seasonId);
         return !states.TryGetValue(mode, out var state)
-            || Plugin.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds);
+            || AnalysisHelpers.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds);
     }
 
     private static void DeleteSqliteFiles(string dbPath)

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -26,13 +26,13 @@ public sealed class TestSkipIntroController
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, itemId, updateMediaSegments: true, out var item);
+        using var pluginScope = CreatePluginScope(itemId, updateMediaSegments: true, out var item);
         await EnsureDatabaseAsync(dbPath);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreatePluginBoundCacheService(), DatabaseTestHelpers.CreatePluginBoundSegmentDatabase());
+        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreateCacheService(pluginScope.CacheDbPath), DatabaseTestHelpers.CreateSegmentDatabase(dbPath));
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -60,13 +60,13 @@ public sealed class TestSkipIntroController
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, itemId, updateMediaSegments: false, out _);
+        using var pluginScope = CreatePluginScope(itemId, updateMediaSegments: false, out _);
         await EnsureDatabaseAsync(dbPath);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
-        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreatePluginBoundCacheService(), DatabaseTestHelpers.CreatePluginBoundSegmentDatabase());
+        var controller = new SkipIntroController(refresher, DatabaseTestHelpers.CreateCacheService(pluginScope.CacheDbPath), DatabaseTestHelpers.CreateSegmentDatabase(dbPath));
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -78,7 +78,7 @@ public sealed class TestSkipIntroController
         Assert.Equal(0, refresher.ItemCallCount);
     }
 
-    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid itemId, bool updateMediaSegments, out Movie item)
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(Guid itemId, bool updateMediaSegments, out Movie item)
     {
         var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         item = new Movie();
@@ -87,7 +87,6 @@ public sealed class TestSkipIntroController
 
         var libraryManager = EntrypointTestHelpers.CreateLibraryManager(item);
         var plugin = Plugin.Instance!;
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
         EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
         return scope;

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -29,14 +29,14 @@ public sealed class TestVisualizationController
         var seasonId = Guid.NewGuid();
         var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: true);
+        using var pluginScope = CreatePluginScope(seriesId, seasonId, episodeIds, updateMediaSegments: true);
         await SeedSeasonAsync(dbPath, seasonId, episodeIds);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath, pluginScope.CacheDbPath);
 
         var actionTask = controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
 
@@ -60,14 +60,14 @@ public sealed class TestVisualizationController
         var seasonId = Guid.NewGuid();
         var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
         var dbPath = CreateTempDbPath();
-        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: false);
+        using var pluginScope = CreatePluginScope(seriesId, seasonId, episodeIds, updateMediaSegments: false);
         await SeedSeasonAsync(dbPath, seasonId, episodeIds);
         var refresher = new RecordingMediaSegmentRefresher
         {
             Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         };
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath, pluginScope.CacheDbPath);
 
         var result = await controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: false, CancellationToken.None);
 
@@ -89,16 +89,15 @@ public sealed class TestVisualizationController
             SeriesExclusions = { "Excluded Show" }
         };
         using var pluginScope = CreatePluginScope(
-            dbPath,
             seriesId,
             seasonId,
             [excludedId, includedId],
             config);
         await SeedSeasonAsync(dbPath, seasonId, [excludedId, includedId]);
-        await SeedCacheAsync(excludedId, includedId);
+        await SeedCacheAsync(pluginScope.CacheDbPath, excludedId, includedId);
         var refresher = new RecordingMediaSegmentRefresher();
         using var loggerFactory = LoggerFactory.Create(builder => { });
-        var controller = CreateController(refresher, loggerFactory);
+        var controller = CreateController(refresher, loggerFactory, dbPath, pluginScope.CacheDbPath);
 
         var result = await controller.ClearExcludedTimestampsAsync(CancellationToken.None);
 
@@ -115,12 +114,12 @@ public sealed class TestVisualizationController
         var seasonStates = await db.DbSeasonState.Where(s => s.SeasonId == seasonId).ToListAsync();
         Assert.All(seasonStates, state => Assert.Equal([includedId], state.EpisodeIds));
 
-        using var cacheDb = Plugin.CreateCacheDbContext();
+        using var cacheDb = new DetectionCacheDbContext(pluginScope.CacheDbPath);
         Assert.False(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == excludedId));
         Assert.True(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == includedId));
     }
 
-    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory)
+    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory, string dbPath, string cacheDbPath)
     {
         return new VisualizationController(
             NullLogger<VisualizationController>.Instance,
@@ -130,24 +129,22 @@ public sealed class TestVisualizationController
             fileSystem: null!,
             loggerFactory,
             ffmpegService: null!,
-            DatabaseTestHelpers.CreatePluginBoundCacheService(),
-            DatabaseTestHelpers.CreatePluginBoundSegmentDatabase(),
-            DatabaseTestHelpers.CreatePluginBoundCacheDatabase());
+            DatabaseTestHelpers.CreateCacheService(cacheDbPath),
+            DatabaseTestHelpers.CreateSegmentDatabase(dbPath),
+            DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath));
     }
 
-    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
         => CreatePluginScope(
-            dbPath,
             seriesId,
             seasonId,
             episodeIds,
             new PluginConfiguration { UpdateMediaSegments = updateMediaSegments });
 
-    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, PluginConfiguration config)
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, PluginConfiguration config)
     {
         var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var plugin = Plugin.Instance!;
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
         EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
         plugin.QueuedMediaItems[seasonId] =
@@ -171,9 +168,9 @@ public sealed class TestVisualizationController
         await db.SaveChangesAsync();
     }
 
-    private static async Task SeedCacheAsync(Guid excludedId, Guid includedId)
+    private static async Task SeedCacheAsync(string cacheDbPath, Guid excludedId, Guid includedId)
     {
-        using var cacheDb = Plugin.CreateCacheDbContext();
+        using var cacheDb = new DetectionCacheDbContext(cacheDbPath);
         cacheDb.DetectionCache.AddRange(
             new DbDetectionCache(excludedId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray),
             new DbDetectionCache(includedId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -78,7 +78,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         }
 
         var seg = new Segment(itemId, new TimeRange(TimeSpan.FromTicks(segment.StartTicks).TotalSeconds, TimeSpan.FromTicks(segment.EndTicks).TotalSeconds));
-        var mode = Plugin.MapSegmentTypeToMode(segment.Type);
+        var mode = AnalysisHelpers.MapSegmentTypeToMode(segment.Type);
 
         await _database.UpdateTimestampAsync(seg, mode, isUserProvided: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/IntroSkipper/Data/AnalysisHelpers.cs
+++ b/IntroSkipper/Data/AnalysisHelpers.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Pure analysis helper functions with no database or plugin state access.
+/// </summary>
+internal static class AnalysisHelpers
+{
+    /// <summary>
+    /// Returns whether a settled-season analysis mode still needs re-analysis for its current episode
+    /// set. Pure set comparison: the decision is committed separately via
+    /// <see cref="Db.IIntroSkipperDatabase.RecordSettleReanalysisAsync(Guid, IReadOnlyCollection{AnalysisMode}, IReadOnlyCollection{Guid}, CancellationToken)"/>
+    /// once the reset has succeeded, so the completed episode set survives plugin restarts.
+    /// </summary>
+    /// <param name="settledEpisodeIds">Episode IDs recorded when the season was last settle-reanalyzed for this mode.</param>
+    /// <param name="episodeIds">Current episode IDs in the season.</param>
+    /// <returns><see langword="true"/> when a re-analysis should be performed; otherwise <see langword="false"/>.</returns>
+    internal static bool ShouldSettleReanalyze(
+        IReadOnlySet<Guid> settledEpisodeIds,
+        IReadOnlyCollection<Guid> episodeIds)
+        => settledEpisodeIds.Count != episodeIds.Count || episodeIds.Any(id => !settledEpisodeIds.Contains(id));
+
+    /// <summary>
+    /// Maps a Jellyfin media segment type to the corresponding analysis mode.
+    /// </summary>
+    /// <param name="type">Media segment type.</param>
+    /// <returns>The corresponding <see cref="AnalysisMode"/>.</returns>
+    internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
+    {
+        return type switch
+        {
+            MediaSegmentType.Intro => AnalysisMode.Introduction,
+            MediaSegmentType.Recap => AnalysisMode.Recap,
+            MediaSegmentType.Preview => AnalysisMode.Preview,
+            MediaSegmentType.Outro => AnalysisMode.Credits,
+            MediaSegmentType.Commercial => AnalysisMode.Commercial,
+            _ => throw new NotImplementedException(),
+        };
+    }
+}

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -12,7 +12,6 @@ using System.Collections.Concurrent;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
-using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Controller.Chapters;
@@ -22,8 +21,6 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
-using Microsoft.Data.Sqlite;
-using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper;
 
@@ -31,21 +28,16 @@ namespace IntroSkipper;
 /// Intro skipper plugin. Uses audio analysis to find common sequences of audio shared between episodes.
 /// </summary>
 /// <remarks>
-/// All database access lives in <see cref="IIntroSkipperDatabase"/> and
-/// <see cref="IDetectionCacheDatabase"/>; every consumer receives the facades by
-/// constructor injection. The only database-related members left here are the
-/// transitional constructor bootstrap and the <see cref="CreateDbContext"/>/
-/// <see cref="CreateCacheDbContext"/> statics still used by tests; both are removed in
-/// the final transition phase.
+/// This class contains no database code. All database access lives in
+/// <see cref="IIntroSkipperDatabase"/> and <see cref="IDetectionCacheDatabase"/>;
+/// every consumer receives the facades by constructor injection, and their
+/// initialization gates own the database lifecycle.
 /// </remarks>
-public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
+public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
     private readonly IPluginManager _pluginManager;
-    private readonly ILogger<Plugin> _logger;
-    private readonly string _dbPath;
-    private readonly string _cacheDbPath;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Plugin"/> class.
@@ -56,15 +48,13 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <param name="libraryManager">Library manager.</param>
     /// <param name="chapterRepository">Chapter repository.</param>
     /// <param name="pluginManager">Plugin manager.</param>
-    /// <param name="logger">Logger.</param>
     public Plugin(
         IApplicationPaths applicationPaths,
         IXmlSerializer xmlSerializer,
         IServerConfigurationManager serverConfiguration,
         ILibraryManager libraryManager,
         IChapterManager chapterRepository,
-        IPluginManager pluginManager,
-        ILogger<Plugin> logger)
+        IPluginManager pluginManager)
         : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
@@ -72,7 +62,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         _libraryManager = libraryManager;
         _chapterRepository = chapterRepository;
         _pluginManager = pluginManager;
-        _logger = logger;
 
         FFmpegPath = serverConfiguration.GetEncodingOptions().EncoderAppPathDisplay;
 
@@ -84,50 +73,12 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         var introsDirectory = IntroSkipperDatabasePaths.GetPluginDirectory(applicationPaths);
         FingerprintCachePath = Path.Join(introsDirectory, pluginCachePath);
 
-        _dbPath = Path.Join(introsDirectory, IntroSkipperDatabasePaths.SegmentDatabaseFileName);
-        _cacheDbPath = Path.Join(introsDirectory, IntroSkipperDatabasePaths.DetectionCacheDatabaseFileName);
-
-        // Initialize segment database.
-        try
-        {
-            using var db = CreateDbContext();
-            // Legacy databases may be missing migration history or columns that EF migrations expect.
-            // Normalize those schemas first so recovery does not log a false initialization failure.
-            db.EnsureLegacySchemaCompatibility();
-            db.ApplyMigrations();
-        }
-        catch (Exception ex)
-        {
-            LogDatabaseInitializationError(_logger, ex);
-        }
-
-        // Initialize detection cache database.
-        try
-        {
-            using var cacheDb = CreateCacheDbContext();
-            cacheDb.EnsureSchema();
-        }
-        catch (Exception ex) when (ex is IOException or SqliteException)
-        {
-            LogCacheDbInitializationError(_logger, ex);
-        }
-
         MigrateLegacyExcludeSeries();
 
         Configuration.FileTransformationPluginEnabled = _pluginManager
             .Plugins
             .Any(p => p.Id == Guid.Parse("5e87cc92-571a-4d8d-8d98-d2d4147f9f90")); // File Transformation plugin ID
     }
-
-    /// <summary>
-    /// Gets the path to the segment database.
-    /// </summary>
-    public string DbPath => _dbPath;
-
-    /// <summary>
-    /// Gets the path to the detection cache database.
-    /// </summary>
-    public string CacheDbPath => _cacheDbPath;
 
     /// <summary>
     /// Gets or sets a value indicating whether to analyze again.
@@ -170,28 +121,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// </summary>
     public static Plugin? Instance { get; private set; }
 
-    /// <summary>
-    /// Creates a new <see cref="IntroSkipperDbContext"/> instance configured for the plugin database.
-    /// </summary>
-    /// <returns>A new <see cref="IntroSkipperDbContext"/>.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
-    public static IntroSkipperDbContext CreateDbContext()
-    {
-        ArgumentNullException.ThrowIfNull(Instance);
-        return new IntroSkipperDbContext(Instance.DbPath);
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="DetectionCacheDbContext"/> instance configured for the plugin cache database.
-    /// </summary>
-    /// <returns>A new <see cref="DetectionCacheDbContext"/>.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when the plugin has not been initialized.</exception>
-    public static DetectionCacheDbContext CreateCacheDbContext()
-    {
-        ArgumentNullException.ThrowIfNull(Instance);
-        return new DetectionCacheDbContext(Instance.CacheDbPath);
-    }
-
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()
     {
@@ -224,33 +153,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? Array.Empty<ChapterInfo>();
 
-    /// <summary>
-    /// Returns whether a settled-season analysis mode still needs re-analysis for its current episode
-    /// set. Pure set comparison: the decision is committed separately via
-    /// <see cref="IIntroSkipperDatabase.RecordSettleReanalysisAsync(Guid, IReadOnlyCollection{AnalysisMode}, IReadOnlyCollection{Guid}, CancellationToken)"/>
-    /// once the reset has succeeded, so the completed episode set survives plugin restarts.
-    /// </summary>
-    /// <param name="settledEpisodeIds">Episode IDs recorded when the season was last settle-reanalyzed for this mode.</param>
-    /// <param name="episodeIds">Current episode IDs in the season.</param>
-    /// <returns><see langword="true"/> when a re-analysis should be performed; otherwise <see langword="false"/>.</returns>
-    internal static bool ShouldSettleReanalyze(
-        IReadOnlySet<Guid> settledEpisodeIds,
-        IReadOnlyCollection<Guid> episodeIds)
-        => settledEpisodeIds.Count != episodeIds.Count || episodeIds.Any(id => !settledEpisodeIds.Contains(id));
-
-    internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
-    {
-        return type switch
-        {
-            MediaSegmentType.Intro => AnalysisMode.Introduction,
-            MediaSegmentType.Recap => AnalysisMode.Recap,
-            MediaSegmentType.Preview => AnalysisMode.Preview,
-            MediaSegmentType.Outro => AnalysisMode.Credits,
-            MediaSegmentType.Commercial => AnalysisMode.Commercial,
-            _ => throw new NotImplementedException(),
-        };
-    }
-
     private void MigrateLegacyExcludeSeries()
     {
         var legacy = Configuration.ExcludeSeries;
@@ -270,10 +172,4 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         Configuration.ExcludeSeries = string.Empty;
         SaveConfiguration();
     }
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing database")]
-    private static partial void LogDatabaseInitializationError(ILogger logger, Exception exception);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Error initializing detection cache database")]
-    private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
 }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -235,7 +235,7 @@ public partial class BaseItemAnalyzerTask(
             var action = stateExists ? state.Action : AnalyzerAction.Default;
             if (action != AnalyzerAction.None &&
                 CanSettleReanalysisRun(mode, action, ffmpegValid) &&
-                (!stateExists || Plugin.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds)))
+                (!stateExists || AnalysisHelpers.ShouldSettleReanalyze(state.SettledReanalysisEpisodeIds, episodeIds)))
             {
                 resetModes.Add(mode);
             }

--- a/docs/db-redesign/theory-b.md
+++ b/docs/db-redesign/theory-b.md
@@ -26,9 +26,10 @@ Principles:
    user-provided segments are never overwritten by analysis results, and auto-detected
    credits must not overlap the stored intro — live inside
    `IntroSkipperDatabase.UpdateTimestampAsync`, exactly where they lived in `Plugin`.
-   No caller can reach a `DbContext` and bypass them (in the end state; see §3).
+   No caller can reach a `DbContext` and bypass them (end state reached in Phase 4;
+   see §14).
 3. **Stateless services.** Each operation creates a fresh short-lived context from the
-   injected factory — identical to the current `using var db = Plugin.CreateDbContext()`
+   injected factory — identical to the pre-redesign `using var db = Plugin.CreateDbContext()`
    discipline, so the concurrency model is unchanged. The only state is a one-shot
    initialization gate (§5).
 4. **Lifecycle is part of the facade.** Migrations, legacy schema repair,
@@ -55,8 +56,8 @@ Db/
   IDetectionCacheDatabase.cs
   DetectionCacheDatabase.cs               single file; the cache is 8 methods
   IntroSkipperDatabasePaths.cs            single source of truth for DB file paths
-  IntroSkipperDbContextPathFactory.cs     transitional/test factory (path resolved lazily)
-  DetectionCacheDbContextPathFactory.cs   transitional/test factory
+  IntroSkipperDbContextPathFactory.cs     test factory (path resolved lazily; test-only since Phase 4)
+  DetectionCacheDbContextPathFactory.cs   test factory (test-only since Phase 4)
 ```
 
 Conventions that keep a ~23-method interface maintainable:
@@ -124,7 +125,7 @@ through the constructor chain (§3).
 | `GetAnalyzerActionAsync` | `IIntroSkipperDatabase.GetAnalyzerActionAsync` | bridge (`BaseItemAnalyzerTask`) |
 | `CleanSeasonStateAsync` | `IIntroSkipperDatabase.CleanSeasonStateAsync` | `CleanCacheTask` injected |
 | `DeleteTimestampAsync` | `IIntroSkipperDatabase.DeleteTimestampAsync` | bridge (`SegmentEditorController`) |
-| `ShouldSettleReanalyze`, `MapSegmentTypeToMode` | stay on `Plugin` — pure functions, no DB access | n/a |
+| `ShouldSettleReanalyze`, `MapSegmentTypeToMode` | pure functions, no DB access — stayed on `Plugin` through Phase 3, moved to `IntroSkipper.Data.AnalysisHelpers` in Phase 4 | done (§14) |
 
 ### 2b. Direct `CreateDbContext()` / `CreateCacheDbContext()` call sites
 
@@ -148,7 +149,7 @@ through the constructor chain (§3).
 `Plugin.CreateCacheDbContext()` references remain in it. Serialization/compression and
 config-hash policy stay in the service; the facade is purely the DB boundary.
 
-### 2c. End state (zero DB code in `Plugin`)
+### 2c. End state (zero DB code in `Plugin`) — **reached in Phase 4 (§14)**
 
 Delete from `Plugin`: all wrappers in §2a, `SegmentDatabase`/`CacheDatabase` bridge
 properties, `CreateDbContext`/`CreateCacheDbContext`, the ctor DB bootstrap, and the
@@ -216,11 +217,12 @@ Notes:
   `IDbContextFactory<TContext>`) are keyed by our context types, so registering them in
   Jellyfin's host container cannot collide with Jellyfin's own EF registrations.
 
-Transitional bridge: `Plugin.SegmentDatabase` / `Plugin.CacheDatabase` are lazily
+Transitional bridge (**deleted**: bridge in Phase 3, remaining `Plugin` DB surface in
+Phase 4, §14): `Plugin.SegmentDatabase` / `Plugin.CacheDatabase` were lazily
 created facade instances over `IntroSkipperDbContextPathFactory(() => DbPath)`. The
-facades are stateless, so the DI instance and the bridge instance coexist safely (same
-file, same pragmas, same short-lived contexts as today). The bridge disappears in the
-end state.
+facades are stateless, so the DI instance and the bridge instance coexisted safely
+(same file, same pragmas, same short-lived contexts). The DI-registered facades are now
+the only production instances.
 
 ---
 
@@ -262,7 +264,9 @@ deliberate parity decision, recorded as risk R4.
 `Database.Migrate()` which is idempotent, and `EnsureLegacySchemaCompatibility` is
 written to be re-runnable). Tests prove the gate alone is sufficient
 (`InitializationGate_CreatesSchemaBeforeFirstQuery` runs the facade against a virgin
-file with no ctor bootstrap at all). The end state deletes the ctor bootstrap.
+file with no ctor bootstrap at all). The end state deletes the ctor bootstrap —
+**done in Phase 4 (§14)**; the facade gates (plus the gated factories of §12.3) are now
+the sole initialization path.
 
 **Rebuild and legacy repair** keep working unchanged: `RebuildDatabaseAsync(bool, ct)`
 wraps the existing context-level salvage flow, passing `_contextFactory.CreateDbContext`
@@ -702,3 +706,75 @@ Verification per commit and at the end: `dotnet build IntroSkipper.sln` 0
 warnings/errors; full suite 411/412 — sole failure remains the known environmental
 `TestSilenceDetection`; `git grep "Plugin\.\(Get\|Set\|Update\|Delete\|Clean\|Record\|Reset\|Remove\)" IntroSkipper/`
 returns no DB-delegator call sites.
+
+---
+
+## 14. Phase 4 — kill the transitional surface (final-plan Plan 1, Phase 4)
+
+The end state of §2c is reached: `Plugin.cs` contains **zero database code** — no
+contexts, no statics, no bootstrap, no paths. Verified by
+`grep -nE "DbContext|DbSegment|DbSeasonState|CreateCacheDb" IntroSkipper/Plugin.cs`
+(zero matches) and `git grep "Plugin\.CreateDbContext\|Plugin\.CreateCacheDbContext"`
+(zero code matches, tests included).
+
+**Deleted from `Plugin`:**
+
+- The constructor DB bootstrap (both try/catch init blocks) and its two
+  `LoggerMessage` definitions (`LogDatabaseInitializationError`,
+  `LogCacheDbInitializationError`). With them gone, the `ILogger<Plugin>` constructor
+  parameter and `_logger` field had no remaining readers and were removed too; the
+  class is no longer `partial` (the partial existed only for the LoggerMessage source
+  generator). The facade init gates — eagerly driven by
+  `IntroSkipperDatabaseInitializer` and structurally enforced by the gated factories
+  (§12.3) — are the sole initialization path; `InitializationGate_CreatesSchemaBeforeFirstQuery`
+  and `TestGatedContextFactories` already pin that the gates alone are sufficient, so
+  no bootstrap-equivalent test was needed.
+- `CreateDbContext()` / `CreateCacheDbContext()` statics, and the `_dbPath` /
+  `_cacheDbPath` fields with their `DbPath` / `CacheDbPath` properties. No production
+  code read the paths (DI resolves them via `IntroSkipperDatabasePaths` +
+  `IApplicationPaths`); the only consumers were tests (below). The
+  `IntroSkipperDatabasePaths.GetPluginDirectory` call stays in the ctor because
+  `FingerprintCachePath` (a non-DB concern) still lives under the plugin data
+  directory; the facades' initialization independently ensures the directory for the
+  database files.
+
+**Helper move (zero behavior change):** the pure functions `MapSegmentTypeToMode` and
+`ShouldSettleReanalyze` moved verbatim to the new internal static class
+`IntroSkipper.Data.AnalysisHelpers` (naming per `TimeRangeHelpers`). Callers updated:
+`SegmentEditorController`, `BaseItemAnalyzerTask`, and the season-reanalysis tests.
+
+**Test migration** (no assertion weakened; test count unchanged at 412):
+
+- `DatabaseTestHelpers` lost the `CreatePluginBound*` lazy-`Plugin.Instance`-path
+  variants and gained explicit-path equivalents: `CreateCacheService(dbPath)`,
+  `CreateTempCacheService()`, `CreateTempCacheDbPath()`. Facades/services in tests are
+  now always bound to explicit temp-file paths — the same pattern the facade tests
+  used since Phase 1.
+- `EntrypointTestHelpers.PluginInstanceScope` no longer reflects `_cacheDbPath` onto
+  the uninitialized `Plugin`; it still owns/creates the cache DB file and exposes
+  `CacheDbPath`, and still sets `FingerprintCachePath`/configuration (the
+  configuration-scoped reflection use, which stays by design). `CreateEntrypoint`
+  takes an optional `cacheDbPath` so entrypoint tests bind the cache service to the
+  scope's database explicitly.
+- Every test-side `Plugin.CreateCacheDbContext()` became
+  `new DetectionCacheDbContext(<explicit path>)`
+  (`TestCacheOperations`, `TestEntrypointEvents`, `TestVisualizationController`,
+  `TestSeasonReanalysis`), and controller tests
+  (`TestSkipIntroController`, `TestVisualizationController`) construct their facades
+  over the test's `dbPath`/`scope.CacheDbPath` directly instead of routing through
+  `Plugin.Instance`.
+- Reflection writes of `_dbPath`/`_logger` onto `Plugin` (vestigial from the
+  delegator era — the facades under test already receive their paths explicitly) were
+  removed, along with `PluginInstanceScope` wrappers that existed *only* to carry
+  `_dbPath`. Scopes that provide configuration/`FingerprintCachePath`/library-manager
+  state (e.g. the `QueueManager` and controller tests) remain.
+
+**End-state confirmation:** the §2c checklist is complete — facades own all DB access
+and lifecycle; manually-constructed consumers receive `IIntroSkipperDatabase` by
+constructor threading (§13); `Plugin.Instance` survives only for configuration/paths
+(separate follow-up per the final plan). The transition-state notes in §2c, §3, and §4
+are updated above.
+
+Verification: `dotnet build IntroSkipper.sln` 0 warnings/errors; full suite 411/412 —
+sole failure remains the known environmental `TestSilenceDetection`; acceptance greps
+above return zero matches.


### PR DESCRIPTION
This PR completes the database-layer rewrite by removing the last database code from Plugin.cs per Plan 1 Phase 4. The constructor DB bootstrap (both try/catch init blocks), CreateDbContext/CreateCacheDbContext statics, _dbPath/_cacheDbPath fields, and the now-unused ILogger parameter/partial modifier are deleted. The pure functions MapSegmentTypeToMode and ShouldSettleReanalyze move verbatim to the new IntroSkipper.Data.AnalysisHelpers. Tests migrate off Plugin-bound DB access to the existing explicit temp-file patterns from Phase 1 (DatabaseTestHelpers.CreateCacheService(path), CreateTempCacheService(), PluginInstanceScope no longer reflects _cacheDbPath, all Plugin.CreateCacheDbContext() sites become new DetectionCacheDbContext(<explicit path>)). Facade init gates (+ gated factories) are now the sole initialization path; IntroSkipperDatabasePaths.GetPluginDirectory stays in the ctor because FingerprintCachePath (non-DB) still lives under the plugin data directory. Docs updated with a Phase 4 section recording completion. Build: 0 warnings/errors. Tests: 411/412, sole failure is the pre-existing environmental TestSilenceDetection.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-064" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/12e6c668-b99b-466b-827b-4b50519e95b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-064"><img alt="INTRO-064" src="https://capy.ai/api/badge/thread.svg?label=INTRO-064"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Remove all database-related responsibilities from Plugin.cs and migrate tests and helpers to use explicit database paths and facades, completing the database-layer redesign end state.

Enhancements:
- Introduce AnalysisHelpers as a dedicated home for pure analysis utilities previously on Plugin, such as mapping segment types to analysis modes and deciding when to reanalyze settled seasons.
- Refine test helpers to construct database facades and cache services over explicit temp-file SQLite paths instead of relying on Plugin.Instance-bound paths.

Documentation:
- Update database redesign documentation to mark Phase 4 as complete and describe the new zero-DB Plugin end state and helper relocation.

Tests:
- Update season reanalysis, segment storage, cache, controller, audio fingerprinting, and FFmpeg service tests to stop reflecting into Plugin for DB paths and to use explicit DetectionCacheDbContext and database facades bound to temp paths.