### PR TITLE
Fix stale media segment cleanup

### DIFF
--- a/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
@@ -104,10 +104,14 @@ public sealed class TestMediaSegmentRefreshService
     }
 
     [Fact]
-    public async Task RemoveIntroSkipperSegmentsAsync_ExcludesIntroSkipperProvider()
+    public async Task RemoveIntroSkipperSegmentsAsync_DeletesOnlyIntroSkipperSegments()
     {
         var itemId = Guid.NewGuid();
-        var manager = new FakeMediaSegmentManager();
+        var segmentId = Guid.NewGuid();
+        var manager = new FakeMediaSegmentManager
+        {
+            SegmentsToReturn = [new MediaSegmentDto { Id = segmentId, ItemId = itemId }]
+        };
         var libraryManager = EntrypointTestHelpers.CreateLibraryManager(CreateMovie(itemId));
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { MaxParallelism = 2 });
@@ -115,20 +119,23 @@ public sealed class TestMediaSegmentRefreshService
 
         await refresher.RemoveIntroSkipperSegmentsAsync([itemId], CancellationToken.None);
 
+        Assert.Equal([segmentId], manager.DeletedSegmentIds);
         Assert.NotNull(manager.LastLibraryOptions);
-        Assert.Contains(Plugin.ProviderName, manager.LastLibraryOptions!.DisabledMediaSegmentProviders);
+        Assert.DoesNotContain(Plugin.ProviderName, manager.LastLibraryOptions!.DisabledMediaSegmentProviders);
         Assert.Contains("Chapter Segments Provider", manager.LastLibraryOptions.DisabledMediaSegmentProviders);
-        Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
+        Assert.True(manager.LastFilterByProvider);
+        Assert.Equal(0, manager.RunCount);
     }
 
     [Fact]
-    public async Task RemoveIntroSkipperSegmentsAsync_PropagatesRefreshFailure()
+    public async Task RemoveIntroSkipperSegmentsAsync_PropagatesDeleteFailure()
     {
         var itemId = Guid.NewGuid();
         var expectedException = new InvalidOperationException("boom");
         var manager = new FakeMediaSegmentManager
         {
-            RunException = expectedException
+            SegmentsToReturn = [new MediaSegmentDto { Id = Guid.NewGuid(), ItemId = itemId }],
+            DeleteSegmentException = expectedException
         };
         var libraryManager = EntrypointTestHelpers.CreateLibraryManager(CreateMovie(itemId));
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
@@ -162,7 +169,15 @@ public sealed class TestMediaSegmentRefreshService
 
         public LibraryOptions? LastLibraryOptions { get; private set; }
 
+        public bool LastFilterByProvider { get; private set; }
+
+        public List<Guid> DeletedSegmentIds { get; } = [];
+
         public Exception? RunException { get; init; }
+
+        public Exception? DeleteSegmentException { get; init; }
+
+        public IReadOnlyList<MediaSegmentDto> SegmentsToReturn { get; init; } = [];
 
         public TaskCompletionSource? RunCompletion { get; init; }
 
@@ -185,17 +200,33 @@ public sealed class TestMediaSegmentRefreshService
 
         public Task<MediaSegmentDto> CreateSegmentAsync(MediaSegmentDto mediaSegment, string segmentProviderId) => Task.FromResult(mediaSegment);
 
-        public Task DeleteSegmentAsync(Guid segmentId) => Task.CompletedTask;
+        public Task DeleteSegmentAsync(Guid segmentId)
+        {
+            if (DeleteSegmentException is not null)
+            {
+                throw DeleteSegmentException;
+            }
+
+            DeletedSegmentIds.Add(segmentId);
+            return Task.CompletedTask;
+        }
 
         public Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<IEnumerable<MediaSegmentDto>> GetSegmentsAsync(BaseItem item, IEnumerable<MediaSegmentType>? typeFilter, LibraryOptions libraryOptions, bool filterByProvider = true)
         {
-            return Task.FromResult<IEnumerable<MediaSegmentDto>>(Array.Empty<MediaSegmentDto>());
+            LastLibraryOptions = libraryOptions;
+            LastFilterByProvider = filterByProvider;
+            return Task.FromResult<IEnumerable<MediaSegmentDto>>(SegmentsToReturn);
         }
 
         public bool HasSegments(Guid itemId) => false;
 
-        public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => [(Plugin.Instance!.Name, "intro-skipper")];
+        public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item)
+            =>
+            [
+                (Plugin.ProviderName, "intro-skipper"),
+                ("Chapter Segments Provider", "chapter")
+            ];
     }
 }

--- a/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
+++ b/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
@@ -17,13 +17,4 @@ internal static class MediaSegmentProviderDefaults
     {
         DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
     };
-
-    /// <summary>
-    /// Gets the <see cref="LibraryOptions"/> used to remove Intro Skipper-owned segments while
-    /// preserving segments produced by other external providers.
-    /// </summary>
-    internal static LibraryOptions ExternalProvidersWithoutIntroSkipper { get; } = new()
-    {
-        DisabledMediaSegmentProviders = ["Chapter Segments Provider", Plugin.ProviderName]
-    };
 }

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace IntroSkipper.Manager;
 
 /// <summary>
-/// Refreshes Jellyfin media segments by running media-segment providers directly.
+/// Manages Jellyfin media segments by running providers and removing Intro Skipper-owned entries.
 /// </summary>
 /// <remarks>
 /// Initializes a new instance of the <see cref="MediaSegmentRefreshService"/> class.
@@ -20,28 +20,31 @@ public sealed partial class MediaSegmentRefreshService(
     ILibraryManager libraryManager,
     ILogger<MediaSegmentRefreshService> logger) : IMediaSegmentRefresher
 {
+    private enum MediaSegmentBatchOperation
+    {
+        Refresh,
+        RemoveIntroSkipperSegments
+    }
+
     /// <inheritdoc />
     public async Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        await RefreshCoreAsync(
-                item,
-                MediaSegmentProviderDefaults.ExternalProviders,
-                suppressErrors: true,
-                cancellationToken)
-            .ConfigureAwait(false);
+        await RefreshCoreAsync(item, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task RefreshCoreAsync(
-        BaseItem item,
-        LibraryOptions libraryOptions,
-        bool suppressErrors,
-        CancellationToken cancellationToken)
+    private async Task RefreshCoreAsync(BaseItem item, CancellationToken cancellationToken)
     {
         try
         {
-            await mediaSegmentManager.RunSegmentPluginProviders(item, libraryOptions, true, cancellationToken).ConfigureAwait(false);
+            await mediaSegmentManager
+                .RunSegmentPluginProviders(
+                    item,
+                    MediaSegmentProviderDefaults.ExternalProviders,
+                    true,
+                    cancellationToken)
+                .ConfigureAwait(false);
             LogUpdatedMediaSegments(logger, item.Id);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -63,54 +66,74 @@ public sealed partial class MediaSegmentRefreshService(
             }
 
             LogErrorRefreshingMediaSegments(logger, ex, item.Id);
-            if (!suppressErrors)
-            {
-                throw;
-            }
         }
     }
 
-    private async Task RefreshByIdAsync(
+    private async Task ProcessByIdAsync(
         Guid itemId,
-        LibraryOptions libraryOptions,
-        bool suppressErrors,
+        MediaSegmentBatchOperation operation,
         CancellationToken cancellationToken)
     {
-        if (itemId == Guid.Empty)
-        {
-            return;
-        }
-
         var item = libraryManager.GetItemById(itemId);
         if (item is null)
         {
-            LogItemNotFoundForMediaSegmentRefresh(logger, itemId);
+            LogItemNotFoundForMediaSegmentOperation(logger, itemId);
             return;
         }
 
-        await RefreshCoreAsync(item, libraryOptions, suppressErrors, cancellationToken).ConfigureAwait(false);
+        switch (operation)
+        {
+            case MediaSegmentBatchOperation.Refresh:
+                await RefreshCoreAsync(item, cancellationToken).ConfigureAwait(false);
+                break;
+            case MediaSegmentBatchOperation.RemoveIntroSkipperSegments:
+                await RemoveIntroSkipperSegmentsCoreAsync(item, cancellationToken).ConfigureAwait(false);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(operation), operation, null);
+        }
+    }
+
+    private async Task RemoveIntroSkipperSegmentsCoreAsync(BaseItem item, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var introSkipperOnlyOptions = new LibraryOptions
+        {
+            DisabledMediaSegmentProviders =
+            [
+                .. mediaSegmentManager
+                    .GetSupportedProviders(item)
+                    .Select(static provider => provider.Name)
+                    .Where(static providerName => !string.Equals(
+                        providerName,
+                        Plugin.ProviderName,
+                        StringComparison.OrdinalIgnoreCase))
+            ]
+        };
+
+        var segments = await mediaSegmentManager
+            .GetSegmentsAsync(item, null, introSkipperOnlyOptions, filterByProvider: true)
+            .ConfigureAwait(false);
+
+        foreach (var segment in segments)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await mediaSegmentManager.DeleteSegmentAsync(segment.Id).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc />
     public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
-        => RefreshByIdsAsync(
-            itemIds,
-            MediaSegmentProviderDefaults.ExternalProviders,
-            suppressErrors: true,
-            cancellationToken);
+        => ProcessByIdsAsync(itemIds, MediaSegmentBatchOperation.Refresh, cancellationToken);
 
     /// <inheritdoc />
     public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
-        => RefreshByIdsAsync(
-            itemIds,
-            MediaSegmentProviderDefaults.ExternalProvidersWithoutIntroSkipper,
-            suppressErrors: false,
-            cancellationToken);
+        => ProcessByIdsAsync(itemIds, MediaSegmentBatchOperation.RemoveIntroSkipperSegments, cancellationToken);
 
-    private async Task RefreshByIdsAsync(
+    private async Task ProcessByIdsAsync(
         IEnumerable<Guid> itemIds,
-        LibraryOptions libraryOptions,
-        bool suppressErrors,
+        MediaSegmentBatchOperation operation,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(itemIds);
@@ -130,7 +153,7 @@ public sealed partial class MediaSegmentRefreshService(
 
         await Parallel.ForEachAsync(ids, options, async (itemId, ct) =>
         {
-            await RefreshByIdAsync(itemId, libraryOptions, suppressErrors, ct).ConfigureAwait(false);
+            await ProcessByIdAsync(itemId, operation, ct).ConfigureAwait(false);
         }).ConfigureAwait(false);
     }
 
@@ -143,6 +166,6 @@ public sealed partial class MediaSegmentRefreshService(
     [LoggerMessage(Level = LogLevel.Error, Message = "Error refreshing media segments for item {ItemId}")]
     private static partial void LogErrorRefreshingMediaSegments(ILogger logger, Exception ex, Guid itemId);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Item not found for media segment refresh {ItemId}")]
-    private static partial void LogItemNotFoundForMediaSegmentRefresh(ILogger logger, Guid itemId);
+    [LoggerMessage(Level = LogLevel.Error, Message = "Item not found for media segment operation {ItemId}")]
+    private static partial void LogItemNotFoundForMediaSegmentOperation(ILogger logger, Guid itemId);
 }

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -166,6 +166,6 @@ public sealed partial class MediaSegmentRefreshService(
     [LoggerMessage(Level = LogLevel.Error, Message = "Error refreshing media segments for item {ItemId}")]
     private static partial void LogErrorRefreshingMediaSegments(ILogger logger, Exception ex, Guid itemId);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Item not found for media segment operation {ItemId}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Item not found for media segment operation {ItemId}")]
     private static partial void LogItemNotFoundForMediaSegmentOperation(ILogger logger, Guid itemId);
 }


### PR DESCRIPTION
## Summary

- remove Intro Skipper-owned Jellyfin segments directly instead of relying on a forced provider refresh
- preserve Chapter and third-party provider segments by querying only the Intro Skipper provider
- retain source timestamps when segment deletion fails so cleanup can retry
- cover selective deletion and failure propagation

## Problem

When Intro Skipper and the Chapter provider were both disabled for the cleanup refresh, Jellyfin could have no enabled providers. Jellyfin returns before applying `forceOverwrite` in that case, leaving stale Intro Skipper segments behind while the source timestamp rows are deleted.

## Verification

- `dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj --filter FullyQualifiedName~TestMediaSegmentRefreshService --no-restore -p:SkipWebBuild=true` — 7 passed, 0 warnings
- `dotnet build IntroSkipper/IntroSkipper.csproj --no-restore -p:SkipWebBuild=true` — 0 errors, 0 warnings

## Summary by Sourcery

Fix stale Intro Skipper media segment cleanup by separating refresh from deletion and ensuring Intro Skipper-owned segments are removed directly.

Bug Fixes:
- Prevent stale Intro Skipper segments from persisting when Jellyfin has no enabled media segment providers during a forced refresh.
- Ensure failures while deleting Intro Skipper segments propagate instead of being silently swallowed.

Enhancements:
- Introduce a unified media-segment batch operation pipeline that supports both refresh and Intro Skipper segment removal by item ID or batch of IDs.
- Adjust logging to use a generic media segment operation message when items cannot be resolved.

Tests:
- Expand media segment refresh service tests to verify selective Intro Skipper-only deletion, provider filtering, and delete-failure propagation.