### PR TITLE
Fix season-state writes crashing on lazy episode ID enumerables

### DIFF
--- a/IntroSkipper.Tests/TestDatabaseFacades.cs
+++ b/IntroSkipper.Tests/TestDatabaseFacades.cs
@@ -325,6 +325,46 @@ public sealed class TestDatabaseFacades
     }
 
     [Fact]
+    public async Task SetEpisodeIdsAsync_AcceptsLazyEnumerable_OnInsertAndUpdate()
+    {
+        // Regression: EF Core maps the IEnumerable<Guid> EpisodeIds property as a primitive
+        // collection whose change tracking only accepts arrays or IList<Guid>. The analyzer
+        // task passes items.Select(i => i.EpisodeId) — a lazy iterator — which made both the
+        // insert and the update path throw InvalidOperationException until the facade
+        // materialized the sequence.
+        var dbPath = CreateTempDbPath();
+        var seasonId = Guid.NewGuid();
+        var retainedEpisodeId = Guid.NewGuid();
+        var removedEpisodeId = Guid.NewGuid();
+        var episodeIds = new List<Guid> { retainedEpisodeId, removedEpisodeId };
+        try
+        {
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+
+            // Insert path with a lazy projection, mirroring BaseItemAnalyzerTask.
+            await database.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, episodeIds.Select(id => id), "hash-1");
+
+            // Update path with a lazy projection over the existing row.
+            await database.SetEpisodeIdsAsync(
+                seasonId,
+                AnalysisMode.Introduction,
+                episodeIds.Where(id => id != removedEpisodeId),
+                "hash-2");
+
+            await using var db = new IntroSkipperDbContext(dbPath);
+            var state = await db.DbSeasonState
+                .AsNoTracking()
+                .SingleAsync(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction);
+            Assert.Equal([retainedEpisodeId], state.EpisodeIds);
+            Assert.Equal("hash-2", state.ConfigHash);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task AnalyzerActions_ReturnStoredRow_AndFillMissingModesWithDefault()
     {
         var dbPath = CreateTempDbPath();

--- a/IntroSkipper/Db/DbSeasonState.cs
+++ b/IntroSkipper/Db/DbSeasonState.cs
@@ -44,11 +44,11 @@ public class DbSeasonState
         Type = mode;
         Action = action;
 
-        // Materialize to arrays: EF Core tracks these IEnumerable<Guid> properties as
+        // Materialize eagerly: EF Core tracks these IEnumerable<Guid> properties as
         // primitive collections, which only accept arrays or IList<Guid> instances.
-        EpisodeIds = episodeIds?.ToArray() ?? [];
+        EpisodeIds = episodeIds is null ? [] : [.. episodeIds];
         ConfigHash = configHash;
-        SettledReanalysisEpisodeIds = settledReanalysisEpisodeIds?.ToArray() ?? [];
+        SettledReanalysisEpisodeIds = settledReanalysisEpisodeIds is null ? [] : [.. settledReanalysisEpisodeIds];
     }
 
     /// <summary>

--- a/IntroSkipper/Db/DbSeasonState.cs
+++ b/IntroSkipper/Db/DbSeasonState.cs
@@ -43,9 +43,12 @@ public class DbSeasonState
         SeasonId = seasonId;
         Type = mode;
         Action = action;
-        EpisodeIds = episodeIds ?? [];
+
+        // Materialize to arrays: EF Core tracks these IEnumerable<Guid> properties as
+        // primitive collections, which only accept arrays or IList<Guid> instances.
+        EpisodeIds = episodeIds?.ToArray() ?? [];
         ConfigHash = configHash;
-        SettledReanalysisEpisodeIds = settledReanalysisEpisodeIds ?? [];
+        SettledReanalysisEpisodeIds = settledReanalysisEpisodeIds?.ToArray() ?? [];
     }
 
     /// <summary>

--- a/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
@@ -46,7 +46,7 @@ public sealed partial class IntroSkipperDatabase
         // EF Core maps IEnumerable<Guid> as a primitive collection and its change tracking
         // only accepts arrays or IList<Guid>; a lazy enumerable (e.g. the Select projection
         // passed by BaseItemAnalyzerTask) makes it throw InvalidOperationException.
-        var ids = episodeIds as Guid[] ?? episodeIds.ToArray();
+        var ids = episodeIds as Guid[] ?? [.. episodeIds];
 
         await EnsureInitializedAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();

--- a/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
@@ -41,6 +41,13 @@ public sealed partial class IntroSkipperDatabase
     /// <inheritdoc/>
     public async Task SetEpisodeIdsAsync(Guid seasonId, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(episodeIds);
+
+        // EF Core maps IEnumerable<Guid> as a primitive collection and its change tracking
+        // only accepts arrays or IList<Guid>; a lazy enumerable (e.g. the Select projection
+        // passed by BaseItemAnalyzerTask) makes it throw InvalidOperationException.
+        var ids = episodeIds as Guid[] ?? episodeIds.ToArray();
+
         await EnsureInitializedAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var seasonState = await db.DbSeasonState
@@ -49,12 +56,12 @@ public sealed partial class IntroSkipperDatabase
 
         if (seasonState is null)
         {
-            seasonState = new DbSeasonState(seasonId, mode, AnalyzerAction.Default, episodeIds, configHash);
+            seasonState = new DbSeasonState(seasonId, mode, AnalyzerAction.Default, ids, configHash);
             db.DbSeasonState.Add(seasonState);
         }
         else
         {
-            db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
+            db.Entry(seasonState).Property(s => s.EpisodeIds).CurrentValue = ids;
             db.Entry(seasonState).Property(s => s.ConfigHash).CurrentValue = configHash;
         }
 


### PR DESCRIPTION
# Fix season-state writes crashing on lazy episode ID enumerables

## Bug

Since #840 removed the explicit `HasConversion`/`ValueComparer` mappings for `DbSeasonState.EpisodeIds`, EF Core maps the `IEnumerable<Guid>` property as a **primitive collection**, and its change tracking only accepts **arrays or `IList<Guid>`** values. Any lazy enumerable makes the change tracker throw:

```
System.InvalidOperationException: The type 'ArraySelectIterator<Guid, Guid>' cannot be used as a
primitive collection because it is not an array and does not implement 'IList<Guid?>'.
Collections of primitive types must be arrays or ordered lists.
```

The only production caller of `SetEpisodeIdsAsync` passes exactly such an iterator (`BaseItemAnalyzerTask.AnalyzeItemsAsync`):

```csharp
await _database.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), configHash, cancellationToken);
```

**Both the insert path (fresh season state) and the update path (existing row) throw** — verified empirically against current `12.0` HEAD. The exception propagates out of the per-season analysis body (`catch (Exception) { … throw; }`), faulting the whole `Parallel.ForEachAsync`, so every scheduled or automatic analysis run that has uncached work fails, season states are never recorded (episodes are re-analyzed from scratch every run), and the post-analysis media segment refresh is skipped.

Existing tests didn't catch this because they all call `SetEpisodeIdsAsync` with collection expressions (`[id]`) or arrays, which compile to `IList<Guid>`-compatible values.

## Fix

Materialize the sequence once at the entity boundary:

- `IntroSkipperDatabase.SetEpisodeIdsAsync`: materialize `episodeIds` to an array (`episodeIds as Guid[] ?? episodeIds.ToArray()`) and use it for both the insert and update paths; add the standard `ArgumentNullException.ThrowIfNull` guard used by sibling methods.
- `DbSeasonState` constructor: normalize `EpisodeIds` and `SettledReanalysisEpisodeIds` to arrays so the entity is always safe for EF change tracking regardless of the caller's enumerable shape.

`RemoveEpisodeIdAsync` and `RemoveItemsFromAnalysisAsync` already assign `List<Guid>` values, which EF accepts (verified), so they are unchanged.

## Tests

- New regression test `SetEpisodeIdsAsync_AcceptsLazyEnumerable_OnInsertAndUpdate` mirrors the production call shape (lazy `Select`/`Where` projections) for both insert and update, and asserts the persisted row.
- Red/green verified: the new test fails with `InvalidOperationException` on unfixed code and passes with the fix.
- Full suite: **422/422 passing** (was 421/421 before the new test).

Legacy compatibility was also verified while investigating: rows written by the old JSON value converter are read correctly by the EF primitive-collection mapping, so this change only affects the in-memory value shape, not the stored format.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-096" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096"><img alt="INTRO-096" src="https://capy.ai/api/badge/thread.svg?label=INTRO-096"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Handle EF Core primitive collection tracking by materializing season episode ID enumerables to arrays and add coverage to prevent regressions when using lazy enumerables.

Bug Fixes:
- Prevent season-state writes from throwing when SetEpisodeIdsAsync is called with lazy IEnumerable<Guid> sources by ensuring EF Core receives array-backed collections.

Enhancements:
- Normalize DbSeasonState episode ID collections to arrays at construction time for consistent EF Core change tracking behavior.

Tests:
- Add regression test verifying SetEpisodeIdsAsync correctly handles lazy enumerable episode ID sequences on both insert and update paths.