### PR TITLE
Adopt Jellyfin-aligned version scheme with versioned prereleases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,14 @@ permissions:
   contents: write
   packages: write
 
+# Serialize runs per ref so rapid successive pushes cannot publish the rolling
+# prerelease (and its manifest dispatch) out of commit order. A newer pending
+# run supersedes an older pending one; the in-flight run is never cancelled
+# mid-publish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     if: ${{ ! startsWith(github.event.head_commit.message, 'release v') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    if: ${{ ! startsWith(github.event.head_commit.message, 'v0.') }}
+    if: ${{ ! startsWith(github.event.head_commit.message, 'release v') }}
 
     runs-on: ubuntu-latest
 
@@ -37,14 +37,33 @@ jobs:
           # Export it as an environment variable
           echo "SANITIZED_BRANCH_NAME=$SANITIZED" >> $GITHUB_ENV
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
+
+      - name: Compute prerelease version
+        run: |
+          BASE_VERSION=$(sed -n 's|.*<FileVersion>\(.*\)</FileVersion>.*|\1|p' IntroSkipper/IntroSkipper.csproj)
+          BASE_PREFIX=${BASE_VERSION%.*}
+          LAST_RELEASE_TAG=$(git describe --tags --match "${MAIN_VERSION}/v*" --abbrev=0 2>/dev/null || true)
+          if [ -n "$LAST_RELEASE_TAG" ]; then
+            COMMITS_SINCE_RELEASE=$(git rev-list --count "${LAST_RELEASE_TAG}..HEAD")
+          else
+            COMMITS_SINCE_RELEASE=$(git rev-list --count HEAD)
+          fi
+          PRERELEASE_VERSION="${BASE_PREFIX}.${COMMITS_SINCE_RELEASE}"
+          echo "Last release tag: ${LAST_RELEASE_TAG:-<none>} (${COMMITS_SINCE_RELEASE} commit(s) since)"
+          echo "Prerelease version: ${PRERELEASE_VERSION}"
+          echo "PRERELEASE_VERSION=${PRERELEASE_VERSION}" >> $GITHUB_ENV
 
       - name: Embed version info
         run: |
           GITHUB_SHA=${{ github.sha }}
           sed -i "s/string\.Empty/\"$GITHUB_SHA\"/g" IntroSkipper/Helper/Commit.cs
+          sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>${PRERELEASE_VERSION}</AssemblyVersion>|" IntroSkipper/IntroSkipper.csproj
+          sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>${PRERELEASE_VERSION}</FileVersion>|" IntroSkipper/IntroSkipper.csproj
 
       - name: Retrieve commit identification
         run: |
@@ -63,12 +82,52 @@ jobs:
 
       - name: Create archive
         if: startsWith(github.ref_name, '10.') || startsWith(github.ref_name, '12.') # only do a preview release on 10.x/12.x branches
-        run: zip -j "intro-skipper-${{ env.GIT_HASH }}.zip" IntroSkipper/bin/Debug/${{ env.DOTNET_TFM }}/IntroSkipper.dll
+        run: zip -j "intro-skipper-v${{ env.PRERELEASE_VERSION }}.zip" IntroSkipper/bin/Debug/${{ env.DOTNET_TFM }}/IntroSkipper.dll
 
       - name: Create/replace the prerelease and upload artifacts
         if: startsWith(github.ref_name, '10.') || startsWith(github.ref_name, '12.') # only do a preview release on 10.x/12.x branches
         run: |
           gh release delete "${{ env.MAIN_VERSION }}/prerelease" --cleanup-tag --yes || true
-          gh release create "${{ env.MAIN_VERSION }}/prerelease" "intro-skipper-${{ env.GIT_HASH }}.zip" --prerelease --title "intro-skipper-${{ env.GIT_HASH }}" --notes "This is a prerelease version."  --target ${{ env.MAIN_VERSION }}
+          gh release create "${{ env.MAIN_VERSION }}/prerelease" "intro-skipper-v${{ env.PRERELEASE_VERSION }}.zip" --prerelease --title "v${{ env.PRERELEASE_VERSION }} (${{ env.GIT_HASH }})" --notes "Automated prerelease build of commit ${{ github.sha }}." --target ${{ env.MAIN_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update prerelease manifest
+        if: startsWith(github.ref_name, '10.') || startsWith(github.ref_name, '12.') # only do a preview release on 10.x/12.x branches
+        run: |
+          if [ "$IS_BETA" = "true" ]; then
+            JELLYFIN_VERSION="${MAIN_VERSION}.0"
+          else
+            JELLYFIN_VERSION=$(curl -fsSL https://api.nuget.org/v3-flatcontainer/jellyfin.model/index.json | jq -r --arg prefix "${MAIN_VERSION}." '[.versions[] | select(startswith($prefix)) | select(contains("-") | not)] | last')
+          fi
+          if [ -z "$JELLYFIN_VERSION" ] || [ "$JELLYFIN_VERSION" = "null" ]; then
+            echo "Failed to determine the current Jellyfin version"
+            exit 1
+          fi
+          TARGET_ABI="${JELLYFIN_VERSION}.0"
+          SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${MAIN_VERSION}/prerelease/intro-skipper-v${PRERELEASE_VERSION}.zip"
+          CHECKSUM=$(md5sum "intro-skipper-v${PRERELEASE_VERSION}.zip" | awk '{print $1}')
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          CHANGELOG="- Prerelease build of commit [\`${GIT_HASH}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${{ github.sha }})"
+          if [[ "$GITHUB_REPOSITORY" == *test* ]]; then
+            MANIFEST_REPO="intro-skipper/manifest_test"
+          else
+            MANIFEST_REPO="intro-skipper/manifest"
+          fi
+          jq -n \
+            --arg version "$PRERELEASE_VERSION" \
+            --arg changelog "$CHANGELOG" \
+            --arg targetAbi "$TARGET_ABI" \
+            --arg sourceUrl "$SOURCE_URL" \
+            --arg checksum "$CHECKSUM" \
+            --arg timestamp "$TIMESTAMP" \
+            '{event_type: "update-prerelease-manifest", client_payload: {pluginName: "Intro Skipper", version: $version, changelog: $changelog, targetAbi: $targetAbi, sourceUrl: $sourceUrl, checksum: $checksum, timestamp: $timestamp}}' \
+            > dispatch-payload.json
+          curl -fsS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_PAT}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d @dispatch-payload.json \
+            "https://api.github.com/repos/${MANIFEST_REPO}/dispatches"
+        env:
+          GITHUB_PAT: ${{ secrets.PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,15 @@ jobs:
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
 
-      - name: Run update version
-        uses: intro-skipper/intro-skipper-action-ts@main
-        with:
-          task-type: "updateVersion"
+      - name: Bump release version
+        run: |
+          CURRENT_VERSION=$(sed -n 's|.*<FileVersion>\(.*\)</FileVersion>.*|\1|p' IntroSkipper/IntroSkipper.csproj)
+          IFS='.' read -r JELLYFIN_MAJOR JELLYFIN_MINOR RELEASE _PRERELEASE <<< "$CURRENT_VERSION"
+          NEW_FILE_VERSION="${JELLYFIN_MAJOR}.${JELLYFIN_MINOR}.$((RELEASE + 1)).0"
+          sed -i "s|<AssemblyVersion>.*</AssemblyVersion>|<AssemblyVersion>${NEW_FILE_VERSION}</AssemblyVersion>|" IntroSkipper/IntroSkipper.csproj
+          sed -i "s|<FileVersion>.*</FileVersion>|<FileVersion>${NEW_FILE_VERSION}</FileVersion>|" IntroSkipper/IntroSkipper.csproj
+          echo "New release version: ${NEW_FILE_VERSION}"
+          echo "NEW_FILE_VERSION=${NEW_FILE_VERSION}" >> $GITHUB_ENV
 
       - name: Embed version info
         run: |

--- a/IntroSkipper/IntroSkipper.csproj
+++ b/IntroSkipper/IntroSkipper.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>IntroSkipper</RootNamespace>
-    <AssemblyVersion>1.12.0.1</AssemblyVersion>
-    <FileVersion>1.12.0.1</FileVersion>
+    <AssemblyVersion>12.0.1.0</AssemblyVersion>
+    <FileVersion>12.0.1.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary

Adopts the new version scheme for the 12.0 branch, aligned with Jellyfin's own post-`10.x` versioning:

```
<jellyfin major>.<jellyfin minor>.<release>.<prerelease>
```

| Digit | Meaning | Changes when |
|---|---|---|
| 1–2 | Minimum compatible Jellyfin version (`12.0`) | Branch retargets a newer Jellyfin ABI |
| 3 | Intro Skipper release counter | Every stable release (`workflow_dispatch`) |
| 4 | Prerelease counter, `0` for stable releases | Every commit between releases |

The fourth digit counts **commits since the last stable release** (post-release counting), so `System.Version` ordering is strictly monotonic across both trains: `12.0.1.0 (stable) < 12.0.1.14 (prerelease) < 12.0.2.0 (next stable)`. A user on a prerelease always upgrades cleanly to the next stable, and a stale prerelease entry can never shadow a newer stable release. All new-scheme versions also sort above the legacy `1.12.0.1`, so existing installs upgrade normally.

## Changes

- **`IntroSkipper.csproj`**: re-seeded `AssemblyVersion`/`FileVersion` from `1.12.0.1` to `12.0.1.0` (the new-scheme representation of the current stable, which was release #1 on this branch). The next release will be `12.0.2.0`.
- **`release.yml`**: replaces the `updateVersion` action call with an inline bump of the third digit (zeroing the fourth). Everything downstream (`NEW_FILE_VERSION`, tag `12.0/v12.0.2.0`, zip name, `updateManifest` dispatch) works unchanged. 10.x branches keep using `intro-skipper-action-ts` untouched.
- **`build.yml`**:
  - computes the prerelease version as `<csproj major.minor.release>.<commits since last 12.0/v* tag>` via `git describe`/`git rev-list` (checkout now uses `fetch-depth: 0` for tag access) and embeds it into the csproj before building (CI-only, like the existing `Commit.cs` sha embed) — prerelease DLLs previously all reported the stable version `1.12.0.1`;
  - names the rolling prerelease archive `intro-skipper-v<version>.zip` instead of `intro-skipper-<githash>.zip`;
  - dispatches a new `update-prerelease-manifest` event to `intro-skipper/manifest` with the version entry payload (targetAbi mirrors the `updateManifest` action logic: `12.0.0.0` while `beta: true`, otherwise latest stable `Jellyfin.Model` from NuGet — with prerelease-suffixed NuGet versions excluded so an RC can never produce an invalid targetAbi);
  - replaces the stale `v0.` commit-message guard with `release v`, so release bump commits no longer trigger a redundant prerelease build.

PR builds still upload artifact-only builds; publish/dispatch steps stay gated to pushes on release branches.

## Verified

- Prerelease version computation simulated against real branch history: `12.0/v1.12.0.1` tag found, 10 commits since → `12.0.1.10`.
- Release bump simulated: `12.0.1.0` → `12.0.2.0`, csproj stays valid XML.
- Dispatch payload built with `jq` and validated end-to-end against the new manifest-repo script (see companion PR).
- NuGet fallback filter tested live: `10.11.` → `10.11.11`; `12.0.` → fails loudly while only RCs exist (path unreachable while `beta: true`).

## Dependencies

Companion PR in `intro-skipper/manifest` adds the `12.0/manifest-prerelease.json` catalog and the dispatch handler; it should merge first so dispatches have a target (a lost dispatch is otherwise harmless).

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/9de5844c-5ff6-4827-bb95-7d61e787a3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-097" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/9de5844c-5ff6-4827-bb95-7d61e787a3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-097&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-097"><img alt="INTRO-097" src="https://capy.ai/api/badge/thread.svg?label=INTRO-097"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Adopt Jellyfin-aligned four-part versioning for Intro Skipper releases and prereleases, updating CI workflows to generate and publish monotonic prerelease versions tied to Jellyfin ABI compatibility.

Enhancements:
- Reseed IntroSkipper assembly and file versions to the new `12.0.x.y` scheme representing Jellyfin compatibility, release counter, and prerelease counter.
- Compute prerelease versions in CI from the current csproj release version and commits since the last `12.0/v*` tag, embedding them into the DLL and using them in artifact names and GitHub prerelease tags.
- Replace the previous `v0.` commit-message guard with a `release v` guard to avoid redundant prerelease builds on release bump commits.
- Inline the release version bump in the release workflow by incrementing the third version digit and resetting the prerelease digit to `0`, exposing the new version via `NEW_FILE_VERSION`.
- Dispatch an `update-prerelease-manifest` event to the manifest repository with metadata (version, changelog, target ABI, source URL, checksum, timestamp), deriving targetAbi from Jellyfin.Model NuGet versions or branch beta status and handling test vs production manifest repos.

CI:
- Update build and release GitHub Actions workflows to support the new versioning scheme, full git history fetch for tag-based versioning, and automated prerelease manifest updates.