### PR TITLE
Guard CleanCacheTask against incomplete library enumeration

### DIFF
--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -13,8 +13,10 @@ using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
+using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -32,24 +34,32 @@ public sealed class TestCleanCacheTask
     {
         var (dbPath, cacheDbPath) = CreateTempDbPaths();
         var liveEpisodeId = Guid.NewGuid();
+        var liveMovieId = Guid.NewGuid();
         try
         {
             using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir(), cacheDbPath);
-            EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { UpdateMediaSegments = false });
+            EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { UpdateMediaSegments = true });
 
             var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
             var cacheDatabase = DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath);
             await SeedAsync(database, cacheDatabase, liveEpisodeId);
 
-            // One library exists but its item enumeration throws, so the queue is incomplete.
+            // One library enumerates fine (non-empty queue) while a second one throws, so the
+            // failure guard is exercised independently of the empty-queue guard.
+            var moviesFolder = NewFolder("Movies");
+            var showsFolder = NewFolder("Shows");
             var libraryManager = FakeLibraryManager.Create(
-                [NewFolder("Shows")],
-                _ => throw new InvalidOperationException("library database unavailable"));
+                [moviesFolder, showsFolder],
+                folderId => folderId == Guid.Parse(moviesFolder.ItemId!)
+                    ? [CreateMovie(liveMovieId)]
+                    : throw new InvalidOperationException("library database unavailable"));
 
             var progress = new RecordingProgress();
-            await CreateTask(libraryManager, database, cacheDatabase).ExecuteAsync(progress, CancellationToken.None);
+            var refresher = new RecordingRefresher();
+            await CreateTask(libraryManager, database, cacheDatabase, refresher).ExecuteAsync(progress, CancellationToken.None);
 
             Assert.Equal(100, progress.Value);
+            Assert.Equal(0, refresher.RemoveCallCount);
             await AssertSeededDataIntactAsync(database, cacheDatabase, liveEpisodeId, dbPath);
         }
         finally
@@ -57,6 +67,77 @@ public sealed class TestCleanCacheTask
             DeleteSqliteFiles(dbPath);
             DeleteSqliteFiles(cacheDbPath);
         }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsAllCleanup_WhenAnItemFailsToQueue()
+    {
+        var (dbPath, cacheDbPath) = CreateTempDbPaths();
+        var brokenEpisodeId = Guid.NewGuid();
+        try
+        {
+            using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir(), cacheDbPath);
+            EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { UpdateMediaSegments = false });
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            var cacheDatabase = DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath);
+            await SeedAsync(database, cacheDatabase, brokenEpisodeId);
+
+            // The episode's queueing throws (its SeasonId repair needs the provider manager,
+            // which is unavailable), while the sibling movie queues fine — so the queue is
+            // non-empty but incomplete, and the broken live episode must not be deleted.
+            var brokenEpisode = new Episode
+            {
+                SeriesId = Guid.NewGuid(),
+                SeasonId = Guid.Empty,
+                ParentIndexNumber = 1,
+                IndexNumber = 1,
+                Path = "/media/show/s01e01.mkv",
+            };
+            EntrypointTestHelpers.SetPropertyOrField(brokenEpisode, "Id", brokenEpisodeId);
+            EntrypointTestHelpers.SetPropertyOrField(brokenEpisode, "SeriesName", "Show");
+            EntrypointTestHelpers.EnsureNonVirtual(brokenEpisode);
+
+            var libraryManager = FakeLibraryManager.Create(
+                [NewFolder("Media")],
+                _ => [brokenEpisode, CreateMovie(Guid.NewGuid())]);
+
+            var progress = new RecordingProgress();
+            await CreateTask(libraryManager, database, cacheDatabase).ExecuteAsync(progress, CancellationToken.None);
+
+            Assert.Equal(100, progress.Value);
+            await AssertSeededDataIntactAsync(database, cacheDatabase, brokenEpisodeId, dbPath);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetMediaItems_ResetsEnumerationFailureCount_AcrossCalls()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration());
+
+        var calls = 0;
+        var libraryManager = FakeLibraryManager.Create(
+            [NewFolder("Movies")],
+            _ => ++calls == 1 ? throw new InvalidOperationException("first pass fails") : []);
+        var queueManager = new QueueManager(
+            NullLogger<QueueManager>.Instance,
+            libraryManager,
+            providerManager: null!,
+            fileSystem: null!,
+            ffmpegService: null!,
+            DatabaseTestHelpers.CreateTempSegmentDatabase());
+
+        await queueManager.GetMediaItems(includeExcluded: true);
+        Assert.Equal(1, queueManager.EnumerationFailureCount);
+
+        await queueManager.GetMediaItems(includeExcluded: true);
+        Assert.Equal(0, queueManager.EnumerationFailureCount);
     }
 
     [Fact]
@@ -106,15 +187,10 @@ public sealed class TestCleanCacheTask
             // Live movie data plus rows for an item that is no longer in any library.
             await database.UpdateTimestampAsync(new Segment(movieId, new TimeRange(10, 40)), AnalysisMode.Introduction);
             await database.SetEpisodeIdsAsync(movieId, AnalysisMode.Introduction, [movieId], "hash");
+            cacheDatabase.Upsert(movieId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 0, EntrypointTestHelpers.EmptyJsonArray, "hash");
             await SeedAsync(database, cacheDatabase, staleEpisodeId);
 
-            var movie = new MediaBrowser.Controller.Entities.Movies.Movie
-            {
-                Id = movieId,
-                Name = "Test Movie",
-                Path = "/media/test-movie.mkv",
-            };
-            var libraryManager = FakeLibraryManager.Create([NewFolder("Movies")], _ => [movie]);
+            var libraryManager = FakeLibraryManager.Create([NewFolder("Movies")], _ => [CreateMovie(movieId)]);
 
             var progress = new RecordingProgress();
             await CreateTask(libraryManager, database, cacheDatabase).ExecuteAsync(progress, CancellationToken.None);
@@ -124,6 +200,8 @@ public sealed class TestCleanCacheTask
             Assert.NotEmpty(await database.GetSegmentsAsync(movieId));
             Assert.Empty(await database.GetSegmentsAsync(staleEpisodeId));
             Assert.Empty(await cacheDatabase.GetStaleItemIdsAsync(new HashSet<Guid> { movieId }));
+            Assert.NotNull(cacheDatabase.FindEntry(movieId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 0));
+            Assert.Null(cacheDatabase.FindEntry(staleEpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 0));
 
             await using var db = new IntroSkipperDbContext(dbPath);
             Assert.True(await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AnyAsync(
@@ -138,7 +216,11 @@ public sealed class TestCleanCacheTask
         }
     }
 
-    private static CleanCacheTask CreateTask(ILibraryManager libraryManager, IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase)
+    private static CleanCacheTask CreateTask(
+        ILibraryManager libraryManager,
+        IIntroSkipperDatabase database,
+        IDetectionCacheDatabase cacheDatabase,
+        IMediaSegmentRefresher? mediaSegmentRefresher = null)
         => new(
             NullLogger<CleanCacheTask>.Instance,
             NullLoggerFactory.Instance,
@@ -148,7 +230,15 @@ public sealed class TestCleanCacheTask
             ffmpegService: null!,
             database,
             cacheDatabase,
-            mediaSegmentRefresher: null!);
+            mediaSegmentRefresher: mediaSegmentRefresher ?? null!);
+
+    private static MediaBrowser.Controller.Entities.Movies.Movie CreateMovie(Guid id)
+        => new()
+        {
+            Id = id,
+            Name = "Test Movie",
+            Path = "/media/test-movie.mkv",
+        };
 
     private static async Task SeedAsync(IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase, Guid episodeId)
     {
@@ -200,6 +290,21 @@ public sealed class TestCleanCacheTask
         public double? Value { get; private set; }
 
         public void Report(double value) => Value = value;
+    }
+
+    private sealed class RecordingRefresher : IMediaSegmentRefresher
+    {
+        public int RemoveCallCount { get; private set; }
+
+        public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+        {
+            RemoveCallCount++;
+            return Task.CompletedTask;
+        }
     }
 
     // ILibraryManager stub for the queue-building path: returns the configured virtual

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="CleanCacheTask"/>. The cleanup task deletes every row that is NOT in
+/// the enumerated library queue, so these tests pin the guards that keep an incomplete or
+/// empty enumeration from mass-deleting healthy data.
+/// </summary>
+public sealed class TestCleanCacheTask
+{
+    [Fact]
+    public async Task ExecuteAsync_SkipsAllCleanup_WhenALibraryFailsToEnumerate()
+    {
+        var (dbPath, cacheDbPath) = CreateTempDbPaths();
+        var liveEpisodeId = Guid.NewGuid();
+        try
+        {
+            using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir(), cacheDbPath);
+            EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { UpdateMediaSegments = false });
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            var cacheDatabase = DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath);
+            await SeedAsync(database, cacheDatabase, liveEpisodeId);
+
+            // One library exists but its item enumeration throws, so the queue is incomplete.
+            var libraryManager = FakeLibraryManager.Create(
+                [NewFolder("Shows")],
+                _ => throw new InvalidOperationException("library database unavailable"));
+
+            var progress = new RecordingProgress();
+            await CreateTask(libraryManager, database, cacheDatabase).ExecuteAsync(progress, CancellationToken.None);
+
+            Assert.Equal(100, progress.Value);
+            await AssertSeededDataIntactAsync(database, cacheDatabase, liveEpisodeId, dbPath);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsAllCleanup_WhenNoEnabledLibrariesHaveItems()
+    {
+        var (dbPath, cacheDbPath) = CreateTempDbPaths();
+        var liveEpisodeId = Guid.NewGuid();
+        try
+        {
+            using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir(), cacheDbPath);
+            EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { UpdateMediaSegments = false });
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            var cacheDatabase = DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath);
+            await SeedAsync(database, cacheDatabase, liveEpisodeId);
+
+            // No virtual folders at all: an empty queue must not classify everything as stale.
+            var libraryManager = FakeLibraryManager.Create([], _ => []);
+
+            var progress = new RecordingProgress();
+            await CreateTask(libraryManager, database, cacheDatabase).ExecuteAsync(progress, CancellationToken.None);
+
+            Assert.Equal(100, progress.Value);
+            await AssertSeededDataIntactAsync(database, cacheDatabase, liveEpisodeId, dbPath);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DeletesOnlyStaleRows_WhenEnumerationSucceeds()
+    {
+        var (dbPath, cacheDbPath) = CreateTempDbPaths();
+        var movieId = Guid.NewGuid();
+        var staleEpisodeId = Guid.NewGuid();
+        try
+        {
+            using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir(), cacheDbPath);
+            EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration { UpdateMediaSegments = false });
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            var cacheDatabase = DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath);
+
+            // Live movie data plus rows for an item that is no longer in any library.
+            await database.UpdateTimestampAsync(new Segment(movieId, new TimeRange(10, 40)), AnalysisMode.Introduction);
+            await database.SetEpisodeIdsAsync(movieId, AnalysisMode.Introduction, [movieId], "hash");
+            await SeedAsync(database, cacheDatabase, staleEpisodeId);
+
+            var movie = new MediaBrowser.Controller.Entities.Movies.Movie
+            {
+                Id = movieId,
+                Name = "Test Movie",
+                Path = "/media/test-movie.mkv",
+            };
+            var libraryManager = FakeLibraryManager.Create([NewFolder("Movies")], _ => [movie]);
+
+            var progress = new RecordingProgress();
+            await CreateTask(libraryManager, database, cacheDatabase).ExecuteAsync(progress, CancellationToken.None);
+
+            Assert.Equal(100, progress.Value);
+
+            Assert.NotEmpty(await database.GetSegmentsAsync(movieId));
+            Assert.Empty(await database.GetSegmentsAsync(staleEpisodeId));
+            Assert.Empty(await cacheDatabase.GetStaleItemIdsAsync(new HashSet<Guid> { movieId }));
+
+            await using var db = new IntroSkipperDbContext(dbPath);
+            Assert.True(await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AnyAsync(
+                db.DbSeasonState, s => s.SeasonId == movieId));
+            Assert.False(await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AnyAsync(
+                db.DbSeasonState, s => s.SeasonId == staleEpisodeId));
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+            DeleteSqliteFiles(cacheDbPath);
+        }
+    }
+
+    private static CleanCacheTask CreateTask(ILibraryManager libraryManager, IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase)
+        => new(
+            NullLogger<CleanCacheTask>.Instance,
+            NullLoggerFactory.Instance,
+            libraryManager,
+            providerManager: null!,
+            fileSystem: null!,
+            ffmpegService: null!,
+            database,
+            cacheDatabase,
+            mediaSegmentRefresher: null!);
+
+    private static async Task SeedAsync(IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase, Guid episodeId)
+    {
+        await database.UpdateTimestampAsync(new Segment(episodeId, new TimeRange(5, 65)), AnalysisMode.Introduction);
+        await database.SetEpisodeIdsAsync(episodeId, AnalysisMode.Introduction, [episodeId], "hash");
+        cacheDatabase.Upsert(episodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 0, EntrypointTestHelpers.EmptyJsonArray, "hash");
+    }
+
+    private static async Task AssertSeededDataIntactAsync(IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase, Guid episodeId, string dbPath)
+    {
+        Assert.NotEmpty(await database.GetSegmentsAsync(episodeId));
+        Assert.NotNull(cacheDatabase.FindEntry(episodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 0));
+
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.True(await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AnyAsync(
+            db.DbSeasonState, s => s.SeasonId == episodeId));
+    }
+
+    private static VirtualFolderInfo NewFolder(string name)
+        => new()
+        {
+            Name = name,
+            ItemId = Guid.NewGuid().ToString(),
+        };
+
+    private static (string DbPath, string CacheDbPath) CreateTempDbPaths()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(directory);
+        return (
+            Path.Combine(directory, Guid.NewGuid().ToString("N") + "-cleantask.db"),
+            Path.Combine(directory, Guid.NewGuid().ToString("N") + "-cleantask-cache.db"));
+    }
+
+    private static void DeleteSqliteFiles(string dbPath)
+    {
+        foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+        {
+            var path = dbPath + suffix;
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private sealed class RecordingProgress : IProgress<double>
+    {
+        public double? Value { get; private set; }
+
+        public void Report(double value) => Value = value;
+    }
+
+    // ILibraryManager stub for the queue-building path: returns the configured virtual
+    // folders and delegates GetItemList to the configured behavior (which may throw to
+    // simulate a failed library enumeration).
+    private class FakeLibraryManager : DispatchProxy
+    {
+        private List<VirtualFolderInfo> _folders = [];
+        private Func<Guid, List<BaseItem>> _getItemList = _ => [];
+
+        public static ILibraryManager Create(List<VirtualFolderInfo> folders, Func<Guid, List<BaseItem>> getItemList)
+        {
+            var proxy = Create<ILibraryManager, FakeLibraryManager>();
+            var fake = (FakeLibraryManager)(object)proxy;
+            fake._folders = folders;
+            fake._getItemList = getItemList;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(ILibraryManager.GetVirtualFolders) => _folders,
+                nameof(ILibraryManager.GetItemList) => _getItemList(ExtractParentId(args)).ToList(),
+                nameof(ILibraryManager.GetItemById) => null,
+                _ => throw new NotImplementedException(targetMethod?.Name),
+            };
+        }
+
+        private static Guid ExtractParentId(object?[]? args)
+            => args?.OfType<InternalItemsQuery>().FirstOrDefault()?.ParentId ?? Guid.Empty;
+    }
+}

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -46,7 +46,16 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private readonly HashSet<Guid> _refreshedEpisodes = [];
     private bool? _ffmpegValid;
     private double _analysisPercent;
+    private int _libraryEnumerationFailures;
     private ExclusionPolicy _exclusionPolicy = ExclusionPolicy.Empty;
+
+    /// <summary>
+    /// Gets the number of libraries that failed to enumerate during the most recent
+    /// <see cref="GetMediaItems(bool, CancellationToken)"/> call. A non-zero value means the
+    /// queue is incomplete; callers that delete data missing from the queue must not treat
+    /// the affected libraries' items as stale.
+    /// </summary>
+    internal int LibraryEnumerationFailureCount => _libraryEnumerationFailures;
 
     /// <summary>
     /// Gets all media items on the server.
@@ -70,6 +79,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
     {
+        _libraryEnumerationFailures = 0;
+
         var plugin = Plugin.Instance;
         if (plugin is null)
         {
@@ -119,6 +130,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
             catch (Exception ex)
             {
+                _libraryEnumerationFailures++;
                 LogFailedEnqueueLibrary(_logger, folder.Name, ex);
             }
         }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -46,16 +46,16 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private readonly HashSet<Guid> _refreshedEpisodes = [];
     private bool? _ffmpegValid;
     private double _analysisPercent;
-    private int _libraryEnumerationFailures;
+    private int _enumerationFailures;
     private ExclusionPolicy _exclusionPolicy = ExclusionPolicy.Empty;
 
     /// <summary>
-    /// Gets the number of libraries that failed to enumerate during the most recent
-    /// <see cref="GetMediaItems(bool, CancellationToken)"/> call. A non-zero value means the
-    /// queue is incomplete; callers that delete data missing from the queue must not treat
-    /// the affected libraries' items as stale.
+    /// Gets the number of libraries or individual items that failed to enumerate or queue
+    /// during the most recent <see cref="GetMediaItems(bool, CancellationToken)"/> call.
+    /// A non-zero value means the queue is incomplete; callers that delete data missing from
+    /// the queue must not treat the affected items as stale.
     /// </summary>
-    internal int LibraryEnumerationFailureCount => _libraryEnumerationFailures;
+    internal int EnumerationFailureCount => _enumerationFailures;
 
     /// <summary>
     /// Gets all media items on the server.
@@ -79,7 +79,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
     {
-        _libraryEnumerationFailures = 0;
+        _enumerationFailures = 0;
 
         var plugin = Plugin.Instance;
         if (plugin is null)
@@ -130,7 +130,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
             catch (Exception ex)
             {
-                _libraryEnumerationFailures++;
+                _enumerationFailures++;
                 LogFailedEnqueueLibrary(_logger, folder.Name, ex);
             }
         }
@@ -236,6 +236,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
             catch (Exception ex)
             {
+                // Count item-level failures too: a live item that failed to queue must not be
+                // classified as stale by cleanup just because its siblings enumerated fine.
+                _enumerationFailures++;
                 LogErrorProcessingItem(_logger, ex, item.Name, item.Id);
             }
         }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -103,6 +103,23 @@ public partial class CleanCacheTask(
             .Select(static episode => episode.EpisodeId)
             .ToHashSet();
 
+        // Every cleanup below deletes rows that are NOT in the enumerated queue, so an
+        // incomplete queue would classify healthy data as stale and mass-delete it (including
+        // the Jellyfin-side media segments). Bail out instead of guessing.
+        if (queueManager.LibraryEnumerationFailureCount > 0)
+        {
+            LogSkippingCleanupEnumerationFailures(_logger, queueManager.LibraryEnumerationFailureCount);
+            progress.Report(100);
+            return;
+        }
+
+        if (enabledLibraryEpisodeIds.Count == 0)
+        {
+            LogSkippingCleanupNoEnabledEpisodes(_logger);
+            progress.Report(100);
+            return;
+        }
+
         var staleTimestampEpisodeIds = await _database
             .GetStaleTimestampEpisodeIdsAsync(enabledLibraryEpisodeIds, cancellationToken)
             .ConfigureAwait(false);
@@ -168,4 +185,10 @@ public partial class CleanCacheTask(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete stale detection cache rows")]
     private static partial void LogDeletingCacheRowsFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping cache cleanup: {Count} library(ies) failed to enumerate, so stale-data detection would over-delete. Check the enumeration errors logged above and re-run the task")]
+    private static partial void LogSkippingCleanupEnumerationFailures(ILogger logger, int count);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping cache cleanup: no episodes or movies were found in enabled libraries. To erase Intro Skipper data intentionally, use the erase actions on the plugin configuration page")]
+    private static partial void LogSkippingCleanupNoEnabledEpisodes(ILogger logger);
 }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -106,9 +106,9 @@ public partial class CleanCacheTask(
         // Every cleanup below deletes rows that are NOT in the enumerated queue, so an
         // incomplete queue would classify healthy data as stale and mass-delete it (including
         // the Jellyfin-side media segments). Bail out instead of guessing.
-        if (queueManager.LibraryEnumerationFailureCount > 0)
+        if (queueManager.EnumerationFailureCount > 0)
         {
-            LogSkippingCleanupEnumerationFailures(_logger, queueManager.LibraryEnumerationFailureCount);
+            LogSkippingCleanupEnumerationFailures(_logger, queueManager.EnumerationFailureCount);
             progress.Report(100);
             return;
         }
@@ -186,7 +186,7 @@ public partial class CleanCacheTask(
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete stale detection cache rows")]
     private static partial void LogDeletingCacheRowsFailed(ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping cache cleanup: {Count} library(ies) failed to enumerate, so stale-data detection would over-delete. Check the enumeration errors logged above and re-run the task")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping cache cleanup: {Count} library(ies) or item(s) failed to enumerate, so stale-data detection would over-delete. Check the enumeration errors logged above and re-run the task")]
     private static partial void LogSkippingCleanupEnumerationFailures(ILogger logger, int count);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping cache cleanup: no episodes or movies were found in enabled libraries. To erase Intro Skipper data intentionally, use the erase actions on the plugin configuration page")]


### PR DESCRIPTION
# Guard CleanCacheTask against incomplete library enumeration

## Problem

Every phase of `CleanCacheTask` is a NOT-IN deletion against the enumerated library queue: stale timestamps (`GetStaleTimestampEpisodeIdsAsync`), detection cache rows (`GetStaleItemIdsAsync`), and season states (`CleanSeasonStateAsync`). `QueueManager.GetMediaItems` swallows per-library enumeration failures (`LogFailedEnqueueLibrary` catches and continues), so a single library that fails to enumerate — a transient Jellyfin DB error, for example — silently drops all of its episodes from the "enabled" set, and the cleanup task then classifies that entire library's data as stale and deletes it. Since #842 this extends beyond the plugin's own rows: the handoff also removes the corresponding Jellyfin-side media segments. An empty enumeration (no folders returned) wipes everything the same way.

## Fix

- `QueueManager` now counts per-library enumeration failures (`LibraryEnumerationFailureCount`, reset on each `GetMediaItems` call) so destructive callers can detect an incomplete queue.
- `CleanCacheTask.ExecuteAsync` bails out with a warning before any deletion when enumeration had failures or produced zero episodes, reporting the task as complete instead of guessing.

Intentional full purges are unaffected — those go through the erase actions on the plugin configuration page, which don't depend on library enumeration.

## Tests

New `TestCleanCacheTask` suite with a `DispatchProxy` library-manager stub:
- enumeration failure → all seeded segment/cache/season-state rows survive,
- zero enabled libraries → all seeded rows survive,
- healthy enumeration (control) → stale rows are still deleted and live rows retained, proving the guards don't disable normal cleanup.

Both guard tests fail on the previous behavior (rows deleted) and pass with the guards; full suite 425/425.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-096" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096"><img alt="INTRO-096" src="https://capy.ai/api/badge/thread.svg?label=INTRO-096"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Guard cache cleanup against incomplete or empty library enumeration to prevent unintended mass deletion of Intro Skipper and Jellyfin media data.

Bug Fixes:
- Prevent CleanCacheTask from deleting healthy cache, segment, and season-state data when library enumeration fails or returns no items.

Enhancements:
- Track per-library enumeration failures in QueueManager so destructive tasks can detect incomplete queues before performing deletions.

Tests:
- Add TestCleanCacheTask suite covering enumeration failure, empty libraries, and healthy enumeration to validate the new cleanup guards.