### PR TITLE
Scope Jellyfin segment deletion by item id

### DIFF
--- a/IntroSkipper.Tests/FakeJellyfinSegmentStore.cs
+++ b/IntroSkipper.Tests/FakeJellyfinSegmentStore.cs
@@ -21,8 +21,8 @@ internal sealed class FakeJellyfinSegmentStore : IJellyfinSegmentStore
     private int _writeCount;
 
     /// <summary>
-    /// Gets the segments served by <see cref="GetSegmentAsync"/>, matched by segment id
-    /// only (editor tests build entries without an item id).
+    /// Gets the segments served by <see cref="GetSegmentAsync"/>, matched by item id and
+    /// segment id exactly like the production store.
     /// </summary>
     public IReadOnlyList<MediaSegmentDto> ExistingSegments { get; init; } = [];
 
@@ -53,7 +53,7 @@ internal sealed class FakeJellyfinSegmentStore : IJellyfinSegmentStore
 
     public List<(Guid ItemId, MediaSegmentDto Segment)> CreatedCommercials { get; } = [];
 
-    public List<Guid> DeletedSegmentIds { get; } = [];
+    public List<(Guid ItemId, Guid SegmentId)> DeletedSegments { get; } = [];
 
     public List<Guid> DeletedOwnItemIds { get; } = [];
 
@@ -101,12 +101,12 @@ internal sealed class FakeJellyfinSegmentStore : IJellyfinSegmentStore
     }
 
     public Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
-        => Task.FromResult(ExistingSegments.FirstOrDefault(segment => segment.Id == segmentId));
+        => Task.FromResult(ExistingSegments.FirstOrDefault(segment => segment.ItemId == itemId && segment.Id == segmentId));
 
-    public Task DeleteSegmentAsync(Guid segmentId, CancellationToken cancellationToken)
+    public Task DeleteSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
     {
         ThrowIfConfigured(DeleteSegmentException);
-        DeletedSegmentIds.Add(segmentId);
+        DeletedSegments.Add((itemId, segmentId));
         return Task.CompletedTask;
     }
 

--- a/IntroSkipper.Tests/TestJellyfinSegmentStore.cs
+++ b/IntroSkipper.Tests/TestJellyfinSegmentStore.cs
@@ -244,10 +244,32 @@ public sealed class TestJellyfinSegmentStore
         var own = CreateEntity(itemId, MediaSegmentType.Outro, 30, 40, JellyfinSegmentStore.ProviderId);
         await SeedAsync(db, foreign, own);
 
-        await store.DeleteSegmentAsync(foreign.Id, CancellationToken.None);
+        await store.DeleteSegmentAsync(itemId, foreign.Id, CancellationToken.None);
 
         var row = Assert.Single(await GetAllAsync(db));
         Assert.Equal(own.Id, row.Id);
+    }
+
+    [Fact]
+    public async Task DeleteSegmentAsync_IgnoresRowsOfOtherItems()
+    {
+        using var db = new TempJellyfinDb();
+        var store = CreateStore(db);
+        var itemA = Guid.NewGuid();
+        var itemB = Guid.NewGuid();
+        var rowA = CreateEntity(itemA, MediaSegmentType.Intro, 10, 20, JellyfinSegmentStore.ProviderId);
+        await SeedAsync(db, rowA);
+
+        // A mismatched item id must not delete another item's segment.
+        await store.DeleteSegmentAsync(itemB, rowA.Id, CancellationToken.None);
+        Assert.Single(await GetAllAsync(db));
+
+        // An unknown segment id is a no-op rather than an error.
+        await store.DeleteSegmentAsync(itemA, Guid.NewGuid(), CancellationToken.None);
+        Assert.Single(await GetAllAsync(db));
+
+        await store.DeleteSegmentAsync(itemA, rowA.Id, CancellationToken.None);
+        Assert.Empty(await GetAllAsync(db));
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
@@ -109,8 +109,8 @@ public sealed class TestMediaSegmentEditorService
         {
             ExistingSegments =
             [
-                CreateSegment(MediaSegmentType.Outro, 30, 40, Guid.NewGuid()),
-                CreateSegment(MediaSegmentType.Intro, 10, 20, segmentId)
+                CreateSegment(MediaSegmentType.Outro, 30, 40, Guid.NewGuid(), itemId),
+                CreateSegment(MediaSegmentType.Intro, 10, 20, segmentId, itemId)
             ]
         };
         var service = CreateService(store);
@@ -119,6 +119,19 @@ public sealed class TestMediaSegmentEditorService
 
         Assert.NotNull(result);
         Assert.Equal(segmentId, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetSegmentAsync_ReturnsNull_WhenItemIdDoesNotMatch()
+    {
+        var segmentId = Guid.NewGuid();
+        var store = new FakeJellyfinSegmentStore
+        {
+            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, segmentId, Guid.NewGuid())]
+        };
+        var service = CreateService(store);
+
+        Assert.Null(await service.GetSegmentAsync(Guid.NewGuid(), segmentId, CancellationToken.None));
     }
 
     [Fact]
@@ -155,11 +168,12 @@ public sealed class TestMediaSegmentEditorService
     {
         var store = new FakeJellyfinSegmentStore();
         var service = CreateService(store);
+        var itemId = Guid.NewGuid();
         var segmentId = Guid.NewGuid();
 
-        await service.DeleteSegmentAsync(segmentId, CancellationToken.None);
+        await service.DeleteSegmentAsync(itemId, segmentId, CancellationToken.None);
 
-        Assert.Equal([segmentId], store.DeletedSegmentIds);
+        Assert.Equal([(itemId, segmentId)], store.DeletedSegments);
     }
 
     private static MediaSegmentEditorService CreateService(FakeJellyfinSegmentStore store)
@@ -173,10 +187,11 @@ public sealed class TestMediaSegmentEditorService
         return item;
     }
 
-    private static MediaSegmentDto CreateSegment(MediaSegmentType type, long startTicks, long endTicks, Guid id = default)
+    private static MediaSegmentDto CreateSegment(MediaSegmentType type, long startTicks, long endTicks, Guid id = default, Guid itemId = default)
         => new()
         {
             Id = id,
+            ItemId = itemId,
             Type = type,
             StartTicks = startTicks,
             EndTicks = endTicks

--- a/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
@@ -137,13 +137,14 @@ public sealed class TestMediaSegmentEditorService
     [Fact]
     public async Task GetSegmentAsync_ReturnsNull_WhenSegmentIdDoesNotMatch()
     {
+        var itemId = Guid.NewGuid();
         var store = new FakeJellyfinSegmentStore
         {
-            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, Guid.NewGuid())]
+            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, Guid.NewGuid(), itemId)]
         };
         var service = CreateService(store);
 
-        var result = await service.GetSegmentAsync(Guid.NewGuid(), Guid.NewGuid(), CancellationToken.None);
+        var result = await service.GetSegmentAsync(itemId, Guid.NewGuid(), CancellationToken.None);
 
         Assert.Null(result);
     }

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -10,8 +10,11 @@ using System.Threading.Tasks;
 using IntroSkipper.Controllers;
 using IntroSkipper.Data;
 using IntroSkipper.Manager;
+using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Model.MediaSegments;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 /// <summary>
@@ -117,7 +120,7 @@ public sealed class SegmentEditorControllerTests
         var response = await controller.DeleteSegmentAsync(segmentId, itemId, "intro", CancellationToken.None);
 
         Assert.IsType<BadRequestObjectResult>(response);
-        Assert.Empty(store.DeletedSegmentIds);
+        Assert.Empty(store.DeletedSegments);
 
         var rows = await database.GetSegmentsAsync(itemId);
         Assert.Equal(2, rows.Count);
@@ -235,7 +238,55 @@ public sealed class SegmentEditorControllerTests
         await controller.DeleteSegmentAsync(segmentId, itemId, "intro", CancellationToken.None);
 
         Assert.Empty(await database.GetSegmentsAsync(itemId));
-        Assert.Equal([segmentId], store.DeletedSegmentIds);
+        Assert.Equal([(itemId, segmentId)], store.DeletedSegments);
+    }
+
+    [Fact]
+    public async Task DeleteSegment_WithMismatchedItemId_NeverTouchesOtherItemsJellyfinRow()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
+        using var jellyfinDb = new TempJellyfinDb();
+        var store = new JellyfinSegmentStore(jellyfinDb.Factory, NullLogger<JellyfinSegmentStore>.Instance);
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+
+        var itemA = Guid.NewGuid();
+        var itemB = Guid.NewGuid();
+        var segmentIdA = Guid.NewGuid();
+
+        var context = jellyfinDb.Factory.CreateDbContext();
+        await using (context)
+        {
+            context.MediaSegments.Add(new MediaSegment
+            {
+                Id = segmentIdA,
+                ItemId = itemA,
+                Type = Jellyfin.Database.Implementations.Enums.MediaSegmentType.Intro,
+                StartTicks = TimeSpan.FromSeconds(10).Ticks,
+                EndTicks = TimeSpan.FromSeconds(60).Ticks,
+                SegmentProviderId = JellyfinSegmentStore.ProviderId,
+            });
+            await context.SaveChangesAsync();
+        }
+
+        await database.UpdateTimestampAsync(new Segment(itemB, new TimeRange(100, 160)), AnalysisMode.Introduction, isUserProvided: true, configHash: "cfg-b");
+
+        var controller = new SegmentEditorController(new MediaSegmentEditorService(store), database);
+
+        // Item B's id paired with item A's segment id: the caller's own orphaned plugin row
+        // is still cleaned up, but item A's Jellyfin segment must survive.
+        var result = await controller.DeleteSegmentAsync(segmentIdA, itemB, "intro", CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
+        Assert.Empty(await database.GetSegmentsAsync(itemB));
+
+        var verify = jellyfinDb.Factory.CreateDbContext();
+        await using (verify)
+        {
+            var survivor = Assert.Single(await verify.MediaSegments.AsNoTracking().ToListAsync());
+            Assert.Equal(itemA, survivor.ItemId);
+            Assert.Equal(segmentIdA, survivor.Id);
+        }
     }
 
     private static SegmentEditorController CreateController(

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -148,7 +148,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
 
         try
         {
-            await _mediaSegmentEditorService.DeleteSegmentAsync(segmentId, cancellationToken).ConfigureAwait(false);
+            await _mediaSegmentEditorService.DeleteSegmentAsync(itemId, segmentId, cancellationToken).ConfigureAwait(false);
         }
         catch
         {

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -89,12 +89,13 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
     /// Delete MediaSgment by segment id.
     /// </summary>
     /// <param name="segmentId">The Id of the media segment to delete.</param>
-    /// <param name="itemId">The item id the segment belongs to (used to remove plugin DB entry).</param>
+    /// <param name="itemId">The item id that owns the segment; scopes both the plugin DB row and the Jellyfin delete.</param>
     /// <param name="type">The media segment type name (Intro/Recap/Preview/Outro).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// HTTP 200 on success, 400 when the requested type does not match the Jellyfin segment,
-    /// or 404 when the commercial segment is not found.
+    /// or 404 when the commercial segment is not found. A segment id owned by a different item
+    /// leaves Jellyfin untouched while the item's own plugin row is still removed.
     /// </returns>
     [HttpDelete("{segmentId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/IntroSkipper/Manager/IJellyfinSegmentStore.cs
+++ b/IntroSkipper/Manager/IJellyfinSegmentStore.cs
@@ -60,10 +60,13 @@ public interface IJellyfinSegmentStore
     Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Deletes a segment by id, regardless of provider.
+    /// Deletes a segment by id when it belongs to the given item, regardless of provider.
+    /// A segment id owned by a different item is left untouched, and an unknown id is a
+    /// no-op so callers can clean up plugin-side rows whose Jellyfin row is already gone.
     /// </summary>
+    /// <param name="itemId">The item id that must own the segment.</param>
     /// <param name="segmentId">The segment id.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task DeleteSegmentAsync(Guid segmentId, CancellationToken cancellationToken);
+    Task DeleteSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken);
 }

--- a/IntroSkipper/Manager/JellyfinSegmentStore.cs
+++ b/IntroSkipper/Manager/JellyfinSegmentStore.cs
@@ -174,15 +174,17 @@ public sealed partial class JellyfinSegmentStore(
     }
 
     /// <inheritdoc />
-    public async Task DeleteSegmentAsync(Guid segmentId, CancellationToken cancellationToken)
+    public async Task DeleteSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
     {
         var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await using (db.ConfigureAwait(false))
         {
             // Deliberately not scoped to Intro Skipper's provider id: the editor lets
-            // users remove any segment by id, matching IMediaSegmentManager semantics.
+            // users remove any of the item's segments by id. It is scoped to the item,
+            // unlike IMediaSegmentManager, so a caller holding a stale or mismatched
+            // segment id can never delete another item's segment.
             await db.MediaSegments
-                .Where(segment => segment.Id == segmentId)
+                .Where(segment => segment.ItemId == itemId && segment.Id == segmentId)
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
         }

--- a/IntroSkipper/Manager/MediaSegmentEditorService.cs
+++ b/IntroSkipper/Manager/MediaSegmentEditorService.cs
@@ -60,12 +60,13 @@ public class MediaSegmentEditorService(IJellyfinSegmentStore segmentStore)
     /// <summary>
     /// Deletes a segment.
     /// </summary>
+    /// <param name="itemId">The Id of the item that owns the segment.</param>
     /// <param name="segmentId">The Id of the segment.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task DeleteSegmentAsync(Guid segmentId, CancellationToken cancellationToken)
+    public async Task DeleteSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
     {
-        await _segmentStore.DeleteSegmentAsync(segmentId, cancellationToken).ConfigureAwait(false);
+        await _segmentStore.DeleteSegmentAsync(itemId, segmentId, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #862. The editor's delete endpoint verified ownership with an `(itemId, segmentId)` lookup but then deleted by `segmentId` alone, so a request pairing item B's id with item A's segment id returned `200 OK` while deleting item A's Jellyfin segment — and item B's plugin-side timestamp with it. `JellyfinSegmentStore.DeleteSegmentAsync` now takes the item id and includes it in the delete predicate: mismatched pairs can no longer touch another item's rows, while unknown segment ids remain a no-op so the existing orphan-cleanup flow (plugin row outliving its Jellyfin segment) keeps working.

- `FakeJellyfinSegmentStore.GetSegmentAsync` now matches item id and segment id exactly like the production store; the lax segment-id-only matching made the mismatched-pair scenario unrepresentable in service and controller tests, and let `GetSegmentAsync_ReturnsMatchingSegment` pass with entries whose `ItemId` was never set.
- Regression tests pin the new behavior at both levels: the store ignores delete requests naming another item's segment, and the controller flow leaves the foreign Jellyfin row intact while still cleaning the caller's own orphaned plugin row.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/d2f42ac3-852d-41a6-83ac-cc8643b2cf25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-121" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/d2f42ac3-852d-41a6-83ac-cc8643b2cf25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-121&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-121"><img alt="INTRO-121" src="https://capy.ai/api/badge/thread.svg?label=INTRO-121"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Scope Jellyfin segment deletion and lookup to the owning item id to prevent cross-item segment removal, and update the editor service, controller, and tests to reflect the new contract.

Bug Fixes:
- Prevent delete requests with mismatched item and segment ids from removing another item's Jellyfin segment or plugin-side timestamp.

Enhancements:
- Change the Jellyfin segment store, interface, and editor service to require an item id when deleting a segment, treating unknown segment ids as a no-op.
- Align FakeJellyfinSegmentStore behavior with the production store by matching segments on both item id and segment id.

Tests:
- Extend controller, service, and Jellyfin store tests to cover item-scoped deletes, mismatched item/segment scenarios, and no-op behavior for unknown segment ids.