### PR TITLE
Fix disabled media-segment provider matching on Jellyfin 10.11

### DIFF
--- a/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
@@ -51,6 +51,7 @@ public sealed class TestMediaSegmentRefreshService
 
         Assert.NotNull(manager.LastLibraryOptions);
         Assert.Contains("Chapter Segments Provider", manager.LastLibraryOptions!.DisabledMediaSegmentProviders);
+        Assert.Contains(MediaSegmentProviderDefaults.GetProviderId("Chapter Segments Provider"), manager.LastLibraryOptions.DisabledMediaSegmentProviders);
         Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
     }
 
@@ -118,6 +119,8 @@ public sealed class TestMediaSegmentRefreshService
         Assert.NotNull(manager.LastLibraryOptions);
         Assert.Contains(Plugin.ProviderName, manager.LastLibraryOptions!.DisabledMediaSegmentProviders);
         Assert.Contains("Chapter Segments Provider", manager.LastLibraryOptions.DisabledMediaSegmentProviders);
+        Assert.Contains(MediaSegmentProviderDefaults.GetProviderId(Plugin.ProviderName), manager.LastLibraryOptions.DisabledMediaSegmentProviders);
+        Assert.Contains(MediaSegmentProviderDefaults.GetProviderId("Chapter Segments Provider"), manager.LastLibraryOptions.DisabledMediaSegmentProviders);
         Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
     }
 
@@ -139,6 +142,17 @@ public sealed class TestMediaSegmentRefreshService
             () => refresher.RemoveIntroSkipperSegmentsAsync([itemId], CancellationToken.None));
 
         Assert.Same(expectedException, exception);
+    }
+
+    [Theory]
+    [InlineData("Intro Skipper", "b0338b450421c081992860f1d02f261f")]
+    [InlineData("Chapter Segments Provider", "882d20e0326c962caf419ae2019c042d")]
+    public void GetProviderId_MatchesJellyfinProviderIdHash(string providerName, string expectedProviderId)
+    {
+        // Known values mirroring Jellyfin's MediaSegmentManager.GetProviderId (MD5 of the
+        // lowercased UTF-16 name, Guid "N" format), which 10.11 servers use to match
+        // LibraryOptions.DisabledMediaSegmentProviders entries.
+        Assert.Equal(expectedProviderId, MediaSegmentProviderDefaults.GetProviderId(providerName));
     }
 
     private static MediaSegmentRefreshService CreateRefresher(FakeMediaSegmentManager manager, ILibraryManager? libraryManager = null)

--- a/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentRefreshService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
@@ -121,7 +122,27 @@ public sealed class TestMediaSegmentRefreshService
         Assert.Contains("Chapter Segments Provider", manager.LastLibraryOptions.DisabledMediaSegmentProviders);
         Assert.Contains(MediaSegmentProviderDefaults.GetProviderId(Plugin.ProviderName), manager.LastLibraryOptions.DisabledMediaSegmentProviders);
         Assert.Contains(MediaSegmentProviderDefaults.GetProviderId("Chapter Segments Provider"), manager.LastLibraryOptions.DisabledMediaSegmentProviders);
-        Assert.True(manager.LastForceOverwrite.GetValueOrDefault());
+        Assert.False(manager.LastForceOverwrite.GetValueOrDefault());
+    }
+
+    [Fact]
+    public async Task RemoveIntroSkipperSegmentsAsync_DeletesStoredSegments_WhenNoExternalProviderRemains()
+    {
+        var itemId = Guid.NewGuid();
+        var manager = new FakeMediaSegmentManager
+        {
+            HasStoredSegments = true,
+            InstalledProviderNames = [Plugin.ProviderName, "Chapter Segments Provider"]
+        };
+        var libraryManager = EntrypointTestHelpers.CreateLibraryManager(CreateMovie(itemId));
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { MaxParallelism = 2 });
+        var refresher = CreateRefresher(manager, libraryManager);
+
+        await refresher.RemoveIntroSkipperSegmentsAsync([itemId], CancellationToken.None);
+
+        Assert.False(manager.HasSegments(itemId));
+        Assert.Equal(1, manager.DeleteCount);
     }
 
     [Fact]
@@ -180,6 +201,12 @@ public sealed class TestMediaSegmentRefreshService
 
         public TaskCompletionSource? RunCompletion { get; init; }
 
+        public IReadOnlyCollection<string>? InstalledProviderNames { get; init; }
+
+        public bool HasStoredSegments { get; set; }
+
+        public int DeleteCount { get; private set; }
+
         public Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken)
         {
             RunCount++;
@@ -192,6 +219,17 @@ public sealed class TestMediaSegmentRefreshService
                 throw RunException;
             }
 
+            if (InstalledProviderNames?.All(providerName =>
+                    libraryOptions.DisabledMediaSegmentProviders.Contains(MediaSegmentProviderDefaults.GetProviderId(providerName))) == true)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (forceOverwrite)
+            {
+                HasStoredSegments = false;
+            }
+
             return RunCompletion?.Task ?? Task.CompletedTask;
         }
 
@@ -201,14 +239,19 @@ public sealed class TestMediaSegmentRefreshService
 
         public Task DeleteSegmentAsync(Guid segmentId) => Task.CompletedTask;
 
-        public Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken)
+        {
+            DeleteCount++;
+            HasStoredSegments = false;
+            return Task.CompletedTask;
+        }
 
         public Task<IEnumerable<MediaSegmentDto>> GetSegmentsAsync(BaseItem item, IEnumerable<MediaSegmentType>? typeFilter, LibraryOptions libraryOptions, bool filterByProvider = true)
         {
             return Task.FromResult<IEnumerable<MediaSegmentDto>>(Array.Empty<MediaSegmentDto>());
         }
 
-        public bool HasSegments(Guid itemId) => false;
+        public bool HasSegments(Guid itemId) => HasStoredSegments;
 
         public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => [(Plugin.Instance!.Name, "intro-skipper")];
     }

--- a/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
+++ b/IntroSkipper/Manager/MediaSegmentProviderDefaults.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using MediaBrowser.Common.Extensions;
 using MediaBrowser.Model.Configuration;
 
 namespace IntroSkipper.Manager;
@@ -7,6 +9,8 @@ namespace IntroSkipper.Manager;
 /// </summary>
 internal static class MediaSegmentProviderDefaults
 {
+    private const string ChapterProviderName = "Chapter Segments Provider";
+
     /// <summary>
     /// Gets the <see cref="LibraryOptions"/> used when querying or running external media-segment
     /// providers. The built-in "Chapter Segments Provider" is disabled so it is never re-run as part
@@ -15,7 +19,7 @@ internal static class MediaSegmentProviderDefaults
     /// </summary>
     internal static LibraryOptions ExternalProviders { get; } = new()
     {
-        DisabledMediaSegmentProviders = ["Chapter Segments Provider"]
+        DisabledMediaSegmentProviders = BuildDisabledProviderEntries(ChapterProviderName)
     };
 
     /// <summary>
@@ -24,6 +28,28 @@ internal static class MediaSegmentProviderDefaults
     /// </summary>
     internal static LibraryOptions ExternalProvidersWithoutIntroSkipper { get; } = new()
     {
-        DisabledMediaSegmentProviders = ["Chapter Segments Provider", Plugin.ProviderName]
+        DisabledMediaSegmentProviders = BuildDisabledProviderEntries(ChapterProviderName, Plugin.ProviderName)
     };
+
+    /// <summary>
+    /// Computes the provider id Jellyfin derives from a media-segment provider name. Mirrors
+    /// <c>MediaSegmentManager.GetProviderId</c>: the lowercased name hashed with MD5 and formatted
+    /// as a 32-digit hex string.
+    /// </summary>
+    /// <param name="providerName">The media-segment provider display name.</param>
+    /// <returns>The hashed provider id.</returns>
+    internal static string GetProviderId(string providerName)
+        => providerName.ToLowerInvariant()
+            .GetMD5()
+            .ToString("N", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Builds <see cref="LibraryOptions.DisabledMediaSegmentProviders"/> entries for the given
+    /// provider names. Jellyfin 10.11 matches entries against the hashed provider id while newer
+    /// servers match the provider name case-insensitively, so both forms are included.
+    /// </summary>
+    /// <param name="providerNames">The media-segment provider display names to disable.</param>
+    /// <returns>The disabled-provider entries.</returns>
+    private static string[] BuildDisabledProviderEntries(params string[] providerNames)
+        => [.. providerNames, .. providerNames.Select(GetProviderId)];
 }

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -28,6 +28,7 @@ public sealed partial class MediaSegmentRefreshService(
         await RefreshCoreAsync(
                 item,
                 MediaSegmentProviderDefaults.ExternalProviders,
+                deleteSegmentsBeforeRefresh: false,
                 suppressErrors: true,
                 cancellationToken)
             .ConfigureAwait(false);
@@ -36,12 +37,20 @@ public sealed partial class MediaSegmentRefreshService(
     private async Task RefreshCoreAsync(
         BaseItem item,
         LibraryOptions libraryOptions,
+        bool deleteSegmentsBeforeRefresh,
         bool suppressErrors,
         CancellationToken cancellationToken)
     {
         try
         {
-            await mediaSegmentManager.RunSegmentPluginProviders(item, libraryOptions, true, cancellationToken).ConfigureAwait(false);
+            if (deleteSegmentsBeforeRefresh)
+            {
+                await mediaSegmentManager.DeleteSegmentsAsync(item.Id, cancellationToken).ConfigureAwait(false);
+            }
+
+            await mediaSegmentManager
+                .RunSegmentPluginProviders(item, libraryOptions, !deleteSegmentsBeforeRefresh, cancellationToken)
+                .ConfigureAwait(false);
             LogUpdatedMediaSegments(logger, item.Id);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -73,6 +82,7 @@ public sealed partial class MediaSegmentRefreshService(
     private async Task RefreshByIdAsync(
         Guid itemId,
         LibraryOptions libraryOptions,
+        bool deleteSegmentsBeforeRefresh,
         bool suppressErrors,
         CancellationToken cancellationToken)
     {
@@ -88,7 +98,13 @@ public sealed partial class MediaSegmentRefreshService(
             return;
         }
 
-        await RefreshCoreAsync(item, libraryOptions, suppressErrors, cancellationToken).ConfigureAwait(false);
+        await RefreshCoreAsync(
+                item,
+                libraryOptions,
+                deleteSegmentsBeforeRefresh,
+                suppressErrors,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -96,6 +112,7 @@ public sealed partial class MediaSegmentRefreshService(
         => RefreshByIdsAsync(
             itemIds,
             MediaSegmentProviderDefaults.ExternalProviders,
+            deleteSegmentsBeforeRefresh: false,
             suppressErrors: true,
             cancellationToken);
 
@@ -104,12 +121,14 @@ public sealed partial class MediaSegmentRefreshService(
         => RefreshByIdsAsync(
             itemIds,
             MediaSegmentProviderDefaults.ExternalProvidersWithoutIntroSkipper,
+            deleteSegmentsBeforeRefresh: true,
             suppressErrors: false,
             cancellationToken);
 
     private async Task RefreshByIdsAsync(
         IEnumerable<Guid> itemIds,
         LibraryOptions libraryOptions,
+        bool deleteSegmentsBeforeRefresh,
         bool suppressErrors,
         CancellationToken cancellationToken)
     {
@@ -130,7 +149,13 @@ public sealed partial class MediaSegmentRefreshService(
 
         await Parallel.ForEachAsync(ids, options, async (itemId, ct) =>
         {
-            await RefreshByIdAsync(itemId, libraryOptions, suppressErrors, ct).ConfigureAwait(false);
+            await RefreshByIdAsync(
+                    itemId,
+                    libraryOptions,
+                    deleteSegmentsBeforeRefresh,
+                    suppressErrors,
+                    ct)
+                .ConfigureAwait(false);
         }).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
Jellyfin 10.11's `MediaSegmentManager.RunSegmentPluginProviders` matches `LibraryOptions.DisabledMediaSegmentProviders` entries against the hashed provider id (`GetProviderId`: MD5 of the lowercased name in Guid "N" format), not the display name — the name-based matching only exists on master ([jellyfin/jellyfin@b84bd34c](https://github.com/jellyfin/jellyfin/commit/b84bd34c)). `MediaSegmentProviderDefaults` passed raw names, so the exclusions never matched on 10.11.

This broke the stale-timestamp handoff added in #842: `RemoveIntroSkipperSegmentsAsync` ran with the Intro Skipper provider still enabled and `forceOverwrite: true`, so the provider re-read the still-present stale timestamps and wrote the segments right back into Jellyfin. `CleanCacheTask` then deleted the plugin's timestamps, leaving the stale media segments permanently stranded with nothing left to refresh them away. It also meant `ExternalProviders` never actually excluded the Chapter Segments Provider during ordinary refreshes.

- `MediaSegmentProviderDefaults` now emits both the display name and the hashed provider id for each excluded provider, so the exclusion works on 10.11 (id matching) and on newer servers (case-insensitive name matching); unmatched extra entries are inert.
- `GetProviderId` mirrors Jellyfin's hash exactly via the same `GetMD5` extension, and a test pins the known hash values for "Intro Skipper" and "Chapter Segments Provider" so the algorithm can't silently drift.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/6c71a74f-85cb-4b09-9055-5eb60f011653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-098" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/6c71a74f-85cb-4b09-9055-5eb60f011653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-098&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-098"><img alt="INTRO-098" src="https://capy.ai/api/badge/thread.svg?label=INTRO-098"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Ensure media segment provider exclusions work correctly across Jellyfin versions by including both display names and hashed provider IDs.

Bug Fixes:
- Prevent Intro Skipper from reapplying stale media segments on Jellyfin 10.11 by correctly disabling the provider during cleanup.
- Ensure the built-in Chapter Segments Provider is reliably excluded during external provider refreshes on Jellyfin 10.11.

Enhancements:
- Add a helper to compute Jellyfin-compatible media segment provider IDs from display names.

Tests:
- Extend media segment refresh tests to assert both name and hashed ID-based provider exclusions.
- Add a unit test that pins the expected hashed provider IDs for Intro Skipper and Chapter Segments Provider to guard against hash algorithm drift.