### PR TITLE
Track in-season specials under their resolved season key

### DIFF
--- a/IntroSkipper.Tests/TestSeasonKeyResolution.cs
+++ b/IntroSkipper.Tests/TestSeasonKeyResolution.cs
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Controllers;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.Manager;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaSegments;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+/// <summary>
+/// In-season specials are grouped under the season they air within, so the analysis queue key
+/// (and every season-state row keyed by it) differs from the special's own Jellyfin SeasonId.
+/// These tests pin that the queued episode carries the resolved key and that the segment
+/// editor resolves the same key when reopening analysis after a segment delete.
+/// </summary>
+public sealed class TestSeasonKeyResolution
+{
+    [Fact]
+    public async Task GetMediaItems_AssignsResolvedSeasonKey_ToInSeasonSpecials()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration());
+        EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
+
+        var seriesId = Guid.NewGuid();
+        var hostSeasonId = Guid.NewGuid();
+        var specialsSeasonId = Guid.NewGuid();
+        var host = CreateEpisode(Guid.NewGuid(), seriesId, hostSeasonId, parentIndexNumber: 1, "/media/show/s01e01.mkv");
+        var special = CreateEpisode(Guid.NewGuid(), seriesId, specialsSeasonId, parentIndexNumber: 0, "/media/show/s00e01.mkv");
+        EntrypointTestHelpers.SetPropertyOrField(special, "AirsBeforeSeasonNumber", (int?)1);
+
+        var queueManager = new QueueManager(
+            NullLogger<QueueManager>.Instance,
+            FakeLibraryManager.Create([NewFolder("Shows")], [host, special]),
+            providerManager: null!,
+            fileSystem: null!,
+            ffmpegService: null!,
+            DatabaseTestHelpers.CreateTempSegmentDatabase());
+
+        var queue = await queueManager.GetMediaItems(includeExcluded: true);
+
+        var season = Assert.Single(queue);
+        Assert.Equal(hostSeasonId, season.Key);
+        Assert.Equal(2, season.Value.Count);
+        Assert.All(season.Value, episode => Assert.Equal(hostSeasonId, episode.SeasonId));
+    }
+
+    [Fact]
+    public async Task DeleteSegment_RemovesEpisodeFromHostSeasonState_ForInSeasonSpecial()
+    {
+        var dbPath = CreateTempDbPath();
+        try
+        {
+            using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+            var seriesId = Guid.NewGuid();
+            var hostSeasonId = Guid.NewGuid();
+            var specialsSeasonId = Guid.NewGuid();
+            var hostEpisodeId = Guid.NewGuid();
+            var specialId = Guid.NewGuid();
+
+            // The Jellyfin item reports the specials season, but the analysis queue tracked the
+            // special under the host season, which is where its season-state entry lives.
+            var special = CreateEpisode(specialId, seriesId, specialsSeasonId, parentIndexNumber: 0, "/media/show/s00e01.mkv");
+            EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager(special));
+            EntrypointTestHelpers.SetPropertyOrField(
+                Plugin.Instance!,
+                "QueuedMediaItems",
+                new ConcurrentDictionary<Guid, List<QueuedEpisode>>
+                {
+                    [hostSeasonId] =
+                    [
+                        new QueuedEpisode { EpisodeId = hostEpisodeId, SeasonId = hostSeasonId },
+                        new QueuedEpisode { EpisodeId = specialId, SeasonId = hostSeasonId },
+                    ],
+                });
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.UpdateTimestampAsync(new Segment(specialId, new TimeRange(100, 160)), AnalysisMode.Introduction);
+            await database.SetEpisodeIdsAsync(hostSeasonId, AnalysisMode.Introduction, [hostEpisodeId, specialId], "hash");
+
+            var service = new MediaSegmentEditorService(
+                new FakeMediaSegmentManager(),
+                EntrypointTestHelpers.CreateLibraryManager(),
+                NullLogger<MediaSegmentEditorService>.Instance);
+            var controller = new SegmentEditorController(service, database);
+
+            await controller.DeleteSegmentAsync(Guid.NewGuid(), specialId, "intro", CancellationToken.None);
+
+            await using var db = new IntroSkipperDbContext(dbPath);
+            var state = await db.DbSeasonState
+                .AsNoTracking()
+                .SingleAsync(s => s.SeasonId == hostSeasonId && s.Type == AnalysisMode.Introduction);
+            Assert.Equal([hostEpisodeId], state.EpisodeIds);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    private static Episode CreateEpisode(Guid id, Guid seriesId, Guid seasonId, int parentIndexNumber, string path)
+    {
+        var episode = new Episode
+        {
+            Name = "Episode",
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            ParentIndexNumber = parentIndexNumber,
+            IndexNumber = 1,
+            Path = path,
+        };
+        EntrypointTestHelpers.SetPropertyOrField(episode, "Id", id);
+        EntrypointTestHelpers.SetPropertyOrField(episode, "SeriesName", "Show");
+        EntrypointTestHelpers.EnsureNonVirtual(episode);
+        return episode;
+    }
+
+    private static VirtualFolderInfo NewFolder(string name)
+        => new()
+        {
+            Name = name,
+            ItemId = Guid.NewGuid().ToString(),
+        };
+
+    private static string CreateTempDbPath()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, Guid.NewGuid().ToString("N") + "-seasonkey.db");
+    }
+
+    private static void DeleteSqliteFiles(string dbPath)
+    {
+        foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+        {
+            var path = dbPath + suffix;
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    // ILibraryManager stub for the queue-building path.
+    private class FakeLibraryManager : DispatchProxy
+    {
+        private List<VirtualFolderInfo> _folders = [];
+        private List<BaseItem> _items = [];
+
+        public static ILibraryManager Create(List<VirtualFolderInfo> folders, List<BaseItem> items)
+        {
+            var proxy = Create<ILibraryManager, FakeLibraryManager>();
+            var fake = (FakeLibraryManager)(object)proxy;
+            fake._folders = folders;
+            fake._items = items;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(ILibraryManager.GetVirtualFolders) => _folders,
+                nameof(ILibraryManager.GetItemList) => _items.ToList(),
+                nameof(ILibraryManager.GetItemById) => null,
+                _ => throw new NotImplementedException(targetMethod?.Name),
+            };
+        }
+    }
+
+    private sealed class FakeMediaSegmentManager : IMediaSegmentManager
+    {
+        public IEnumerable<(string Name, string Id)> GetSupportedProviders(BaseItem item) => [(Plugin.ProviderName, "intro-skipper")];
+
+        public Task<IEnumerable<MediaSegmentDto>> GetSegmentsAsync(BaseItem item, IEnumerable<Jellyfin.Database.Implementations.Enums.MediaSegmentType>? typeFilter, LibraryOptions libraryOptions, bool filterByProvider = true)
+            => Task.FromResult<IEnumerable<MediaSegmentDto>>([]);
+
+        public Task<MediaSegmentDto> CreateSegmentAsync(MediaSegmentDto mediaSegment, string segmentProviderId) => Task.FromResult(mediaSegment);
+
+        public Task DeleteSegmentAsync(Guid segmentId) => Task.CompletedTask;
+
+        public Task DeleteSegmentsAsync(Guid itemId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task RunSegmentPluginProviders(BaseItem baseItem, LibraryOptions libraryOptions, bool forceOverwrite, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public bool HasSegments(Guid itemId) => false;
+
+        public bool IsTypeSupported(BaseItem baseItem) => true;
+    }
+}

--- a/IntroSkipper.Tests/TestSeasonKeyResolution.cs
+++ b/IntroSkipper.Tests/TestSeasonKeyResolution.cs
@@ -118,6 +118,49 @@ public sealed class TestSeasonKeyResolution
         }
     }
 
+    [Fact]
+    public async Task DeleteSegment_FallsBackToItemSeasonId_WhenQueueIsNotBuilt()
+    {
+        var dbPath = CreateTempDbPath();
+        try
+        {
+            using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+            var seasonId = Guid.NewGuid();
+            var episodeId = Guid.NewGuid();
+
+            // No analysis has run yet: the cached queue is empty, so the editor must fall back
+            // to the item's own SeasonId — which is the correct key for regular episodes.
+            var episode = CreateEpisode(episodeId, Guid.NewGuid(), seasonId, parentIndexNumber: 1, "/media/show/s01e01.mkv");
+            EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager(episode));
+            EntrypointTestHelpers.SetPropertyOrField(
+                Plugin.Instance!,
+                "QueuedMediaItems",
+                new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.UpdateTimestampAsync(new Segment(episodeId, new TimeRange(100, 160)), AnalysisMode.Introduction);
+            await database.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeId], "hash");
+
+            var service = new MediaSegmentEditorService(
+                new FakeMediaSegmentManager(),
+                EntrypointTestHelpers.CreateLibraryManager(),
+                NullLogger<MediaSegmentEditorService>.Instance);
+            var controller = new SegmentEditorController(service, database);
+
+            await controller.DeleteSegmentAsync(Guid.NewGuid(), episodeId, "intro", CancellationToken.None);
+
+            await using var db = new IntroSkipperDbContext(dbPath);
+            var state = await db.DbSeasonState
+                .AsNoTracking()
+                .SingleAsync(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction);
+            Assert.Empty(state.EpisodeIds);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
     private static Episode CreateEpisode(Guid id, Guid seriesId, Guid seasonId, int parentIndexNumber, string path)
     {
         var episode = new Episode

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -9,6 +9,7 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using MediaBrowser.Common.Api;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.MediaSegments;
 using MediaBrowser.Model.Querying;
@@ -167,10 +168,31 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         var deletedItem = Plugin.Instance!.GetItem(itemId);
         if (deletedItem is not null)
         {
-            var seasonId = deletedItem is Episode ep ? ep.SeasonId : deletedItem.Id;
-            await _database.RemoveEpisodeIdAsync(seasonId, mode, itemId, cancellationToken).ConfigureAwait(false);
+            await _database.RemoveEpisodeIdAsync(ResolveSeasonStateKey(deletedItem, itemId), mode, itemId, cancellationToken).ConfigureAwait(false);
         }
 
         return Ok();
+    }
+
+    /// <summary>
+    /// Resolves the season-state key for an item. Season states are keyed by the analysis
+    /// queue's season key, which differs from the item's own SeasonId for in-season specials
+    /// (grouped with the season they air within) and for episodes whose SeasonId could not be
+    /// resolved. Prefer the queue key when the item is present in the cached queue.
+    /// </summary>
+    /// <param name="item">The item whose season-state key to resolve.</param>
+    /// <param name="itemId">The item id.</param>
+    /// <returns>The season-state key.</returns>
+    private static Guid ResolveSeasonStateKey(BaseItem item, Guid itemId)
+    {
+        foreach (var (seasonId, episodes) in Plugin.Instance!.QueuedMediaItems)
+        {
+            if (episodes.Any(e => e.EpisodeId == itemId))
+            {
+                return seasonId;
+            }
+        }
+
+        return item is Episode episode ? episode.SeasonId : item.Id;
     }
 }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -276,7 +276,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             SeriesName = episode.SeriesName,
             SeasonNumber = episode.AiredSeasonNumber ?? 0,
             SeriesId = episode.SeriesId,
-            SeasonId = episode.SeasonId,
+            // Use the resolved queue key, not the raw Jellyfin SeasonId: for in-season specials
+            // (and unresolved SeasonIds) they differ, and season-state rows are keyed by the
+            // resolved value everywhere downstream.
+            SeasonId = seasonId,
             EpisodeNumber = episode.IndexNumber ?? 0,
             EpisodeId = episode.Id,
             Name = episode.Name,


### PR DESCRIPTION
# Track in-season specials under their resolved season key

## Problem

`QueueManager.GetSeasonId` groups in-season specials (`ParentIndexNumber == 0` airing within a regular season) under the host season's queue key, and every season-state row is written with that key (`SetEpisodeIdsAsync(first.SeasonId, …)` where `first` is a host episode). But the `QueuedEpisode` itself carried the raw Jellyfin `episode.SeasonId` — the Specials season — so consumers that group by `QueuedEpisode.SeasonId` (for example `ClearExcludedTimestampsAsync`) or resolve the key from the Jellyfin item (`SegmentEditorController.DeleteSegmentAsync` → `RemoveEpisodeIdAsync(ep.SeasonId, …)`) addressed a season-state row that doesn't exist. Concretely: deleting an in-season special's segment in the editor never removed it from the host season's analyzed list, so the special stayed negative-cached and was never re-analyzed. The same held for episodes whose unresolved `SeasonId` falls back to the episode id.

## Fix

- `QueueEpisode` now stores the resolved queue key on `QueuedEpisode.SeasonId`, so the queued episode and the queue dictionary key can no longer disagree. For regular episodes the value is unchanged.
- `SegmentEditorController.DeleteSegmentAsync` resolves the season-state key by locating the episode in `Plugin.QueuedMediaItems` (the same source the visualization endpoints already use), falling back to the item's own `SeasonId` when the queue hasn't been built.

## Tests

New `TestSeasonKeyResolution` suite, both red-green verified:
- a queue build over a host episode plus an in-season special yields one season keyed by the host season, with both queued episodes carrying that key,
- deleting the special's segment through the editor removes it from the host season's analyzed-episode state (previously a silent no-op against the Specials season).

Full suite 424/424.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-096" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/421f0755-0066-417a-bddb-d9ce02db485d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-096"><img alt="INTRO-096" src="https://capy.ai/api/badge/thread.svg?label=INTRO-096"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Resolve season-state keys consistently for queued episodes and segment deletions involving in-season specials.

Bug Fixes:
- Align queued episodes' SeasonId with the resolved queue key so season-state rows are addressed correctly for in-season specials and unresolved seasons.
- Ensure segment deletions resolve the season-state key via the queued media items, so removing a special's segment updates the host season's analyzed state instead of a nonexistent specials season.

Tests:
- Add TestSeasonKeyResolution suite to pin queue season key assignment and segment deletion behavior for in-season specials.