### PR TITLE
Simplify database facade layer and consolidate duplicated policies

### DIFF
--- a/IntroSkipper.Tests/DatabaseTestHelpers.cs
+++ b/IntroSkipper.Tests/DatabaseTestHelpers.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 
 /// <summary>
@@ -18,7 +19,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 internal static class DatabaseTestHelpers
 {
     internal static IntroSkipperDatabase CreateSegmentDatabase(string dbPath)
-        => new(new TestDbContextFactory<IntroSkipperDbContext>(() => new IntroSkipperDbContext(dbPath)), NullLogger.Instance);
+        => new(new TestDbContextFactory<IntroSkipperDbContext>(() => new IntroSkipperDbContext(dbPath)), NullLogger<IntroSkipperDatabase>.Instance);
 
     /// <summary>
     /// Creates a segment database facade over a fresh temp-file path, for consumers
@@ -30,7 +31,7 @@ internal static class DatabaseTestHelpers
         => CreateSegmentDatabase(CreateTempDbPath(Guid.NewGuid().ToString("N") + ".db"));
 
     internal static DetectionCacheDatabase CreateCacheDatabase(string dbPath)
-        => new(new TestDbContextFactory<DetectionCacheDbContext>(() => new DetectionCacheDbContext(dbPath)), NullLogger.Instance);
+        => new(new TestDbContextFactory<DetectionCacheDbContext>(() => new DetectionCacheDbContext(dbPath)), NullLogger<DetectionCacheDatabase>.Instance);
 
     internal static DetectionCacheService CreateCacheService(string dbPath)
         => new(NullLogger<DetectionCacheService>.Instance, CreateCacheDatabase(dbPath));
@@ -58,10 +59,30 @@ internal static class DatabaseTestHelpers
     /// </summary>
     /// <param name="fileName">Database file name.</param>
     /// <returns>The database path.</returns>
-    private static string CreateTempDbPath(string fileName)
+    internal static string CreateTempDbPath(string fileName)
     {
         var directory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
         Directory.CreateDirectory(directory);
         return Path.Combine(directory, fileName);
+    }
+
+    /// <summary>
+    /// Deletes a SQLite database and its WAL/SHM sidecar files. Clears pooled
+    /// connections first so Windows file locks from earlier contexts cannot make the
+    /// delete flaky.
+    /// </summary>
+    /// <param name="dbPath">Database path.</param>
+    internal static void DeleteSqliteFiles(string dbPath)
+    {
+        SqliteConnection.ClearAllPools();
+
+        foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
+        {
+            var path = dbPath + suffix;
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
     }
 }

--- a/IntroSkipper.Tests/TestBaseItemAnalyzerTaskOrchestration.cs
+++ b/IntroSkipper.Tests/TestBaseItemAnalyzerTaskOrchestration.cs
@@ -1,0 +1,38 @@
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.ScheduledTasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+public sealed class TestBaseItemAnalyzerTaskOrchestration
+{
+    [Fact]
+    public async Task AnalyzeItemsAsync_PropagatesCancellationToFfmpegValidation()
+    {
+        using var pluginScope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration());
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        var analyzer = new BaseItemAnalyzerTask(
+            NullLogger.Instance,
+            NullLoggerFactory.Instance,
+            EntrypointTestHelpers.CreateLibraryManager(),
+            providerManager: null!,
+            fileSystem: null!,
+            mediaSegmentRefresher: null!,
+            ffmpegService: new FFmpegService(
+                NullLogger<FFmpegService>.Instance,
+                DatabaseTestHelpers.CreateTempCacheService()),
+            cacheService: null!,
+            database: null!);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => analyzer.AnalyzeItemsAsync(new Progress<double>(), cancellation.Token));
+    }
+}

--- a/IntroSkipper.Tests/TestChapterAnalyzerOrchestration.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzerOrchestration.cs
@@ -1,0 +1,117 @@
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using MediaBrowser.Controller.Chapters;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+public sealed class TestChapterAnalyzerOrchestration
+{
+    [Fact]
+    public async Task AnalyzeMediaFiles_ReturnsUnchangedQueueWithoutPersisting_WhenChapterManagerReturnsNull()
+    {
+        var dbPath = CreateTempDbPath();
+        var episode = CreateEpisode();
+        IReadOnlyList<QueuedEpisode> queue = [episode];
+        try
+        {
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            using var pluginScope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+            ConfigurePlugin();
+            var chapterManager = NullChapterManager.Create(out var chapterManagerProxy);
+            EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_chapterRepository", chapterManager);
+            var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, null!, database);
+
+            var result = await analyzer.AnalyzeMediaFiles(queue, AnalysisMode.Introduction, CancellationToken.None);
+
+            Assert.Same(queue, result);
+            Assert.Equal(1, chapterManagerProxy.GetChaptersCallCount);
+            Assert.Equal(EpisodeState.NotAnalyzed, episode.GetAnalyzed(AnalysisMode.Introduction));
+            Assert.Empty(await database.GetSegmentsAsync(episode.EpisodeId));
+        }
+        finally
+        {
+            DatabaseTestHelpers.DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeMediaFiles_PropagatesCancellationBeforeChapterLookupOrPersistence()
+    {
+        var dbPath = CreateTempDbPath();
+        var episode = CreateEpisode();
+        IReadOnlyList<QueuedEpisode> queue = [episode];
+        try
+        {
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            using var pluginScope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+            ConfigurePlugin();
+            var chapterManager = NullChapterManager.Create(out var chapterManagerProxy);
+            EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_chapterRepository", chapterManager);
+            var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, null!, database);
+            using var cancellationSource = new CancellationTokenSource();
+            await cancellationSource.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => analyzer.AnalyzeMediaFiles(queue, AnalysisMode.Introduction, cancellationSource.Token));
+
+            Assert.Equal(0, chapterManagerProxy.GetChaptersCallCount);
+            Assert.Equal(EpisodeState.NotAnalyzed, episode.GetAnalyzed(AnalysisMode.Introduction));
+            Assert.Empty(await database.GetSegmentsAsync(episode.EpisodeId));
+        }
+        finally
+        {
+            DatabaseTestHelpers.DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    private static void ConfigurePlugin()
+    {
+        EntrypointTestHelpers.SetPropertyOrField(
+            Plugin.Instance!,
+            "Configuration",
+            new PluginConfiguration
+            {
+                ChapterAnalyzerIntroductionPattern = "Introduction",
+            });
+    }
+
+    private static QueuedEpisode CreateEpisode() => new()
+    {
+        EpisodeId = Guid.NewGuid(),
+        Duration = 1800,
+    };
+
+    private static string CreateTempDbPath()
+        => DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-chapter-analyzer.db");
+
+    private class NullChapterManager : DispatchProxy
+    {
+        public int GetChaptersCallCount { get; private set; }
+
+        public static IChapterManager Create(out NullChapterManager proxy)
+        {
+            var chapterManager = DispatchProxy.Create<IChapterManager, NullChapterManager>();
+            proxy = (NullChapterManager)(object)chapterManager;
+            return chapterManager;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IChapterManager.GetChapters))
+            {
+                GetChaptersCallCount++;
+                return null;
+            }
+
+            throw new NotImplementedException(targetMethod?.Name);
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestChromaprintFinalSampleMatch.cs
+++ b/IntroSkipper.Tests/TestChromaprintFinalSampleMatch.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+public sealed class TestChromaprintFinalSampleMatch
+{
+    [Fact]
+    public void CompareEpisodes_ReturnsMatchEndingAtFinalSample()
+    {
+        using var pluginScope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance;
+        Assert.NotNull(plugin);
+        EntrypointTestHelpers.SetPropertyOrField(
+            plugin,
+            "Configuration",
+            new PluginConfiguration
+            {
+                MinimumIntroDuration = 1,
+                MaximumFingerprintPointDifferences = 0,
+                MaximumTimeSkip = 0.2,
+                InvertedIndexShift = 0,
+            });
+        uint[] fingerprint = [
+            0x1000u, 0x1100u, 0x1200u, 0x1300u, 0x1400u,
+            0x1500u, 0x1600u, 0x1700u, 0x1800u, 0x1900u,
+        ];
+        var lhsId = Guid.NewGuid();
+        var rhsId = Guid.NewGuid();
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            null!,
+            null!,
+            DatabaseTestHelpers.CreateTempSegmentDatabase());
+
+        var (lhs, rhs) = analyzer.CompareEpisodes(lhsId, fingerprint, rhsId, fingerprint);
+
+        var expectedEnd = (fingerprint.Length - 1) * ChromaprintConstants.SampleDuration;
+        Assert.True(lhs.Valid);
+        Assert.True(rhs.Valid);
+        Assert.Equal(lhsId, lhs.EpisodeId);
+        Assert.Equal(rhsId, rhs.EpisodeId);
+        Assert.Equal(expectedEnd, lhs.End);
+        Assert.Equal(expectedEnd, rhs.End);
+    }
+}

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -265,25 +265,11 @@ public sealed class TestCleanCacheTask
         };
 
     private static (string DbPath, string CacheDbPath) CreateTempDbPaths()
-    {
-        var directory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
-        Directory.CreateDirectory(directory);
-        return (
-            Path.Combine(directory, Guid.NewGuid().ToString("N") + "-cleantask.db"),
-            Path.Combine(directory, Guid.NewGuid().ToString("N") + "-cleantask-cache.db"));
-    }
+        => (DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-cleantask.db"),
+            DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-cleantask-cache.db"));
 
     private static void DeleteSqliteFiles(string dbPath)
-    {
-        foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
-        {
-            var path = dbPath + suffix;
-            if (File.Exists(path))
-            {
-                File.Delete(path);
-            }
-        }
-    }
+        => DatabaseTestHelpers.DeleteSqliteFiles(dbPath);
 
     private sealed class RecordingProgress : IProgress<double>
     {

--- a/IntroSkipper.Tests/TestDatabaseFacades.cs
+++ b/IntroSkipper.Tests/TestDatabaseFacades.cs
@@ -831,7 +831,7 @@ public sealed class TestDatabaseFacades
                 Interlocked.Increment(ref contextCreations);
                 return new IntroSkipperDbContext(dbPath);
             }),
-            NullLogger.Instance);
+            NullLogger<IntroSkipperDatabase>.Instance);
 
         try
         {
@@ -876,7 +876,7 @@ public sealed class TestDatabaseFacades
                 Interlocked.Increment(ref contextCreations);
                 return new DetectionCacheDbContext(dbPath);
             }),
-            NullLogger.Instance);
+            NullLogger<DetectionCacheDatabase>.Instance);
 
         try
         {
@@ -914,7 +914,7 @@ public sealed class TestDatabaseFacades
                 contextCreations++;
                 throw new IOException("Simulated unavailable cache database.");
             }),
-            NullLogger.Instance);
+            NullLogger<DetectionCacheDatabase>.Instance);
         var itemId = Guid.NewGuid();
 
         Assert.Null(database.FindEntry(
@@ -1139,22 +1139,8 @@ public sealed class TestDatabaseFacades
     }
 
     private static string CreateTempDbPath()
-    {
-        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests", "database-facades");
-        Directory.CreateDirectory(tempDir);
-        return Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
-    }
+        => DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-facades.db");
 
     private static void DeleteSqliteFiles(string dbPath)
-    {
-        SqliteConnection.ClearAllPools();
-
-        foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
-        {
-            if (File.Exists(path))
-            {
-                File.Delete(path);
-            }
-        }
-    }
+        => DatabaseTestHelpers.DeleteSqliteFiles(dbPath);
 }

--- a/IntroSkipper.Tests/TestDatabaseInitializer.cs
+++ b/IntroSkipper.Tests/TestDatabaseInitializer.cs
@@ -96,6 +96,41 @@ public sealed class TestDatabaseInitializer
         Assert.Equal(0, cacheCalls);
     }
 
+    [Fact]
+    public async Task StartAsync_CancellationDuringCacheWarmup_ReturnsWithoutInterruptingCache()
+    {
+        using var cts = new CancellationTokenSource();
+        using var releaseCache = new ManualResetEventSlim();
+        var cacheStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cacheCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var segmentDatabase = FacadeProxy.CreateSegmentDatabase(() => Task.CompletedTask);
+        var cacheDatabase = FacadeProxy.CreateCacheDatabase(() =>
+        {
+            cacheStarted.SetResult();
+            releaseCache.Wait();
+            cacheCompleted.SetResult();
+        });
+        var initializer = new IntroSkipperDatabaseInitializer(
+            segmentDatabase, cacheDatabase, NullLogger<IntroSkipperDatabaseInitializer>.Instance);
+
+        var startTask = initializer.StartAsync(cts.Token);
+        await cacheStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            await cts.CancelAsync();
+            Assert.Null(await Record.ExceptionAsync(
+                () => startTask.WaitAsync(TimeSpan.FromSeconds(30))));
+            Assert.False(cacheCompleted.Task.IsCompleted);
+        }
+        finally
+        {
+            releaseCache.Set();
+        }
+
+        await cacheCompleted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
     // Strict facade fakes: only the initialization member is stubbed; any other member
     // access throws, proving the warm-up touches nothing else.
     private class FacadeProxy : DispatchProxy

--- a/IntroSkipper.Tests/TestEntrypointLifecycle.cs
+++ b/IntroSkipper.Tests/TestEntrypointLifecycle.cs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Services;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Tasks;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestEntrypointLifecycle
+{
+    [Fact]
+    public async Task StartAsync_SubscribesHandlersUntilStopAsync()
+    {
+        var libraryManager = LibraryManagerEventProxy.Create(out var libraryManagerService);
+        var taskManager = TaskManagerEventProxy.Create(out var taskManagerService);
+        var ffmpegService = FFmpegVersionProxy.Create(out var ffmpegServiceProxy);
+        using var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        EntrypointTestHelpers.SetPrivateField(entrypoint, "_libraryManager", libraryManagerService);
+        EntrypointTestHelpers.SetPrivateField(entrypoint, "_taskManager", taskManagerService);
+        EntrypointTestHelpers.SetPrivateField(entrypoint, "_ffmpegService", ffmpegService);
+
+        using var pluginScope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        await entrypoint.StartAsync(CancellationToken.None);
+
+        Assert.Equal(1, ffmpegServiceProxy.CheckVersionCallCount);
+        Assert.Equal(1, libraryManager.ItemAddedSubscriberCount);
+        Assert.Equal(1, libraryManager.ItemUpdatedSubscriberCount);
+        Assert.Equal(1, libraryManager.ItemRemovedSubscriberCount);
+        Assert.Equal(1, taskManager.TaskCompletedSubscriberCount);
+
+        await entrypoint.StopAsync(CancellationToken.None);
+
+        Assert.Equal(0, libraryManager.ItemAddedSubscriberCount);
+        Assert.Equal(0, libraryManager.ItemUpdatedSubscriberCount);
+        Assert.Equal(0, libraryManager.ItemRemovedSubscriberCount);
+        Assert.Equal(0, taskManager.TaskCompletedSubscriberCount);
+        Assert.Equal(TaskState.Idle, Entrypoint.AutomaticTaskState);
+    }
+
+    [Fact]
+    public async Task CancelAutomaticTaskAsync_CancelsActiveTaskAndRetainsCancellingState()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        var cancellationObserved = false;
+        using var registration = cancellationSource.Token.Register(() => cancellationObserved = true);
+        EntrypointTestHelpers.SetPrivateStaticField(typeof(Entrypoint), "_cancellationTokenSource", cancellationSource);
+
+        try
+        {
+            await Entrypoint.CancelAutomaticTaskAsync(CancellationToken.None);
+
+            Assert.True(cancellationObserved);
+            Assert.True(cancellationSource.IsCancellationRequested);
+            Assert.Equal(TaskState.Cancelling, Entrypoint.AutomaticTaskState);
+        }
+        finally
+        {
+            EntrypointTestHelpers.SetPrivateStaticField(typeof(Entrypoint), "_cancellationTokenSource", null);
+        }
+    }
+
+    private class LibraryManagerEventProxy : DispatchProxy
+    {
+        internal int ItemAddedSubscriberCount { get; private set; }
+
+        internal int ItemUpdatedSubscriberCount { get; private set; }
+
+        internal int ItemRemovedSubscriberCount { get; private set; }
+
+        internal static LibraryManagerEventProxy Create(out ILibraryManager service)
+        {
+            service = Create<ILibraryManager, LibraryManagerEventProxy>();
+            return (LibraryManagerEventProxy)(object)service;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            switch (targetMethod?.Name)
+            {
+                case "add_ItemAdded":
+                    ItemAddedSubscriberCount++;
+                    return null;
+                case "remove_ItemAdded":
+                    ItemAddedSubscriberCount--;
+                    return null;
+                case "add_ItemUpdated":
+                    ItemUpdatedSubscriberCount++;
+                    return null;
+                case "remove_ItemUpdated":
+                    ItemUpdatedSubscriberCount--;
+                    return null;
+                case "add_ItemRemoved":
+                    ItemRemovedSubscriberCount++;
+                    return null;
+                case "remove_ItemRemoved":
+                    ItemRemovedSubscriberCount--;
+                    return null;
+                default:
+                    throw new NotImplementedException(targetMethod?.Name);
+            }
+        }
+    }
+
+    private class TaskManagerEventProxy : DispatchProxy
+    {
+        internal int TaskCompletedSubscriberCount { get; private set; }
+
+        internal static TaskManagerEventProxy Create(out ITaskManager service)
+        {
+            service = Create<ITaskManager, TaskManagerEventProxy>();
+            return (TaskManagerEventProxy)(object)service;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            switch (targetMethod?.Name)
+            {
+                case "add_TaskCompleted":
+                    TaskCompletedSubscriberCount++;
+                    return null;
+                case "remove_TaskCompleted":
+                    TaskCompletedSubscriberCount--;
+                    return null;
+                default:
+                    throw new NotImplementedException(targetMethod?.Name);
+            }
+        }
+    }
+
+    private class FFmpegVersionProxy : DispatchProxy
+    {
+        internal int CheckVersionCallCount { get; private set; }
+
+        internal static IFFmpegService Create(out FFmpegVersionProxy proxy)
+        {
+            var service = Create<IFFmpegService, FFmpegVersionProxy>();
+            proxy = (FFmpegVersionProxy)(object)service;
+            return service;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IFFmpegService.CheckFFmpegVersionAsync))
+            {
+                CheckVersionCallCount++;
+                return Task.FromResult(true);
+            }
+
+            throw new NotImplementedException(targetMethod?.Name);
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Manager;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+public sealed class TestQueueManager
+{
+    [Fact]
+    public async Task GetMediaItems_QueuesRegularEpisodeAndMovie_AndPublishesQueueState()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration());
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+        EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
+
+        var seriesId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var seasonId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var episodeId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var movieId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        var episode = CreateEpisode(episodeId, seriesId, seasonId);
+        var movie = new Movie
+        {
+            Id = movieId,
+            Name = "Feature",
+            Path = "/media/feature.mkv",
+            RunTimeTicks = TimeSpan.FromMinutes(4).Ticks,
+        };
+
+        var queueManager = new QueueManager(
+            NullLogger<QueueManager>.Instance,
+            QueueLibraryManager.Create([NewFolder("Media")], [episode, movie]),
+            providerManager: null!,
+            fileSystem: null!,
+            ffmpegService: null!,
+            DatabaseTestHelpers.CreateTempSegmentDatabase());
+
+        var queue = await queueManager.GetMediaItems();
+
+        var queuedEpisode = Assert.Single(queue[seasonId]);
+        Assert.Equal(episodeId, queuedEpisode.EpisodeId);
+        Assert.Equal(seriesId, queuedEpisode.SeriesId);
+        Assert.Equal(seasonId, queuedEpisode.SeasonId);
+        Assert.Equal("Pilot", queuedEpisode.Name);
+        Assert.Equal("Series", queuedEpisode.SeriesName);
+        Assert.Equal(QueuedMediaCategory.Episode, queuedEpisode.Category);
+        Assert.Equal(240, queuedEpisode.Duration);
+        Assert.False(queuedEpisode.IsExcluded);
+
+        var queuedMovie = Assert.Single(queue[movieId]);
+        Assert.Equal(movieId, queuedMovie.EpisodeId);
+        Assert.Equal(movieId, queuedMovie.SeriesId);
+        Assert.Equal(movieId, queuedMovie.SeasonId);
+        Assert.Equal("Feature", queuedMovie.Name);
+        Assert.Equal(QueuedMediaCategory.Movie, queuedMovie.Category);
+        Assert.Equal(240, queuedMovie.Duration);
+        Assert.False(queuedMovie.IsExcluded);
+
+        Assert.Equal(2, plugin.TotalQueued);
+        Assert.Equal(2, plugin.TotalSeasons);
+        Assert.Equal(2, plugin.QueuedMediaItems.Count);
+        Assert.Equal(episodeId, Assert.Single(plugin.QueuedMediaItems[seasonId]).EpisodeId);
+        Assert.Equal(movieId, Assert.Single(plugin.QueuedMediaItems[movieId]).EpisodeId);
+    }
+
+    private static Episode CreateEpisode(Guid episodeId, Guid seriesId, Guid seasonId)
+    {
+        var episode = new Episode
+        {
+            Name = "Pilot",
+            SeriesId = seriesId,
+            SeasonId = seasonId,
+            ParentIndexNumber = 1,
+            IndexNumber = 1,
+            Path = "/media/series/s01e01.mkv",
+            RunTimeTicks = TimeSpan.FromMinutes(4).Ticks,
+        };
+        EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+        EntrypointTestHelpers.SetPropertyOrField(episode, "SeriesName", "Series");
+        EntrypointTestHelpers.EnsureNonVirtual(episode);
+        return episode;
+    }
+
+    private static VirtualFolderInfo NewFolder(string name)
+        => new()
+        {
+            Name = name,
+            ItemId = Guid.Parse("55555555-5555-5555-5555-555555555555").ToString(),
+        };
+
+    private class QueueLibraryManager : DispatchProxy
+    {
+        private List<VirtualFolderInfo> _folders = [];
+        private List<BaseItem> _items = [];
+
+        public static ILibraryManager Create(List<VirtualFolderInfo> folders, List<BaseItem> items)
+        {
+            var proxy = Create<ILibraryManager, QueueLibraryManager>();
+            var fake = (QueueLibraryManager)(object)proxy;
+            fake._folders = folders;
+            fake._items = items;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(ILibraryManager.GetVirtualFolders) => _folders,
+                nameof(ILibraryManager.GetItemList) => new List<BaseItem>(_items),
+                nameof(ILibraryManager.GetItemById) => null,
+                _ => throw new NotImplementedException(targetMethod?.Name),
+            };
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestSeasonKeyResolution.cs
+++ b/IntroSkipper.Tests/TestSeasonKeyResolution.cs
@@ -186,23 +186,10 @@ public sealed class TestSeasonKeyResolution
         };
 
     private static string CreateTempDbPath()
-    {
-        var directory = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests");
-        Directory.CreateDirectory(directory);
-        return Path.Combine(directory, Guid.NewGuid().ToString("N") + "-seasonkey.db");
-    }
+        => DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-seasonkey.db");
 
     private static void DeleteSqliteFiles(string dbPath)
-    {
-        foreach (var suffix in new[] { string.Empty, "-wal", "-shm" })
-        {
-            var path = dbPath + suffix;
-            if (File.Exists(path))
-            {
-                File.Delete(path);
-            }
-        }
-    }
+        => DatabaseTestHelpers.DeleteSqliteFiles(dbPath);
 
     // ILibraryManager stub for the queue-building path.
     private class FakeLibraryManager : DispatchProxy

--- a/IntroSkipper.Tests/TestVisualizationControllerSeams.cs
+++ b/IntroSkipper.Tests/TestVisualizationControllerSeams.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Controllers;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Manager;
+using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestVisualizationControllerSeams
+{
+    [Fact]
+    public async Task GetAnalyzerAction_ReturnsNotFound_WhenSeasonIsNotQueued()
+    {
+        using var scope = CreatePluginScope();
+        var controller = CreateController(DatabaseTestHelpers.CreateTempSegmentDatabase(), scope.CacheDbPath);
+
+        var result = await controller.GetAnalyzerAction(Guid.NewGuid());
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetAnalyzerAction_ReturnsStoredAndDefaultActions_WhenSeasonIsQueued()
+    {
+        using var scope = CreatePluginScope();
+        var seasonId = Guid.NewGuid();
+        QueueSeason(seasonId, Guid.NewGuid());
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        await database.SetAnalyzerActionAsync(
+            seasonId,
+            new Dictionary<AnalysisMode, AnalyzerAction> { [AnalysisMode.Introduction] = AnalyzerAction.Chapter });
+        var controller = CreateController(database, scope.CacheDbPath);
+
+        var result = await controller.GetAnalyzerAction(seasonId);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var actions = Assert.IsAssignableFrom<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>>(ok.Value);
+        Assert.Equal(AnalyzerAction.Chapter, actions[AnalysisMode.Introduction]);
+        Assert.Equal(AnalyzerAction.Default, actions[AnalysisMode.Credits]);
+    }
+
+    [Fact]
+    public void GetSeasonEpisodes_ReturnsQueuedEpisodes_WhenSeriesMatches()
+    {
+        using var scope = CreatePluginScope();
+        var seasonId = Guid.NewGuid();
+        var seriesId = Guid.NewGuid();
+        var firstEpisodeId = Guid.NewGuid();
+        var secondEpisodeId = Guid.NewGuid();
+        QueueSeason(seasonId, firstEpisodeId, seriesId, "First", secondEpisodeId, seriesId, "Second");
+        var controller = CreateController(DatabaseTestHelpers.CreateTempSegmentDatabase(), scope.CacheDbPath);
+
+        var result = controller.GetSeasonEpisodes(seriesId, seasonId);
+
+        Assert.Equal(
+            [new EpisodeVisualization(firstEpisodeId, "First"), new EpisodeVisualization(secondEpisodeId, "Second")],
+            result.Value);
+    }
+
+    [Fact]
+    public void GetSeasonEpisodes_ReturnsNotFound_WhenSeasonIsMissingOrSeriesDoesNotMatch()
+    {
+        using var scope = CreatePluginScope();
+        var seasonId = Guid.NewGuid();
+        QueueSeason(seasonId, Guid.NewGuid());
+        var controller = CreateController(DatabaseTestHelpers.CreateTempSegmentDatabase(), scope.CacheDbPath);
+
+        var missingSeason = controller.GetSeasonEpisodes(Guid.NewGuid(), Guid.NewGuid());
+        var wrongSeries = controller.GetSeasonEpisodes(Guid.NewGuid(), seasonId);
+
+        Assert.IsType<NotFoundResult>(missingSeason.Result);
+        Assert.IsType<NotFoundResult>(wrongSeries.Result);
+    }
+
+    [Fact]
+    public async Task UpdateAnalyzerActions_PersistsRequestAndReturnsNoContent()
+    {
+        using var scope = CreatePluginScope();
+        var seasonId = Guid.NewGuid();
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        var controller = CreateController(database, scope.CacheDbPath);
+        var request = new UpdateAnalyzerActionsRequest
+        {
+            Id = seasonId,
+            AnalyzerActions = new Dictionary<AnalysisMode, AnalyzerAction>
+            {
+                [AnalysisMode.Introduction] = AnalyzerAction.BlackFrame,
+            },
+        };
+
+        var result = await controller.UpdateAnalyzerActions(request);
+        var actions = await database.GetAllAnalyzerActionsAsync(seasonId);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Equal(AnalyzerAction.BlackFrame, actions[AnalysisMode.Introduction]);
+        Assert.Equal(AnalyzerAction.Default, actions[AnalysisMode.Credits]);
+    }
+
+    [Fact]
+    public async Task GetScanStatus_ReflectsHeldScanLease()
+    {
+        using var scope = CreatePluginScope();
+        var controller = CreateController(DatabaseTestHelpers.CreateTempSegmentDatabase(), scope.CacheDbPath);
+        Assert.False(Assert.IsType<ScanStatusResponse>(controller.GetScanStatus().Value).IsRunning);
+
+        var lease = Assert.IsAssignableFrom<IDisposable>(await ScheduledTaskSemaphore.TryAcquireAsync());
+        try
+        {
+            Assert.True(Assert.IsType<ScanStatusResponse>(controller.GetScanStatus().Value).IsRunning);
+        }
+        finally
+        {
+            lease.Dispose();
+        }
+
+        Assert.False(Assert.IsType<ScanStatusResponse>(controller.GetScanStatus().Value).IsRunning);
+    }
+
+    [Fact]
+    public async Task ScanSeason_ReturnsConflict_WhenScanLeaseIsHeld()
+    {
+        using var scope = CreatePluginScope();
+        var controller = CreateController(
+            DatabaseTestHelpers.CreateTempSegmentDatabase(),
+            scope.CacheDbPath,
+            EntrypointTestHelpers.CreateLibraryManager());
+        var lease = Assert.IsAssignableFrom<IDisposable>(await ScheduledTaskSemaphore.TryAcquireAsync());
+        try
+        {
+            var result = await controller.ScanSeason(Guid.NewGuid(), Guid.NewGuid());
+
+            var conflict = Assert.IsType<ConflictObjectResult>(result);
+            Assert.Equal("A scan is already in progress.", conflict.Value!.GetType().GetProperty("message")!.GetValue(conflict.Value));
+            Assert.True(ScheduledTaskSemaphore.IsBusy);
+        }
+        finally
+        {
+            lease.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ScanSeason_ReturnsAccepted_AndReleasesItsBackgroundLease()
+    {
+        using var scope = CreatePluginScope();
+        var controller = CreateController(
+            DatabaseTestHelpers.CreateTempSegmentDatabase(),
+            scope.CacheDbPath,
+            EntrypointTestHelpers.CreateLibraryManager());
+
+        var result = await controller.ScanSeason(Guid.NewGuid(), Guid.NewGuid(), new CancellationToken(canceled: true));
+
+        Assert.IsType<AcceptedResult>(result);
+        await WaitForScanLeaseReleaseAsync();
+    }
+
+    private static VisualizationController CreateController(IIntroSkipperDatabase database, string cacheDbPath, ILibraryManager? libraryManager = null)
+        => new(
+            NullLogger<VisualizationController>.Instance,
+            new NoOpMediaSegmentRefresher(),
+            libraryManager!,
+            providerManager: null!,
+            fileSystem: null!,
+            NullLoggerFactory.Instance,
+            ffmpegService: null!,
+            DatabaseTestHelpers.CreateCacheService(cacheDbPath),
+            database,
+            DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath));
+
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope()
+    {
+        var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+        return scope;
+    }
+
+    private static void QueueSeason(Guid seasonId, Guid episodeId)
+        => QueueSeason(seasonId, episodeId, Guid.NewGuid(), "Episode");
+
+    private static void QueueSeason(Guid seasonId, Guid firstEpisodeId, Guid firstSeriesId, string firstName, Guid? secondEpisodeId = null, Guid? secondSeriesId = null, string? secondName = null)
+    {
+        Plugin.Instance!.QueuedMediaItems[seasonId] =
+        [
+            new QueuedEpisode { EpisodeId = firstEpisodeId, SeasonId = seasonId, SeriesId = firstSeriesId, Name = firstName },
+        ];
+
+        if (secondEpisodeId is not null)
+        {
+            Plugin.Instance.QueuedMediaItems[seasonId].Add(
+                new QueuedEpisode { EpisodeId = secondEpisodeId.Value, SeasonId = seasonId, SeriesId = secondSeriesId!.Value, Name = secondName! });
+        }
+    }
+
+    private static async Task WaitForScanLeaseReleaseAsync()
+    {
+        for (var attempt = 0; ScheduledTaskSemaphore.IsBusy && attempt < 100; attempt++)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.False(ScheduledTaskSemaphore.IsBusy);
+    }
+
+    private sealed class NoOpMediaSegmentRefresher : IMediaSegmentRefresher
+    {
+        public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -178,7 +178,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         var deletedItem = Plugin.Instance!.GetItem(itemId);
         if (deletedItem is not null)
         {
-            await _database.RemoveEpisodeIdAsync(ResolveSeasonStateKey(deletedItem, itemId), mode, itemId, cancellationToken).ConfigureAwait(false);
+            await _database.RemoveEpisodeIdAsync(ResolveSeasonStateKey(deletedItem), mode, itemId, cancellationToken).ConfigureAwait(false);
         }
 
         return Ok();
@@ -191,18 +191,29 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
     /// resolved. Prefer the queue key when the item is present in the cached queue.
     /// </summary>
     /// <param name="item">The item whose season-state key to resolve.</param>
-    /// <param name="itemId">The item id.</param>
     /// <returns>The season-state key.</returns>
-    private static Guid ResolveSeasonStateKey(BaseItem item, Guid itemId)
+    private static Guid ResolveSeasonStateKey(BaseItem item)
     {
-        foreach (var (seasonId, episodes) in Plugin.Instance!.QueuedMediaItems)
+        var queue = Plugin.Instance!.QueuedMediaItems;
+
+        // Nearly every episode is queued under its own season, so check that bucket
+        // before falling back to a scan of the whole queue for in-season specials
+        // grouped under another season's key.
+        if (item is Episode episode
+            && queue.TryGetValue(episode.SeasonId, out var seasonEpisodes)
+            && seasonEpisodes.Any(e => e.EpisodeId == item.Id))
         {
-            if (episodes.Any(e => e.EpisodeId == itemId))
+            return episode.SeasonId;
+        }
+
+        foreach (var (seasonId, episodes) in queue)
+        {
+            if (episodes.Any(e => e.EpisodeId == item.Id))
             {
                 return seasonId;
             }
         }
 
-        return item is Episode episode ? episode.SeasonId : item.Id;
+        return item is Episode fallbackEpisode ? fallbackEpisode.SeasonId : item.Id;
     }
 }

--- a/IntroSkipper/Data/AnalysisHelpers.cs
+++ b/IntroSkipper/Data/AnalysisHelpers.cs
@@ -11,6 +11,23 @@ namespace IntroSkipper.Data;
 internal static class AnalysisHelpers
 {
     /// <summary>
+    /// Gets the single source of truth for the correspondence between analysis modes and
+    /// Jellyfin media segment types; <see cref="MapSegmentTypeToMode"/> is derived from it.
+    /// </summary>
+    internal static IReadOnlyDictionary<AnalysisMode, MediaSegmentType> ModeToSegmentType { get; } = new Dictionary<AnalysisMode, MediaSegmentType>
+    {
+        [AnalysisMode.Introduction] = MediaSegmentType.Intro,
+        [AnalysisMode.Recap] = MediaSegmentType.Recap,
+        [AnalysisMode.Preview] = MediaSegmentType.Preview,
+        [AnalysisMode.Credits] = MediaSegmentType.Outro,
+        [AnalysisMode.Commercial] = MediaSegmentType.Commercial
+    };
+
+    // Must be declared after ModeToSegmentType: property initializers run in textual order.
+    private static IReadOnlyDictionary<MediaSegmentType, AnalysisMode> SegmentTypeToMode { get; } =
+        ModeToSegmentType.ToDictionary(pair => pair.Value, pair => pair.Key);
+
+    /// <summary>
     /// Returns whether a settled-season analysis mode still needs re-analysis for its current episode
     /// set. Pure set comparison: the decision is committed separately via
     /// <see cref="Db.IIntroSkipperDatabase.RecordSettleReanalysisAsync(Guid, IReadOnlyCollection{AnalysisMode}, IReadOnlyCollection{Guid}, CancellationToken)"/>
@@ -30,15 +47,5 @@ internal static class AnalysisHelpers
     /// <param name="type">Media segment type.</param>
     /// <returns>The corresponding <see cref="AnalysisMode"/>.</returns>
     internal static AnalysisMode MapSegmentTypeToMode(MediaSegmentType type)
-    {
-        return type switch
-        {
-            MediaSegmentType.Intro => AnalysisMode.Introduction,
-            MediaSegmentType.Recap => AnalysisMode.Recap,
-            MediaSegmentType.Preview => AnalysisMode.Preview,
-            MediaSegmentType.Outro => AnalysisMode.Credits,
-            MediaSegmentType.Commercial => AnalysisMode.Commercial,
-            _ => throw new NotImplementedException(),
-        };
-    }
+        => SegmentTypeToMode.TryGetValue(type, out var mode) ? mode : throw new NotImplementedException();
 }

--- a/IntroSkipper/Db/DetectionCacheDatabase.cs
+++ b/IntroSkipper/Db/DetectionCacheDatabase.cs
@@ -23,7 +23,7 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
     /// </summary>
     /// <param name="contextFactory">Factory used to create cache database contexts.</param>
     /// <param name="logger">Logger.</param>
-    public DetectionCacheDatabase(IDbContextFactory<DetectionCacheDbContext> contextFactory, ILogger logger)
+    public DetectionCacheDatabase(IDbContextFactory<DetectionCacheDbContext> contextFactory, ILogger<DetectionCacheDatabase> logger)
     {
         ArgumentNullException.ThrowIfNull(contextFactory);
         ArgumentNullException.ThrowIfNull(logger);
@@ -36,20 +36,12 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
     /// <inheritdoc/>
     public bool TryInitialize()
     {
-        var initialization = _initialization.GetAttempt();
-
         try
         {
-            _ = initialization.Value;
-            return true;
+            return _initialization.GetValue(ex => LogCacheDbInitializationError(_logger, ex));
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            if (_initialization.ResetIfCurrent(initialization))
-            {
-                LogCacheDbInitializationError(_logger, ex);
-            }
-
             return false;
         }
     }
@@ -63,9 +55,9 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
         }
 
         using var db = _contextFactory.CreateDbContext();
-        return db.DetectionCache
+        return QueryByKey(db, itemId, mode, type, start, end)
             .AsNoTracking()
-            .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+            .FirstOrDefault();
     }
 
     /// <inheritdoc/>
@@ -78,10 +70,7 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
 
         using var db = _contextFactory.CreateDbContext();
 
-        // NOTE: Start/End are compared with == which is safe only because the exact same
-        // double values that were written are used for lookup (no intermediate arithmetic).
-        var existing = db.DetectionCache
-            .FirstOrDefault(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+        var existing = QueryByKey(db, itemId, mode, type, start, end).FirstOrDefault();
 
         if (existing is not null)
         {
@@ -105,13 +94,8 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
         }
 
         using var db = _contextFactory.CreateDbContext();
-        return db.DetectionCache.Any(e =>
-            e.ItemId == itemId &&
-            e.Mode == mode &&
-            e.Type == type &&
-            e.Start == start &&
-            e.End == end &&
-            (e.ConfigHash == string.Empty || e.ConfigHash == expectedConfigHash));
+        return QueryByKey(db, itemId, mode, type, start, end)
+            .Any(e => e.ConfigHash == string.Empty || e.ConfigHash == expectedConfigHash);
     }
 
     /// <inheritdoc/>
@@ -189,16 +173,28 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Filters the cache table by the full cache key. Start/End are compared with ==
+    /// which is safe only because the exact same double values that were written are
+    /// used for lookup (no intermediate arithmetic).
+    /// </summary>
+    /// <param name="db">The cache database context.</param>
+    /// <param name="itemId">Item id.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="type">Cache entry type.</param>
+    /// <param name="start">Segment start.</param>
+    /// <param name="end">Segment end.</param>
+    /// <returns>The entries matching the cache key.</returns>
+    private static IQueryable<DbDetectionCache> QueryByKey(DetectionCacheDbContext db, Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end)
+        => db.DetectionCache
+            .Where(e => e.ItemId == itemId && e.Mode == mode && e.Type == type && e.Start == start && e.End == end);
+
     private bool InitializeCore()
     {
         using var db = _contextFactory.CreateDbContext();
 
         db.EnsureSchema();
-
-        // WAL is a persistent database property, but EF only sets it when *it*
-        // creates the database file. Enforce it idempotently so databases
-        // vacuumed or recreated by external tooling are covered as well.
-        db.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");
+        SqlitePragmas.EnforceWal(db.Database);
 
         return true;
     }

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -21,7 +21,7 @@ public sealed partial class IntroSkipperDatabase
 
         var enabledIds = enabledEpisodeIds.Distinct().ToArray();
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         // EF.Parameter forces the single-JSON-parameter json_each translation on SQLite,
@@ -50,7 +50,7 @@ public sealed partial class IntroSkipperDatabase
             return;
         }
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         await db.DbSegment
             .Where(s => EF.Parameter(ids).Contains(s.ItemId)
@@ -71,7 +71,7 @@ public sealed partial class IntroSkipperDatabase
 
         var ids = itemIds.Distinct().ToArray();
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -113,7 +113,7 @@ public sealed partial class IntroSkipperDatabase
             .ToArray();
         var seasonIds = itemIdsBySeason.Keys.ToArray();
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -168,7 +168,7 @@ public sealed partial class IntroSkipperDatabase
             return;
         }
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -199,7 +199,7 @@ public sealed partial class IntroSkipperDatabase
 
         var retainedIds = seasonIds.Distinct().ToArray();
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         // Single NOT-IN delete; EF.Parameter binds the retained set as one JSON

--- a/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
@@ -16,7 +16,7 @@ public sealed partial class IntroSkipperDatabase
     {
         ArgumentNullException.ThrowIfNull(analyzerActions);
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var existingEntries = await db.DbSeasonState
             .Where(s => s.SeasonId == seasonId)
@@ -48,7 +48,7 @@ public sealed partial class IntroSkipperDatabase
         // passed by BaseItemAnalyzerTask) makes it throw InvalidOperationException.
         var ids = episodeIds as Guid[] ?? [.. episodeIds];
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var seasonState = await db.DbSeasonState
             .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
@@ -76,7 +76,7 @@ public sealed partial class IntroSkipperDatabase
     /// </remarks>
     public async Task RemoveEpisodeIdAsync(Guid seasonId, AnalysisMode mode, Guid episodeId, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var seasonState = await db.DbSeasonState
             .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
@@ -102,7 +102,7 @@ public sealed partial class IntroSkipperDatabase
         Guid seasonId,
         CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var states = await db.DbSeasonState
             .AsNoTracking()
@@ -138,7 +138,7 @@ public sealed partial class IntroSkipperDatabase
 
         var settledEpisodeIds = DbSeasonState.SerializeEpisodeIds(episodeIds);
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         foreach (var mode in modes)
         {
@@ -156,7 +156,7 @@ public sealed partial class IntroSkipperDatabase
     /// <inheritdoc/>
     public async Task<IReadOnlyDictionary<AnalysisMode, AnalyzerAction>> GetAllAnalyzerActionsAsync(Guid seasonId, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var states = await db.DbSeasonState
             .Where(s => s.SeasonId == seasonId)
@@ -176,7 +176,7 @@ public sealed partial class IntroSkipperDatabase
     /// <inheritdoc/>
     public async Task<AnalyzerAction> GetAnalyzerActionAsync(Guid seasonId, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var state = await db.DbSeasonState
             .FirstOrDefaultAsync(s => s.SeasonId == seasonId && s.Type == mode, cancellationToken)
@@ -187,7 +187,7 @@ public sealed partial class IntroSkipperDatabase
     /// <inheritdoc/>
     public async Task<SeasonQueueSnapshot> GetSeasonQueueSnapshotAsync(Guid seasonId, IReadOnlyCollection<Guid> episodeIds, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         var episodeIdArray = (Guid[])[.. episodeIds.Distinct()];
 
@@ -211,11 +211,7 @@ public sealed partial class IntroSkipperDatabase
                 .GroupBy(s => s.ItemId)
                 .ToDictionary(
                     group => group.Key,
-                    group => (IReadOnlyDictionary<AnalysisMode, Segment>)group
-                        .GroupBy(segment => segment.Type)
-                        .ToDictionary(
-                            segmentGroup => segmentGroup.Key,
-                            segmentGroup => segmentGroup.OrderBy(segment => segment.Start).First().ToSegment())),
+                    group => (IReadOnlyDictionary<AnalysisMode, Segment>)ToCanonicalTimestamps(group)),
             segments
                 .Where(s => s.IsUserProvided)
                 .GroupBy(s => s.Type)

--- a/IntroSkipper/Db/IntroSkipperDatabase.Segments.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Segments.cs
@@ -21,7 +21,7 @@ public sealed partial class IntroSkipperDatabase
     {
         ArgumentNullException.ThrowIfNull(segment);
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         try
@@ -102,17 +102,27 @@ public sealed partial class IntroSkipperDatabase
     {
         var segments = await GetSegmentsAsync(id, cancellationToken).ConfigureAwait(false);
 
-        return segments
+        return ToCanonicalTimestamps(segments);
+    }
+
+    /// <summary>
+    /// Reduces stored segments to one canonical timestamp per mode: the segment with the
+    /// earliest start wins. Shared by the per-episode timestamp API and the season queue
+    /// snapshot so both surfaces always report the same segment.
+    /// </summary>
+    /// <param name="segments">Stored segments of a single episode.</param>
+    /// <returns>The canonical timestamp per analysis mode.</returns>
+    private static Dictionary<AnalysisMode, Segment> ToCanonicalTimestamps(IEnumerable<DbSegment> segments)
+        => segments
             .GroupBy(segment => segment.Type)
             .ToDictionary(
                 group => group.Key,
                 group => group.OrderBy(segment => segment.Start).First().ToSegment());
-    }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         return await db.DbSegment
@@ -125,7 +135,7 @@ public sealed partial class IntroSkipperDatabase
     /// <inheritdoc/>
     public async Task DeleteItemSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         await db.DbSegment
             .Where(s => s.ItemId == itemId)
@@ -145,7 +155,7 @@ public sealed partial class IntroSkipperDatabase
             return;
         }
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         var query = db.DbSegment.Where(s => s.ItemId == itemId && s.Type == mode);
@@ -168,7 +178,7 @@ public sealed partial class IntroSkipperDatabase
     /// <inheritdoc/>
     public async Task DeleteSegmentsByModeAsync(AnalysisMode mode, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         await db.DbSegment
             .Where(s => s.Type == mode)
@@ -187,7 +197,7 @@ public sealed partial class IntroSkipperDatabase
             return 0;
         }
 
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
         // EF.Parameter binds the ID set as a single JSON parameter (json_each), so the

--- a/IntroSkipper/Db/IntroSkipperDatabase.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.cs
@@ -32,7 +32,7 @@ public sealed partial class IntroSkipperDatabase : IIntroSkipperDatabase
     /// </summary>
     /// <param name="contextFactory">Factory used to create database contexts.</param>
     /// <param name="logger">Logger.</param>
-    public IntroSkipperDatabase(IDbContextFactory<IntroSkipperDbContext> contextFactory, ILogger logger)
+    public IntroSkipperDatabase(IDbContextFactory<IntroSkipperDbContext> contextFactory, ILogger<IntroSkipperDatabase> logger)
     {
         ArgumentNullException.ThrowIfNull(contextFactory);
         ArgumentNullException.ThrowIfNull(logger);
@@ -42,49 +42,29 @@ public sealed partial class IntroSkipperDatabase : IIntroSkipperDatabase
         // Task.Run is load-bearing, not redundant: InitializeCoreAsync begins with fully
         // synchronous work (EnsureLegacySchemaCompatibility can rebuild whole tables on
         // large legacy databases), so invoking the factory inline would make every
-        // concurrent first-touch caller — including purely async ones on the playback
-        // hot path — block its thread on the Lazy monitor until the factory's first
+        // concurrent first-touch caller - including purely async ones on the playback
+        // hot path - block its thread on the Lazy monitor until the factory's first
         // incomplete await. Dispatching to the thread pool makes the factory return a
         // Task immediately, so waiters genuinely await instead of blocking.
         _initialization = new RetryableInitializationGate<Task>(() => Task.Run(InitializeCoreAsync));
     }
 
     /// <inheritdoc/>
-    public async Task InitializeAsync()
-    {
-        var initialization = _initialization.GetAttempt();
-
-        try
-        {
-            await initialization.Value.ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            if (_initialization.ResetIfCurrent(initialization))
-            {
-                LogDatabaseInitializationError(_logger, ex);
-            }
-
-            throw;
-        }
-    }
+    /// <remarks>
+    /// Every public data operation awaits this first, which guarantees that no query can
+    /// observe the database before legacy schema repair and EF migrations have completed
+    /// regardless of whether the eager initializer (hosted service) has already run.
+    /// </remarks>
+    public Task InitializeAsync()
+        => _initialization.AwaitValueAsync(ex => LogDatabaseInitializationError(_logger, ex));
 
     /// <inheritdoc/>
     public async Task RebuildDatabaseAsync(bool forceCleanOnBackupFailure = false, CancellationToken cancellationToken = default)
     {
-        await EnsureInitializedAsync().ConfigureAwait(false);
+        await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
         await db.RebuildDatabaseAsync(_contextFactory.CreateDbContext, forceCleanOnBackupFailure, cancellationToken).ConfigureAwait(false);
     }
-
-    /// <summary>
-    /// Awaits the retryable initialization gate. Every public data operation calls this
-    /// first, which guarantees that no query can observe the database before legacy
-    /// schema repair and EF migrations have completed — regardless of whether the
-    /// eager initializer (hosted service) has already run.
-    /// </summary>
-    /// <returns>The shared initialization task.</returns>
-    private Task EnsureInitializedAsync() => InitializeAsync();
 
     private async Task InitializeCoreAsync()
     {
@@ -96,10 +76,7 @@ public sealed partial class IntroSkipperDatabase : IIntroSkipperDatabase
         db.EnsureLegacySchemaCompatibility();
         await db.ApplyMigrationsAsync().ConfigureAwait(false);
 
-        // WAL is a persistent database property, but EF only sets it when *it*
-        // creates the database file. Enforce it idempotently so databases
-        // vacuumed or recreated by external tooling are covered as well.
-        await db.Database.ExecuteSqlRawAsync("PRAGMA journal_mode=WAL;").ConfigureAwait(false);
+        await SqlitePragmas.EnforceWalAsync(db.Database).ConfigureAwait(false);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Database initialization failed; the next database operation will retry")]

--- a/IntroSkipper/Db/RetryableInitializationGate.cs
+++ b/IntroSkipper/Db/RetryableInitializationGate.cs
@@ -27,6 +27,34 @@ internal sealed class RetryableInitializationGate<T>
     }
 
     /// <summary>
+    /// Returns the current attempt's value, resetting the gate on failure so the next
+    /// caller retries. <paramref name="onFirstFailure"/> runs only for the caller that
+    /// installed the replacement, so a shared failure is reported exactly once.
+    /// </summary>
+    /// <param name="onFirstFailure">Invoked once per failed attempt with its exception.</param>
+    /// <returns>The initialization result.</returns>
+    public T GetValue(Action<Exception> onFirstFailure)
+    {
+        ArgumentNullException.ThrowIfNull(onFirstFailure);
+
+        var attempt = GetAttempt();
+
+        try
+        {
+            return attempt.Value;
+        }
+        catch (Exception ex)
+        {
+            if (ResetIfCurrent(attempt))
+            {
+                onFirstFailure(ex);
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Returns the current shared initialization attempt.
     /// </summary>
     /// <returns>The current lazy attempt.</returns>

--- a/IntroSkipper/Db/RetryableInitializationGateExtensions.cs
+++ b/IntroSkipper/Db/RetryableInitializationGateExtensions.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// Awaitable helpers for gates whose result is an asynchronous initialization task.
+/// </summary>
+internal static class RetryableInitializationGateExtensions
+{
+    /// <summary>
+    /// Awaits the current attempt's task, resetting the gate on failure so the next
+    /// caller retries. <paramref name="onFirstFailure"/> runs only for the caller that
+    /// installed the replacement, so a shared failure is reported exactly once.
+    /// </summary>
+    /// <param name="gate">The initialization gate.</param>
+    /// <param name="onFirstFailure">Invoked once per failed attempt with its exception.</param>
+    /// <returns>A task that completes when initialization has completed.</returns>
+    public static async Task AwaitValueAsync(this RetryableInitializationGate<Task> gate, Action<Exception> onFirstFailure)
+    {
+        ArgumentNullException.ThrowIfNull(gate);
+        ArgumentNullException.ThrowIfNull(onFirstFailure);
+
+        var attempt = gate.GetAttempt();
+
+        try
+        {
+            await attempt.Value.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            if (gate.ResetIfCurrent(attempt))
+            {
+                onFirstFailure(ex);
+            }
+
+            throw;
+        }
+    }
+}

--- a/IntroSkipper/Db/SqlitePragmaInterceptor.cs
+++ b/IntroSkipper/Db/SqlitePragmaInterceptor.cs
@@ -22,7 +22,7 @@ internal sealed class SqlitePragmaInterceptor : DbConnectionInterceptor
         using var cmd = connection.CreateCommand();
         try
         {
-            cmd.CommandText = "PRAGMA busy_timeout=5000;";
+            cmd.CommandText = SqlitePragmas.BusyTimeoutCommand;
             cmd.ExecuteNonQuery();
         }
         catch (SqliteException)
@@ -36,7 +36,7 @@ internal sealed class SqlitePragmaInterceptor : DbConnectionInterceptor
         using var cmd = connection.CreateCommand();
         try
         {
-            cmd.CommandText = "PRAGMA busy_timeout=5000;";
+            cmd.CommandText = SqlitePragmas.BusyTimeoutCommand;
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (SqliteException)

--- a/IntroSkipper/Db/SqlitePragmas.cs
+++ b/IntroSkipper/Db/SqlitePragmas.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace IntroSkipper.Db;
+
+/// <summary>
+/// SQLite pragma policy shared by both plugin databases.
+/// </summary>
+internal static class SqlitePragmas
+{
+    /// <summary>
+    /// Per-connection busy timeout applied by <see cref="SqlitePragmaInterceptor"/>.
+    /// </summary>
+    public const string BusyTimeoutCommand = "PRAGMA busy_timeout=5000;";
+
+    private const string WalCommand = "PRAGMA journal_mode=WAL;";
+
+    /// <summary>
+    /// Enforces WAL journal mode. WAL is a persistent database property, but EF only
+    /// sets it when *it* creates the database file. Enforce it idempotently so databases
+    /// vacuumed or recreated by external tooling are covered as well.
+    /// </summary>
+    /// <param name="database">The database facade to apply the pragma to.</param>
+    public static void EnforceWal(DatabaseFacade database)
+        => database.ExecuteSqlRaw(WalCommand);
+
+    /// <summary>
+    /// Enforces WAL journal mode asynchronously. See <see cref="EnforceWal"/>.
+    /// </summary>
+    /// <param name="database">The database facade to apply the pragma to.</param>
+    /// <returns>A task that completes when the pragma has been applied.</returns>
+    public static Task EnforceWalAsync(DatabaseFacade database)
+        => database.ExecuteSqlRawAsync(WalCommand);
+}

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -59,8 +59,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
                 return false;
             }
 
-            var json = DecompressBrotli<T[]>(entry.Data);
-            result = json ?? [];
+            result = DecompressBrotli<T[]>(entry.Data) ?? [];
 
             if (_logger.IsEnabled(LogLevel.Trace))
             {
@@ -120,10 +119,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         try
         {
             var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), CacheEntryType.Chromaprint, mode);
-            if (_cacheDatabase.HasEntry(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, expectedHash))
-            {
-                return true;
-            }
+            return _cacheDatabase.HasEntry(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, expectedHash);
         }
         catch (DbException ex)
         {

--- a/IntroSkipper/Manager/MediaSegmentRefreshService.cs
+++ b/IntroSkipper/Manager/MediaSegmentRefreshService.cs
@@ -20,12 +20,6 @@ public sealed partial class MediaSegmentRefreshService(
     ILibraryManager libraryManager,
     ILogger<MediaSegmentRefreshService> logger) : IMediaSegmentRefresher
 {
-    private enum MediaSegmentBatchOperation
-    {
-        Refresh,
-        RemoveIntroSkipperSegments
-    }
-
     /// <inheritdoc />
     public async Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
     {
@@ -71,7 +65,7 @@ public sealed partial class MediaSegmentRefreshService(
 
     private async Task ProcessByIdAsync(
         Guid itemId,
-        MediaSegmentBatchOperation operation,
+        Func<BaseItem, CancellationToken, Task> operation,
         CancellationToken cancellationToken)
     {
         var item = libraryManager.GetItemById(itemId);
@@ -81,17 +75,7 @@ public sealed partial class MediaSegmentRefreshService(
             return;
         }
 
-        switch (operation)
-        {
-            case MediaSegmentBatchOperation.Refresh:
-                await RefreshCoreAsync(item, cancellationToken).ConfigureAwait(false);
-                break;
-            case MediaSegmentBatchOperation.RemoveIntroSkipperSegments:
-                await RemoveIntroSkipperSegmentsCoreAsync(item, cancellationToken).ConfigureAwait(false);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(operation), operation, null);
-        }
+        await operation(item, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task RemoveIntroSkipperSegmentsCoreAsync(BaseItem item, CancellationToken cancellationToken)
@@ -125,15 +109,15 @@ public sealed partial class MediaSegmentRefreshService(
 
     /// <inheritdoc />
     public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
-        => ProcessByIdsAsync(itemIds, MediaSegmentBatchOperation.Refresh, cancellationToken);
+        => ProcessByIdsAsync(itemIds, RefreshCoreAsync, cancellationToken);
 
     /// <inheritdoc />
     public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
-        => ProcessByIdsAsync(itemIds, MediaSegmentBatchOperation.RemoveIntroSkipperSegments, cancellationToken);
+        => ProcessByIdsAsync(itemIds, RemoveIntroSkipperSegmentsCoreAsync, cancellationToken);
 
     private async Task ProcessByIdsAsync(
         IEnumerable<Guid> itemIds,
-        MediaSegmentBatchOperation operation,
+        Func<BaseItem, CancellationToken, Task> operation,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(itemIds);

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -148,8 +148,6 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     internal BaseItem? GetItem(Guid id) => id != Guid.Empty ? _libraryManager.GetItemById(id) : null;
 
-    internal ICollection<Folder> GetCollectionFolders(Guid id) => GetItem(id) is var item && item is not null ? _libraryManager.GetCollectionFolders(item) : [];
-
     internal string GetItemPath(Guid id) => GetItem(id) is var item && item is not null ? item.Path : string.Empty;
 
     internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? Array.Empty<ChapterInfo>();

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -16,7 +16,6 @@ using MediaBrowser.Controller.Plugins;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper
 {
@@ -41,12 +40,8 @@ namespace IntroSkipper
                     .AddInterceptors(_pragmaInterceptor));
             // The facades own database initialization via their internal retryable
             // gates; every consumer goes through a facade.
-            serviceCollection.AddSingleton<IIntroSkipperDatabase>(serviceProvider => new IntroSkipperDatabase(
-                serviceProvider.GetRequiredService<IDbContextFactory<IntroSkipperDbContext>>(),
-                serviceProvider.GetRequiredService<ILogger<IntroSkipperDatabase>>()));
-            serviceCollection.AddSingleton<IDetectionCacheDatabase>(serviceProvider => new DetectionCacheDatabase(
-                serviceProvider.GetRequiredService<IDbContextFactory<DetectionCacheDbContext>>(),
-                serviceProvider.GetRequiredService<ILogger<DetectionCacheDatabase>>()));
+            serviceCollection.AddSingleton<IIntroSkipperDatabase, IntroSkipperDatabase>();
+            serviceCollection.AddSingleton<IDetectionCacheDatabase, DetectionCacheDatabase>();
 
             // Registered before Entrypoint so migrations are warmed as the first hosted
             // service; the facades' internal gate still guarantees ordering for any

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -26,18 +26,6 @@ namespace IntroSkipper.Providers
     {
         private readonly IIntroSkipperDatabase _database = database;
 
-        /// <summary>
-        /// Mappings between AnalysisMode and MediaSegmentType.
-        /// </summary>
-        private static readonly Dictionary<AnalysisMode, MediaSegmentType> _segmentMappings = new()
-        {
-            [AnalysisMode.Introduction] = MediaSegmentType.Intro,
-            [AnalysisMode.Recap] = MediaSegmentType.Recap,
-            [AnalysisMode.Preview] = MediaSegmentType.Preview,
-            [AnalysisMode.Credits] = MediaSegmentType.Outro,
-            [AnalysisMode.Commercial] = MediaSegmentType.Commercial
-        };
-
         /// <inheritdoc/>
         public string Name => Plugin.Instance!.Name;
 
@@ -53,7 +41,7 @@ namespace IntroSkipper.Providers
 
             foreach (var segment in itemSegments.OrderBy(segment => segment.Start))
             {
-                if (!_segmentMappings.TryGetValue(segment.Type, out var type))
+                if (!AnalysisHelpers.ModeToSegmentType.TryGetValue(segment.Type, out var type))
                 {
                     continue;
                 }

--- a/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
+++ b/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
@@ -68,8 +68,18 @@ public sealed partial class IntroSkipperDatabaseInitializer : IHostedService
 
         // The cache init is synchronous SQLite I/O (schema creation, possibly a
         // corrupt-file rebuild); run it on the thread pool so the startup thread
-        // never blocks on it.
-        await Task.Run(_cacheDatabase.TryInitialize, CancellationToken.None).ConfigureAwait(false);
+        // never blocks on it. Cancellation only abandons the wait so recovery is
+        // never interrupted halfway through.
+        try
+        {
+            await Task.Run(_cacheDatabase.TryInitialize, CancellationToken.None)
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
     }
 
     /// <inheritdoc/>

--- a/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
+++ b/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
@@ -38,14 +38,14 @@ public sealed partial class IntroSkipperDatabaseInitializer : IHostedService
     /// <inheritdoc/>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        // Segment initialization can fail and must not abort Jellyfin startup. Cancellation
-        // only abandons this wait; the shared initialization task keeps running so legacy
-        // repair or migration work is never interrupted halfway through.
         if (cancellationToken.IsCancellationRequested)
         {
             return;
         }
 
+        // Segment initialization can fail and must not abort Jellyfin startup. Cancellation
+        // only abandons this wait; the shared initialization task keeps running so legacy
+        // repair or migration work is never interrupted halfway through.
         try
         {
             await _segmentDatabase.InitializeAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -66,7 +66,10 @@ public sealed partial class IntroSkipperDatabaseInitializer : IHostedService
             return;
         }
 
-        _ = _cacheDatabase.TryInitialize();
+        // The cache init is synchronous SQLite I/O (schema creation, possibly a
+        // corrupt-file rebuild); run it on the thread pool so the startup thread
+        // never blocks on it.
+        await Task.Run(_cacheDatabase.TryInitialize, CancellationToken.None).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Cleanup pass over the 12.0 database refactor (`/simplify` review: reuse, simplification, efficiency, altitude), plus new test coverage.

## Shared infrastructure
- `RetryableInitializationGate` now owns the retry/reset/log-once ceremony via `GetValue(onFirstFailure)` and an `AwaitValueAsync` extension — both facades' copy-pasted 15-line rituals become one-liners and the log-once invariant is enforced by the gate.
- Restored a shared `SqlitePragmas` home: WAL enforcement (comment + command previously duplicated in both facades) and the busy-timeout command text (previously inlined twice in `SqlitePragmaInterceptor`).
- The "canonical timestamp per mode = earliest start wins" rule is now a single `ToCanonicalTimestamps` helper used by both `GetTimestampsAsync` and the season queue snapshot.
- `DetectionCacheDatabase`: single `QueryByKey` helper replaces the 5-condition cache-key predicate that was written out three times; the double-equality invariant note lives in one place.
- `AnalysisHelpers` owns one mode↔segment-type map; `SegmentProvider`'s mirror dictionary is derived from it so the directions cannot drift.

## Simplifications
- `MediaSegmentRefreshService`: enum + switch + unreachable-throw dispatch replaced by a delegate parameter.
- Facades take `ILogger<T>`, so DI factory lambdas collapse to plain `AddSingleton<TInterface, TImpl>()`.
- Removed the `EnsureInitializedAsync` forwarding alias and the dead `Plugin.GetCollectionFolders`.
- `DetectionCacheService`: minor flow simplifications.

## Efficiency
- `SegmentEditorController.ResolveSeasonStateKey` no longer scans the whole queued library per delete — checks the episode's own season bucket first, falling back to the full scan only for in-season specials; also drops a derivable parameter.
- Startup initializer runs the synchronous cache init on the thread pool so Jellyfin's startup thread never blocks on SQLite I/O (skip-on-cancel semantics unchanged and still pinned by tests).

## Tests
- `DatabaseTestHelpers` gains shared `CreateTempDbPath`/`DeleteSqliteFiles` (with `SqliteConnection.ClearAllPools()` — two new copies were missing it, a Windows file-lock flake); per-file copies now delegate.
- New test files: analyzer task orchestration, chapter analyzer orchestration, chromaprint final-sample match, entrypoint lifecycle, QueueManager, VisualizationController seams.

Build: 0 warnings. Tests: 448/448 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify the IntroSkipper database and cache facades, centralize shared SQLite policy and initialization logic, and strengthen orchestration seams around analysis, queuing, and visualization with new tests.

New Features:
- Add shared SqlitePragmas utility to enforce WAL mode and busy-timeout settings across plugin databases.
- Introduce RetryableInitializationGateExtensions to provide a reusable async initialization helper for database gates.
- Add new tests covering analyzer orchestration paths, queue manager behavior, visualization controller APIs, entrypoint lifecycle, and Chromaprint matching edge cases.

Bug Fixes:
- Fix season-state key resolution so deletes prefer the episode's own season bucket and avoid unnecessary full-queue scans.
- Ensure SQLite test databases are deleted reliably by clearing connection pools and removing WAL/SHM sidecar files before deletion.
- Prevent Jellyfin startup from blocking on synchronous cache initialization by offloading it to the thread pool.

Enhancements:
- Refine DetectionCacheDatabase and IntroSkipperDatabase initialization to use typed loggers and shared retryable gate helpers, reducing duplication and enforcing single log-once semantics.
- Unify analysis mode ↔ media segment type mappings in AnalysisHelpers and consume them from SegmentProvider to keep mappings consistent.
- Factor the canonical per-mode timestamp selection into a shared helper used by per-episode timestamps and season queue snapshots.
- Simplify MediaSegmentRefreshService batch operations by replacing enum-based dispatch with delegate-based callbacks.
- Streamline DetectionCacheService read and existence checks for cleaner control flow.
- Update DI registration to use simple interface-to-implementation singletons for database facades and rely on constructor-injected loggers.

Tests:
- Refactor DatabaseTestHelpers to provide shared temp-db path creation and SQLite file deletion utilities, and update existing tests to use them.
- Add tests validating VisualizationController behavior for analyzer actions, episode enumeration, scan status, and scan concurrency.
- Add entrypoint lifecycle tests ensuring event subscriptions, FFmpeg version checks, and cancellation behavior are correct.
- Add QueueManager tests to verify episode/movie queuing and publication of queue state to the plugin.
- Add chapter analyzer orchestration tests for null chapter data and cancellation propagation, ensuring no unintended persistence.
- Add Chromaprint analyzer tests to confirm matches can end at the final sample boundary.
- Add BaseItemAnalyzerTask orchestration test to ensure cancellation is propagated to FFmpeg validation.