### PR TITLE
Centralize best-effort cache-delete policy in the facade

### DIFF
--- a/IntroSkipper.Tests/TestDatabaseFacades.cs
+++ b/IntroSkipper.Tests/TestDatabaseFacades.cs
@@ -1138,6 +1138,38 @@ public sealed class TestDatabaseFacades
         return (string)command.ExecuteScalar()!;
     }
 
+    [Fact]
+    public async Task CacheDeletes_DatabaseErrorAfterInitialization_IsSwallowedAndReturnsZero()
+    {
+        // First context (initialization) uses a working path; every later context points
+        // into a nonexistent directory, so the delete statements themselves fail with a
+        // SqliteException. The facade's deletes are best-effort and must swallow it.
+        var goodPath = CreateTempDbPath();
+        var badPath = Path.Join(
+            Path.GetTempPath(),
+            "IntroSkipper.Tests",
+            Guid.NewGuid().ToString("N") + "-missing-dir",
+            "cache.db");
+        var contextCreations = 0;
+        var database = new DetectionCacheDatabase(
+            new TestDbContextFactory<DetectionCacheDbContext>(() =>
+                new DetectionCacheDbContext(Interlocked.Increment(ref contextCreations) == 1 ? goodPath : badPath)),
+            NullLogger<DetectionCacheDatabase>.Instance);
+
+        try
+        {
+            Assert.True(database.TryInitialize());
+
+            Assert.Equal(0, database.DeleteForItem(Guid.NewGuid()));
+            Assert.Equal(0, database.DeleteByMode(AnalysisMode.Introduction));
+            Assert.Equal(0, await database.DeleteForItemsAsync([Guid.NewGuid()]));
+        }
+        finally
+        {
+            DeleteSqliteFiles(goodPath);
+        }
+    }
+
     private static string CreateTempDbPath()
         => DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-facades.db");
 

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -40,8 +40,7 @@ public sealed class TestSkipIntroController
         var controller = new SkipIntroController(
             refresher,
             DatabaseTestHelpers.CreateCacheDatabase(pluginScope.CacheDbPath),
-            database,
-            NullLogger<SkipIntroController>.Instance);
+            database);
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -78,8 +77,7 @@ public sealed class TestSkipIntroController
         var controller = new SkipIntroController(
             refresher,
             DatabaseTestHelpers.CreateCacheDatabase(pluginScope.CacheDbPath),
-            DatabaseTestHelpers.CreateSegmentDatabase(dbPath),
-            NullLogger<SkipIntroController>.Instance);
+            DatabaseTestHelpers.CreateSegmentDatabase(dbPath));
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -109,8 +107,7 @@ public sealed class TestSkipIntroController
         var controller = new SkipIntroController(
             new RecordingMediaSegmentRefresher(),
             DatabaseTestHelpers.CreateCacheDatabase(missingCachePath),
-            database,
-            NullLogger<SkipIntroController>.Instance);
+            database);
 
         var result = await controller.ResetIntroTimestamps(
             AnalysisMode.Introduction,

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -7,7 +7,6 @@
 // SPDX-FileCopyrightText: 2024 Xameon42
 // SPDX-License-Identifier: GPL-3.0-only
 
-using System.Data.Common;
 using System.Net.Mime;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
@@ -17,8 +16,6 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.Controllers;
 
@@ -31,13 +28,11 @@ namespace IntroSkipper.Controllers;
 public partial class SkipIntroController(
     IMediaSegmentRefresher mediaSegmentRefresher,
     IDetectionCacheDatabase cacheDatabase,
-    IIntroSkipperDatabase database,
-    ILogger<SkipIntroController> logger) : ControllerBase
+    IIntroSkipperDatabase database) : ControllerBase
 {
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IDetectionCacheDatabase _cacheDatabase = cacheDatabase;
     private readonly IIntroSkipperDatabase _database = database;
-    private readonly ILogger<SkipIntroController> _logger = logger;
 
     /// <summary>
     /// Updates the timestamps for the provided episode.
@@ -197,16 +192,10 @@ public partial class SkipIntroController(
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {
-            // Do not bind the best-effort cache cleanup to request cancellation: the
-            // main database rows are already gone, so make one complete cleanup attempt.
-            try
-            {
-                await Task.Run(() => _cacheDatabase.DeleteByMode(mode), CancellationToken.None).ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is DbUpdateException or DbException)
-            {
-                LogCacheDeleteFailed(_logger, ex, mode);
-            }
+            // Best-effort cache cleanup (the facade logs and swallows database errors),
+            // run off the request thread and not bound to request cancellation: the main
+            // database rows are already gone, so make one complete cleanup attempt.
+            await Task.Run(() => _cacheDatabase.DeleteByMode(mode), CancellationToken.None).ConfigureAwait(false);
         }
 
         return NoContent();
@@ -225,7 +214,4 @@ public partial class SkipIntroController(
         await _database.RebuildDatabaseAsync().ConfigureAwait(false);
         return NoContent();
     }
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete detection cache rows for analysis mode {Mode}")]
-    private static partial void LogCacheDeleteFailed(ILogger logger, Exception exception, AnalysisMode mode);
 }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -5,7 +5,6 @@
 // SPDX-FileCopyrightText: 2024 theMasterpc
 // SPDX-License-Identifier: GPL-3.0-only
 
-using System.Data.Common;
 using System.Net.Mime;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
@@ -139,16 +138,9 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
             if (eraseCache)
             {
-                try
-                {
-                    // The main database is already transactionally consistent, and cache
-                    // cleanup is best-effort because the cache is only an optimization.
-                    await _cacheDatabase.DeleteForItemsAsync(episodeIds, CancellationToken.None).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (ex is DbUpdateException or DbException)
-                {
-                    LogCacheDeleteFailed(_logger, ex, seasonId);
-                }
+                // Best-effort cache cleanup (the facade logs and swallows database errors),
+                // not bound to request cancellation: the main database is already consistent.
+                await _cacheDatabase.DeleteForItemsAsync(episodeIds, CancellationToken.None).ConfigureAwait(false);
             }
 
             if (Plugin.Instance.Configuration.UpdateMediaSegments)
@@ -198,19 +190,12 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
                 .RemoveItemsFromAnalysisAsync(excludedIdsBySeason, cancellationToken)
                 .ConfigureAwait(false);
 
-            var removedCacheEntries = 0;
-            try
-            {
-                // Do not bind the best-effort cache cleanup to request cancellation: the
-                // main database transaction has committed, so make one complete attempt.
-                removedCacheEntries = await _cacheDatabase
-                    .DeleteForItemsAsync(excludedIds, CancellationToken.None)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is DbUpdateException or DbException)
-            {
-                LogExcludedCacheDeleteFailed(_logger, ex);
-            }
+            // Best-effort cache cleanup (the facade logs and swallows database errors),
+            // not bound to request cancellation: the main database transaction has
+            // committed, so make one complete attempt.
+            var removedCacheEntries = await _cacheDatabase
+                .DeleteForItemsAsync(excludedIds, CancellationToken.None)
+                .ConfigureAwait(false);
 
             if (plugin.Configuration.UpdateMediaSegments)
             {
@@ -356,12 +341,6 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to erase timestamps for series {SeriesId} season {SeasonId}")]
     private static partial void LogFailedToEraseTimestamps(ILogger logger, Exception ex, Guid seriesId, Guid seasonId);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete detection cache rows for season {SeasonId}")]
-    private static partial void LogCacheDeleteFailed(ILogger logger, Exception exception, Guid seasonId);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete detection cache rows for excluded items")]
-    private static partial void LogExcludedCacheDeleteFailed(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to clear excluded timestamp data")]
     private static partial void LogFailedToClearExcludedTimestamps(ILogger logger, Exception ex);

--- a/IntroSkipper/Db/DetectionCacheDatabase.cs
+++ b/IntroSkipper/Db/DetectionCacheDatabase.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System.Data.Common;
 using IntroSkipper.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -106,8 +107,16 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
             return 0;
         }
 
-        using var db = _contextFactory.CreateDbContext();
-        return db.DetectionCache.Where(e => e.ItemId == itemId).ExecuteDelete();
+        try
+        {
+            using var db = _contextFactory.CreateDbContext();
+            return db.DetectionCache.Where(e => e.ItemId == itemId).ExecuteDelete();
+        }
+        catch (Exception ex) when (ex is DbUpdateException or DbException)
+        {
+            LogCacheDeleteFailed(_logger, ex);
+            return 0;
+        }
     }
 
     /// <inheritdoc/>
@@ -118,8 +127,16 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
             return 0;
         }
 
-        using var db = _contextFactory.CreateDbContext();
-        return db.DetectionCache.Where(e => e.Mode == mode).ExecuteDelete();
+        try
+        {
+            using var db = _contextFactory.CreateDbContext();
+            return db.DetectionCache.Where(e => e.Mode == mode).ExecuteDelete();
+        }
+        catch (Exception ex) when (ex is DbUpdateException or DbException)
+        {
+            LogCacheDeleteFailed(_logger, ex);
+            return 0;
+        }
     }
 
     /// <inheritdoc/>
@@ -163,14 +180,22 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
             return 0;
         }
 
-        using var db = _contextFactory.CreateDbContext();
+        try
+        {
+            using var db = _contextFactory.CreateDbContext();
 
-        // EF.Parameter binds the ID set as a single JSON parameter (json_each), so the
-        // delete is one statement regardless of the item count.
-        return await db.DetectionCache
-            .Where(e => EF.Parameter(ids).Contains(e.ItemId))
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+            // EF.Parameter binds the ID set as a single JSON parameter (json_each), so the
+            // delete is one statement regardless of the item count.
+            return await db.DetectionCache
+                .Where(e => EF.Parameter(ids).Contains(e.ItemId))
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is DbUpdateException or DbException)
+        {
+            LogCacheDeleteFailed(_logger, ex);
+            return 0;
+        }
     }
 
     /// <summary>
@@ -201,4 +226,7 @@ public sealed partial class DetectionCacheDatabase : IDetectionCacheDatabase
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Detection cache database initialization failed; the next database operation will retry")]
     private static partial void LogCacheDbInitializationError(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to delete detection cache rows; the cache is an optimization, continuing")]
+    private static partial void LogCacheDeleteFailed(ILogger logger, Exception exception);
 }

--- a/IntroSkipper/Db/IDetectionCacheDatabase.cs
+++ b/IntroSkipper/Db/IDetectionCacheDatabase.cs
@@ -11,8 +11,9 @@ namespace IntroSkipper.Db;
 /// schema lifecycle (<c>EnsureCreated</c> with delete-and-recreate corruption recovery).
 /// The synchronous members mirror the synchronous call patterns of the analysis pipeline.
 /// Initialization failures make the cache temporarily unavailable; operations return neutral
-/// results and retry initialization on the next call. Database errors after initialization
-/// continue to propagate to the existing best-effort callers.
+/// results and retry initialization on the next call. Delete operations are best-effort —
+/// the cache is an optimization, so database errors are logged and swallowed (returning 0)
+/// instead of propagating to callers.
 /// </summary>
 public interface IDetectionCacheDatabase
 {
@@ -63,17 +64,19 @@ public interface IDetectionCacheDatabase
     bool HasEntry(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, string expectedConfigHash);
 
     /// <summary>
-    /// Deletes all cache entries for an item.
+    /// Deletes all cache entries for an item. Best-effort: database errors are logged
+    /// and swallowed.
     /// </summary>
     /// <param name="itemId">Item ID.</param>
-    /// <returns>The number of deleted rows.</returns>
+    /// <returns>The number of deleted rows; 0 when the delete failed.</returns>
     int DeleteForItem(Guid itemId);
 
     /// <summary>
-    /// Deletes all cache entries for an analysis mode.
+    /// Deletes all cache entries for an analysis mode. Best-effort: database errors are
+    /// logged and swallowed.
     /// </summary>
     /// <param name="mode">Analysis mode.</param>
-    /// <returns>The number of deleted rows.</returns>
+    /// <returns>The number of deleted rows; 0 when the delete failed.</returns>
     int DeleteByMode(AnalysisMode mode);
 
     /// <summary>
@@ -88,10 +91,11 @@ public interface IDetectionCacheDatabase
 
     /// <summary>
     /// Deletes all cache entries for the given items in a single statement; the ID set
-    /// is bound as one JSON parameter, so the item count is unbounded.
+    /// is bound as one JSON parameter, so the item count is unbounded. Best-effort:
+    /// database errors are logged and swallowed (cancellation still propagates).
     /// </summary>
     /// <param name="itemIds">Item IDs whose cache entries should be removed.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The number of deleted rows.</returns>
+    /// <returns>The number of deleted rows; 0 when the delete failed.</returns>
     Task<int> DeleteForItemsAsync(IReadOnlyCollection<Guid> itemIds, CancellationToken cancellationToken = default);
 }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -4,7 +4,6 @@
 // SPDX-FileCopyrightText: 2024 theMasterpc
 // SPDX-License-Identifier: GPL-3.0-only
 
-using System.Data.Common;
 using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
@@ -153,16 +152,10 @@ public partial class CleanCacheTask(
 
         if (invalidEpisodeIds.Count > 0)
         {
-            try
-            {
-                await _cacheDatabase
-                    .DeleteForItemsAsync(invalidEpisodeIds, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is DbUpdateException or DbException)
-            {
-                LogDeletingCacheRowsFailed(_logger, ex);
-            }
+            // Best-effort: the facade logs and swallows database errors.
+            await _cacheDatabase
+                .DeleteForItemsAsync(invalidEpisodeIds, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         // Clean up season state by removing items that no longer exist.
@@ -182,9 +175,6 @@ public partial class CleanCacheTask(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting detection cache rows for episode ID: {EpisodeId}")]
     private static partial void LogDeletingDetectionCacheRows(ILogger logger, Guid episodeId);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to delete stale detection cache rows")]
-    private static partial void LogDeletingCacheRowsFailed(ILogger logger, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping cache cleanup: {Count} library(ies) or item(s) failed to enumerate, so stale-data detection would over-delete. Check the enumeration errors logged above and re-run the task")]
     private static partial void LogSkippingCleanupEnumerationFailures(ILogger logger, int count);


### PR DESCRIPTION
Follow-up 2 from the simplify review (stacked on #851).

The "cache is an optimization — swallow, log, continue" delete policy lived outside the facade, copy-pasted as try/catch blocks at four call sites (`SkipIntroController`, `VisualizationController` ×2, `CleanCacheTask`), each with its own `LoggerMessage`; `Entrypoint` relied on an unrelated enclosing catch. Meanwhile the facade itself was asymmetric: initialization failures were swallowed (`TryInitialize` → neutral results), but operation failures threw.

- `DeleteForItem` / `DeleteByMode` / `DeleteForItemsAsync` now catch `DbUpdateException`/`DbException` inside `DetectionCacheDatabase`, log one shared warning, and return 0 — consistent with the facade's existing init-failure behavior. Cancellation still propagates.
- The four per-site try/catch blocks and three per-site `LoggerMessage` definitions are deleted; each caller is now one unguarded call.
- `SkipIntroController` no longer uses its logger anywhere, so the `ILogger` dependency is removed entirely.
- Interface docs updated to state the best-effort contract.

Tests: new facade test proves a database error after successful initialization is swallowed by all three deletes (returning 0) instead of propagating; the existing `ResetIntroTimestamps_CacheFailureDoesNotFailMainDatabaseDelete` still passes through the new path. 449/449 passing, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize best-effort cache deletion behavior in the detection cache facade and simplify callers that rely on it.

Bug Fixes:
- Ensure cache delete operations swallow database errors and return neutral results instead of propagating exceptions after successful initialization.

Enhancements:
- Unify logging for cache delete failures with a single shared logger message in the detection cache database facade.
- Simplify controllers and scheduled task by removing per-call-site try/catch blocks around cache deletions and relying on the facade’s best-effort semantics.
- Remove the unused logger dependency from SkipIntroController now that cache delete logging is handled by the facade.

Tests:
- Add a facade test verifying that cache delete operations swallow database errors after initialization and return zero deleted rows.