### PR TITLE
Memoize successful ffmpeg validity probe in FFmpegService

### DIFF
--- a/IntroSkipper.Tests/TestBaseItemAnalyzerTaskOrchestration.cs
+++ b/IntroSkipper.Tests/TestBaseItemAnalyzerTaskOrchestration.cs
@@ -1,11 +1,19 @@
 namespace IntroSkipper.Tests;
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
+using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -33,5 +41,99 @@ public sealed class TestBaseItemAnalyzerTaskOrchestration
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => analyzer.AnalyzeItemsAsync(new Progress<double>(), cancellation.Token));
+    }
+
+    [Fact]
+    public async Task AnalyzeItemsAsync_InvalidFfmpeg_IsProbedOnceAcrossAnalyzerAndQueueVerification()
+    {
+        using var pluginScope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "Configuration", new PluginConfiguration());
+        EntrypointTestHelpers.SetPropertyOrField(Plugin.Instance!, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+
+        var episode = new Episode
+        {
+            Name = "Episode",
+            SeriesId = Guid.NewGuid(),
+            SeasonId = Guid.NewGuid(),
+            ParentIndexNumber = 1,
+            IndexNumber = 1,
+            Path = "/media/missing-episode.mkv",
+            RunTimeTicks = TimeSpan.FromMinutes(4).Ticks,
+        };
+        EntrypointTestHelpers.SetPropertyOrField(episode, "Id", Guid.NewGuid());
+        EntrypointTestHelpers.SetPropertyOrField(episode, "SeriesName", "Series");
+        EntrypointTestHelpers.EnsureNonVirtual(episode);
+
+        var libraryManager = QueueLibraryManager.Create(episode);
+        EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_libraryManager", libraryManager);
+        var ffmpegService = CountingFfmpegService.Create(out var ffmpegProxy);
+        var analyzer = new AnalyzerTaskFactory(
+            NullLoggerFactory.Instance,
+            libraryManager,
+            providerManager: null!,
+            fileSystem: null!,
+            mediaSegmentRefresher: null!,
+            ffmpegService,
+            cacheService: null!,
+            DatabaseTestHelpers.CreateTempSegmentDatabase()).CreateAnalyzerTask();
+
+        await analyzer.AnalyzeItemsAsync(new Progress<double>(), CancellationToken.None);
+
+        Assert.Equal(1, ffmpegProxy.VersionCheckCount);
+    }
+
+    private class CountingFfmpegService : DispatchProxy
+    {
+        private int _versionCheckCount;
+
+        public int VersionCheckCount => Volatile.Read(ref _versionCheckCount);
+
+        public static IFFmpegService Create(out CountingFfmpegService proxy)
+        {
+            var service = Create<IFFmpegService, CountingFfmpegService>();
+            proxy = (CountingFfmpegService)(object)service;
+            return service;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == nameof(IFFmpegService.CheckFFmpegVersionAsync))
+            {
+                Interlocked.Increment(ref _versionCheckCount);
+                return Task.FromResult(false);
+            }
+
+            throw new NotImplementedException(targetMethod?.Name);
+        }
+    }
+
+    private class QueueLibraryManager : DispatchProxy
+    {
+        private Episode _episode = null!;
+
+        public static ILibraryManager Create(Episode episode)
+        {
+            var libraryManager = Create<ILibraryManager, QueueLibraryManager>();
+            ((QueueLibraryManager)(object)libraryManager)._episode = episode;
+            return libraryManager;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(ILibraryManager.GetVirtualFolders) => new List<VirtualFolderInfo>
+                {
+                    new()
+                    {
+                        Name = "Media",
+                        ItemId = Guid.NewGuid().ToString(),
+                    },
+                },
+                nameof(ILibraryManager.GetItemList) => new List<BaseItem> { _episode },
+                nameof(ILibraryManager.GetItemById) => null,
+                _ => throw new NotImplementedException(targetMethod?.Name),
+            };
+        }
     }
 }

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
@@ -19,6 +20,121 @@ namespace IntroSkipper.Tests;
 
 public class TestFFmpegService
 {
+    [Fact]
+    public async Task CheckFFmpegVersionAsync_MemoizesSuccess()
+    {
+        var probeCount = 0;
+        var ffmpegService = CreateFFmpegService(_ =>
+        {
+            Interlocked.Increment(ref probeCount);
+            return Task.FromResult(true);
+        });
+
+        Assert.True(await ffmpegService.CheckFFmpegVersionAsync());
+        Assert.True(await ffmpegService.CheckFFmpegVersionAsync());
+        Assert.Equal(1, probeCount);
+    }
+
+    [Fact]
+    public async Task CheckFFmpegVersionAsync_RetriesFailure()
+    {
+        var probeCount = 0;
+        var ffmpegService = CreateFFmpegService(_ =>
+        {
+            Interlocked.Increment(ref probeCount);
+            return Task.FromResult(false);
+        });
+
+        Assert.False(await ffmpegService.CheckFFmpegVersionAsync());
+        Assert.False(await ffmpegService.CheckFFmpegVersionAsync());
+        Assert.Equal(2, probeCount);
+    }
+
+    [Fact]
+    public async Task CheckFFmpegVersionAsync_SharesConcurrentProbe()
+    {
+        var probeCount = 0;
+        var probeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProbe = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var ffmpegService = CreateFFmpegService(_ =>
+        {
+            Interlocked.Increment(ref probeCount);
+            probeStarted.SetResult();
+            return releaseProbe.Task;
+        });
+
+        var first = ffmpegService.CheckFFmpegVersionAsync();
+        await probeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var second = ffmpegService.CheckFFmpegVersionAsync();
+
+        Assert.Equal(1, probeCount);
+        releaseProbe.SetResult(true);
+        Assert.True(await first);
+        Assert.True(await second);
+        Assert.Equal(1, probeCount);
+    }
+
+    [Fact]
+    public async Task CheckFFmpegVersionAsync_SharesConcurrentFailedProbeThenRetries()
+    {
+        var probeCount = 0;
+        var probeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProbe = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var ffmpegService = CreateFFmpegService(_ =>
+        {
+            if (Interlocked.Increment(ref probeCount) == 1)
+            {
+                probeStarted.SetResult();
+                return releaseProbe.Task;
+            }
+
+            return Task.FromResult(true);
+        });
+
+        var first = ffmpegService.CheckFFmpegVersionAsync();
+        await probeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var second = ffmpegService.CheckFFmpegVersionAsync();
+
+        Assert.Equal(1, probeCount);
+        releaseProbe.SetResult(false);
+        Assert.False(await first);
+        Assert.False(await second);
+
+        Assert.True(await ffmpegService.CheckFFmpegVersionAsync());
+        Assert.True(await ffmpegService.CheckFFmpegVersionAsync());
+        Assert.Equal(2, probeCount);
+    }
+
+    [Fact]
+    public async Task CheckFFmpegVersionAsync_CancelsCallerWithoutCancelingSharedProbe()
+    {
+        var probeCount = 0;
+        var probeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProbe = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var ffmpegService = CreateFFmpegService(cancellationToken =>
+        {
+            Assert.False(cancellationToken.CanBeCanceled);
+            Interlocked.Increment(ref probeCount);
+            probeStarted.SetResult();
+            return releaseProbe.Task;
+        });
+        using var cancellation = new CancellationTokenSource();
+
+        var canceledCaller = ffmpegService.CheckFFmpegVersionAsync(cancellation.Token);
+        await probeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var remainingCaller = ffmpegService.CheckFFmpegVersionAsync();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledCaller);
+        Assert.False(remainingCaller.IsCompleted);
+        Assert.Equal(1, probeCount);
+
+        releaseProbe.SetResult(true);
+        Assert.True(await remainingCaller);
+        Assert.True(await ffmpegService.CheckFFmpegVersionAsync());
+        Assert.Equal(1, probeCount);
+    }
+
     #region Info Query Tests
 
     [FactSkipFFmpegTests]
@@ -219,6 +335,14 @@ public class TestFFmpegService
         return new FFmpegService(
             NullLogger<FFmpegService>.Instance,
             DatabaseTestHelpers.CreateTempCacheService());
+    }
+
+    private static FFmpegService CreateFFmpegService(Func<CancellationToken, Task<bool>> versionProbe)
+    {
+        return new FFmpegService(
+            NullLogger<FFmpegService>.Instance,
+            DatabaseTestHelpers.CreateTempCacheService(),
+            versionProbe);
     }
 
     private static QueuedEpisode QueueFile(string path)

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -32,17 +32,24 @@ public sealed partial class FFmpegService(
 
     private readonly ILogger<FFmpegService> _logger = logger;
     private readonly IDetectionCacheService _cacheService = cacheService;
+    private readonly Func<CancellationToken, Task<bool>>? _versionProbe;
 
-    // Written by CheckFFmpegVersionAsync (serialized via ScheduledTaskSemaphore) but read concurrently
-    // by the support bundle endpoint, so a concurrent dictionary is required.
+    // Version checks share one in-flight probe, but the support bundle endpoint can read
+    // these logs while that probe writes them, so a concurrent dictionary is required.
     private readonly ConcurrentDictionary<string, string> _chromaprintLogs = new();
 
-    // Memoizes a successful probe for the service lifetime: a valid ffmpeg does not
-    // spontaneously become invalid, so re-running the multi-process probe every analysis
-    // run is wasted work. A failed probe is deliberately NOT memoized — the user can fix
-    // or replace the ffmpeg binary while the server runs, and the next call must observe
-    // the recovery.
+    private readonly Lock _versionProbeLock = new();
+    private Task<bool>? _versionProbeTask;
     private volatile bool _versionProbeSucceeded;
+
+    internal FFmpegService(
+        ILogger<FFmpegService> logger,
+        IDetectionCacheService cacheService,
+        Func<CancellationToken, Task<bool>> versionProbe)
+        : this(logger, cacheService)
+    {
+        _versionProbe = versionProbe;
+    }
 
     /// <inheritdoc/>
     public async Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
@@ -54,13 +61,59 @@ public sealed partial class FFmpegService(
             return true;
         }
 
-        var valid = await ProbeFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
-        if (valid)
+        TaskCompletionSource<bool>? probeCompletion = null;
+        Task<bool> probeTask;
+        lock (_versionProbeLock)
         {
-            _versionProbeSucceeded = true;
+            if (_versionProbeSucceeded)
+            {
+                return true;
+            }
+
+            if (_versionProbeTask is null)
+            {
+                probeCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                _versionProbeTask = probeCompletion.Task;
+            }
+
+            probeTask = _versionProbeTask;
         }
 
-        return valid;
+        if (probeCompletion is not null)
+        {
+            _ = RunVersionProbeAsync(probeCompletion);
+        }
+
+        return await probeTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task RunVersionProbeAsync(TaskCompletionSource<bool> completion)
+    {
+        try
+        {
+            var valid = await (_versionProbe ?? ProbeFFmpegVersionAsync)(CancellationToken.None).ConfigureAwait(false);
+            lock (_versionProbeLock)
+            {
+                if (valid)
+                {
+                    _versionProbeSucceeded = true;
+                }
+
+                completion.SetResult(valid);
+                if (!valid)
+                {
+                    _versionProbeTask = null;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            lock (_versionProbeLock)
+            {
+                completion.SetException(ex);
+                _versionProbeTask = null;
+            }
+        }
     }
 
     private async Task<bool> ProbeFFmpegVersionAsync(CancellationToken cancellationToken)

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -37,11 +37,34 @@ public sealed partial class FFmpegService(
     // by the support bundle endpoint, so a concurrent dictionary is required.
     private readonly ConcurrentDictionary<string, string> _chromaprintLogs = new();
 
+    // Memoizes a successful probe for the service lifetime: a valid ffmpeg does not
+    // spontaneously become invalid, so re-running the multi-process probe every analysis
+    // run is wasted work. A failed probe is deliberately NOT memoized — the user can fix
+    // or replace the ffmpeg binary while the server runs, and the next call must observe
+    // the recovery.
+    private volatile bool _versionProbeSucceeded;
+
     /// <inheritdoc/>
     public async Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (_versionProbeSucceeded)
+        {
+            return true;
+        }
+
+        var valid = await ProbeFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
+        if (valid)
+        {
+            _versionProbeSucceeded = true;
+        }
+
+        return valid;
+    }
+
+    private async Task<bool> ProbeFFmpegVersionAsync(CancellationToken cancellationToken)
+    {
         try
         {
             // Always log ffmpeg's version information.

--- a/IntroSkipper/FFmpeg/IFFmpegService.cs
+++ b/IntroSkipper/FFmpeg/IFFmpegService.cs
@@ -12,7 +12,9 @@ namespace IntroSkipper.FFmpeg;
 public interface IFFmpegService
 {
     /// <summary>
-    /// Check that the installed version of ffmpeg supports chromaprint.
+    /// Check that the installed version of ffmpeg supports chromaprint. A successful
+    /// probe is memoized for the service lifetime; a failed probe is retried on the
+    /// next call so a repaired ffmpeg installation is observed without a restart.
     /// </summary>
     /// <param name="cancellationToken">Token used to cancel FFmpeg requirement checks.</param>
     /// <returns>A task that returns <see langword="true"/> if a compatible version of ffmpeg is installed, <see langword="false"/> on any error.</returns>

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -68,7 +68,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     // Per-run memo on top of the service's success-only memoization: while ffmpeg is
     // invalid the service re-probes every call, so cache the verdict here to keep an
     // analysis run at one probe instead of one per season.
-    private async Task<bool> GetFfmpegValidAsync(CancellationToken cancellationToken = default)
+    internal async Task<bool> GetFfmpegValidAsync(CancellationToken cancellationToken = default)
     {
         if (_ffmpegValid is { } cached)
         {

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -65,7 +65,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
         => GetMediaItems(includeExcluded: false, cancellationToken);
 
-    internal async Task<bool> GetFfmpegValidAsync(CancellationToken cancellationToken = default)
+    // Per-run memo on top of the service's success-only memoization: while ffmpeg is
+    // invalid the service re-probes every call, so cache the verdict here to keep an
+    // analysis run at one probe instead of one per season.
+    private async Task<bool> GetFfmpegValidAsync(CancellationToken cancellationToken = default)
     {
         if (_ffmpegValid is { } cached)
         {

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -88,7 +88,7 @@ public partial class BaseItemAnalyzerTask(
         var queueManager = _analyzerFactory.CreateQueueManager();
 
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
-        var ffmpegValid = await _ffmpegService.CheckFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
+        var ffmpegValid = await queueManager.GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
 
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -88,7 +88,7 @@ public partial class BaseItemAnalyzerTask(
         var queueManager = _analyzerFactory.CreateQueueManager();
 
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
-        var ffmpegValid = await queueManager.GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
+        var ffmpegValid = await _ffmpegService.CheckFFmpegVersionAsync(cancellationToken).ConfigureAwait(false);
 
         var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Follow-up 4 from the simplify review (stacked on #854).

FFmpeg validity was only cheap for callers holding the right `QueueManager` instance: `BaseItemAnalyzerTask` routed its check through the queue manager's per-instance memo, while every other consumer of `CheckFFmpegVersionAsync` re-ran the full multi-process probe (`-version`, `-muxers`, muxer options, silencedetect options).

- The memoization now lives where the capability does: `FFmpegService` (a DI singleton) caches a **successful** probe for the service lifetime — a valid ffmpeg does not spontaneously become invalid. Steady state is one probe per server lifetime instead of one per analysis run.
- A failed probe is deliberately **not** cached: the user can fix or replace the ffmpeg binary while the server runs, and the next call must observe the recovery (this preserves today's behavior where the next analysis run picks up a repaired install).
- `QueueManager` keeps a small per-run memo on top (now `private`), so an analysis run with broken ffmpeg still probes once instead of once per season.
- `BaseItemAnalyzerTask` calls the service directly instead of routing through its `QueueManager`.

448/448 tests passing, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Memoize successful ffmpeg capability probes in the shared FFmpeg service to avoid redundant checks across analysis runs while preserving the ability to recover from failed probes without restarting.

Enhancements:
- Introduce service-lifetime memoization of successful ffmpeg version/capability probes in FFmpegService to reduce repeated multi-process checks.
- Restrict QueueManager's ffmpeg validity helper to a private, per-run cache layered on top of the service-level memoization.
- Update BaseItemAnalyzerTask to query ffmpeg validity directly via IFFmpegService instead of routing through QueueManager.

Documentation:
- Document the memoization behavior of ffmpeg validity checks in the IFFmpegService interface XML comments.