### PR TITLE
Make DeleteTimestampAsync authoritative and return deleted rows

### DIFF
--- a/IntroSkipper.Tests/TestDatabaseFacades.cs
+++ b/IntroSkipper.Tests/TestDatabaseFacades.cs
@@ -174,7 +174,8 @@ public sealed class TestDatabaseFacades
             await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(0, 5)), AnalysisMode.Introduction);
 
             // Outside the 0.001 epsilon: nothing matches, nothing is removed.
-            await database.DeleteTimestampAsync(itemId, AnalysisMode.Commercial, new Segment(itemId, new TimeRange(10.01, 20)));
+            var noMatch = await database.DeleteTimestampAsync(itemId, AnalysisMode.Commercial, new Segment(itemId, new TimeRange(10.01, 20)));
+            Assert.Empty(noMatch);
 
             await using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -182,8 +183,12 @@ public sealed class TestDatabaseFacades
             }
 
             // Within epsilon on both bounds: removes exactly the matching commercial,
-            // leaving the other commercial and the intro untouched.
-            await database.DeleteTimestampAsync(itemId, AnalysisMode.Commercial, new Segment(itemId, new TimeRange(10.0005, 20.0005)));
+            // leaving the other commercial and the intro untouched — and returns the
+            // deleted row so callers can restore it faithfully.
+            var deleted = await database.DeleteTimestampAsync(itemId, AnalysisMode.Commercial, new Segment(itemId, new TimeRange(10.0005, 20.0005)));
+            var deletedRow = Assert.Single(deleted);
+            Assert.Equal(10, deletedRow.Start);
+            Assert.Equal(20, deletedRow.End);
 
             await using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -214,7 +219,7 @@ public sealed class TestDatabaseFacades
 
             // Commercial without a segment argument takes the early-return branch:
             // deleting "the" commercial is ambiguous, so nothing may be removed.
-            await database.DeleteTimestampAsync(itemId, AnalysisMode.Commercial);
+            Assert.Empty(await database.DeleteTimestampAsync(itemId, AnalysisMode.Commercial));
 
             await using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -222,7 +227,7 @@ public sealed class TestDatabaseFacades
             }
 
             // Non-commercial without a segment argument deletes the whole mode.
-            await database.DeleteTimestampAsync(itemId, AnalysisMode.Introduction);
+            Assert.Single(await database.DeleteTimestampAsync(itemId, AnalysisMode.Introduction));
 
             await using (var db = new IntroSkipperDbContext(dbPath))
             {

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -90,8 +90,11 @@ public sealed class SegmentEditorControllerTests
         Assert.Equal("cfg-2", restored.ConfigHash);
     }
 
-    [Fact]
-    public async Task DeleteSegment_RejectsMismatchedExistingSegmentType_WithoutMutatingEitherStore()
+    [Theory]
+    [InlineData(Jellyfin.Database.Implementations.Enums.MediaSegmentType.Outro)]
+    [InlineData((Jellyfin.Database.Implementations.Enums.MediaSegmentType)int.MaxValue)]
+    public async Task DeleteSegment_RejectsMismatchedOrUnsupportedExistingSegmentType_WithoutMutatingEitherStore(
+        Jellyfin.Database.Implementations.Enums.MediaSegmentType existingType)
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var itemId = Guid.NewGuid();
@@ -111,7 +114,7 @@ public sealed class SegmentEditorControllerTests
                 {
                     Id = segmentId,
                     ItemId = itemId,
-                    Type = Jellyfin.Database.Implementations.Enums.MediaSegmentType.Outro,
+                    Type = existingType,
                     StartTicks = TimeSpan.FromSeconds(1200).Ticks,
                     EndTicks = TimeSpan.FromSeconds(1260).Ticks,
                 }

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -90,6 +90,43 @@ public sealed class TestSegmentEditorController
     }
 
     [Fact]
+    public async Task DeleteSegment_RestoresNonCommercialMetadata_WhenJellyfinRangeDriftedOutsideEpsilon()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var itemId = Guid.NewGuid();
+        var segmentId = Guid.NewGuid();
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, configHash: "cfg-original");
+
+        var movie = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            ExistingSegments =
+            [
+                new MediaSegmentDto
+                {
+                    Id = segmentId,
+                    ItemId = itemId,
+                    Type = Jellyfin.Database.Implementations.Enums.MediaSegmentType.Intro,
+                    StartTicks = TimeSpan.FromSeconds(100.005).Ticks,
+                    EndTicks = TimeSpan.FromSeconds(160.005).Ticks,
+                }
+            ],
+            DeleteException = new InvalidOperationException("jellyfin down"),
+        };
+        var controller = CreateController(manager, database, movie);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            controller.DeleteSegmentAsync(segmentId, itemId, "intro", CancellationToken.None));
+
+        var restored = Assert.Single(await database.GetSegmentsAsync(itemId));
+        Assert.Equal(100, restored.Start);
+        Assert.Equal(160, restored.End);
+        Assert.False(restored.IsUserProvided);
+        Assert.Equal("cfg-original", restored.ConfigHash);
+    }
+
+    [Fact]
     public async Task DeleteSegment_RollbackRestoresExactRow_WhenMultipleCloseCommercialsExist()
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -90,6 +90,53 @@ public sealed class TestSegmentEditorController
     }
 
     [Fact]
+    public async Task DeleteSegment_RollbackRestoresExactRow_WhenMultipleCloseCommercialsExist()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var itemId = Guid.NewGuid();
+        var segmentId = Guid.NewGuid();
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+
+        // Two commercials 0.005s apart: farther than the facade's delete epsilon (0.001)
+        // but closer than the 0.01 tolerance the controller used to re-match with. A
+        // rollback must restore the actually-deleted row and its metadata, not the
+        // neighbor's.
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(10, 20)), AnalysisMode.Commercial, isUserProvided: false, configHash: "cfg-a");
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(10.005, 20.005)), AnalysisMode.Commercial, isUserProvided: true, configHash: "cfg-b");
+
+        var movie = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            ExistingSegments =
+            [
+                new MediaSegmentDto
+                {
+                    Id = segmentId,
+                    ItemId = itemId,
+                    Type = Jellyfin.Database.Implementations.Enums.MediaSegmentType.Commercial,
+                    StartTicks = TimeSpan.FromSeconds(10.005).Ticks,
+                    EndTicks = TimeSpan.FromSeconds(20.005).Ticks,
+                }
+            ],
+            DeleteException = new InvalidOperationException("jellyfin down"),
+        };
+        var controller = CreateController(manager, database, movie);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            controller.DeleteSegmentAsync(segmentId, itemId, "commercial", CancellationToken.None));
+
+        var rows = (await database.GetSegmentsAsync(itemId)).OrderBy(s => s.Start).ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.False(rows[0].IsUserProvided);
+        Assert.Equal("cfg-a", rows[0].ConfigHash);
+        var restored = rows[1];
+        Assert.Equal(10.005, restored.Start);
+        Assert.Equal(20.005, restored.End);
+        Assert.True(restored.IsUserProvided);
+        Assert.Equal("cfg-b", restored.ConfigHash);
+    }
+
+    [Fact]
     public async Task DeleteSegment_RemovesPluginRow_WhenJellyfinDeleteSucceeds_AndJellyfinSegmentAlreadyGone()
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -16,16 +16,17 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.MediaSegments;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 /// <summary>
-/// Tests for <see cref="SegmentEditorController.DeleteSegmentAsync"/> rollback behavior:
+/// Tests for <see cref="SegmentEditorController.DeleteSegmentAsync"/> validation and rollback behavior:
 /// the plugin DB row is deleted before the Jellyfin-side delete, so a Jellyfin failure must
 /// restore the row — including when the Jellyfin segment was already gone and the row was
 /// identified from the plugin database alone.
 /// </summary>
-public sealed class TestSegmentEditorController
+public sealed class SegmentEditorControllerTests
 {
     [Fact]
     public async Task DeleteSegment_RestoresPluginRow_WhenJellyfinDeleteFails_AndJellyfinSegmentAlreadyGone()
@@ -87,6 +88,56 @@ public sealed class TestSegmentEditorController
         Assert.Equal(160, restored.End);
         Assert.True(restored.IsUserProvided);
         Assert.Equal("cfg-2", restored.ConfigHash);
+    }
+
+    [Fact]
+    public async Task DeleteSegment_RejectsMismatchedExistingSegmentType_WithoutMutatingEitherStore()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var itemId = Guid.NewGuid();
+        var segmentId = Guid.NewGuid();
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(100, 160)), AnalysisMode.Introduction, configHash: "cfg-intro");
+        await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(1200, 1260)), AnalysisMode.Credits, configHash: "cfg-credits");
+        await database.SetEpisodeIdsAsync(itemId, AnalysisMode.Introduction, [itemId], "cfg-intro");
+        await database.SetEpisodeIdsAsync(itemId, AnalysisMode.Credits, [itemId], "cfg-credits");
+
+        var movie = CreateMovie(itemId);
+        var manager = new FakeMediaSegmentManager
+        {
+            ExistingSegments =
+            [
+                new MediaSegmentDto
+                {
+                    Id = segmentId,
+                    ItemId = itemId,
+                    Type = Jellyfin.Database.Implementations.Enums.MediaSegmentType.Outro,
+                    StartTicks = TimeSpan.FromSeconds(1200).Ticks,
+                    EndTicks = TimeSpan.FromSeconds(1260).Ticks,
+                }
+            ],
+        };
+        var controller = CreateController(manager, database, movie);
+
+        var response = await controller.DeleteSegmentAsync(segmentId, itemId, "intro", CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(response);
+        Assert.Empty(manager.DeletedSegmentIds);
+
+        var rows = await database.GetSegmentsAsync(itemId);
+        Assert.Equal(2, rows.Count);
+        var intro = Assert.Single(rows, row => row.Type == AnalysisMode.Introduction);
+        Assert.Equal(100, intro.Start);
+        Assert.Equal(160, intro.End);
+        Assert.Equal("cfg-intro", intro.ConfigHash);
+        var credits = Assert.Single(rows, row => row.Type == AnalysisMode.Credits);
+        Assert.Equal(1200, credits.Start);
+        Assert.Equal(1260, credits.End);
+        Assert.Equal("cfg-credits", credits.ConfigHash);
+
+        var snapshot = await database.GetSeasonQueueSnapshotAsync(itemId, [itemId]);
+        Assert.Contains(itemId, snapshot.EpisodeIdsByMode[AnalysisMode.Introduction]);
+        Assert.Contains(itemId, snapshot.EpisodeIdsByMode[AnalysisMode.Credits]);
     }
 
     [Fact]

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -129,10 +129,11 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             return NotFound();
         }
 
-        // Delete from the plugin DB first so it is consistent even if the Jellyfin delete fails.
-        // The facade returns the rows it deleted (matched with its own epsilon), so a rollback
-        // restores exactly those rows instead of re-implementing the matching here.
-        var deletedRows = await _database.DeleteTimestampAsync(itemId, mode, dbSegment, cancellationToken).ConfigureAwait(false);
+        // Non-commercial modes have exactly one row per item and mode, so delete that
+        // unambiguous counterpart even if Jellyfin's reported range has drifted. Commercial
+        // rows still require the facade's exact epsilon match.
+        var deleteSegment = mode == AnalysisMode.Commercial ? dbSegment : null;
+        var deletedRows = await _database.DeleteTimestampAsync(itemId, mode, deleteSegment, cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -144,7 +145,8 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             // user-provided flag and config hash, so the restored rows are not treated as
             // stale) to avoid an orphaned Jellyfin segment. When the plugin DB had no matching
             // row, fall back to the Jellyfin-reported range so the still-existing Jellyfin
-            // segment keeps a plugin-side counterpart.
+            // segment keeps a plugin-side counterpart. Rollback is deliberately uncancelable
+            // once the plugin delete has completed.
             if (deletedRows.Count > 0)
             {
                 foreach (var row in deletedRows)

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -33,9 +33,6 @@ namespace IntroSkipper.Controllers;
 [Route("MediaSegmentsApi")]
 public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEditorService, IIntroSkipperDatabase database) : ControllerBase
 {
-    // Maximum difference in seconds between two time values to be considered equal.
-    private const double TimeComparisonToleranceSeconds = 0.01;
-
     private readonly MediaSegmentEditorService _mediaSegmentEditorService = mediaSegmentEditorService;
     private readonly IIntroSkipperDatabase _database = database;
 
@@ -132,29 +129,10 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             return NotFound();
         }
 
-        // Read IsUserProvided and ConfigHash before deleting so a rollback can restore the row
-        // faithfully. Match on type AND start/end times so that when multiple segments of the
-        // same mode exist (e.g. Commercial) we identify the exact one being deleted rather than
-        // an arbitrary first match.
-        var wasUserProvided = false;
-        var configHash = string.Empty;
-        var pluginSegments = await _database.GetSegmentsAsync(itemId, cancellationToken).ConfigureAwait(false);
-        var matchingSegment = pluginSegments.FirstOrDefault(s =>
-            s.Type == mode &&
-            (dbSegment is null || (Math.Abs(s.Start - dbSegment.Start) < TimeComparisonToleranceSeconds && Math.Abs(s.End - dbSegment.End) < TimeComparisonToleranceSeconds)));
-        if (matchingSegment is not null)
-        {
-            wasUserProvided = matchingSegment.IsUserProvided;
-            configHash = matchingSegment.ConfigHash;
-        }
-
-        // Prefer the Jellyfin-reported range for the rollback; fall back to the plugin DB row so
-        // a failed Jellyfin delete can still restore the row when the Jellyfin segment was
-        // already gone (dbSegment is null deletes the mode's row below, so it must be restorable).
-        var restoreSegment = dbSegment ?? matchingSegment?.ToSegment();
-
         // Delete from the plugin DB first so it is consistent even if the Jellyfin delete fails.
-        await _database.DeleteTimestampAsync(itemId, mode, dbSegment, cancellationToken).ConfigureAwait(false);
+        // The facade returns the rows it deleted (matched with its own epsilon), so a rollback
+        // restores exactly those rows instead of re-implementing the matching here.
+        var deletedRows = await _database.DeleteTimestampAsync(itemId, mode, dbSegment, cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -162,12 +140,21 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         }
         catch
         {
-            // Jellyfin delete failed — restore the plugin DB entry (including its user-provided
-            // flag and config hash, so the restored row is not treated as stale) to avoid an
-            // orphaned Jellyfin segment.
-            if (restoreSegment is not null)
+            // Jellyfin delete failed — restore the deleted plugin DB rows (including their
+            // user-provided flag and config hash, so the restored rows are not treated as
+            // stale) to avoid an orphaned Jellyfin segment. When the plugin DB had no matching
+            // row, fall back to the Jellyfin-reported range so the still-existing Jellyfin
+            // segment keeps a plugin-side counterpart.
+            if (deletedRows.Count > 0)
             {
-                await _database.UpdateTimestampAsync(restoreSegment, mode, isUserProvided: wasUserProvided, configHash: configHash, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                foreach (var row in deletedRows)
+                {
+                    await _database.UpdateTimestampAsync(row.ToSegment(), mode, isUserProvided: row.IsUserProvided, configHash: row.ConfigHash, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+            else if (dbSegment is not null)
+            {
+                await _database.UpdateTimestampAsync(dbSegment, mode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
             }
 
             throw;

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -121,13 +121,10 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             .ConfigureAwait(false);
 
         var mode = requestedMode;
-        if (existingSegment is not null)
+        if (existingSegment is not null
+            && existingSegment.Type != AnalysisHelpers.ModeToSegmentType[requestedMode])
         {
-            mode = AnalysisHelpers.MapSegmentTypeToMode(existingSegment.Type);
-            if (mode != requestedMode)
-            {
-                return BadRequest($"Segment '{segmentId}' is {existingSegment.Type}, not requested type '{type}'.");
-            }
+            return BadRequest($"Segment '{segmentId}' is {existingSegment.Type}, not requested type '{type}'.");
         }
 
         Segment? dbSegment = null;

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -92,9 +92,13 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
     /// <param name="itemId">The item id the segment belongs to (used to remove plugin DB entry).</param>
     /// <param name="type">The media segment type name (Intro/Recap/Preview/Outro).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>HTTP 200 on success, 404 when the commercial segment is not found.</returns>
+    /// <returns>
+    /// HTTP 200 on success, 400 when the requested type does not match the Jellyfin segment,
+    /// or 404 when the commercial segment is not found.
+    /// </returns>
     [HttpDelete("{segmentId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteSegmentAsync(
         [FromRoute, Required] Guid segmentId,
@@ -102,11 +106,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         [FromQuery, Required] string type,
         CancellationToken cancellationToken = default)
     {
-        var existingSegment = await _mediaSegmentEditorService
-            .GetSegmentAsync(itemId, segmentId, cancellationToken)
-            .ConfigureAwait(false);
-
-        AnalysisMode mode = type.ToLowerInvariant() switch
+        AnalysisMode requestedMode = type.ToLowerInvariant() switch
         {
             "intro" => AnalysisMode.Introduction,
             "recap" => AnalysisMode.Recap,
@@ -115,6 +115,20 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             "commercial" => AnalysisMode.Commercial,
             _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown segment type '{type}'")
         };
+
+        var existingSegment = await _mediaSegmentEditorService
+            .GetSegmentAsync(itemId, segmentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var mode = requestedMode;
+        if (existingSegment is not null)
+        {
+            mode = AnalysisHelpers.MapSegmentTypeToMode(existingSegment.Type);
+            if (mode != requestedMode)
+            {
+                return BadRequest($"Segment '{segmentId}' is {existingSegment.Type}, not requested type '{type}'.");
+            }
+        }
 
         Segment? dbSegment = null;
         if (existingSegment is not null)

--- a/IntroSkipper/Db/IIntroSkipperDatabase.cs
+++ b/IntroSkipper/Db/IIntroSkipperDatabase.cs
@@ -63,14 +63,18 @@ public interface IIntroSkipperDatabase
     Task DeleteItemSegmentsAsync(Guid itemId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deletes a stored timestamp for the specified item and analysis mode.
+    /// Deletes a stored timestamp for the specified item and analysis mode. The delete is
+    /// authoritative: the rows it matched (using the facade's own comparison epsilon) are
+    /// returned, so callers can restore exactly what was deleted — including
+    /// <see cref="DbSegment.IsUserProvided"/> and <see cref="DbSegment.ConfigHash"/> —
+    /// without re-implementing the matching.
     /// </summary>
     /// <param name="itemId">The item ID whose timestamp should be removed.</param>
     /// <param name="mode">The analysis mode representing the segment type.</param>
     /// <param name="segment">Optional segment details used to remove a specific entry.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task DeleteTimestampAsync(Guid itemId, AnalysisMode mode, Segment? segment = null, CancellationToken cancellationToken = default);
+    /// <returns>The deleted segment rows; empty when nothing matched.</returns>
+    Task<IReadOnlyList<DbSegment>> DeleteTimestampAsync(Guid itemId, AnalysisMode mode, Segment? segment = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes every stored segment of the given analysis mode.

--- a/IntroSkipper/Db/IntroSkipperDatabase.Segments.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Segments.cs
@@ -144,7 +144,7 @@ public sealed partial class IntroSkipperDatabase
     }
 
     /// <inheritdoc/>
-    public async Task DeleteTimestampAsync(
+    public async Task<IReadOnlyList<DbSegment>> DeleteTimestampAsync(
         Guid itemId,
         AnalysisMode mode,
         Segment? segment = null,
@@ -152,7 +152,7 @@ public sealed partial class IntroSkipperDatabase
     {
         if (segment is null && mode == AnalysisMode.Commercial)
         {
-            return;
+            return [];
         }
 
         await InitializeAsync().ConfigureAwait(false);
@@ -173,6 +173,8 @@ public sealed partial class IntroSkipperDatabase
             db.DbSegment.RemoveRange(entries);
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
+
+        return entries;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Follow-up 1 from the simplify review (stacked on #851).

`SegmentEditorController.DeleteSegmentAsync` pre-fetched all segments and re-matched the row being deleted with a **0.01s** tolerance, while `DeleteTimestampAsync` re-matched internally with a **0.001s** epsilon — the two layers could select different rows (rollback data captured for row A while row B was deleted, or deleted nothing).

- `IIntroSkipperDatabase.DeleteTimestampAsync` now returns `IReadOnlyList<DbSegment>` — the rows it actually deleted, matched with the facade's own epsilon.
- The controller's pre-fetch, 0.01s re-match, and `TimeComparisonToleranceSeconds` constant are gone. On a failed Jellyfin delete it restores exactly the returned rows (including `IsUserProvided`/`ConfigHash`); when the plugin DB had no matching row it still falls back to the Jellyfin-reported range so the surviving Jellyfin segment keeps a plugin-side counterpart.
- Rollback now restores *all* deleted rows (relevant for Commercial, where several rows per mode can exist), not just one.

Tests: facade delete tests now pin the return value; new regression test with two commercials 0.005s apart (outside the facade epsilon, inside the old controller tolerance) with distinct metadata proves the rollback restores the actually-deleted row, not the neighbor's. 449/449 passing, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make database-driven segment deletion authoritative and ensure controller rollback restores exactly the rows actually deleted.

Bug Fixes:
- Ensure rollback after a failed Jellyfin delete restores the exact segment rows that were deleted, even when multiple close-together commercials exist.

Enhancements:
- Change DeleteTimestampAsync to return the set of DbSegment rows it deleted so callers can faithfully restore them with original metadata.
- Simplify SegmentEditorController deletion logic to rely on the database facade’s matching epsilon instead of re-implementing time-based matching with its own tolerance.
- Update facade deletion tests to assert on returned deleted rows and cover the multi-commercial rollback scenario.

Tests:
- Add regression test to verify rollback restores the correct commercial when multiple segments are within the previous controller tolerance but outside the facade epsilon.