### PR TITLE
Fix blank config page after view eviction with module script

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -128,8 +128,13 @@ findAndBind();
 // the lifetime of the document so a freshly injected, unbound root is picked
 // up and bound again.
 const observer = new MutationObserver(() => {
-    if (boundRoot?.isConnected) {
-        return;
+    if (boundRoot) {
+        if (boundRoot.isConnected) {
+            return;
+        }
+
+        // Release the evicted view subtree so it can be garbage collected.
+        boundRoot = null;
     }
 
     findAndBind();

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -31,10 +31,10 @@ const tabs: readonly Tab[] = [
 
 const ROOT_SELECTOR = "#intro-skipper-dashboard-root";
 const DEFAULT_TAB_ID = "general";
-const OBSERVER_TIMEOUT_MS = 30_000;
 
 let cleanupPage: (() => void) | null = null;
 let mountVersion = 0;
+let boundRoot: HTMLElement | null = null;
 
 function destroyMountedPage(): void {
     mountVersion += 1;
@@ -90,6 +90,7 @@ function bindPage(rootEl: HTMLElement): void {
     }
 
     rootEl.dataset.introSkipperBound = "true";
+    boundRoot = rootEl;
 
     const page = getPageElement(rootEl);
 
@@ -117,17 +118,22 @@ function findAndBind(): boolean {
     return true;
 }
 
-if (!findAndBind()) {
-    const observer = new MutationObserver(() => {
-        if (findAndBind()) {
-            observer.disconnect();
-            window.clearTimeout(observerTimeoutId);
-        }
-    });
+findAndBind();
 
-    const observerRoot = document.body ?? document.documentElement;
-    observer.observe(observerRoot, { childList: true, subtree: true });
+// This bundle is loaded as `<script type="module">`, so the browser's module
+// map evaluates it at most once per document. Jellyfin's view manager keeps
+// only a few views cached and re-injects the config page HTML (including this
+// script tag) with a brand-new DOM once the view has been evicted, but that
+// re-injection never re-runs an already-evaluated module. Keep observing for
+// the lifetime of the document so a freshly injected, unbound root is picked
+// up and bound again.
+const observer = new MutationObserver(() => {
+    if (boundRoot?.isConnected) {
+        return;
+    }
 
-    // Safety net: stop observing if the page never appears.
-    const observerTimeoutId = window.setTimeout(() => observer.disconnect(), OBSERVER_TIMEOUT_MS);
-}
+    findAndBind();
+});
+
+const observerRoot = document.body ?? document.documentElement;
+observer.observe(observerRoot, { childList: true, subtree: true });


### PR DESCRIPTION
Since 7e6741b the dashboard bundle is loaded with `<script type="module">`, and the browser's module map evaluates a module URL at most once per document. Jellyfin's `viewContainer` keeps only 3 cached views; once the config page is evicted (e.g. after visiting other plugin pages) a revisit re-fetches the HTML and re-injects the script tag via jQuery's `DOMEval`, but the already-evaluated module never runs again — the freshly created `#intro-skipper-dashboard-root` stays unbound and the config page renders blank until a full browser reload. Before the module switch, jQuery re-executed the classic script on every injection, which is what the one-shot bootstrap relied on.

The fix keeps the bootstrap `MutationObserver` alive for the lifetime of the document instead of disconnecting after the first successful bind, and tracks the currently bound root so the observer callback is a cheap `isConnected` check while the page is live. When Jellyfin injects a new, unbound root after eviction, the observer rebinds and remounts it; the existing `data-intro-skipper-bound` guard still prevents double-binding.

Verified in headless Chrome by simulating Jellyfin's eviction flow (remove page DOM, inject fresh root, re-add the module script exactly like jQuery `DOMEval` does): the old bundle leaves the second root unbound and empty, the fixed bundle rebinds and renders (`secondBound:true`). `tsc && vite build` passes.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/0a3c32b8-d51e-48d8-853e-1c9ee4a969b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-109" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/0a3c32b8-d51e-48d8-853e-1c9ee4a969b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-109&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-109"><img alt="INTRO-109" src="https://capy.ai/api/badge/thread.svg?label=INTRO-109"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Keep the dashboard bootstrap observer active for the lifetime of the document so newly injected config page roots are re-bound after Jellyfin view eviction.

Bug Fixes:
- Prevent the dashboard config page from rendering blank when its view is evicted and reloaded under a module script setup.

Enhancements:
- Track the currently bound root element to avoid unnecessary re-binding while the page remains connected.