### PR TITLE
Reject cross-item segment deletion without data loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ IntroSkipper/Configuration/introskipper.css
 
 # Web dashboard dependencies
 web/node_modules
+docs/agents
 
 # Visual Studio
 .vs/
@@ -21,3 +22,4 @@ web/node_modules
 /.cursor
 .agents/
 .omo
+CLAUDE.md

--- a/IntroSkipper.Tests/FakeJellyfinSegmentStore.cs
+++ b/IntroSkipper.Tests/FakeJellyfinSegmentStore.cs
@@ -21,8 +21,8 @@ internal sealed class FakeJellyfinSegmentStore : IJellyfinSegmentStore
     private int _writeCount;
 
     /// <summary>
-    /// Gets the segments served by <see cref="GetSegmentAsync"/>, matched by item id and
-    /// segment id exactly like the production store.
+    /// Gets the segments served by <see cref="GetSegmentByIdAsync"/>, matched by segment
+    /// id exactly like the production store.
     /// </summary>
     public IReadOnlyList<MediaSegmentDto> ExistingSegments { get; init; } = [];
 
@@ -99,9 +99,6 @@ internal sealed class FakeJellyfinSegmentStore : IJellyfinSegmentStore
         DeletedOwnItemIds.AddRange(itemIds);
         return Task.CompletedTask;
     }
-
-    public Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
-        => Task.FromResult(ExistingSegments.FirstOrDefault(segment => segment.ItemId == itemId && segment.Id == segmentId));
 
     public Task<MediaSegmentDto?> GetSegmentByIdAsync(Guid segmentId, CancellationToken cancellationToken)
         => Task.FromResult(ExistingSegments.FirstOrDefault(segment => segment.Id == segmentId));

--- a/IntroSkipper.Tests/FakeJellyfinSegmentStore.cs
+++ b/IntroSkipper.Tests/FakeJellyfinSegmentStore.cs
@@ -103,6 +103,9 @@ internal sealed class FakeJellyfinSegmentStore : IJellyfinSegmentStore
     public Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
         => Task.FromResult(ExistingSegments.FirstOrDefault(segment => segment.ItemId == itemId && segment.Id == segmentId));
 
+    public Task<MediaSegmentDto?> GetSegmentByIdAsync(Guid segmentId, CancellationToken cancellationToken)
+        => Task.FromResult(ExistingSegments.FirstOrDefault(segment => segment.Id == segmentId));
+
     public Task DeleteSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
     {
         ThrowIfConfigured(DeleteSegmentException);

--- a/IntroSkipper.Tests/TestJellyfinSegmentStore.cs
+++ b/IntroSkipper.Tests/TestJellyfinSegmentStore.cs
@@ -213,7 +213,7 @@ public sealed class TestJellyfinSegmentStore
     }
 
     [Fact]
-    public async Task GetSegmentAsync_ReturnsAllFields_AcrossProviders()
+    public async Task GetSegmentByIdAsync_ReturnsAllFields_AcrossProviders()
     {
         using var db = new TempJellyfinDb();
         var store = CreateStore(db);
@@ -221,7 +221,7 @@ public sealed class TestJellyfinSegmentStore
         var segmentId = Guid.NewGuid();
         await SeedAsync(db, CreateEntity(itemId, MediaSegmentType.Intro, 10, 20, ForeignProviderId, segmentId));
 
-        var result = await store.GetSegmentAsync(itemId, segmentId, CancellationToken.None);
+        var result = await store.GetSegmentByIdAsync(segmentId, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(segmentId, result!.Id);
@@ -230,8 +230,7 @@ public sealed class TestJellyfinSegmentStore
         Assert.Equal(10, result.StartTicks);
         Assert.Equal(20, result.EndTicks);
 
-        Assert.Null(await store.GetSegmentAsync(Guid.NewGuid(), segmentId, CancellationToken.None));
-        Assert.Null(await store.GetSegmentAsync(itemId, Guid.NewGuid(), CancellationToken.None));
+        Assert.Null(await store.GetSegmentByIdAsync(Guid.NewGuid(), CancellationToken.None));
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
+++ b/IntroSkipper.Tests/TestMediaSegmentEditorService.cs
@@ -101,7 +101,7 @@ public sealed class TestMediaSegmentEditorService
     }
 
     [Fact]
-    public async Task GetSegmentAsync_ReturnsMatchingSegment()
+    public async Task GetSegmentByIdAsync_ReturnsMatchingSegment()
     {
         var itemId = Guid.NewGuid();
         var segmentId = Guid.NewGuid();
@@ -115,42 +115,29 @@ public sealed class TestMediaSegmentEditorService
         };
         var service = CreateService(store);
 
-        var result = await service.GetSegmentAsync(itemId, segmentId, CancellationToken.None);
+        var result = await service.GetSegmentByIdAsync(segmentId, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(segmentId, result!.Id);
+        Assert.Equal(itemId, result.ItemId);
     }
 
     [Fact]
-    public async Task GetSegmentAsync_ReturnsNull_WhenItemIdDoesNotMatch()
+    public async Task GetSegmentByIdAsync_ReturnsNull_WhenSegmentIdDoesNotMatch()
     {
-        var segmentId = Guid.NewGuid();
         var store = new FakeJellyfinSegmentStore
         {
-            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, segmentId, Guid.NewGuid())]
+            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, Guid.NewGuid(), Guid.NewGuid())]
         };
         var service = CreateService(store);
 
-        Assert.Null(await service.GetSegmentAsync(Guid.NewGuid(), segmentId, CancellationToken.None));
-    }
-
-    [Fact]
-    public async Task GetSegmentAsync_ReturnsNull_WhenSegmentIdDoesNotMatch()
-    {
-        var itemId = Guid.NewGuid();
-        var store = new FakeJellyfinSegmentStore
-        {
-            ExistingSegments = [CreateSegment(MediaSegmentType.Intro, 10, 20, Guid.NewGuid(), itemId)]
-        };
-        var service = CreateService(store);
-
-        var result = await service.GetSegmentAsync(itemId, Guid.NewGuid(), CancellationToken.None);
+        var result = await service.GetSegmentByIdAsync(Guid.NewGuid(), CancellationToken.None);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public async Task GetSegmentAsync_Throws_WhenCancelled()
+    public async Task GetSegmentByIdAsync_Throws_WhenCancelled()
     {
         var store = new FakeJellyfinSegmentStore
         {
@@ -161,7 +148,7 @@ public sealed class TestMediaSegmentEditorService
         await cts.CancelAsync();
 
         await Assert.ThrowsAsync<OperationCanceledException>(
-            () => service.GetSegmentAsync(Guid.NewGuid(), Guid.NewGuid(), cts.Token));
+            () => service.GetSegmentByIdAsync(Guid.NewGuid(), cts.Token));
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -273,12 +273,13 @@ public sealed class SegmentEditorControllerTests
 
         var controller = new SegmentEditorController(new MediaSegmentEditorService(store), database);
 
-        // Item B's id paired with item A's segment id: the caller's own orphaned plugin row
-        // is still cleaned up, but item A's Jellyfin segment must survive.
+        // Item B's id paired with item A's segment id must not mutate either item's data.
         var result = await controller.DeleteSegmentAsync(segmentIdA, itemB, "intro", CancellationToken.None);
 
-        Assert.IsType<OkResult>(result);
-        Assert.Empty(await database.GetSegmentsAsync(itemB));
+        Assert.IsType<BadRequestObjectResult>(result);
+        var pluginRow = Assert.Single(await database.GetSegmentsAsync(itemB));
+        Assert.Equal(100, pluginRow.Start);
+        Assert.Equal(160, pluginRow.End);
 
         var verify = jellyfinDb.Factory.CreateDbContext();
         await using (verify)

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -95,7 +95,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
     /// <returns>
     /// HTTP 200 on success, 400 when the requested type does not match the Jellyfin segment,
     /// or 404 when the commercial segment is not found. A segment id owned by a different item
-    /// leaves Jellyfin untouched while the item's own plugin row is still removed.
+    /// is rejected without mutating either item.
     /// </returns>
     [HttpDelete("{segmentId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
@@ -117,9 +117,15 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown segment type '{type}'")
         };
 
-        var existingSegment = await _mediaSegmentEditorService
-            .GetSegmentAsync(itemId, segmentId, cancellationToken)
+        var segmentById = await _mediaSegmentEditorService
+            .GetSegmentByIdAsync(segmentId, cancellationToken)
             .ConfigureAwait(false);
+        if (segmentById is not null && segmentById.ItemId != itemId)
+        {
+            return BadRequest($"Segment '{segmentId}' does not belong to item '{itemId}'.");
+        }
+
+        var existingSegment = segmentById;
 
         var mode = requestedMode;
         if (existingSegment is not null

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -107,7 +107,7 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
         [FromQuery, Required] string type,
         CancellationToken cancellationToken = default)
     {
-        AnalysisMode requestedMode = type.ToLowerInvariant() switch
+        AnalysisMode mode = type.ToLowerInvariant() switch
         {
             "intro" => AnalysisMode.Introduction,
             "recap" => AnalysisMode.Recap,
@@ -117,19 +117,16 @@ public class SegmentEditorController(MediaSegmentEditorService mediaSegmentEdito
             _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unknown segment type '{type}'")
         };
 
-        var segmentById = await _mediaSegmentEditorService
+        var existingSegment = await _mediaSegmentEditorService
             .GetSegmentByIdAsync(segmentId, cancellationToken)
             .ConfigureAwait(false);
-        if (segmentById is not null && segmentById.ItemId != itemId)
+        if (existingSegment is not null && existingSegment.ItemId != itemId)
         {
             return BadRequest($"Segment '{segmentId}' does not belong to item '{itemId}'.");
         }
 
-        var existingSegment = segmentById;
-
-        var mode = requestedMode;
         if (existingSegment is not null
-            && existingSegment.Type != AnalysisHelpers.ModeToSegmentType[requestedMode])
+            && existingSegment.Type != AnalysisHelpers.ModeToSegmentType[mode])
         {
             return BadRequest($"Segment '{segmentId}' is {existingSegment.Type}, not requested type '{type}'.");
         }

--- a/IntroSkipper/Manager/IJellyfinSegmentStore.cs
+++ b/IntroSkipper/Manager/IJellyfinSegmentStore.cs
@@ -60,6 +60,14 @@ public interface IJellyfinSegmentStore
     Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Retrieves a segment by id, regardless of item or provider.
+    /// </summary>
+    /// <param name="segmentId">The segment id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching segment, or <c>null</c> if not found.</returns>
+    Task<MediaSegmentDto?> GetSegmentByIdAsync(Guid segmentId, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Deletes a segment by id when it belongs to the given item, regardless of provider.
     /// A segment id owned by a different item is left untouched, and an unknown id is a
     /// no-op so callers can clean up plugin-side rows whose Jellyfin row is already gone.

--- a/IntroSkipper/Manager/IJellyfinSegmentStore.cs
+++ b/IntroSkipper/Manager/IJellyfinSegmentStore.cs
@@ -51,15 +51,6 @@ public interface IJellyfinSegmentStore
     Task CreateCommercialIfAbsentAsync(Guid itemId, MediaSegmentDto segment, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves a segment by item and segment id, regardless of provider.
-    /// </summary>
-    /// <param name="itemId">The item id that owns the segment.</param>
-    /// <param name="segmentId">The segment id.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The matching segment, or <c>null</c> if not found.</returns>
-    Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Retrieves a segment by id, regardless of item or provider.
     /// </summary>
     /// <param name="segmentId">The segment id.</param>
@@ -71,6 +62,8 @@ public interface IJellyfinSegmentStore
     /// Deletes a segment by id when it belongs to the given item, regardless of provider.
     /// A segment id owned by a different item is left untouched, and an unknown id is a
     /// no-op so callers can clean up plugin-side rows whose Jellyfin row is already gone.
+    /// The item scoping is a silent backstop; callers that must report a cross-item
+    /// mismatch resolve ownership first via <see cref="GetSegmentByIdAsync"/>.
     /// </summary>
     /// <param name="itemId">The item id that must own the segment.</param>
     /// <param name="segmentId">The segment id.</param>

--- a/IntroSkipper/Manager/JellyfinSegmentStore.cs
+++ b/IntroSkipper/Manager/JellyfinSegmentStore.cs
@@ -157,23 +157,6 @@ public sealed partial class JellyfinSegmentStore(
     }
 
     /// <inheritdoc />
-    public async Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
-    {
-        var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await using (db.ConfigureAwait(false))
-        {
-            var entity = await db.MediaSegments
-                .AsNoTracking()
-                .FirstOrDefaultAsync(
-                    segment => segment.ItemId == itemId && segment.Id == segmentId,
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            return entity is null ? null : Map(entity);
-        }
-    }
-
-    /// <inheritdoc />
     public async Task<MediaSegmentDto?> GetSegmentByIdAsync(Guid segmentId, CancellationToken cancellationToken)
     {
         var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Manager/JellyfinSegmentStore.cs
+++ b/IntroSkipper/Manager/JellyfinSegmentStore.cs
@@ -174,6 +174,21 @@ public sealed partial class JellyfinSegmentStore(
     }
 
     /// <inheritdoc />
+    public async Task<MediaSegmentDto?> GetSegmentByIdAsync(Guid segmentId, CancellationToken cancellationToken)
+    {
+        var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            var entity = await db.MediaSegments
+                .AsNoTracking()
+                .FirstOrDefaultAsync(segment => segment.Id == segmentId, cancellationToken)
+                .ConfigureAwait(false);
+
+            return entity is null ? null : Map(entity);
+        }
+    }
+
+    /// <inheritdoc />
     public async Task DeleteSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
     {
         var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Manager/MediaSegmentEditorService.cs
+++ b/IntroSkipper/Manager/MediaSegmentEditorService.cs
@@ -84,4 +84,19 @@ public class MediaSegmentEditorService(IJellyfinSegmentStore segmentStore)
 
         return segment;
     }
+
+    /// <summary>
+    /// Retrieves a segment from Jellyfin by id without item scoping.
+    /// </summary>
+    /// <param name="segmentId">The segment id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matching segment, or <c>null</c> if not found.</returns>
+    public async Task<MediaSegmentDto?> GetSegmentByIdAsync(Guid segmentId, CancellationToken cancellationToken)
+    {
+        var segment = await _segmentStore.GetSegmentByIdAsync(segmentId, cancellationToken).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return segment;
+    }
 }

--- a/IntroSkipper/Manager/MediaSegmentEditorService.cs
+++ b/IntroSkipper/Manager/MediaSegmentEditorService.cs
@@ -70,22 +70,6 @@ public class MediaSegmentEditorService(IJellyfinSegmentStore segmentStore)
     }
 
     /// <summary>
-    /// Retrieves a segment from Jellyfin by id.
-    /// </summary>
-    /// <param name="itemId">The item id that owns the segment.</param>
-    /// <param name="segmentId">The segment id.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The matching segment, or <c>null</c> if not found.</returns>
-    public async Task<MediaSegmentDto?> GetSegmentAsync(Guid itemId, Guid segmentId, CancellationToken cancellationToken)
-    {
-        var segment = await _segmentStore.GetSegmentAsync(itemId, segmentId, cancellationToken).ConfigureAwait(false);
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        return segment;
-    }
-
-    /// <summary>
     /// Retrieves a segment from Jellyfin by id without item scoping.
     /// </summary>
     /// <param name="segmentId">The segment id.</param>


### PR DESCRIPTION
The item-scoped Jellyfin deletion fix still removed the requested item's Intro Skipper row when the supplied segment ID belonged to another item. Resolve the segment owner before mutation and reject mismatched item/segment pairs, preserving both the Jellyfin segment and the requested item's plugin data while retaining cleanup for genuinely missing Jellyfin rows.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/16df6b76-0882-42ac-bd3b-65aa4006f132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-158" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/16df6b76-0882-42ac-bd3b-65aa4006f132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-158&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-158"><img alt="INTRO-158" src="https://capy.ai/api/badge/thread.svg?label=INTRO-158"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Reject deletion requests where the segment id belongs to a different item, preventing cross-item data mutation while preserving existing cleanup behavior for genuinely missing Jellyfin segments.

Bug Fixes:
- Prevent deletion of plugin data and Jellyfin segments when the requested segment id does not belong to the specified item.

Enhancements:
- Expose an item-agnostic segment lookup in the Jellyfin segment store and editor service to support ownership validation before deletions.

Tests:
- Extend SegmentEditorController tests to cover mismatched item/segment ownership and verify that neither Jellyfin nor plugin rows are altered in that case.