### PR TITLE
Restore plugin DB row on failed Jellyfin delete without a Jellyfin segment

### DIFF
--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Controllers;
+using IntroSkipper.Data;
+using IntroSkipper.Manager;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.MediaSegments;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="SegmentEditorController.DeleteSegmentAsync"/> rollback behavior:
+/// the plugin DB row is deleted before the Jellyfin-side delete, so a Jellyfin failure must
+/// restore the row — including when the Jellyfin segment was already gone and the row was
+/// identified from the plugin database alone.
+/// </summary>
+public sealed class TestSegmentEditorController
+{
+    [Fact]
+    public async Task DeleteSegment_RestoresPluginRow_WhenJellyfinDeleteFails_AndJellyfinSegmentAlreadyGone()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var itemId = Guid.NewGuid();
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, isUserProvided: true);
+
+        // Jellyfin has no segment with this id (lookup returns null) and its delete throws.
+        var manager = new FakeMediaSegmentManager { DeleteException = new InvalidOperationException("jellyfin down") };
+        var controller = CreateController(manager, database);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            controller.DeleteSegmentAsync(Guid.NewGuid(), itemId, "intro", CancellationToken.None));
+
+        var rows = await database.GetSegmentsAsync(itemId);
+        var restored = Assert.Single(rows);
+        Assert.Equal(AnalysisMode.Introduction, restored.Type);
+        Assert.Equal(100, restored.Start);
+        Assert.Equal(160, restored.End);
+        Assert.True(restored.IsUserProvided);
+    }
+
+    [Fact]
+    public async Task DeleteSegment_RestoresPluginRow_WhenJellyfinDeleteFails_WithKnownJellyfinSegment()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var itemId = Guid.NewGuid();
+        var segmentId = Guid.NewGuid();
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, isUserProvided: true);
+
+        var movie = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            ExistingSegments =
+            [
+                new MediaSegmentDto
+                {
+                    Id = segmentId,
+                    ItemId = itemId,
+                    Type = Jellyfin.Database.Implementations.Enums.MediaSegmentType.Intro,
+                    StartTicks = TimeSpan.FromSeconds(100).Ticks,
+                    EndTicks = TimeSpan.FromSeconds(160).Ticks,
+                }
+            ],
+            DeleteException = new InvalidOperationException("jellyfin down"),
+        };
+        var controller = CreateController(manager, database, movie);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            controller.DeleteSegmentAsync(segmentId, itemId, "intro", CancellationToken.None));
+
+        var rows = await database.GetSegmentsAsync(itemId);
+        var restored = Assert.Single(rows);
+        Assert.Equal(100, restored.Start);
+        Assert.Equal(160, restored.End);
+        Assert.True(restored.IsUserProvided);
+    }
+
+    [Fact]
+    public async Task DeleteSegment_RemovesPluginRow_WhenJellyfinDeleteSucceeds_AndJellyfinSegmentAlreadyGone()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
+        var itemId = Guid.NewGuid();
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction);
+
+        // Jellyfin segment already gone; the delete of the unknown id succeeds as a no-op,
+        // so the orphaned plugin row is cleaned up.
+        var manager = new FakeMediaSegmentManager();
+        var controller = CreateController(manager, database);
+
+        await controller.DeleteSegmentAsync(Guid.NewGuid(), itemId, "intro", CancellationToken.None);
+
+        Assert.Empty(await database.GetSegmentsAsync(itemId));
+    }
+
+    private static SegmentEditorController CreateController(
+        FakeMediaSegmentManager manager,
+        IntroSkipper.Db.IIntroSkipperDatabase database,
+        BaseItem? item = null)
+    {
+        var libraryManager = item is null
+            ? EntrypointTestHelpers.CreateLibraryManager()
+            : EntrypointTestHelpers.CreateLibraryManager(item);
+        var service = new MediaSegmentEditorService(manager, libraryManager, NullLogger<MediaSegmentEditorService>.Instance);
+        return new SegmentEditorController(service, database);
+    }
+
+    private static Movie CreateMovie(Guid id)
+    {
+        var item = new Movie();
+        EntrypointTestHelpers.SetPropertyOrField(item, "Id", id);
+        EntrypointTestHelpers.EnsureNonVirtual(item);
+        return item;
+    }
+
+    private sealed class FakeMediaSegmentManager : IMediaSegmentManager
+    {
+        public IReadOnlyList<MediaSegmentDto> ExistingSegments { get; init; } = [];
+
+        public Exception? DeleteException { get; init; }
+
+        public List<Guid> DeletedSegmentIds { get; } = [];
+
+        public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => [(Plugin.ProviderName, "intro-skipper")];
+
+        public Task<IEnumerable<MediaSegmentDto>> GetSegmentsAsync(BaseItem item, IEnumerable<Jellyfin.Database.Implementations.Enums.MediaSegmentType>? typeFilter, LibraryOptions libraryOptions, bool filterByProvider = true)
+            => Task.FromResult<IEnumerable<MediaSegmentDto>>(ExistingSegments);
+
+        public Task<MediaSegmentDto> CreateSegmentAsync(MediaSegmentDto mediaSegment, string segmentProviderId) => Task.FromResult(mediaSegment);
+
+        public Task DeleteSegmentAsync(Guid segmentId)
+        {
+            if (DeleteException is not null)
+            {
+                throw DeleteException;
+            }
+
+            DeletedSegmentIds.Add(segmentId);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public bool HasSegments(Guid itemId) => false;
+
+        public bool IsTypeSupported(BaseItem baseItem) => true;
+    }
+}

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -33,7 +33,7 @@ public sealed class TestSegmentEditorController
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var itemId = Guid.NewGuid();
         var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
-        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, isUserProvided: true);
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, isUserProvided: true, configHash: "cfg-1");
 
         // Jellyfin has no segment with this id (lookup returns null) and its delete throws.
         var manager = new FakeMediaSegmentManager { DeleteException = new InvalidOperationException("jellyfin down") };
@@ -48,6 +48,7 @@ public sealed class TestSegmentEditorController
         Assert.Equal(100, restored.Start);
         Assert.Equal(160, restored.End);
         Assert.True(restored.IsUserProvided);
+        Assert.Equal("cfg-1", restored.ConfigHash);
     }
 
     [Fact]
@@ -57,7 +58,7 @@ public sealed class TestSegmentEditorController
         var itemId = Guid.NewGuid();
         var segmentId = Guid.NewGuid();
         var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
-        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, isUserProvided: true);
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, isUserProvided: true, configHash: "cfg-2");
 
         var movie = CreateMovie(itemId);
         var manager = new FakeMediaSegmentManager
@@ -85,6 +86,7 @@ public sealed class TestSegmentEditorController
         Assert.Equal(100, restored.Start);
         Assert.Equal(160, restored.End);
         Assert.True(restored.IsUserProvided);
+        Assert.Equal("cfg-2", restored.ConfigHash);
     }
 
     [Fact]
@@ -100,10 +102,12 @@ public sealed class TestSegmentEditorController
         // so the orphaned plugin row is cleaned up.
         var manager = new FakeMediaSegmentManager();
         var controller = CreateController(manager, database);
+        var segmentId = Guid.NewGuid();
 
-        await controller.DeleteSegmentAsync(Guid.NewGuid(), itemId, "intro", CancellationToken.None);
+        await controller.DeleteSegmentAsync(segmentId, itemId, "intro", CancellationToken.None);
 
         Assert.Empty(await database.GetSegmentsAsync(itemId));
+        Assert.Equal([segmentId], manager.DeletedSegmentIds);
     }
 
     private static SegmentEditorController CreateController(

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -144,6 +144,11 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             wasUserProvided = matchingSegment.IsUserProvided;
         }
 
+        // Prefer the Jellyfin-reported range for the rollback; fall back to the plugin DB row so
+        // a failed Jellyfin delete can still restore the row when the Jellyfin segment was
+        // already gone (dbSegment is null deletes the mode's row below, so it must be restorable).
+        var restoreSegment = dbSegment ?? matchingSegment?.ToSegment();
+
         // Delete from the plugin DB first so it is consistent even if the Jellyfin delete fails.
         await _database.DeleteTimestampAsync(itemId, mode, dbSegment, cancellationToken).ConfigureAwait(false);
 
@@ -154,9 +159,9 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         catch
         {
             // Jellyfin delete failed — restore the plugin DB entry to avoid an orphaned Jellyfin segment.
-            if (dbSegment is not null)
+            if (restoreSegment is not null)
             {
-                await _database.UpdateTimestampAsync(dbSegment, mode, isUserProvided: wasUserProvided, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                await _database.UpdateTimestampAsync(restoreSegment, mode, isUserProvided: wasUserProvided, cancellationToken: CancellationToken.None).ConfigureAwait(false);
             }
 
             throw;

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -131,10 +131,12 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             return NotFound();
         }
 
-        // Read IsUserProvided before deleting so we can restore it accurately on rollback.
-        // Match on type AND start/end times so that when multiple segments of the same mode exist
-        // (e.g. Commercial) we identify the exact one being deleted rather than an arbitrary first match.
+        // Read IsUserProvided and ConfigHash before deleting so a rollback can restore the row
+        // faithfully. Match on type AND start/end times so that when multiple segments of the
+        // same mode exist (e.g. Commercial) we identify the exact one being deleted rather than
+        // an arbitrary first match.
         var wasUserProvided = false;
+        var configHash = string.Empty;
         var pluginSegments = await _database.GetSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
         var matchingSegment = pluginSegments.FirstOrDefault(s =>
             s.Type == mode &&
@@ -142,6 +144,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         if (matchingSegment is not null)
         {
             wasUserProvided = matchingSegment.IsUserProvided;
+            configHash = matchingSegment.ConfigHash;
         }
 
         // Prefer the Jellyfin-reported range for the rollback; fall back to the plugin DB row so
@@ -158,10 +161,12 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         }
         catch
         {
-            // Jellyfin delete failed — restore the plugin DB entry to avoid an orphaned Jellyfin segment.
+            // Jellyfin delete failed — restore the plugin DB entry (including its user-provided
+            // flag and config hash, so the restored row is not treated as stale) to avoid an
+            // orphaned Jellyfin segment.
             if (restoreSegment is not null)
             {
-                await _database.UpdateTimestampAsync(restoreSegment, mode, isUserProvided: wasUserProvided, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                await _database.UpdateTimestampAsync(restoreSegment, mode, isUserProvided: wasUserProvided, configHash: configHash, cancellationToken: CancellationToken.None).ConfigureAwait(false);
             }
 
             throw;


### PR DESCRIPTION
# Restore plugin DB row when a failed Jellyfin delete follows a missing Jellyfin segment

## Problem

`SegmentEditorController.DeleteSegmentAsync` deletes the plugin DB row first, then the Jellyfin segment, and on a Jellyfin failure rolls the plugin row back — but the rollback source was `dbSegment`, which is only populated when the Jellyfin segment lookup succeeded. When the Jellyfin segment was already gone (`existingSegment` null, non-commercial mode), `DeleteTimestampAsync(itemId, mode, segment: null)` still deletes the mode's plugin row, and a subsequent Jellyfin-side failure skipped the restore entirely — silently losing the row (including user-provided timestamps).

## Fix

The rollback now falls back to the plugin row that was matched for the `IsUserProvided` read (`matchingSegment.ToSegment()`) when no Jellyfin range is available, so the delete-then-rollback sequence is symmetric in both lookup outcomes. The happy paths are unchanged: a successful Jellyfin delete still cleans up the orphaned plugin row, and the known-segment rollback still uses the Jellyfin-reported range.

## Tests

New `TestSegmentEditorController` suite:
- Jellyfin segment already gone + Jellyfin delete throws → plugin row restored with its `IsUserProvided` flag (fails without the fix),
- known Jellyfin segment + delete throws → row restored (pins the pre-existing rollback path),
- Jellyfin segment gone + delete succeeds → orphaned plugin row removed (pins intended cleanup).

Full suite 425/425.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-096" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096"><img alt="INTRO-096" src="https://capy.ai/api/badge/thread.svg?label=INTRO-096"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Improve DeleteSegmentAsync rollback logic so failed Jellyfin deletes consistently restore the corresponding plugin database row, and add tests to pin this behavior.

Bug Fixes:
- Ensure plugin database segments are restored when Jellyfin delete fails even if the Jellyfin segment was already missing.

Tests:
- Add unit tests for SegmentEditorController.DeleteSegmentAsync rollback behavior covering Jellyfin failures and missing Jellyfin segments.