### PR TITLE
Skip library enumeration when no seasons are queued

### DIFF
--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -29,10 +29,12 @@ public sealed class TestSeasonReanalysisPlanner
     [Fact]
     public async Task AnalyzeItemsAsync_EmptySeasonSet_DoesNotEnumerateLibrary()
     {
+        // The test proxy throws on enumeration calls such as GetVirtualFolders.
+        var libraryManager = EntrypointTestHelpers.CreateLibraryManager();
         var analyzer = new BaseItemAnalyzerTask(
             NullLogger.Instance,
             NullLoggerFactory.Instance,
-            libraryManager: null!,
+            libraryManager,
             providerManager: null!,
             fileSystem: null!,
             mediaSegmentRefresher: null!,

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -26,12 +26,19 @@ public sealed class TestSeasonReanalysisPlanner
 {
     private static readonly DateTime Now = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+    private sealed class RecordingProgress : IProgress<double>
+    {
+        public double? Value { get; private set; }
+
+        public void Report(double value) => Value = value;
+    }
+
     [Fact]
     public async Task AnalyzeItemsAsync_EmptySeasonSet_DoesNotEnumerateLibrary()
     {
         // The test proxy throws on enumeration calls such as GetVirtualFolders.
         var libraryManager = EntrypointTestHelpers.CreateLibraryManager();
-        double? reportedProgress = null;
+        var progress = new RecordingProgress();
         var analyzer = new BaseItemAnalyzerTask(
             NullLogger.Instance,
             NullLoggerFactory.Instance,
@@ -43,11 +50,11 @@ public sealed class TestSeasonReanalysisPlanner
             cacheService: new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
 
         await analyzer.AnalyzeItemsAsync(
-            new Progress<double>(value => reportedProgress = value),
+            progress,
             CancellationToken.None,
             []);
 
-        Assert.Equal(100, reportedProgress);
+        Assert.Equal(100, progress.Value);
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -27,6 +27,22 @@ public sealed class TestSeasonReanalysisPlanner
     private static readonly DateTime Now = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
     [Fact]
+    public async Task AnalyzeItemsAsync_EmptySeasonSet_DoesNotEnumerateLibrary()
+    {
+        var analyzer = new BaseItemAnalyzerTask(
+            NullLogger.Instance,
+            NullLoggerFactory.Instance,
+            libraryManager: null!,
+            providerManager: null!,
+            fileSystem: null!,
+            mediaSegmentRefresher: null!,
+            ffmpegService: null!,
+            cacheService: new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+
+        await analyzer.AnalyzeItemsAsync(new Progress<double>(), CancellationToken.None, []);
+    }
+
+    [Fact]
     public void IsSettledForReanalysis_ReturnsFalse_WhenDisabled()
     {
         var config = new PluginConfiguration { ReanalyzeSettledSeasons = false };

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -31,6 +31,7 @@ public sealed class TestSeasonReanalysisPlanner
     {
         // The test proxy throws on enumeration calls such as GetVirtualFolders.
         var libraryManager = EntrypointTestHelpers.CreateLibraryManager();
+        double? reportedProgress = null;
         var analyzer = new BaseItemAnalyzerTask(
             NullLogger.Instance,
             NullLoggerFactory.Instance,
@@ -41,7 +42,12 @@ public sealed class TestSeasonReanalysisPlanner
             ffmpegService: null!,
             cacheService: new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
 
-        await analyzer.AnalyzeItemsAsync(new Progress<double>(), CancellationToken.None, []);
+        await analyzer.AnalyzeItemsAsync(
+            new Progress<double>(value => reportedProgress = value),
+            CancellationToken.None,
+            []);
+
+        Assert.Equal(100, reportedProgress);
     }
 
     [Fact]

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -96,7 +96,7 @@ public partial class BaseItemAnalyzerTask(
 
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
 
-        if (seasonsToAnalyze is not null)
+        if (seasonsToAnalyze is { Count: > 0 })
         {
             queue = queue.Where(kvp => seasonsToAnalyze.Contains(kvp.Key))
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -79,6 +79,11 @@ public partial class BaseItemAnalyzerTask(
             .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
+        if (seasonsToAnalyze is { Count: 0 })
+        {
+            return;
+        }
+
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager,
@@ -91,7 +96,7 @@ public partial class BaseItemAnalyzerTask(
 
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
 
-        if (seasonsToAnalyze?.Count > 0)
+        if (seasonsToAnalyze is not null)
         {
             queue = queue.Where(kvp => seasonsToAnalyze.Contains(kvp.Key))
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -79,12 +79,13 @@ public partial class BaseItemAnalyzerTask(
             .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
-        var seasonFilter = seasonsToAnalyze?.ToHashSet();
-        if (seasonFilter is { Count: 0 })
+        if (seasonsToAnalyze?.Count == 0)
         {
             progress.Report(100);
             return;
         }
+
+        var seasonFilter = seasonsToAnalyze?.ToHashSet();
 
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -79,8 +79,10 @@ public partial class BaseItemAnalyzerTask(
             .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
-        if (seasonsToAnalyze is { Count: 0 })
+        var seasonFilter = seasonsToAnalyze?.ToHashSet();
+        if (seasonFilter is { Count: 0 })
         {
+            progress.Report(100);
             return;
         }
 
@@ -96,9 +98,9 @@ public partial class BaseItemAnalyzerTask(
 
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
 
-        if (seasonsToAnalyze is { Count: > 0 })
+        if (seasonFilter is not null)
         {
-            queue = queue.Where(kvp => seasonsToAnalyze.Contains(kvp.Key))
+            queue = queue.Where(kvp => seasonFilter.Contains(kvp.Key))
                          .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -75,7 +75,7 @@ public partial class CleanCacheTask(
             throw new InvalidOperationException("Library manager was null");
         }
 
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
+        _ = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
@@ -130,8 +130,6 @@ public partial class CleanCacheTask(
 
         // Clean up season state by removing items that no longer exist.
         await Plugin.CleanSeasonStateAsync(queue.Keys, cancellationToken).ConfigureAwait(false);
-
-        plugin.AnalyzeAgain = true;
 
         progress.Report(100);
     }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -75,8 +75,6 @@ public partial class CleanCacheTask(
             throw new InvalidOperationException("Library manager was null");
         }
 
-        _ = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
-
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager,


### PR DESCRIPTION
## Summary by Sourcery

Skip library enumeration and queue construction when no seasons are scheduled for analysis, and adjust cache cleaning behavior accordingly.

Bug Fixes:
- Prevent library enumeration in the analyzer task when the season list is empty to avoid unnecessary or failing calls into the library manager.

Enhancements:
- Short-circuit the analyzer task when no seasons are queued and use a hash set for season filtering to improve performance of season-based queue filtering.
- Simplify the cache cleaning task by removing reliance on the plugin instance and its AnalyzeAgain flag.

Tests:
- Add a unit test verifying that running the analyzer with an empty season set does not enumerate the library and still reports 100% progress.