### PR TITLE
Fix blank config page after view eviction with module script (12.0)

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -128,8 +128,13 @@ findAndBind();
 // the lifetime of the document so a freshly injected, unbound root is picked
 // up and bound again.
 const observer = new MutationObserver(() => {
-    if (boundRoot?.isConnected) {
-        return;
+    if (boundRoot) {
+        if (boundRoot.isConnected) {
+            return;
+        }
+
+        // Release the evicted view subtree so it can be garbage collected.
+        boundRoot = null;
     }
 
     findAndBind();

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -31,10 +31,10 @@ const tabs: readonly Tab[] = [
 
 const ROOT_SELECTOR = "#intro-skipper-dashboard-root";
 const DEFAULT_TAB_ID = "general";
-const OBSERVER_TIMEOUT_MS = 30_000;
 
 let cleanupPage: (() => void) | null = null;
 let mountVersion = 0;
+let boundRoot: HTMLElement | null = null;
 
 function destroyMountedPage(): void {
     mountVersion += 1;
@@ -90,6 +90,7 @@ function bindPage(rootEl: HTMLElement): void {
     }
 
     rootEl.dataset.introSkipperBound = "true";
+    boundRoot = rootEl;
 
     const page = getPageElement(rootEl);
 
@@ -117,17 +118,22 @@ function findAndBind(): boolean {
     return true;
 }
 
-if (!findAndBind()) {
-    const observer = new MutationObserver(() => {
-        if (findAndBind()) {
-            observer.disconnect();
-            window.clearTimeout(observerTimeoutId);
-        }
-    });
+findAndBind();
 
-    const observerRoot = document.body ?? document.documentElement;
-    observer.observe(observerRoot, { childList: true, subtree: true });
+// This bundle is loaded as `<script type="module">`, so the browser's module
+// map evaluates it at most once per document. Jellyfin's view manager keeps
+// only a few views cached and re-injects the config page HTML (including this
+// script tag) with a brand-new DOM once the view has been evicted, but that
+// re-injection never re-runs an already-evaluated module. Keep observing for
+// the lifetime of the document so a freshly injected, unbound root is picked
+// up and bound again.
+const observer = new MutationObserver(() => {
+    if (boundRoot?.isConnected) {
+        return;
+    }
 
-    // Safety net: stop observing if the page never appears.
-    const observerTimeoutId = window.setTimeout(() => observer.disconnect(), OBSERVER_TIMEOUT_MS);
-}
+    findAndBind();
+});
+
+const observerRoot = document.body ?? document.documentElement;
+observer.observe(observerRoot, { childList: true, subtree: true });


### PR DESCRIPTION
Ports #860 to the 12.0 branch, which has the same `<script type="module">` config page (from 7e6741b) and the same one-shot bootstrap. Because the browser's module map evaluates a module URL at most once per document, Jellyfin's `viewContainer` re-injecting the config page with fresh DOM after view-cache eviction never re-runs the bundle, leaving the new `#intro-skipper-dashboard-root` unbound and the page blank until a full reload.

Same fix as #860: keep the bootstrap `MutationObserver` alive for the document lifetime and track the currently bound root (cheap `isConnected` check while live), so a freshly injected unbound root is rebound and remounted. Verified in headless Chrome on the 10.11 bundle by simulating the eviction/re-injection flow; the cherry-pick applies cleanly here and `tsc && vite build` passes on 12.0.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/0a3c32b8-d51e-48d8-853e-1c9ee4a969b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-109" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/0a3c32b8-d51e-48d8-853e-1c9ee4a969b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-109&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-109"><img alt="INTRO-109" src="https://capy.ai/api/badge/thread.svg?label=INTRO-109"></picture></a>
<!-- capy-pr-badge:end -->