### PR TITLE
Refresh media segments after cleaning stale timestamps

### DIFF
--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -58,6 +58,9 @@ internal static class EntrypointTestHelpers
         public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 
     // Lightweight ILibraryManager stub that resolves the supplied items by id via GetItemById

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -150,7 +150,7 @@ public sealed class TestDbSegmentStorage
     }
 
     [Fact]
-    public async Task CleanTimestampsAsync_DoesNotExceedSqliteVariableLimit_WhenEpisodeListIsLarge()
+    public async Task TimestampCleanup_DoesNotExceedSqliteVariableLimit_WhenEpisodeListIsLarge()
     {
         const int LargeEpisodeCount = 33_000;
 
@@ -181,8 +181,15 @@ public sealed class TestDbSegmentStorage
                 var plugin = Plugin.Instance!;
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
 
-                var staleEpisodeIds = await plugin.CleanTimestampsAsync(enabledEpisodeIds);
+                var staleEpisodeIds = await Plugin.GetStaleTimestampEpisodeIdsAsync(enabledEpisodeIds);
                 Assert.Equal([staleItemId], staleEpisodeIds);
+
+                using (var db = new IntroSkipperDbContext(dbPath))
+                {
+                    Assert.Equal(2, db.DbSegment.Count());
+                }
+
+                await Plugin.DeleteTimestampsAsync(staleEpisodeIds);
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -181,7 +181,8 @@ public sealed class TestDbSegmentStorage
                 var plugin = Plugin.Instance!;
                 EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
 
-                await Plugin.CleanTimestampsAsync(enabledEpisodeIds);
+                var staleEpisodeIds = await plugin.CleanTimestampsAsync(enabledEpisodeIds);
+                Assert.Equal([staleItemId], staleEpisodeIds);
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))

--- a/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
@@ -103,6 +103,44 @@ public sealed class TestMediaSegmentRefreshService
         Assert.Equal(itemId, manager.LastItemId);
     }
 
+    [Fact]
+    public async Task RemoveIntroSkipperSegmentsAsync_ExcludesIntroSkipperProvider()
+    {
+        var itemId = Guid.NewGuid();
+        var manager = new FakeMediaSegmentManager();
+        var libraryManager = EntrypointTestHelpers.CreateLibraryManager(CreateMovie(itemId));
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { MaxParallelism = 2 });
+        var refresher = CreateRefresher(manager, libraryManager);
+
+        await refresher.RemoveIntroSkipperSegmentsAsync([itemId], CancellationToken.None);
+
+        Assert.NotNull(manager.LastLibraryOptions);
+        Assert.Contains(Plugin.ProviderName, manager.LastLibraryOptions!.DisabledMediaSegmentProviders);
+        Assert.Contains("Chapter Segments Provider", manager.LastLibraryOptions.DisabledMediaSegmentProviders);
+        Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
+    }
+
+    [Fact]
+    public async Task RemoveIntroSkipperSegmentsAsync_PropagatesRefreshFailure()
+    {
+        var itemId = Guid.NewGuid();
+        var expectedException = new InvalidOperationException("boom");
+        var manager = new FakeMediaSegmentManager
+        {
+            RunException = expectedException
+        };
+        var libraryManager = EntrypointTestHelpers.CreateLibraryManager(CreateMovie(itemId));
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { MaxParallelism = 2 });
+        var refresher = CreateRefresher(manager, libraryManager);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => refresher.RemoveIntroSkipperSegmentsAsync([itemId], CancellationToken.None));
+
+        Assert.Same(expectedException, exception);
+    }
+
     private static MediaSegmentRefreshService CreateRefresher(FakeMediaSegmentManager manager, ILibraryManager? libraryManager = null)
         => new(manager, libraryManager ?? EntrypointTestHelpers.CreateLibraryManager(), NullLogger<MediaSegmentRefreshService>.Instance);
 

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -125,5 +125,8 @@ public sealed class TestSkipIntroController
         {
             return Completion?.Task ?? Task.CompletedTask;
         }
+
+        public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+            => RefreshAsync(itemIds, cancellationToken);
     }
 }

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -205,5 +205,8 @@ public sealed class TestVisualizationController
             LastItemIds = [.. itemIds];
             return Completion?.Task ?? Task.CompletedTask;
         }
+
+        public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+            => RefreshAsync(itemIds, cancellationToken);
     }
 }

--- a/IntroSkipper/Manager/IMediaSegmentRefresher.cs
+++ b/IntroSkipper/Manager/IMediaSegmentRefresher.cs
@@ -22,4 +22,12 @@ public interface IMediaSegmentRefresher
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes Intro Skipper-owned media segments by refreshing items with only other providers.
+    /// </summary>
+    /// <param name="itemIds">The item ids whose Intro Skipper segments should be removed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default);
 }

--- a/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
+++ b/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
@@ -17,4 +17,13 @@ internal static class MediaSegmentProviderDefaults
     {
         DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
     };
+
+    /// <summary>
+    /// Gets the <see cref="LibraryOptions"/> used to remove Intro Skipper-owned segments while
+    /// preserving segments produced by other external providers.
+    /// </summary>
+    internal static LibraryOptions ExternalProvidersWithoutIntroSkipper { get; } = new()
+    {
+        DisabledMediaSegmentProviders = ["Chapter Segments Provider", Plugin.ProviderName]
+    };
 }

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -1,6 +1,7 @@
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Manager;
@@ -24,9 +25,23 @@ public sealed partial class MediaSegmentRefreshService(
     {
         ArgumentNullException.ThrowIfNull(item);
 
+        await RefreshCoreAsync(
+                item,
+                MediaSegmentProviderDefaults.ExternalProviders,
+                suppressErrors: true,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task RefreshCoreAsync(
+        BaseItem item,
+        LibraryOptions libraryOptions,
+        bool suppressErrors,
+        CancellationToken cancellationToken)
+    {
         try
         {
-            await mediaSegmentManager.RunSegmentPluginProviders(item, MediaSegmentProviderDefaults.ExternalProviders, true, cancellationToken).ConfigureAwait(false);
+            await mediaSegmentManager.RunSegmentPluginProviders(item, libraryOptions, true, cancellationToken).ConfigureAwait(false);
             LogUpdatedMediaSegments(logger, item.Id);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -47,13 +62,19 @@ public sealed partial class MediaSegmentRefreshService(
                 throw;
             }
 
-            // Log and continue so that one item's provider failure does not
-            // abort the surrounding batch refresh.
             LogErrorRefreshingMediaSegments(logger, ex, item.Id);
+            if (!suppressErrors)
+            {
+                throw;
+            }
         }
     }
 
-    private async Task RefreshByIdAsync(Guid itemId, CancellationToken cancellationToken)
+    private async Task RefreshByIdAsync(
+        Guid itemId,
+        LibraryOptions libraryOptions,
+        bool suppressErrors,
+        CancellationToken cancellationToken)
     {
         if (itemId == Guid.Empty)
         {
@@ -67,11 +88,30 @@ public sealed partial class MediaSegmentRefreshService(
             return;
         }
 
-        await RefreshAsync(item, cancellationToken).ConfigureAwait(false);
+        await RefreshCoreAsync(item, libraryOptions, suppressErrors, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+    public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+        => RefreshByIdsAsync(
+            itemIds,
+            MediaSegmentProviderDefaults.ExternalProviders,
+            suppressErrors: true,
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+        => RefreshByIdsAsync(
+            itemIds,
+            MediaSegmentProviderDefaults.ExternalProvidersWithoutIntroSkipper,
+            suppressErrors: false,
+            cancellationToken);
+
+    private async Task RefreshByIdsAsync(
+        IEnumerable<Guid> itemIds,
+        LibraryOptions libraryOptions,
+        bool suppressErrors,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(itemIds);
 
@@ -90,7 +130,7 @@ public sealed partial class MediaSegmentRefreshService(
 
         await Parallel.ForEachAsync(ids, options, async (itemId, ct) =>
         {
-            await RefreshByIdAsync(itemId, ct).ConfigureAwait(false);
+            await RefreshByIdAsync(itemId, libraryOptions, suppressErrors, ct).ConfigureAwait(false);
         }).ConfigureAwait(false);
     }
 

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -35,6 +35,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     private const double SegmentComparisonEpsilon = 0.001;
     private const int SqliteParameterBatchSize = 500;
+    internal const string ProviderName = "Intro Skipper";
     private readonly ILibraryManager _libraryManager;
     private readonly IChapterManager _chapterRepository;
     private readonly IPluginManager _pluginManager;
@@ -159,7 +160,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public string FFmpegPath { get; private set; }
 
     /// <inheritdoc />
-    public override string Name => "Intro Skipper";
+    public override string Name => ProviderName;
 
     /// <inheritdoc />
     public override Guid Id => Guid.Parse("c83d86bb-a1e0-4c35-a113-e2101cf4ee6b");
@@ -333,7 +334,9 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             .ConfigureAwait(false);
     }
 
-    internal async Task<IReadOnlyCollection<Guid>> CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
+    internal static async Task<IReadOnlyCollection<Guid>> GetStaleTimestampEpisodeIdsAsync(
+        IEnumerable<Guid> episodeIds,
+        CancellationToken cancellationToken = default)
     {
         var enabledEpisodeIds = episodeIds.ToHashSet();
 
@@ -345,19 +348,29 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var staleEpisodeIds = segmentEpisodeIds
+        return segmentEpisodeIds
             .Where(id => !enabledEpisodeIds.Contains(id))
             .ToArray();
+    }
 
-        foreach (var staleEpisodeIdBatch in staleEpisodeIds.Chunk(SqliteParameterBatchSize))
+    internal static async Task DeleteTimestampsAsync(
+        IEnumerable<Guid> episodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        var episodeIdArray = episodeIds.Distinct().ToArray();
+        if (episodeIdArray.Length == 0)
+        {
+            return;
+        }
+
+        using var db = CreateDbContext();
+        foreach (var episodeIdBatch in episodeIdArray.Chunk(SqliteParameterBatchSize))
         {
             await db.DbSegment
-                .Where(s => staleEpisodeIdBatch.Contains(s.ItemId))
+                .Where(s => episodeIdBatch.Contains(s.ItemId))
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
         }
-
-        return staleEpisodeIds;
     }
 
     internal static async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -333,7 +333,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             .ConfigureAwait(false);
     }
 
-    internal static async Task<IReadOnlyList<Guid>> CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
+    internal async Task<IReadOnlyCollection<Guid>> CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
         var enabledEpisodeIds = episodeIds.ToHashSet();
 

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -333,7 +333,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             .ConfigureAwait(false);
     }
 
-    internal static async Task CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
+    internal static async Task<IReadOnlyList<Guid>> CleanTimestampsAsync(IEnumerable<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
         var enabledEpisodeIds = episodeIds.ToHashSet();
 
@@ -356,6 +356,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
         }
+
+        return staleEpisodeIds;
     }
 
     internal static async Task SetAnalyzerActionAsync(Guid id, IReadOnlyDictionary<AnalysisMode, AnalyzerAction> analyzerActions, CancellationToken cancellationToken = default)

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -25,7 +25,6 @@ namespace IntroSkipper
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
             serviceCollection.AddHostedService<Entrypoint>();
-            serviceCollection.AddSingleton<Plugin>(_ => Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null"));
             serviceCollection.AddSingleton<IDetectionCacheService, DetectionCacheService>();
             serviceCollection.AddSingleton<IFFmpegService, FFmpegService>();
             serviceCollection.AddSingleton<IMediaSegmentProvider, SegmentProvider>();

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -25,6 +25,7 @@ namespace IntroSkipper
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
             serviceCollection.AddHostedService<Entrypoint>();
+            serviceCollection.AddSingleton<Plugin>(_ => Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null"));
             serviceCollection.AddSingleton<IDetectionCacheService, DetectionCacheService>();
             serviceCollection.AddSingleton<IFFmpegService, FFmpegService>();
             serviceCollection.AddSingleton<IMediaSegmentProvider, SegmentProvider>();

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -26,7 +26,6 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="fileSystem">File system.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
-/// <param name="plugin">Intro Skipper plugin.</param>
 public partial class CleanCacheTask(
     ILogger<CleanCacheTask> logger,
     ILoggerFactory loggerFactory,
@@ -34,8 +33,7 @@ public partial class CleanCacheTask(
     IProviderManager providerManager,
     IFileSystem fileSystem,
     IFFmpegService ffmpegService,
-    IMediaSegmentRefresher mediaSegmentRefresher,
-    Plugin plugin) : IScheduledTask
+    IMediaSegmentRefresher mediaSegmentRefresher) : IScheduledTask
 {
     private readonly ILogger<CleanCacheTask> _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
@@ -44,7 +42,6 @@ public partial class CleanCacheTask(
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
-    private readonly Plugin _plugin = plugin;
 
     /// <summary>
     /// Gets the task name.
@@ -81,6 +78,8 @@ public partial class CleanCacheTask(
             throw new InvalidOperationException("Library manager was null");
         }
 
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager,
@@ -91,21 +90,27 @@ public partial class CleanCacheTask(
         // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders.
         var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
-        var enabledLibraryEpisodes = queue.Values.SelectMany(static episodes => episodes).ToList();
-
-        var enabledLibraryEpisodeIds = enabledLibraryEpisodes
-            .Select(e => e.EpisodeId)
+        var enabledLibraryEpisodeIds = queue.Values
+            .SelectMany(static episodes => episodes)
+            .Select(static episode => episode.EpisodeId)
             .ToHashSet();
 
-        // Remove stale plugin timestamps and return the affected episode IDs for segment refresh.
-        var staleTimestampEpisodeIds = await _plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
+        var staleTimestampEpisodeIds = await Plugin
+            .GetStaleTimestampEpisodeIdsAsync(enabledLibraryEpisodeIds, cancellationToken)
+            .ConfigureAwait(false);
 
-        // The provider was disabled for these libraries, so the analyzer no longer refreshes
-        // their Jellyfin segments. Refresh after deleting the plugin rows to remove any segments
-        // that were previously synchronized by Intro Skipper.
-        if (staleTimestampEpisodeIds.Count > 0 && _plugin.Configuration.UpdateMediaSegments)
+        if (staleTimestampEpisodeIds.Count > 0)
         {
-            await _mediaSegmentRefresher.RefreshAsync(staleTimestampEpisodeIds, cancellationToken).ConfigureAwait(false);
+            // Refresh first with Intro Skipper excluded. If refresh fails or is canceled, the
+            // timestamps remain available so a later cleanup run can retry the handoff.
+            if (plugin.Configuration.UpdateMediaSegments)
+            {
+                await _mediaSegmentRefresher
+                    .RemoveIntroSkipperSegmentsAsync(staleTimestampEpisodeIds, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            await Plugin.DeleteTimestampsAsync(staleTimestampEpisodeIds, cancellationToken).ConfigureAwait(false);
         }
 
         // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -25,13 +25,15 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="providerManager">Provider manager.</param>
 /// <param name="fileSystem">File system.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
+/// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 public partial class CleanCacheTask(
     ILogger<CleanCacheTask> logger,
     ILoggerFactory loggerFactory,
     ILibraryManager libraryManager,
     IProviderManager providerManager,
     IFileSystem fileSystem,
-    IFFmpegService ffmpegService) : IScheduledTask
+    IFFmpegService ffmpegService,
+    IMediaSegmentRefresher mediaSegmentRefresher) : IScheduledTask
 {
     private readonly ILogger<CleanCacheTask> _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
@@ -39,6 +41,7 @@ public partial class CleanCacheTask(
     private readonly IProviderManager _providerManager = providerManager;
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
 
     /// <summary>
     /// Gets the task name.
@@ -75,6 +78,8 @@ public partial class CleanCacheTask(
             throw new InvalidOperationException("Library manager was null");
         }
 
+        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
+
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager,
@@ -91,7 +96,15 @@ public partial class CleanCacheTask(
             .Select(e => e.EpisodeId)
             .ToHashSet();
 
-        await Plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
+        var staleTimestampEpisodeIds = await Plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
+
+        // The provider was disabled for these libraries, so the analyzer no longer refreshes
+        // their Jellyfin segments. Refresh after deleting the plugin rows to remove any segments
+        // that were previously synchronized by Intro Skipper.
+        if (staleTimestampEpisodeIds.Count > 0 && plugin.Configuration.UpdateMediaSegments)
+        {
+            await _mediaSegmentRefresher.RefreshAsync(staleTimestampEpisodeIds, cancellationToken).ConfigureAwait(false);
+        }
 
         // Identify episode IDs in the SQLite cache that are no longer in enabled libraries.
         HashSet<Guid> invalidEpisodeIds;

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -96,7 +96,7 @@ public partial class CleanCacheTask(
             .Select(e => e.EpisodeId)
             .ToHashSet();
 
-        var staleTimestampEpisodeIds = await Plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
+        var staleTimestampEpisodeIds = await plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
 
         // The provider was disabled for these libraries, so the analyzer no longer refreshes
         // their Jellyfin segments. Refresh after deleting the plugin rows to remove any segments

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -26,6 +26,7 @@ namespace IntroSkipper.ScheduledTasks;
 /// <param name="fileSystem">File system.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
+/// <param name="plugin">Intro Skipper plugin.</param>
 public partial class CleanCacheTask(
     ILogger<CleanCacheTask> logger,
     ILoggerFactory loggerFactory,
@@ -33,7 +34,8 @@ public partial class CleanCacheTask(
     IProviderManager providerManager,
     IFileSystem fileSystem,
     IFFmpegService ffmpegService,
-    IMediaSegmentRefresher mediaSegmentRefresher) : IScheduledTask
+    IMediaSegmentRefresher mediaSegmentRefresher,
+    Plugin plugin) : IScheduledTask
 {
     private readonly ILogger<CleanCacheTask> _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
@@ -42,6 +44,7 @@ public partial class CleanCacheTask(
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
+    private readonly Plugin _plugin = plugin;
 
     /// <summary>
     /// Gets the task name.
@@ -78,8 +81,6 @@ public partial class CleanCacheTask(
             throw new InvalidOperationException("Library manager was null");
         }
 
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
-
         var queueManager = new QueueManager(
             _loggerFactory.CreateLogger<QueueManager>(),
             _libraryManager,
@@ -96,12 +97,13 @@ public partial class CleanCacheTask(
             .Select(e => e.EpisodeId)
             .ToHashSet();
 
-        var staleTimestampEpisodeIds = await plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
+        // Remove stale plugin timestamps and return the affected episode IDs for segment refresh.
+        var staleTimestampEpisodeIds = await _plugin.CleanTimestampsAsync(enabledLibraryEpisodeIds, cancellationToken).ConfigureAwait(false);
 
         // The provider was disabled for these libraries, so the analyzer no longer refreshes
         // their Jellyfin segments. Refresh after deleting the plugin rows to remove any segments
         // that were previously synchronized by Intro Skipper.
-        if (staleTimestampEpisodeIds.Count > 0 && plugin.Configuration.UpdateMediaSegments)
+        if (staleTimestampEpisodeIds.Count > 0 && _plugin.Configuration.UpdateMediaSegments)
         {
             await _mediaSegmentRefresher.RefreshAsync(staleTimestampEpisodeIds, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary by Sourcery

Refresh media segments for episodes whose stale timestamps are cleaned from the plugin cache.

New Features:
- Trigger media segment refresh for episodes with stale timestamps when the scheduled cache clean task runs and media segment updates are enabled.

Bug Fixes:
- Ensure Jellyfin media segments are resynchronized after Intro Skipper removes stale timestamp entries for episodes in libraries where the provider was disabled.

Enhancements:
- Refine Plugin.CleanTimestampsAsync to return the IDs of episodes with stale timestamps for downstream processing.
- Inject and use IMediaSegmentRefresher in the cache cleaning scheduled task instead of relying solely on timestamp deletion.

Tests:
- Extend CleanTimestampsAsync tests to assert that the method returns the expected set of stale episode IDs.