### PR TITLE
Do not override user provided timestamps

### DIFF
--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -145,10 +145,10 @@ public sealed class TestVisualizationController
         {
             Assert.True(await db.DbDisabledEpisode.AnyAsync(e => e.SeasonId == seasonId && e.EpisodeId == episodeIds[0]));
         }
-        var disabledSegments = await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[0]);
+        var disabledSegments = await Plugin.GetSegmentsForOutputAsync(episodeIds[0]);
         var retainedSegment = Assert.Single(disabledSegments);
         Assert.True(retainedSegment.IsUserProvided);
-        Assert.Single(await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[1]));
+        Assert.Single(await Plugin.GetSegmentsForOutputAsync(episodeIds[1]));
 
         var disabled = await controller.GetDisabledEpisodes(seasonId, CancellationToken.None);
         var disabledIds = Assert.IsAssignableFrom<IReadOnlySet<Guid>>(Assert.IsType<OkObjectResult>(disabled.Result).Value);
@@ -159,7 +159,7 @@ public sealed class TestVisualizationController
             CancellationToken.None);
 
         Assert.IsType<NoContentResult>(enableResult);
-        var enabledSegments = await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[0]);
+        var enabledSegments = await Plugin.GetSegmentsForOutputAsync(episodeIds[0]);
         Assert.Equal(2, enabledSegments.Count);
         Assert.Equal(2, refresher.RefreshCallCount);
         Assert.Equal(0, refresher.RemoveCallCount);

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -128,7 +128,7 @@ public sealed class TestVisualizationController
         var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
         var dbPath = CreateTempDbPath();
         using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: false);
-        await SeedSeasonAsync(dbPath, seasonId, episodeIds);
+        await SeedSeasonAsync(dbPath, seasonId, episodeIds, includeUserProvidedSegments: true);
         var refresher = new RecordingMediaSegmentRefresher();
         using var loggerFactory = LoggerFactory.Create(builder => { });
         var controller = CreateController(refresher, loggerFactory);
@@ -159,7 +159,8 @@ public sealed class TestVisualizationController
             CancellationToken.None);
 
         Assert.IsType<NoContentResult>(enableResult);
-        Assert.Single(await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[0]));
+        var enabledSegments = await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[0]);
+        Assert.Equal(2, enabledSegments.Count);
         Assert.Equal(2, refresher.RefreshCallCount);
         Assert.Equal(0, refresher.RemoveCallCount);
         await using (var db = new IntroSkipperDbContext(dbPath))
@@ -204,14 +205,28 @@ public sealed class TestVisualizationController
         return scope;
     }
 
-    private static async Task SeedSeasonAsync(string dbPath, Guid seasonId, IReadOnlyList<Guid> episodeIds)
+    private static async Task SeedSeasonAsync(
+        string dbPath,
+        Guid seasonId,
+        IReadOnlyList<Guid> episodeIds,
+        bool includeUserProvidedSegments = false)
     {
         await using var db = new IntroSkipperDbContext(dbPath);
         await db.Database.EnsureCreatedAsync();
-        db.DbSegment.AddRange(
-            new DbSegment(new Segment(episodeIds[0], new TimeRange(10, 20)), AnalysisMode.Introduction, isUserProvided: true),
-            new DbSegment(new Segment(episodeIds[0], new TimeRange(20, 30)), AnalysisMode.Credits),
-            new DbSegment(new Segment(episodeIds[1], new TimeRange(30, 40)), AnalysisMode.Introduction));
+        var segments = new List<DbSegment>
+        {
+            new DbSegment(
+                new Segment(episodeIds[0], new TimeRange(10, 20)),
+                AnalysisMode.Introduction,
+                isUserProvided: includeUserProvidedSegments)
+        };
+        if (includeUserProvidedSegments)
+        {
+            segments.Add(new DbSegment(new Segment(episodeIds[0], new TimeRange(20, 30)), AnalysisMode.Credits));
+        }
+
+        segments.Add(new DbSegment(new Segment(episodeIds[1], new TimeRange(30, 40)), AnalysisMode.Introduction));
+        db.DbSegment.AddRange(segments);
         db.DbSeasonState.AddRange(
             new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, episodeIds),
             new DbSeasonState(seasonId, AnalysisMode.Credits, AnalyzerAction.Default, episodeIds));

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -139,11 +139,15 @@ public sealed class TestVisualizationController
 
         Assert.IsType<NoContentResult>(disableResult);
         Assert.Equal([episodeIds[0]], refresher.LastItemIds);
+        Assert.Equal(1, refresher.RefreshCallCount);
+        Assert.Equal(0, refresher.RemoveCallCount);
         await using (var db = new IntroSkipperDbContext(dbPath))
         {
             Assert.True(await db.DbDisabledEpisode.AnyAsync(e => e.SeasonId == seasonId && e.EpisodeId == episodeIds[0]));
         }
-        Assert.Empty(await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[0]));
+        var disabledSegments = await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[0]);
+        var retainedSegment = Assert.Single(disabledSegments);
+        Assert.True(retainedSegment.IsUserProvided);
         Assert.Single(await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[1]));
 
         var disabled = await controller.GetDisabledEpisodes(seasonId, CancellationToken.None);
@@ -156,6 +160,8 @@ public sealed class TestVisualizationController
 
         Assert.IsType<NoContentResult>(enableResult);
         Assert.Single(await Plugin.GetSegmentsUnlessExcludedAsync(episodeIds[0]));
+        Assert.Equal(2, refresher.RefreshCallCount);
+        Assert.Equal(0, refresher.RemoveCallCount);
         await using (var db = new IntroSkipperDbContext(dbPath))
         {
             Assert.False(await db.DbDisabledEpisode.AnyAsync(e => e.SeasonId == seasonId && e.EpisodeId == episodeIds[0]));
@@ -203,7 +209,8 @@ public sealed class TestVisualizationController
         await using var db = new IntroSkipperDbContext(dbPath);
         await db.Database.EnsureCreatedAsync();
         db.DbSegment.AddRange(
-            new DbSegment(new Segment(episodeIds[0], new TimeRange(10, 20)), AnalysisMode.Introduction),
+            new DbSegment(new Segment(episodeIds[0], new TimeRange(10, 20)), AnalysisMode.Introduction, isUserProvided: true),
+            new DbSegment(new Segment(episodeIds[0], new TimeRange(20, 30)), AnalysisMode.Credits),
             new DbSegment(new Segment(episodeIds[1], new TimeRange(30, 40)), AnalysisMode.Introduction));
         db.DbSeasonState.AddRange(
             new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, episodeIds),
@@ -233,6 +240,10 @@ public sealed class TestVisualizationController
 
         public int CollectionCallCount { get; private set; }
 
+        public int RefreshCallCount { get; private set; }
+
+        public int RemoveCallCount { get; private set; }
+
         public IReadOnlyList<Guid> LastItemIds { get; private set; } = [];
 
         public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
@@ -243,12 +254,17 @@ public sealed class TestVisualizationController
 
         public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
         {
+            RefreshCallCount++;
             CollectionCallCount++;
             LastItemIds = [.. itemIds];
             return Completion?.Task ?? Task.CompletedTask;
         }
 
         public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
-            => RefreshAsync(itemIds, cancellationToken);
+        {
+            RemoveCallCount++;
+            LastItemIds = [.. itemIds];
+            return Completion?.Task ?? Task.CompletedTask;
+        }
     }
 }

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -263,6 +263,7 @@ public sealed class TestVisualizationController
 
         public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
         {
+            RefreshCallCount++;
             LastItemIds = [item.Id];
             return Completion?.Task ?? Task.CompletedTask;
         }
@@ -278,6 +279,7 @@ public sealed class TestVisualizationController
         public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
         {
             RemoveCallCount++;
+            RefreshCallCount++;
             LastItemIds = [.. itemIds];
             return Completion?.Task ?? Task.CompletedTask;
         }

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -279,9 +279,7 @@ public sealed class TestVisualizationController
         public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
         {
             RemoveCallCount++;
-            RefreshCallCount++;
-            LastItemIds = [.. itemIds];
-            return Completion?.Task ?? Task.CompletedTask;
+            return RefreshAsync(itemIds, cancellationToken);
         }
     }
 }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -110,14 +110,9 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
             request.Disabled,
             cancellationToken).ConfigureAwait(false);
 
-        if (request.Disabled)
-        {
-            await _mediaSegmentRefresher.RemoveIntroSkipperSegmentsAsync([request.EpisodeId], cancellationToken).ConfigureAwait(false);
-        }
-        else
-        {
-            await _mediaSegmentRefresher.RefreshAsync([request.EpisodeId], cancellationToken).ConfigureAwait(false);
-        }
+        // Refresh in both directions. The provider filters automatic rows for a disabled episode
+        // while retaining user-provided rows, so a delete-only refresh would remove user edits.
+        await _mediaSegmentRefresher.RefreshAsync([request.EpisodeId], cancellationToken).ConfigureAwait(false);
 
         return NoContent();
     }

--- a/IntroSkipper/Manager/IMediaSegmentRefresher.cs
+++ b/IntroSkipper/Manager/IMediaSegmentRefresher.cs
@@ -24,7 +24,9 @@ public interface IMediaSegmentRefresher
     Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Removes Intro Skipper-owned media segments by refreshing items with only other providers.
+    /// Removes Intro Skipper-owned media segments by refreshing each item with only other providers.
+    /// Existing segments are deleted before the refresh, so this operation both removes the
+    /// Intro Skipper segments and refreshes the remaining providers' output.
     /// </summary>
     /// <param name="itemIds">The item ids whose Intro Skipper segments should be removed.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -452,20 +452,14 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     internal static async Task<IReadOnlyList<DbSegment>> GetSegmentsForOutputAsync(Guid id, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        var disabledEpisodeIds = db.DbDisabledEpisode
+        var isDisabled = await db.DbDisabledEpisode
             .AsNoTracking()
-            .Where(e => e.EpisodeId == id)
-            .Select(e => (Guid?)e.EpisodeId)
-            .Distinct();
+            .AnyAsync(e => e.EpisodeId == id, cancellationToken)
+            .ConfigureAwait(false);
 
-        var query =
-            from segment in db.DbSegment.AsNoTracking()
-            join disabledEpisodeId in disabledEpisodeIds
-                on (Guid?)segment.ItemId equals disabledEpisodeId into disabledEpisodeMatches
-            from disabledEpisodeId in disabledEpisodeMatches.DefaultIfEmpty()
-            where segment.ItemId == id &&
-                  (disabledEpisodeId == null || segment.IsUserProvided)
-            select segment;
+        var query = db.DbSegment
+            .AsNoTracking()
+            .Where(segment => segment.ItemId == id && (!isDisabled || segment.IsUserProvided));
 
         return await query
             .ToListAsync(cancellationToken)

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -443,17 +443,19 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     }
 
     /// <summary>
-    /// Gets the segments for an episode, returning none when the episode is excluded from media-segment output.
+    /// Gets the segments for an episode, excluding automatically generated segments when the episode is
+    /// excluded from media-segment output while retaining user-provided segments.
     /// </summary>
     /// <param name="id">Episode identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The episode's segments, or an empty list when the episode is excluded.</returns>
+    /// <returns>The episode's media-segment output.</returns>
     internal static async Task<IReadOnlyList<DbSegment>> GetSegmentsUnlessExcludedAsync(Guid id, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
         return await db.DbSegment
             .AsNoTracking()
-            .Where(s => s.ItemId == id && !db.DbDisabledEpisode.Any(e => e.EpisodeId == id))
+            .Where(s => s.ItemId == id &&
+                        (!db.DbDisabledEpisode.Any(e => e.EpisodeId == id) || s.IsUserProvided))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
     }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -443,19 +443,31 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     }
 
     /// <summary>
-    /// Gets the segments for an episode, excluding automatically generated segments when the episode is
-    /// excluded from media-segment output while retaining user-provided segments.
+    /// Gets the segments for media-segment output. When an episode is excluded, only its user-provided
+    /// segments are returned; otherwise, all of its segments are returned.
     /// </summary>
     /// <param name="id">Episode identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The episode's media-segment output.</returns>
-    internal static async Task<IReadOnlyList<DbSegment>> GetSegmentsUnlessExcludedAsync(Guid id, CancellationToken cancellationToken = default)
+    internal static async Task<IReadOnlyList<DbSegment>> GetSegmentsForOutputAsync(Guid id, CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
-        return await db.DbSegment
+        var disabledEpisodeIds = db.DbDisabledEpisode
             .AsNoTracking()
-            .Where(s => s.ItemId == id &&
-                        (!db.DbDisabledEpisode.Any(e => e.EpisodeId == id) || s.IsUserProvided))
+            .Where(e => e.EpisodeId == id)
+            .Select(e => (Guid?)e.EpisodeId)
+            .Distinct();
+
+        var query =
+            from segment in db.DbSegment.AsNoTracking()
+            join disabledEpisodeId in disabledEpisodeIds
+                on (Guid?)segment.ItemId equals disabledEpisodeId into disabledEpisodeMatches
+            from disabledEpisodeId in disabledEpisodeMatches.DefaultIfEmpty()
+            where segment.ItemId == id &&
+                  (disabledEpisodeId == null || segment.IsUserProvided)
+            select segment;
+
+        return await query
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
     }

--- a/IntroSkipper/Providers/SegmentProvider.cs
+++ b/IntroSkipper/Providers/SegmentProvider.cs
@@ -41,7 +41,7 @@ namespace IntroSkipper.Providers
             ArgumentNullException.ThrowIfNull(Plugin.Instance);
 
             var segments = new List<MediaSegmentDto>();
-            var itemSegments = await Plugin.GetSegmentsUnlessExcludedAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
+            var itemSegments = await Plugin.GetSegmentsForOutputAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
             var dedupedModes = new HashSet<AnalysisMode>();
 
             foreach (var segment in itemSegments.OrderBy(segment => segment.Start))


### PR DESCRIPTION
## Summary by Sourcery

Preserve user-provided media segments when episodes are disabled by changing segment retrieval and refresh behavior.

New Features:
- Support returning user-provided segments for disabled episodes via a dedicated segment-output query.

Bug Fixes:
- Prevent removal or override of user-provided media segments when toggling an episode’s disabled state.

Enhancements:
- Unify visualization refresh behavior to always perform a full refresh regardless of disabled state.
- Extend tests to cover segment preservation and media refresher call patterns when disabling and re-enabling episodes.

Tests:
- Add and update visualization controller tests to validate user-provided segment retention, output counts, and media refresher interactions.