### PR TITLE
Feed full darkness distribution to recap black frame normalization

### DIFF
--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -9,6 +9,7 @@ namespace IntroSkipper.Tests;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -102,7 +103,7 @@ public class TestChapterAnalyzer
     }
 
     [Fact]
-    public async Task DetectAdaptiveRecapBlackFrames_UsesAdaptiveThresholdWithCurrentBlackFrameScan()
+    public async Task DetectAdaptiveRecapBlackFrames_NormalizesThresholdFromFullDistributionScan()
     {
         var config = new PluginConfiguration
         {
@@ -113,6 +114,8 @@ public class TestChapterAnalyzer
         };
         var ffmpeg = new RecapBlackFrameFfmpeg(
         [
+            new(2, 12, 5),
+            new(5, 15, 8),
             new(50, 20, 10),
             new(95, 40, 20),
             new(88, 80, 30),
@@ -127,15 +130,80 @@ public class TestChapterAnalyzer
         var blackFrames = await analyzer.DetectAdaptiveRecapBlackFramesAsync(episode, 120, CancellationToken.None);
         var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120);
 
-        Assert.Single(blackFrames);
-        Assert.Equal(95, blackFrames[0].Percentage);
+        // Baseline (1st percentile) is 2, so the normalized minimum stays at the configured 85.
+        Assert.Equal(new[] { 95, 88 }, blackFrames.Select(frame => frame.Percentage));
         Assert.NotNull(recap);
-        Assert.Equal(40, recap.End);
-        Assert.Equal(50, ffmpeg.LastMinimum);
+        Assert.Equal(80, recap.End);
+        Assert.Equal(0, ffmpeg.LastMinimum);
         Assert.Equal(32, ffmpeg.LastThreshold);
         Assert.Equal(AnalysisMode.Recap, ffmpeg.LastMode);
         Assert.Equal(0, ffmpeg.LastRange?.Start);
         Assert.Equal(120, ffmpeg.LastRange?.End);
+    }
+
+    [Fact]
+    public async Task DetectAdaptiveRecapBlackFrames_BrightContent_KeepsConfiguredMinimum()
+    {
+        // An 87% fade in normal (bright) content must satisfy the default 85% minimum;
+        // the adaptive floor may only tighten the threshold for globally dark content.
+        var config = new PluginConfiguration { MinimumRecapDetectionDuration = 5 };
+        Assert.Equal(85, config.BlackFrameMinimumPercentage);
+
+        var scan = Enumerable.Range(0, 40)
+            .Select(i => new BlackFrame(i % 4, i * 0.5, i))
+            .Append(new BlackFrame(87, 42.0, 1008))
+            .ToArray();
+        var analyzer = new ChapterAnalyzer(
+            NullLogger<ChapterAnalyzer>.Instance,
+            new RecapBlackFrameFfmpeg(scan),
+            DatabaseTestHelpers.CreateTempSegmentDatabase(),
+            config);
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 1200, Path = "episode.mkv" };
+
+        var blackFrames = await analyzer.DetectAdaptiveRecapBlackFramesAsync(episode, 120, CancellationToken.None);
+        var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120);
+
+        var frame = Assert.Single(blackFrames);
+        Assert.Equal(87, frame.Percentage);
+        Assert.NotNull(recap);
+        Assert.Equal(42.0, recap.End);
+    }
+
+    [Fact]
+    public async Task DetectAdaptiveRecapBlackFrames_DarkContent_RaisesThreshold()
+    {
+        // The same 87% fade inside globally dark content (baseline 45% black) must be
+        // rejected: the floor caps at 30, lifting the normalized minimum to 89.
+        var config = new PluginConfiguration { MinimumRecapDetectionDuration = 5 };
+
+        var scan = Enumerable.Range(0, 100)
+            .Select(i => new BlackFrame(45, i * 0.5, i))
+            .Append(new BlackFrame(87, 42.0, 1008))
+            .ToArray();
+        var analyzer = new ChapterAnalyzer(
+            NullLogger<ChapterAnalyzer>.Instance,
+            new RecapBlackFrameFfmpeg(scan),
+            DatabaseTestHelpers.CreateTempSegmentDatabase(),
+            config);
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 1200, Path = "episode.mkv" };
+
+        var blackFrames = await analyzer.DetectAdaptiveRecapBlackFramesAsync(episode, 120, CancellationToken.None);
+
+        Assert.Empty(blackFrames);
+        Assert.Null(ChapterAnalyzer.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120));
+    }
+
+    [Fact]
+    public void NormalizeThreshold_MovesWithScanDistribution()
+    {
+        var bright = Enumerable.Range(0, 200).Select(i => new BlackFrame(i < 190 ? 2 : 95, i, i)).ToList();
+        var dark = Enumerable.Range(0, 200).Select(i => new BlackFrame(i < 190 ? 45 : 95, i, i)).ToList();
+
+        var (brightMinimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(bright, 85);
+        var (darkMinimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(dark, 85);
+
+        Assert.Equal(85, brightMinimum);
+        Assert.Equal(89, darkMinimum);
     }
 
     [Theory]

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -149,10 +149,9 @@ public class TestChapterAnalyzer
         var config = new PluginConfiguration { MinimumRecapDetectionDuration = 5 };
         Assert.Equal(85, config.BlackFrameMinimumPercentage);
 
-        var scan = Enumerable.Range(0, 40)
+        BlackFrame[] scan = [.. Enumerable.Range(0, 40)
             .Select(i => new BlackFrame(i % 4, i * 0.5, i))
-            .Append(new BlackFrame(87, 42.0, 1008))
-            .ToArray();
+            .Append(new BlackFrame(87, 42.0, 1008))];
         var analyzer = new ChapterAnalyzer(
             NullLogger<ChapterAnalyzer>.Instance,
             new RecapBlackFrameFfmpeg(scan),
@@ -176,10 +175,9 @@ public class TestChapterAnalyzer
         // rejected: the floor caps at 30, lifting the normalized minimum to 89.
         var config = new PluginConfiguration { MinimumRecapDetectionDuration = 5 };
 
-        var scan = Enumerable.Range(0, 100)
+        BlackFrame[] scan = [.. Enumerable.Range(0, 100)
             .Select(i => new BlackFrame(45, i * 0.5, i))
-            .Append(new BlackFrame(87, 42.0, 1008))
-            .ToArray();
+            .Append(new BlackFrame(87, 42.0, 1008))];
         var analyzer = new ChapterAnalyzer(
             NullLogger<ChapterAnalyzer>.Instance,
             new RecapBlackFrameFfmpeg(scan),

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -32,10 +32,6 @@ public partial class ChapterAnalyzer(
     IIntroSkipperDatabase database,
     PluginConfiguration? configuration = null) : IMediaFileAnalyzer
 {
-    // Keep the adaptive discovery scan broad enough to find darker recap boundaries; the
-    // configured percentage is applied afterward when the scan results are normalized.
-    private const int RecapAdaptiveBlackFrameScanMinimumPercentageCap = 50;
-
     private readonly ILogger<ChapterAnalyzer> _logger = logger;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IIntroSkipperDatabase _database = database;
@@ -251,26 +247,11 @@ public partial class ChapterAnalyzer(
             maxRecapBoundary);
     }
 
-    internal async Task<BlackFrame[]> DetectAdaptiveRecapBlackFramesAsync(
+    internal Task<BlackFrame[]> DetectAdaptiveRecapBlackFramesAsync(
         QueuedEpisode episode,
         double maxRecapBoundary,
         CancellationToken cancellationToken)
-    {
-        var blackFrames = await _ffmpegService.DetectBlackFramesAsync(
-            episode,
-            new TimeRange(0, maxRecapBoundary),
-            Math.Min(_config.BlackFrameMinimumPercentage, RecapAdaptiveBlackFrameScanMinimumPercentageCap),
-            _config.BlackFrameThreshold,
-            AnalysisMode.Recap,
-            cancellationToken).ConfigureAwait(false);
-        if (blackFrames.Length == 0)
-        {
-            return [];
-        }
-
-        var (minimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(blackFrames, _config.BlackFrameMinimumPercentage);
-        return [.. blackFrames.Where(frame => frame.Percentage >= minimum)];
-    }
+        => RecapDetectionHelper.DetectAdaptiveBlackFramesAsync(_ffmpegService, episode, maxRecapBoundary, _config, cancellationToken);
 
     internal static Segment? BuildRecapFromBlackFrames(
         Guid episodeId,

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -277,12 +277,13 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
 
         if (!_recapBlackFrameCache.TryGetValue(episode.EpisodeId, out var blackFrames))
         {
-            blackFrames = await _ffmpegService.DetectBlackFramesAsync(
+            // Share the adaptive scan with ChapterAnalyzer so both recap consumers agree on
+            // which frames count as black instead of diverging by analyzer order.
+            blackFrames = await RecapDetectionHelper.DetectAdaptiveBlackFramesAsync(
+                _ffmpegService,
                 episode,
-                new TimeRange(0, maximumBoundary),
-                _config.BlackFrameMinimumPercentage,
-                _config.BlackFrameThreshold,
-                AnalysisMode.Recap,
+                maximumBoundary,
+                _config,
                 cancellationToken).ConfigureAwait(false);
             _recapBlackFrameCache[episode.EpisodeId] = blackFrames;
         }

--- a/IntroSkipper/Analyzers/RecapDetectionHelper.cs
+++ b/IntroSkipper/Analyzers/RecapDetectionHelper.cs
@@ -4,6 +4,7 @@
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
 
 namespace IntroSkipper.Analyzers;
 
@@ -36,5 +37,40 @@ internal static class RecapDetectionHelper
         }
 
         return maximumBoundary;
+    }
+
+    /// <summary>
+    /// Scans for recap black frames and applies adaptive threshold normalization to the
+    /// full darkness distribution, so every recap consumer shares one definition of "black".
+    /// </summary>
+    /// <param name="ffmpegService">FFmpeg service.</param>
+    /// <param name="episode">Queued episode.</param>
+    /// <param name="maxRecapBoundary">The latest timestamp the scan should cover.</param>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The black frames that satisfy the normalized threshold.</returns>
+    internal static async Task<BlackFrame[]> DetectAdaptiveBlackFramesAsync(
+        IFFmpegService ffmpegService,
+        QueuedEpisode episode,
+        double maxRecapBoundary,
+        PluginConfiguration config,
+        CancellationToken cancellationToken)
+    {
+        // Request the scan unfiltered (minimum 0): NormalizeThreshold measures the content's
+        // baseline darkness from the full distribution before the configured percentage applies.
+        var blackFrames = await ffmpegService.DetectBlackFramesAsync(
+            episode,
+            new TimeRange(0, maxRecapBoundary),
+            0,
+            config.BlackFrameThreshold,
+            AnalysisMode.Recap,
+            cancellationToken).ConfigureAwait(false);
+        if (blackFrames.Length == 0)
+        {
+            return [];
+        }
+
+        var (minimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(blackFrames, config.BlackFrameMinimumPercentage);
+        return [.. blackFrames.Where(frame => frame.Percentage >= minimum)];
     }
 }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -255,14 +255,17 @@ public sealed partial class FFmpegService(
             return [.. cached.Where(bf => bf.Percentage >= minimum)];
         }
 
-        // Seek to the start of the time range and find frames that are at least 50% black.
+        // Recap scans report every frame (amount=0) so adaptive threshold normalization can
+        // observe the content's full darkness distribution; other modes keep the amount=50
+        // superset that existing cache rows and their callers' post-filters rely on.
+        var amount = mode == AnalysisMode.Recap ? 0 : 50;
         var args = new List<string>
         {
             "-ss", range.Start.ToString(CultureInfo.InvariantCulture),
             "-i", episode.Path,
             "-to", range.Duration.ToString(CultureInfo.InvariantCulture),
             "-an", "-dn", "-sn",
-            "-vf", $"blackframe=amount=50:threshold={threshold}",
+            "-vf", $"blackframe=amount={amount}:threshold={threshold}",
             "-f", "null", "-",
         };
 

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -45,7 +45,7 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Recap => Invariant(
-                $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
+                $"analysis|v3|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
                 $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
@@ -85,7 +85,7 @@ public static class ConfigHasher
                 $"cache|v1|{type}|noise={config.SilenceDetectionMaximumNoise}|dur={config.SilenceDetectionMinimumDuration}"),
 
             CacheEntryType.BlackFrame => Invariant(
-                $"cache|v1|{type}|{mode}|threshold={config.BlackFrameThreshold}"),
+                $"cache|v1|{type}|{mode}|threshold={config.BlackFrameThreshold}{BlackFrameAmountToken(mode)}"),
 
             CacheEntryType.BlackInterval => Invariant(
                 $"cache|v1|{type}|{mode}|blackdetect=v1|threshold={config.BlackFrameThreshold}|bfmin={config.BlackFrameMinimumPercentage}|duration={BlackInterval.MinimumDetectionDuration}"),
@@ -107,6 +107,12 @@ public static class ConfigHasher
         => config.UseAlternativeBlackFrameAnalyzer
             ? FormattableString.Invariant($"|nonblack={config.DetectNonBlackCredits}")
             : string.Empty;
+
+    // The recap black-frame scan reports every frame (blackframe amount=0) so adaptive threshold
+    // normalization can observe the full darkness distribution; the token invalidates truncated
+    // amount=50 recap rows written before that change without touching other modes' cache rows.
+    private static string BlackFrameAmountToken(AnalysisMode mode)
+        => mode == AnalysisMode.Recap ? "|amount=0" : string.Empty;
 
     private static string AdjustmentHash(PluginConfiguration config)
         => Invariant(


### PR DESCRIPTION
After #819 the recap "adaptive" threshold could never adapt: the 6-arg `DetectBlackFramesAsync` hardcodes `blackframe=amount=50`, so `NormalizeThreshold` only ever saw frames ≥ 50% black, its percentile floor pinned at the 30 cap, and the normalized minimum collapsed to the constant `0.7 × configMin + 30` for every possible distribution — a silent tightening from 85 to 89 at default config that dropped 85–88% fades it used to detect. The `ChromaprintAnalyzer` recap-card path meanwhile kept filtering at the raw configured minimum, so the two recap consumers disagreed about what counts as a black frame.

- Recap-mode black frame scans now run `blackframe=amount=0`, so the scan (and its cache rows) carries the full darkness distribution; other modes keep the `amount=50` superset, and since `minimum` still post-filters, their results are byte-identical. Verified against real ffmpeg: `amount=0` reports bright frames as `pblack:0`, giving the normalization its baseline.
- `RecapDetectionHelper.DetectAdaptiveBlackFramesAsync` is now the single scan → normalize → filter entry point: `ChapterAnalyzer` delegates to it and the `ChromaprintAnalyzer` recap-card path uses it too, so both consumers share one definition of "black". The now-meaningless `RecapAdaptiveBlackFrameScanMinimumPercentageCap` is gone.
- Net behavior: bright content keeps exactly the configured minimum (an 87% fade detects again at the default 85), and only globally dark content raises the bar toward 89 — the same semantics the credits analyzer already has.
- Cache/hash hygiene: the `CacheEntryType.BlackFrame` detection-cache hash gains a recap-only `|amount=0` token so truncated pre-fix recap rows re-scan once while credits rows stay warm, and the recap analysis hash is bumped to `v3` because `v2` shipped in `12.0/prerelease` (tag points at 0ad3fc5).
- Tests now prove distribution sensitivity instead of enshrining the constant: the same 87% fade is kept in bright content and rejected in dark content, `NormalizeThreshold` returns different minimums for different distributions (85 vs 89), and the updated scan test asserts the unfiltered (`minimum=0`) request.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/bb6a8155-e111-41b0-929a-fc68e810fbbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-144" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/bb6a8155-e111-41b0-929a-fc68e810fbbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-144&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-144"><img alt="INTRO-144" src="https://capy.ai/api/badge/thread.svg?label=INTRO-144"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Unify recap black-frame detection around an adaptive threshold that uses the full darkness distribution and align all recap analyzers and caches with the new behavior.

Bug Fixes:
- Restore adaptive recap black-frame thresholding so bright-content fades at the configured minimum are detected and globally dark content tightens the threshold instead of using an effectively constant minimum.

Enhancements:
- Introduce RecapDetectionHelper.DetectAdaptiveBlackFramesAsync as the shared entry point for recap black-frame scanning and threshold normalization used by both ChapterAnalyzer and ChromaprintAnalyzer.
- Adjust FFmpeg black-frame detection for recap mode to scan with amount=0 so the full darkness distribution is available for normalization while preserving existing behavior for other modes.

Tests:
- Extend recap-related tests to validate threshold normalization against bright vs dark scan distributions, the unfiltered recap scan, and the resulting inclusion or exclusion of representative fades.

Chores:
- Bump recap analysis hashing to v3 and add a recap-only black-frame cache token for amount=0 to invalidate stale recap cache entries without affecting other modes.