### PR TITLE
Introduce AnalyzerTaskFactory to own per-run analysis construction

### DIFF
--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -41,16 +41,19 @@ internal static class EntrypointTestHelpers
 
         var entrypoint = new Entrypoint(
             libraryManager: null!,
-            providerManager: null!,
-            fileSystem: null!,
             taskManager: null!,
-            cacheService: DatabaseTestHelpers.CreateCacheService(resolvedCacheDbPath),
             cacheDatabase: DatabaseTestHelpers.CreateCacheDatabase(resolvedCacheDbPath),
             ffmpegService: null!,
             logger: logger,
-            loggerFactory: loggerFactory,
-            mediaSegmentRefresher: new FakeMediaSegmentRefresher(),
-            database: DatabaseTestHelpers.CreateTempSegmentDatabase());
+            analyzerFactory: new AnalyzerTaskFactory(
+                loggerFactory,
+                libraryManager: null!,
+                providerManager: null!,
+                fileSystem: null!,
+                mediaSegmentRefresher: new FakeMediaSegmentRefresher(),
+                ffmpegService: null!,
+                cacheService: DatabaseTestHelpers.CreateCacheService(resolvedCacheDbPath),
+                database: DatabaseTestHelpers.CreateTempSegmentDatabase()));
 
         SetPrivateField(entrypoint, "_config", new PluginConfiguration { AutoDetectIntros = autoDetectIntros });
         return entrypoint;

--- a/IntroSkipper.Tests/TestBaseItemAnalyzerTaskOrchestration.cs
+++ b/IntroSkipper.Tests/TestBaseItemAnalyzerTaskOrchestration.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
 using IntroSkipper.FFmpeg;
-using IntroSkipper.ScheduledTasks;
+using IntroSkipper.Manager;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -19,8 +19,7 @@ public sealed class TestBaseItemAnalyzerTaskOrchestration
         using var cancellation = new CancellationTokenSource();
         await cancellation.CancelAsync();
 
-        var analyzer = new BaseItemAnalyzerTask(
-            NullLogger.Instance,
+        var analyzer = new AnalyzerTaskFactory(
             NullLoggerFactory.Instance,
             EntrypointTestHelpers.CreateLibraryManager(),
             providerManager: null!,
@@ -30,7 +29,7 @@ public sealed class TestBaseItemAnalyzerTaskOrchestration
                 NullLogger<FFmpegService>.Instance,
                 DatabaseTestHelpers.CreateTempCacheService()),
             cacheService: null!,
-            database: null!);
+            database: null!).CreateAnalyzerTask();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => analyzer.AnalyzeItemsAsync(new Progress<double>(), cancellation.Token));

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -223,11 +223,15 @@ public sealed class TestCleanCacheTask
         IMediaSegmentRefresher? mediaSegmentRefresher = null)
         => new(
             NullLogger<CleanCacheTask>.Instance,
-            NullLoggerFactory.Instance,
-            libraryManager,
-            providerManager: null!,
-            fileSystem: null!,
-            ffmpegService: null!,
+            new AnalyzerTaskFactory(
+                NullLoggerFactory.Instance,
+                libraryManager,
+                providerManager: null!,
+                fileSystem: null!,
+                mediaSegmentRefresher: null!,
+                ffmpegService: null!,
+                cacheService: null!,
+                database),
             database,
             cacheDatabase,
             mediaSegmentRefresher: mediaSegmentRefresher ?? null!);

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -39,8 +39,7 @@ public sealed class TestSeasonReanalysisPlanner
         // The test proxy throws on enumeration calls such as GetVirtualFolders.
         var libraryManager = EntrypointTestHelpers.CreateLibraryManager();
         var progress = new RecordingProgress();
-        var analyzer = new BaseItemAnalyzerTask(
-            NullLogger.Instance,
+        var analyzer = new AnalyzerTaskFactory(
             NullLoggerFactory.Instance,
             libraryManager,
             providerManager: null!,
@@ -48,7 +47,7 @@ public sealed class TestSeasonReanalysisPlanner
             mediaSegmentRefresher: null!,
             ffmpegService: null!,
             cacheService: DatabaseTestHelpers.CreateTempCacheService(),
-            database: DatabaseTestHelpers.CreateTempSegmentDatabase());
+            database: DatabaseTestHelpers.CreateTempSegmentDatabase()).CreateAnalyzerTask();
 
         await analyzer.AnalyzeItemsAsync(
             progress,

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -216,11 +216,15 @@ public sealed class TestVisualizationController
             NullLogger<VisualizationController>.Instance,
             refresher,
             libraryManager: null!,
-            providerManager: null!,
-            fileSystem: null!,
-            loggerFactory,
-            ffmpegService: null!,
-            DatabaseTestHelpers.CreateCacheService(cacheDbPath),
+            new AnalyzerTaskFactory(
+                loggerFactory,
+                libraryManager: null!,
+                providerManager: null!,
+                fileSystem: null!,
+                mediaSegmentRefresher: null!,
+                ffmpegService: null!,
+                DatabaseTestHelpers.CreateCacheService(cacheDbPath),
+                database),
             database,
             DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath));
     }

--- a/IntroSkipper.Tests/TestVisualizationControllerSeams.cs
+++ b/IntroSkipper.Tests/TestVisualizationControllerSeams.cs
@@ -171,11 +171,15 @@ public sealed class TestVisualizationControllerSeams
             NullLogger<VisualizationController>.Instance,
             new NoOpMediaSegmentRefresher(),
             libraryManager!,
-            providerManager: null!,
-            fileSystem: null!,
-            NullLoggerFactory.Instance,
-            ffmpegService: null!,
-            DatabaseTestHelpers.CreateCacheService(cacheDbPath),
+            new AnalyzerTaskFactory(
+                NullLoggerFactory.Instance,
+                libraryManager!,
+                providerManager: null!,
+                fileSystem: null!,
+                new NoOpMediaSegmentRefresher(),
+                ffmpegService: null!,
+                DatabaseTestHelpers.CreateCacheService(cacheDbPath),
+                database),
             database,
             DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath));
 

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -34,27 +34,19 @@ namespace IntroSkipper.Controllers;
 /// <param name="logger">Logger.</param>
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 /// <param name="libraryManager">libraryManager.</param>
-/// <param name="providerManager">providerManager.</param>
-/// <param name="fileSystem">fileSystem.</param>
-/// <param name="loggerFactory">loggerFactory.</param>
-/// <param name="ffmpegService">FFmpeg service.</param>
-/// <param name="cacheService">Detection cache service.</param>
+/// <param name="analyzerFactory">Factory for per-run queue managers and analyzer tasks.</param>
 /// <param name="database">Segment database facade.</param>
 /// <param name="cacheDatabase">Detection cache database facade.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("Intros")]
-public partial class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentRefresher mediaSegmentRefresher, ILibraryManager libraryManager, IProviderManager providerManager, IFileSystem fileSystem, ILoggerFactory loggerFactory, IFFmpegService ffmpegService, IDetectionCacheService cacheService, IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase) : ControllerBase
+public partial class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentRefresher mediaSegmentRefresher, ILibraryManager libraryManager, AnalyzerTaskFactory analyzerFactory, IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase) : ControllerBase
 {
     private readonly ILogger<VisualizationController> _logger = logger;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly ILibraryManager _libraryManager = libraryManager;
-    private readonly IProviderManager _providerManager = providerManager;
-    private readonly IFileSystem _fileSystem = fileSystem;
-    private readonly ILoggerFactory _loggerFactory = loggerFactory;
-    private readonly IFFmpegService _ffmpegService = ffmpegService;
-    private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly AnalyzerTaskFactory _analyzerFactory = analyzerFactory;
     private readonly IIntroSkipperDatabase _database = database;
     private readonly IDetectionCacheDatabase _cacheDatabase = cacheDatabase;
 
@@ -234,13 +226,7 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     {
         if (_libraryManager is not null)
         {
-            var queueManager = new QueueManager(
-                _loggerFactory.CreateLogger<QueueManager>(),
-                _libraryManager,
-                _providerManager,
-                _fileSystem,
-                _ffmpegService,
-                _database);
+            var queueManager = _analyzerFactory.CreateQueueManager();
             var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
             return [.. queue.Values.SelectMany(static episodes => episodes).Where(static episode => episode.IsExcluded)];
         }
@@ -307,16 +293,7 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
                         // Erase season timestamps and cache first
                         await EraseSeasonAsync(seriesId, seasonId, true, CancellationToken.None).ConfigureAwait(false);
 
-                        var baseIntroAnalyzer = new BaseItemAnalyzerTask(
-                            _loggerFactory.CreateLogger<DetectSegmentsTask>(),
-                            _loggerFactory,
-                            _libraryManager,
-                            _providerManager,
-                            _fileSystem,
-                            _mediaSegmentRefresher,
-                            _ffmpegService,
-                            _cacheService,
-                            _database);
+                        var baseIntroAnalyzer = _analyzerFactory.CreateAnalyzerTask();
 
                         await baseIntroAnalyzer.AnalyzeItemsAsync(new Progress<double>(), CancellationToken.None, [seasonId]).ConfigureAwait(false);
                     }

--- a/IntroSkipper/Manager/AnalyzerTaskFactory.cs
+++ b/IntroSkipper/Manager/AnalyzerTaskFactory.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.Manager;
+
+/// <summary>
+/// Creates the per-run analysis objects. <see cref="QueueManager"/> and
+/// <see cref="BaseItemAnalyzerTask"/> hold per-run state (queue contents, enumeration
+/// failures, memoized ffmpeg validity, captured configuration), so they cannot be DI
+/// singletons; this factory owns their shared dependency set instead, so adding a
+/// dependency means changing this one class rather than every construction site.
+/// </summary>
+/// <param name="loggerFactory">Logger factory.</param>
+/// <param name="libraryManager">Library manager.</param>
+/// <param name="providerManager">Provider manager.</param>
+/// <param name="fileSystem">File system.</param>
+/// <param name="mediaSegmentRefresher">Media segment refresher.</param>
+/// <param name="ffmpegService">FFmpeg service.</param>
+/// <param name="cacheService">Detection cache service.</param>
+/// <param name="database">Segment database facade.</param>
+public class AnalyzerTaskFactory(
+    ILoggerFactory loggerFactory,
+    ILibraryManager libraryManager,
+    IProviderManager providerManager,
+    IFileSystem fileSystem,
+    IMediaSegmentRefresher mediaSegmentRefresher,
+    IFFmpegService ffmpegService,
+    IDetectionCacheService cacheService,
+    IIntroSkipperDatabase database)
+{
+    /// <summary>
+    /// Creates a fresh queue manager for one enumeration run.
+    /// </summary>
+    /// <returns>The queue manager.</returns>
+    public QueueManager CreateQueueManager()
+        => new(
+            loggerFactory.CreateLogger<QueueManager>(),
+            libraryManager,
+            providerManager,
+            fileSystem,
+            ffmpegService,
+            database);
+
+    /// <summary>
+    /// Creates a fresh analyzer task for one analysis run.
+    /// </summary>
+    /// <returns>The analyzer task.</returns>
+    public BaseItemAnalyzerTask CreateAnalyzerTask()
+        => new(
+            loggerFactory.CreateLogger<BaseItemAnalyzerTask>(),
+            loggerFactory,
+            this,
+            mediaSegmentRefresher,
+            ffmpegService,
+            cacheService,
+            database);
+}

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -49,6 +49,10 @@ namespace IntroSkipper
             serviceCollection.AddHostedService<IntroSkipperDatabaseInitializer>();
 
             serviceCollection.AddHostedService<Entrypoint>();
+            // Owns the shared dependency set of the per-run analysis objects
+            // (QueueManager, BaseItemAnalyzerTask), which are stateful per run and
+            // therefore created fresh by this factory instead of being singletons.
+            serviceCollection.AddSingleton<AnalyzerTaskFactory>();
             serviceCollection.AddSingleton<IDetectionCacheService, DetectionCacheService>();
             serviceCollection.AddSingleton<IFFmpegService, FFmpegService>();
             serviceCollection.AddSingleton<IMediaSegmentProvider, SegmentProvider>();

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -27,9 +27,7 @@ namespace IntroSkipper.ScheduledTasks;
 /// </remarks>
 /// <param name="logger">Task logger.</param>
 /// <param name="loggerFactory">Logger factory.</param>
-/// <param name="libraryManager">Library manager.</param>
-/// <param name="providerManager">Provider manager.</param>
-/// <param name="fileSystem">File system.</param>
+/// <param name="analyzerFactory">Factory used to create fresh queue managers per run.</param>
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 /// <param name="ffmpegService">FFmpeg service.</param>
 /// <param name="cacheService">Detection cache service.</param>
@@ -37,9 +35,7 @@ namespace IntroSkipper.ScheduledTasks;
 public partial class BaseItemAnalyzerTask(
     ILogger logger,
     ILoggerFactory loggerFactory,
-    ILibraryManager libraryManager,
-    IProviderManager providerManager,
-    IFileSystem fileSystem,
+    AnalyzerTaskFactory analyzerFactory,
     IMediaSegmentRefresher mediaSegmentRefresher,
     IFFmpegService ffmpegService,
     IDetectionCacheService cacheService,
@@ -54,9 +50,7 @@ public partial class BaseItemAnalyzerTask(
 
     private readonly ILogger _logger = logger;
     private readonly ILoggerFactory _loggerFactory = loggerFactory;
-    private readonly ILibraryManager _libraryManager = libraryManager;
-    private readonly IProviderManager _providerManager = providerManager;
-    private readonly IFileSystem _fileSystem = fileSystem;
+    private readonly AnalyzerTaskFactory _analyzerFactory = analyzerFactory;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
@@ -91,13 +85,7 @@ public partial class BaseItemAnalyzerTask(
 
         var seasonFilter = seasonsToAnalyze?.ToHashSet();
 
-        var queueManager = new QueueManager(
-            _loggerFactory.CreateLogger<QueueManager>(),
-            _libraryManager,
-            _providerManager,
-            _fileSystem,
-            _ffmpegService,
-            _database);
+        var queueManager = _analyzerFactory.CreateQueueManager();
 
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var ffmpegValid = await queueManager.GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -20,31 +20,19 @@ namespace IntroSkipper.ScheduledTasks;
 /// Clean the Intro Skipper cache of unused rows.
 /// </summary>
 /// <param name="logger">Logger.</param>
-/// <param name="loggerFactory">Logger factory.</param>
-/// <param name="libraryManager">Library manager.</param>
-/// <param name="providerManager">Provider manager.</param>
-/// <param name="fileSystem">File system.</param>
-/// <param name="ffmpegService">FFmpeg service.</param>
+/// <param name="analyzerFactory">Factory for per-run queue managers.</param>
 /// <param name="database">Segment database facade.</param>
 /// <param name="cacheDatabase">Detection cache database facade.</param>
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
 public partial class CleanCacheTask(
     ILogger<CleanCacheTask> logger,
-    ILoggerFactory loggerFactory,
-    ILibraryManager libraryManager,
-    IProviderManager providerManager,
-    IFileSystem fileSystem,
-    IFFmpegService ffmpegService,
+    AnalyzerTaskFactory analyzerFactory,
     IIntroSkipperDatabase database,
     IDetectionCacheDatabase cacheDatabase,
     IMediaSegmentRefresher mediaSegmentRefresher) : IScheduledTask
 {
     private readonly ILogger<CleanCacheTask> _logger = logger;
-    private readonly ILoggerFactory _loggerFactory = loggerFactory;
-    private readonly ILibraryManager _libraryManager = libraryManager;
-    private readonly IProviderManager _providerManager = providerManager;
-    private readonly IFileSystem _fileSystem = fileSystem;
-    private readonly IFFmpegService _ffmpegService = ffmpegService;
+    private readonly AnalyzerTaskFactory _analyzerFactory = analyzerFactory;
     private readonly IIntroSkipperDatabase _database = database;
     private readonly IDetectionCacheDatabase _cacheDatabase = cacheDatabase;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
@@ -79,20 +67,9 @@ public partial class CleanCacheTask(
     /// <returns>Task.</returns>
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        if (_libraryManager is null)
-        {
-            throw new InvalidOperationException("Library manager was null");
-        }
-
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
 
-        var queueManager = new QueueManager(
-            _loggerFactory.CreateLogger<QueueManager>(),
-            _libraryManager,
-            _providerManager,
-            _fileSystem,
-            _ffmpegService,
-            _database);
+        var queueManager = _analyzerFactory.CreateQueueManager();
 
         // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders.

--- a/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
+++ b/IntroSkipper/ScheduledTasks/DetectSegmentsTask.cs
@@ -22,35 +22,14 @@ namespace IntroSkipper.ScheduledTasks;
 /// <remarks>
 /// Initializes a new instance of the <see cref="DetectSegmentsTask"/> class.
 /// </remarks>
-/// <param name="loggerFactory">Logger factory.</param>
-/// <param name="libraryManager">Library manager.</param>
-/// <param name="providerManager">Provider manager.</param>
-/// <param name="fileSystem">File system.</param>
 /// <param name="logger">Logger.</param>
-/// <param name="mediaSegmentRefresher">Media segment refresher.</param>
-/// <param name="ffmpegService">FFmpeg service.</param>
-/// <param name="cacheService">Detection cache service.</param>
-/// <param name="database">Segment database facade.</param>
+/// <param name="analyzerFactory">Factory for per-run analyzer tasks.</param>
 public partial class DetectSegmentsTask(
     ILogger<DetectSegmentsTask> logger,
-    ILoggerFactory loggerFactory,
-    ILibraryManager libraryManager,
-    IProviderManager providerManager,
-    IFileSystem fileSystem,
-    IMediaSegmentRefresher mediaSegmentRefresher,
-    IFFmpegService ffmpegService,
-    IDetectionCacheService cacheService,
-    IIntroSkipperDatabase database) : IScheduledTask
+    AnalyzerTaskFactory analyzerFactory) : IScheduledTask
 {
     private readonly ILogger<DetectSegmentsTask> _logger = logger;
-    private readonly ILoggerFactory _loggerFactory = loggerFactory;
-    private readonly ILibraryManager _libraryManager = libraryManager;
-    private readonly IProviderManager _providerManager = providerManager;
-    private readonly IFileSystem _fileSystem = fileSystem;
-    private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
-    private readonly IFFmpegService _ffmpegService = ffmpegService;
-    private readonly IDetectionCacheService _cacheService = cacheService;
-    private readonly IIntroSkipperDatabase _database = database;
+    private readonly AnalyzerTaskFactory _analyzerFactory = analyzerFactory;
 
     /// <summary>
     /// Gets the task name.
@@ -80,11 +59,6 @@ public partial class DetectSegmentsTask(
     /// <returns>Task.</returns>
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        if (_libraryManager is null)
-        {
-            throw new InvalidOperationException("Library manager was null");
-        }
-
         // abort automatic analyzer if running
         if (Entrypoint.AutomaticTaskState == TaskState.Running || Entrypoint.AutomaticTaskState == TaskState.Cancelling)
         {
@@ -96,16 +70,7 @@ public partial class DetectSegmentsTask(
         {
             LogScheduledTaskStarting(_logger);
 
-            var baseIntroAnalyzer = new BaseItemAnalyzerTask(
-                _loggerFactory.CreateLogger<DetectSegmentsTask>(),
-                _loggerFactory,
-                _libraryManager,
-                _providerManager,
-                _fileSystem,
-                _mediaSegmentRefresher,
-                _ffmpegService,
-                _cacheService,
-                _database);
+            var baseIntroAnalyzer = _analyzerFactory.CreateAnalyzerTask();
 
             await baseIntroAnalyzer.AnalyzeItemsAsync(progress, cancellationToken).ConfigureAwait(false);
         }

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -35,15 +35,10 @@ namespace IntroSkipper.Services
     {
         private readonly ITaskManager _taskManager;
         private readonly ILibraryManager _libraryManager;
-        private readonly IProviderManager _providerManager;
-        private readonly IFileSystem _fileSystem;
-        private readonly IDetectionCacheService _cacheService;
         private readonly IDetectionCacheDatabase _cacheDatabase;
         private readonly IFFmpegService _ffmpegService;
         private readonly ILogger<Entrypoint> _logger;
-        private readonly ILoggerFactory _loggerFactory;
-        private readonly IMediaSegmentRefresher _mediaSegmentRefresher;
-        private readonly IIntroSkipperDatabase _database;
+        private readonly AnalyzerTaskFactory _analyzerFactory;
         private readonly HashSet<Guid> _seasonsToAnalyze = [];
         private readonly Lock _seasonsLock = new();
         private readonly Timer _queueTimer;
@@ -56,40 +51,25 @@ namespace IntroSkipper.Services
         /// Initializes a new instance of the <see cref="Entrypoint"/> class.
         /// </summary>
         /// <param name="libraryManager">Library manager.</param>
-        /// <param name="providerManager">Provider manager.</param>
-        /// <param name="fileSystem">File system.</param>
         /// <param name="taskManager">Task manager.</param>
-        /// <param name="cacheService">Detection cache service.</param>
         /// <param name="cacheDatabase">Detection cache database facade.</param>
         /// <param name="ffmpegService">FFmpeg service.</param>
         /// <param name="logger">Logger.</param>
-        /// <param name="loggerFactory">Logger factory.</param>
-        /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
-        /// <param name="database">Segment database facade.</param>
+        /// <param name="analyzerFactory">Factory for per-run analyzer tasks.</param>
         public Entrypoint(
             ILibraryManager libraryManager,
-            IProviderManager providerManager,
-            IFileSystem fileSystem,
             ITaskManager taskManager,
-            IDetectionCacheService cacheService,
             IDetectionCacheDatabase cacheDatabase,
             IFFmpegService ffmpegService,
             ILogger<Entrypoint> logger,
-            ILoggerFactory loggerFactory,
-            IMediaSegmentRefresher mediaSegmentRefresher,
-            IIntroSkipperDatabase database)
+            AnalyzerTaskFactory analyzerFactory)
         {
             _libraryManager = libraryManager;
-            _providerManager = providerManager;
-            _fileSystem = fileSystem;
             _taskManager = taskManager;
-            _cacheService = cacheService;
             _cacheDatabase = cacheDatabase;
             _ffmpegService = ffmpegService;
             _logger = logger;
-            _loggerFactory = loggerFactory;
-            _mediaSegmentRefresher = mediaSegmentRefresher;
-            _database = database;
+            _analyzerFactory = analyzerFactory;
 
             _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
             _queueTimer = new Timer(
@@ -362,7 +342,7 @@ namespace IntroSkipper.Services
 
                         _analyzeAgain = false;
 
-                        var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentRefresher, _ffmpegService, _cacheService, _database);
+                        var analyzer = _analyzerFactory.CreateAnalyzerTask();
                         await analyzer.AnalyzeItemsAsync(new Progress<double>(), cts.Token, seasonIds).ConfigureAwait(false);
 
                         if (_analyzeAgain && !cts.IsCancellationRequested)


### PR DESCRIPTION
Follow-up 3 from the simplify review (stacked on #851).

`QueueManager` and `BaseItemAnalyzerTask` hold per-run state (queue contents, enumeration-failure count, memoized ffmpeg validity, configuration captured at construction), so they can't be DI singletons — and were instead hand-constructed at six call sites (`Entrypoint`, `DetectSegmentsTask`, `CleanCacheTask`, `VisualizationController` ×2, `BaseItemAnalyzerTask` itself), each threading the full shared dependency set through its own constructor. The database refactor had to touch ~10 constructors to add one dependency, and call sites had already diverged (`VisualizationController` built its analyzer with a different logger category than `DetectSegmentsTask`).

- New `AnalyzerTaskFactory` (DI singleton) owns the shared dependency set and exposes `CreateQueueManager()` / `CreateAnalyzerTask()` — fresh instances per run, preserving the per-run statefulness.
- Consumers now inject the factory: `Entrypoint` drops 6 constructor deps, `DetectSegmentsTask` 7, `CleanCacheTask` 4, `VisualizationController` 4, `BaseItemAnalyzerTask` 3.
- The vestigial `_libraryManager is null` throw-checks in the scheduled tasks are gone with the fields; `VisualizationController` keeps its library-manager null seam (`GetExcludedInventoryAsync` fallback) unchanged.
- Analyzer/queue log categories are normalized to their own types instead of varying by call site.

No behavior change beyond log categories. 448/448 tests passing, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a singleton factory to construct per-run analyzer and queue manager instances and update consumers to depend on this factory instead of directly wiring all analysis dependencies.

Enhancements:
- Centralize construction of QueueManager and BaseItemAnalyzerTask into AnalyzerTaskFactory to own shared analysis dependencies and ensure fresh per-run instances.
- Simplify constructors for Entrypoint, DetectSegmentsTask, CleanCacheTask, VisualizationController, and BaseItemAnalyzerTask by replacing multiple analysis-related dependencies with the factory.
- Normalize analyzer and queue logging to use type-based logger categories and remove redundant null checks for library manager in scheduled tasks.

Tests:
- Update unit tests to construct and use AnalyzerTaskFactory when creating Entrypoint, CleanCacheTask, VisualizationController, and BaseItemAnalyzerTask instances.