### PR TITLE
Fix always-visible "Skip to content" link on the config page

### DIFF
--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -11,21 +11,29 @@
     font-size: 1.4em;
 }
 
+/* Visually hidden until focused; clipping does not depend on viewport geometry. */
 .skip-link {
     position: absolute;
     top: 8px;
     left: 16px;
     z-index: 20;
-    padding: 8px 12px;
-    border-radius: 4px;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
     background: var(--is-accent);
     color: var(--is-on-accent);
     text-decoration: none;
-    transform: translateY(-160%);
 }
 
-.skip-link:focus-visible {
-    transform: translateY(0);
+.skip-link:focus {
+    width: auto;
+    height: auto;
+    padding: 8px 12px;
+    border-radius: 4px;
+    clip-path: none;
     outline: 2px solid var(--is-on-accent);
     outline-offset: 2px;
 }


### PR DESCRIPTION
## Problem

The dashboard's accessibility skip link (rendered by `web/src/components/app-shell.ts`) was permanently visible in the top-left corner of the Intro Skipper configuration page, overlapping Jellyfin's toolbar.

## Root cause

`web/src/styles/layout.css` hid the link by translating it up out of view:

```css
.skip-link {
    position: absolute;
    top: 8px;
    left: 16px;
    transform: translateY(-160%);
}
```

That only hides the element when its positioned containing block starts at the viewport's top edge (or clips overflow). In Jellyfin's dashboard the plugin page container is positioned below the fixed toolbar and nothing clips overflow, so translating the link up ~56px just parked it — fully visible — over the toolbar area.

## Fix

Hide the skip link with the standard visually-hidden pattern (1×1 px, `overflow: hidden`, `clip-path: inset(50%)`), which is independent of the container's viewport geometry, and restore its size/padding on `:focus`. Revealing on `:focus` (instead of `:focus-visible`) keeps the skip link usable in browsers without `:focus-visible` support; since the link is fully clipped when unfocused, it cannot be mouse-focused, so behavior is unchanged for pointer users.

## Verification

Tested the built bundle in a harness replicating Jellyfin's dashboard geometry (fixed toolbar, drawer, positioned page container below the toolbar):

- Pre-fix rules: "Skip to content" visible in the top-left of the content area, matching the bug report.
- Fixed rules: link invisible on load; pressing <kbd>Tab</kbd> reveals it with a focus outline; <kbd>Enter</kbd> moves focus into the main content (next <kbd>Tab</kbd> lands on the first form control).

No changes needed in `IntroSkipper/Configuration/configPage.html` or `web/index.html` (the latter is only the Vite dev harness).

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/457dd56f-0b7a-4027-941e-38a829452aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-095" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/457dd56f-0b7a-4027-941e-38a829452aff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-095&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-095"><img alt="INTRO-095" src="https://capy.ai/api/badge/thread.svg?label=INTRO-095"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Improve accessibility skip link behavior so it remains hidden until focused and no longer overlaps the dashboard toolbar.

Bug Fixes:
- Fix skip link being permanently visible and overlapping the Jellyfin dashboard toolbar on the configuration page.

Enhancements:
- Adopt a viewport-independent visually hidden pattern for the skip link and reveal it on focus to maintain keyboard accessibility.