### PR TITLE
Prefer configured audio language for Chromaprint fingerprints

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -230,6 +230,31 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
+    public void DetectionCacheHash_Chromaprint_ChangesWithPreferredAudioLanguage()
+    {
+        var baseline = new PluginConfiguration();
+        var changed = new PluginConfiguration { PreferredAudioLanguage = "eng" };
+
+        Assert.NotEqual(
+            ConfigHasher.DetectionCache(baseline, CacheEntryType.Chromaprint, AnalysisMode.Introduction),
+            ConfigHasher.DetectionCache(changed, CacheEntryType.Chromaprint, AnalysisMode.Introduction));
+    }
+
+    [Theory]
+    [InlineData(AnalysisMode.Introduction)]
+    [InlineData(AnalysisMode.Credits)]
+    [InlineData(AnalysisMode.Recap)]
+    public void AnalysisHash_ChromaprintModes_ChangesWithPreferredAudioLanguage(AnalysisMode mode)
+    {
+        var baseline = new PluginConfiguration();
+        var changed = new PluginConfiguration { PreferredAudioLanguage = "eng" };
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(baseline, mode, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(changed, mode, AnalyzerAction.Default, ffmpegValid: true));
+    }
+
+    [Fact]
     public void DetectionCacheHash_BlackFrame_ChangesWithMode()
     {
         var config = new PluginConfiguration { BlackFrameThreshold = 32 };

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -251,6 +251,21 @@ public sealed class TestCacheOperations
             ConfigHasher.DetectionCache(upper, CacheEntryType.Chromaprint, AnalysisMode.Introduction));
     }
 
+    [Fact]
+    public void DetectionCacheHash_Chromaprint_ChangesWithAudioStreamSelectionPolicy()
+    {
+        var mostChannels = new PluginConfiguration { PreferAudioStreamWithMostChannels = true };
+        var lowestIndex = new PluginConfiguration { PreferAudioStreamWithMostChannels = false };
+
+        Assert.NotEqual(
+            ConfigHasher.DetectionCache(mostChannels, CacheEntryType.Chromaprint, AnalysisMode.Introduction),
+            ConfigHasher.DetectionCache(lowestIndex, CacheEntryType.Chromaprint, AnalysisMode.Introduction));
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(mostChannels, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(lowestIndex, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true));
+    }
+
     [Theory]
     [InlineData(AnalysisMode.Introduction)]
     [InlineData(AnalysisMode.Credits)]

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -21,6 +21,8 @@ using Xunit;
 
 public sealed class TestCacheOperations
 {
+    private const string MostChannelsStreamCacheVariant = "policy=most-channels";
+
     [Fact]
     public void DeleteCacheFiles_Introduction_DeletesIntroFilesOnly()
     {
@@ -229,26 +231,20 @@ public sealed class TestCacheOperations
             ConfigHasher.DetectionCache(changed, CacheEntryType.BlackFrame, AnalysisMode.Credits));
     }
 
-    [Fact]
-    public void DetectionCacheHash_Chromaprint_ChangesWithPreferredAudioLanguage()
+    [Theory]
+    [InlineData("", "eng", false)]
+    [InlineData("eng", " ENG ", true)]
+    public void DetectionCacheHash_Chromaprint_NormalizesPreferredAudioLanguage(
+        string firstLanguage,
+        string secondLanguage,
+        bool expectEqual)
     {
-        var baseline = new PluginConfiguration();
-        var changed = new PluginConfiguration { PreferredAudioLanguage = "eng" };
+        var first = new PluginConfiguration { PreferredAudioLanguage = firstLanguage };
+        var second = new PluginConfiguration { PreferredAudioLanguage = secondLanguage };
+        var firstHash = ConfigHasher.DetectionCache(first, CacheEntryType.Chromaprint, AnalysisMode.Introduction);
+        var secondHash = ConfigHasher.DetectionCache(second, CacheEntryType.Chromaprint, AnalysisMode.Introduction);
 
-        Assert.NotEqual(
-            ConfigHasher.DetectionCache(baseline, CacheEntryType.Chromaprint, AnalysisMode.Introduction),
-            ConfigHasher.DetectionCache(changed, CacheEntryType.Chromaprint, AnalysisMode.Introduction));
-    }
-
-    [Fact]
-    public void DetectionCacheHash_Chromaprint_IgnoresPreferredAudioLanguageCase()
-    {
-        var lower = new PluginConfiguration { PreferredAudioLanguage = "eng" };
-        var upper = new PluginConfiguration { PreferredAudioLanguage = " ENG " };
-
-        Assert.Equal(
-            ConfigHasher.DetectionCache(lower, CacheEntryType.Chromaprint, AnalysisMode.Introduction),
-            ConfigHasher.DetectionCache(upper, CacheEntryType.Chromaprint, AnalysisMode.Introduction));
+        Assert.Equal(expectEqual, firstHash == secondHash);
     }
 
     [Fact]
@@ -280,8 +276,8 @@ public sealed class TestCacheOperations
         };
 
         Assert.Equal(
-            ConfigHasher.DetectionCache(languagePreferred, CacheEntryType.Chromaprint, AnalysisMode.Introduction, "policy=most-channels"),
-            ConfigHasher.DetectionCache(defaultSelection, CacheEntryType.Chromaprint, AnalysisMode.Introduction, "policy=most-channels"));
+            ConfigHasher.DetectionCache(languagePreferred, CacheEntryType.Chromaprint, AnalysisMode.Introduction, MostChannelsStreamCacheVariant),
+            ConfigHasher.DetectionCache(defaultSelection, CacheEntryType.Chromaprint, AnalysisMode.Introduction, MostChannelsStreamCacheVariant));
     }
 
     [Fact]
@@ -289,24 +285,20 @@ public sealed class TestCacheOperations
     {
         var episodeId = Guid.NewGuid();
         var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
-        var fingerprint = new uint[] { 111u, 222u };
+        uint[] fingerprint = [111u, 222u];
 
         using var cachingScope = new CachingPluginScope(cacheDir);
         var config = Plugin.Instance!.Configuration;
         var legacyHash = ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, AnalysisMode.Introduction);
 
-        using (var db = new DetectionCacheDbContext(cachingScope.CacheDbPath))
-        {
-            db.DetectionCache.Add(new DbDetectionCache(
-                episodeId,
-                AnalysisMode.Introduction,
-                CacheEntryType.Chromaprint,
-                DetectionCacheService.CompressBrotli(fingerprint),
-                0,
-                600,
-                legacyHash));
-            db.SaveChanges();
-        }
+        DatabaseTestHelpers.CreateCacheDatabase(cachingScope.CacheDbPath).Upsert(
+            episodeId,
+            AnalysisMode.Introduction,
+            CacheEntryType.Chromaprint,
+            0,
+            600,
+            DetectionCacheService.CompressBrotli(fingerprint),
+            legacyHash);
 
         Assert.True(cachingScope.CacheService.TryRead(
             episodeId,
@@ -315,7 +307,7 @@ public sealed class TestCacheOperations
             0,
             600,
             out uint[] result,
-            "policy=most-channels",
+            MostChannelsStreamCacheVariant,
             legacyHash));
         Assert.Equal(fingerprint, result);
     }

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -240,6 +240,17 @@ public sealed class TestCacheOperations
             ConfigHasher.DetectionCache(changed, CacheEntryType.Chromaprint, AnalysisMode.Introduction));
     }
 
+    [Fact]
+    public void DetectionCacheHash_Chromaprint_IgnoresPreferredAudioLanguageCase()
+    {
+        var lower = new PluginConfiguration { PreferredAudioLanguage = "eng" };
+        var upper = new PluginConfiguration { PreferredAudioLanguage = " ENG " };
+
+        Assert.Equal(
+            ConfigHasher.DetectionCache(lower, CacheEntryType.Chromaprint, AnalysisMode.Introduction),
+            ConfigHasher.DetectionCache(upper, CacheEntryType.Chromaprint, AnalysisMode.Introduction));
+    }
+
     [Theory]
     [InlineData(AnalysisMode.Introduction)]
     [InlineData(AnalysisMode.Credits)]

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -266,6 +266,60 @@ public sealed class TestCacheOperations
             ConfigHasher.Analysis(lowestIndex, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true));
     }
 
+    [Fact]
+    public void DetectionCacheHash_Chromaprint_StreamIdentityReusesAcrossSelectionSettings()
+    {
+        var languagePreferred = new PluginConfiguration
+        {
+            PreferredAudioLanguage = "eng",
+            PreferAudioStreamWithMostChannels = true
+        };
+        var defaultSelection = new PluginConfiguration
+        {
+            PreferAudioStreamWithMostChannels = false
+        };
+
+        Assert.Equal(
+            ConfigHasher.DetectionCache(languagePreferred, CacheEntryType.Chromaprint, AnalysisMode.Introduction, "policy=most-channels"),
+            ConfigHasher.DetectionCache(defaultSelection, CacheEntryType.Chromaprint, AnalysisMode.Introduction, "policy=most-channels"));
+    }
+
+    [Fact]
+    public void StreamScopedChromaprintCache_AcceptsMatchingLegacyDefaultHash()
+    {
+        var episodeId = Guid.NewGuid();
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var fingerprint = new uint[] { 111u, 222u };
+
+        using var cachingScope = new CachingPluginScope(cacheDir);
+        var config = Plugin.Instance!.Configuration;
+        var legacyHash = ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, AnalysisMode.Introduction);
+
+        using (var db = new DetectionCacheDbContext(cachingScope.CacheDbPath))
+        {
+            db.DetectionCache.Add(new DbDetectionCache(
+                episodeId,
+                AnalysisMode.Introduction,
+                CacheEntryType.Chromaprint,
+                DetectionCacheService.CompressBrotli(fingerprint),
+                0,
+                600,
+                legacyHash));
+            db.SaveChanges();
+        }
+
+        Assert.True(cachingScope.CacheService.TryRead(
+            episodeId,
+            AnalysisMode.Introduction,
+            CacheEntryType.Chromaprint,
+            0,
+            600,
+            out uint[] result,
+            "policy=most-channels",
+            legacyHash));
+        Assert.Equal(fingerprint, result);
+    }
+
     [Theory]
     [InlineData(AnalysisMode.Introduction)]
     [InlineData(AnalysisMode.Credits)]

--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -26,6 +26,7 @@ public class TestPluginConfiguration
         Assert.False(config.DetectRecapUsingBlackFrames);
         Assert.Equal(PluginConfiguration.DefaultSettledSeasonDelayHours, config.SettledSeasonDelayHours);
         Assert.Equal(string.Empty, config.ExcludeSeries);
+        Assert.Equal(string.Empty, config.PreferredAudioLanguage);
         Assert.Empty(config.SeriesExclusions);
         Assert.Empty(config.MovieExclusions);
         Assert.Empty(config.PathExclusions);

--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -27,6 +27,7 @@ public class TestPluginConfiguration
         Assert.Equal(PluginConfiguration.DefaultSettledSeasonDelayHours, config.SettledSeasonDelayHours);
         Assert.Equal(string.Empty, config.ExcludeSeries);
         Assert.Equal(string.Empty, config.PreferredAudioLanguage);
+        Assert.True(config.PreferAudioStreamWithMostChannels);
         Assert.Empty(config.SeriesExclusions);
         Assert.Empty(config.MovieExclusions);
         Assert.Empty(config.PathExclusions);

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -258,6 +258,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool ProbeAudioDuration { get; set; }
 
     /// <summary>
+    /// Gets or sets the preferred language tag for the audio stream used by Chromaprint.
+    /// When no matching stream is found, the first audio stream is used.
+    /// </summary>
+    public string PreferredAudioLanguage { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the minimum length of similar audio that will be considered a recap.
     /// </summary>
     public int MinimumRecapDuration { get; set; } = 15;

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -259,9 +259,15 @@ public class PluginConfiguration : BasePluginConfiguration
 
     /// <summary>
     /// Gets or sets the preferred language tag for the audio stream used by Chromaprint.
-    /// When no matching stream is found, FFmpeg's default audio stream selection is used.
+    /// When no matching stream is found, the configured audio stream selection policy is used.
     /// </summary>
     public string PreferredAudioLanguage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Chromaprint should prefer the audio stream with the most channels.
+    /// Streams with equal channel counts are ordered by their stream index.
+    /// </summary>
+    public bool PreferAudioStreamWithMostChannels { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the minimum length of similar audio that will be considered a recap.

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -259,7 +259,7 @@ public class PluginConfiguration : BasePluginConfiguration
 
     /// <summary>
     /// Gets or sets the preferred language tag for the audio stream used by Chromaprint.
-    /// When no matching stream is found, the first audio stream is used.
+    /// When no matching stream is found, FFmpeg's default audio stream selection is used.
     /// </summary>
     public string PreferredAudioLanguage { get; set; } = string.Empty;
 

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -31,7 +31,15 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
     public bool IsEnabled => Plugin.Instance?.Configuration.CacheFingerprints ?? false;
 
     /// <inheritdoc/>
-    public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
+    public bool TryRead<T>(
+        Guid itemId,
+        AnalysisMode mode,
+        CacheEntryType type,
+        double start,
+        double end,
+        out T[] result,
+        string? cacheVariant = null,
+        string? legacyConfigHash = null)
     {
         result = [];
 
@@ -52,9 +60,10 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
                 return false;
             }
 
-            var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), type, mode);
+            var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), type, mode, cacheVariant);
             if (!string.IsNullOrEmpty(entry.ConfigHash)
-                && !string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal))
+                && !string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal)
+                && !string.Equals(entry.ConfigHash, legacyConfigHash, StringComparison.Ordinal))
             {
                 return false;
             }
@@ -77,7 +86,14 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
     }
 
     /// <inheritdoc/>
-    public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
+    public bool Write<T>(
+        Guid itemId,
+        AnalysisMode mode,
+        CacheEntryType type,
+        double start,
+        double end,
+        T[] items,
+        string? cacheVariant = null)
     {
         if (!IsEnabled)
         {
@@ -85,7 +101,7 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         }
 
         var data = CompressBrotli(items);
-        var configHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), type, mode);
+        var configHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), type, mode, cacheVariant);
 
         try
         {
@@ -118,8 +134,16 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
         try
         {
+            var entry = _cacheDatabase.FindEntry(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end);
+            if (entry is null)
+            {
+                return false;
+            }
+
             var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), CacheEntryType.Chromaprint, mode);
-            return _cacheDatabase.HasEntry(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, expectedHash);
+            return string.IsNullOrEmpty(entry.ConfigHash)
+                || string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal)
+                || ConfigHasher.IsStreamScopedDetectionCacheHash(entry.ConfigHash);
         }
         catch (DbException ex)
         {

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -781,7 +781,7 @@ public sealed partial class FFmpegService(
 
                     if (preferredStream is null ||
                         channels > preferredStream.Value.Channels ||
-                        channels == preferredStream.Value.Channels && streamIndex < preferredStream.Value.Index)
+                        (channels == preferredStream.Value.Channels && streamIndex < preferredStream.Value.Index))
                     {
                         preferredStream = (streamIndex, channels);
                     }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -728,7 +728,9 @@ public sealed partial class FFmpegService(
         return Path.Join(Path.GetDirectoryName(ffmpegPath) ?? string.Empty, "ffprobe" + extension);
     }
 
-    private async Task<int?> FindAudioStreamIndexAsync(
+    private sealed record AudioStreamSelection(int? StreamIndex, string CacheVariant, bool LegacyDefaultCompatible);
+
+    private async Task<AudioStreamSelection?> FindAudioStreamSelectionAsync(
         string filePath,
         string preferredLanguage,
         bool preferMostChannels,
@@ -737,8 +739,8 @@ public sealed partial class FFmpegService(
         var hasLanguagePreference = !string.IsNullOrWhiteSpace(preferredLanguage);
         if (!hasLanguagePreference && preferMostChannels)
         {
-            // No explicit map preserves FFmpeg's default selection: most channels, then lowest index.
-            return null;
+            // No probe or explicit map is needed to preserve FFmpeg's default selection: most channels, then lowest index.
+            return new AudioStreamSelection(null, "policy=most-channels", true);
         }
 
         try
@@ -783,30 +785,33 @@ public sealed partial class FFmpegService(
                 }
             }
 
+            if (audioStreams.Count == 0)
+            {
+                return null;
+            }
+
+            var fallbackStream = SelectAudioStream(audioStreams, preferMostChannels);
+            var defaultStream = SelectAudioStream(audioStreams, preferMostChannels: true);
             var candidates = hasLanguagePreference
                 ? audioStreams.Where(stream => string.Equals(stream.Language, preferredLanguage, StringComparison.OrdinalIgnoreCase)).ToList()
                 : audioStreams;
 
             if (candidates.Count == 0)
             {
-                if (hasLanguagePreference && preferMostChannels)
-                {
-                    // No match preserves FFmpeg's default most-channel selection.
-                    return null;
-                }
-
-                // With lowest-index selection, an unmatched language preference falls back to all audio streams.
+                // An unmatched language preference falls back to all audio streams using the configured policy.
                 candidates = audioStreams;
             }
 
-            if (candidates.Count == 0)
-            {
-                return null;
-            }
+            var selectedStream = SelectAudioStream(candidates, preferMostChannels);
+            var selectsDefaultMostStream = selectedStream.Index == defaultStream.Index;
+            var cacheVariant = selectsDefaultMostStream
+                ? "policy=most-channels"
+                : FormattableString.Invariant($"stream-index={selectedStream.Index}");
 
-            return preferMostChannels
-                ? candidates.OrderByDescending(stream => stream.Channels).ThenBy(stream => stream.Index).First().Index
-                : candidates.Min(stream => stream.Index);
+            return new AudioStreamSelection(
+                preferMostChannels && selectsDefaultMostStream ? null : selectedStream.Index,
+                cacheVariant,
+                selectedStream.Index == fallbackStream.Index);
         }
         catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception)
         {
@@ -829,8 +834,21 @@ public sealed partial class FFmpegService(
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Try to load this episode from cache before running ffmpeg.
-        if (LoadCachedFingerprint(episode, mode, start, end, out uint[] cachedFingerprint))
+        var configuration = Plugin.Instance?.Configuration;
+        var preferredLanguage = AudioLanguageHelper.Normalize(configuration?.PreferredAudioLanguage);
+        var streamSelection = await FindAudioStreamSelectionAsync(
+            episode.Path,
+            preferredLanguage,
+            configuration?.PreferAudioStreamWithMostChannels ?? true,
+            cancellationToken).ConfigureAwait(false);
+        var cacheVariant = streamSelection?.CacheVariant;
+        var legacyConfigHash = streamSelection?.LegacyDefaultCompatible == true
+            ? ConfigHasher.LegacyChromaprintCacheWithoutLanguage(configuration ?? new(), mode)
+            : null;
+
+        // Resolve the stream before reading the cache so a language preference can reuse a fingerprint
+        // generated with the same effective stream under the default selection.
+        if (LoadCachedFingerprint(episode, mode, start, end, cacheVariant, legacyConfigHash, out uint[] cachedFingerprint))
         {
             LogFingerprintCacheHit(_logger, episode.Path);
             cancellationToken.ThrowIfCancellationRequested();
@@ -839,14 +857,6 @@ public sealed partial class FFmpegService(
 
         LogFingerprinting(_logger, start, end, episode.Path, episode.EpisodeId);
 
-        var configuration = Plugin.Instance?.Configuration;
-        var preferredLanguage = AudioLanguageHelper.Normalize(configuration?.PreferredAudioLanguage);
-        var preferredAudioStreamIndex = await FindAudioStreamIndexAsync(
-            episode.Path,
-            preferredLanguage,
-            configuration?.PreferAudioStreamWithMostChannels ?? true,
-            cancellationToken).ConfigureAwait(false);
-
         var args = new List<string>
         {
             "-ss", start.ToString(CultureInfo.InvariantCulture),
@@ -854,7 +864,7 @@ public sealed partial class FFmpegService(
             "-to", (end - start).ToString(CultureInfo.InvariantCulture),
         };
 
-        if (preferredAudioStreamIndex is int streamIndex)
+        if (streamSelection?.StreamIndex is int streamIndex)
         {
             args.Add("-map");
             args.Add($"0:{streamIndex}?");
@@ -885,7 +895,7 @@ public sealed partial class FFmpegService(
 
         // Try to cache this fingerprint.
         cancellationToken.ThrowIfCancellationRequested();
-        _cacheService.Write(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, [.. results]);
+        _cacheService.Write(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, [.. results], cacheVariant);
 
         return [.. results];
     }
@@ -897,6 +907,8 @@ public sealed partial class FFmpegService(
     /// <param name="mode">Analysis mode.</param>
     /// <param name="start">Start time (in seconds) used when the fingerprint was cached.</param>
     /// <param name="end">End time (in seconds) used when the fingerprint was cached.</param>
+    /// <param name="cacheVariant">Effective audio stream selection identity.</param>
+    /// <param name="legacyConfigHash">Legacy no-language hash accepted when the selected stream is unchanged.</param>
     /// <param name="fingerprint">Array to store the fingerprint in.</param>
     /// <returns><c>true</c> if the episode was successfully loaded from cache; otherwise <c>false</c>.</returns>
     private bool LoadCachedFingerprint(
@@ -904,11 +916,28 @@ public sealed partial class FFmpegService(
         AnalysisMode mode,
         double start,
         double end,
+        string? cacheVariant,
+        string? legacyConfigHash,
         out uint[] fingerprint)
     {
         fingerprint = [];
-        return _cacheService.TryRead(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, out fingerprint);
+        return _cacheService.TryRead(
+            episode.EpisodeId,
+            mode,
+            CacheEntryType.Chromaprint,
+            start,
+            end,
+            out fingerprint,
+            cacheVariant,
+            legacyConfigHash);
     }
+
+    private static (int Index, int Channels, string? Language) SelectAudioStream(
+        IReadOnlyList<(int Index, int Channels, string? Language)> streams,
+        bool preferMostChannels)
+        => preferMostChannels
+            ? streams.OrderByDescending(stream => stream.Channels).ThenBy(stream => stream.Index).First()
+            : streams.OrderBy(stream => stream.Index).First();
 
     private string FormatFFmpegLog(string key)
     {

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using IntroSkipper.Data;
 using IntroSkipper.Helper;
 using Microsoft.Extensions.Logging;
@@ -724,6 +725,63 @@ public sealed partial class FFmpegService(
         return Path.Join(Path.GetDirectoryName(ffmpegPath) ?? string.Empty, "ffprobe" + extension);
     }
 
+    private async Task<int?> FindPreferredAudioStreamIndexAsync(
+        string filePath,
+        string preferredLanguage,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(preferredLanguage))
+        {
+            return null;
+        }
+
+        try
+        {
+            var args = new List<string>
+            {
+                "-v", "error",
+                "-select_streams", "a",
+                "-show_entries", "stream=index:stream_tags=language",
+                "-of", "json",
+                filePath,
+            };
+
+            var output = Encoding.UTF8.GetString(await GetProcessOutputAsync(
+                GetFFprobePath(),
+                args,
+                stderr: false,
+                timeout: 10 * 1000,
+                cancellationToken: cancellationToken).ConfigureAwait(false));
+
+            using var document = JsonDocument.Parse(output);
+            if (!document.RootElement.TryGetProperty("streams", out var streams))
+            {
+                return null;
+            }
+
+            foreach (var stream in streams.EnumerateArray())
+            {
+                if (!stream.TryGetProperty("tags", out var tags) ||
+                    !tags.TryGetProperty("language", out var language) ||
+                    !string.Equals(language.GetString()?.Trim(), preferredLanguage, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (stream.TryGetProperty("index", out var index) && index.TryGetInt32(out var streamIndex))
+                {
+                    return streamIndex;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception)
+        {
+            LogPreferredAudioLanguageProbeFailed(_logger, ex, filePath, preferredLanguage);
+        }
+
+        return null;
+    }
+
     /// <summary>
     /// Fingerprint a queued episode.
     /// </summary>
@@ -747,11 +805,18 @@ public sealed partial class FFmpegService(
 
         LogFingerprinting(_logger, start, end, episode.Path, episode.EpisodeId);
 
+        var preferredLanguage = (Plugin.Instance?.Configuration.PreferredAudioLanguage ?? string.Empty).Trim();
+        var preferredAudioStreamIndex = await FindPreferredAudioStreamIndexAsync(
+            episode.Path,
+            preferredLanguage,
+            cancellationToken).ConfigureAwait(false);
+
         var args = new List<string>
         {
             "-ss", start.ToString(CultureInfo.InvariantCulture),
             "-i", episode.Path,
             "-to", (end - start).ToString(CultureInfo.InvariantCulture),
+            "-map", preferredAudioStreamIndex is int streamIndex ? $"0:{streamIndex}" : "0:a:0?",
             "-ac", "2",
             "-f", "chromaprint",
             "-fp_format", "raw",
@@ -855,6 +920,9 @@ public sealed partial class FFmpegService(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to probe audio duration for {File}")]
     private static partial void LogAudioDurationProbeFailed(ILogger logger, Exception ex, string file);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to probe preferred audio language {Language} for {File}; using the first audio stream")]
+    private static partial void LogPreferredAudioLanguageProbeFailed(ILogger logger, Exception ex, string file, string language);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "ffmpeg process already gone while killing process tree")]
     private static partial void LogFfmpegProcessAlreadyGone(ILogger logger, Exception ex);

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -728,8 +728,6 @@ public sealed partial class FFmpegService(
         return Path.Join(Path.GetDirectoryName(ffmpegPath) ?? string.Empty, "ffprobe" + extension);
     }
 
-    private sealed record AudioStreamSelection(int? StreamIndex, string CacheVariant, bool LegacyDefaultCompatible);
-
     private async Task<AudioStreamSelection?> FindAudioStreamSelectionAsync(
         string filePath,
         string preferredLanguage,
@@ -1000,4 +998,6 @@ public sealed partial class FFmpegService(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "ffmpeg process already gone while killing process tree")]
     private static partial void LogFfmpegProcessAlreadyGone(ILogger logger, Exception ex);
+
+    private sealed record AudioStreamSelection(int? StreamIndex, string CacheVariant, bool LegacyDefaultCompatible);
 }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -744,7 +744,7 @@ public sealed partial class FFmpegService(
             {
                 "-v", "error",
                 "-select_streams", "a",
-                "-show_entries", "stream=index:stream_tags=language",
+                "-show_entries", "stream=index,channels:stream_tags=language",
                 "-of", "json",
                 filePath,
             };
@@ -762,6 +762,7 @@ public sealed partial class FFmpegService(
                 return null;
             }
 
+            (int Index, int Channels)? preferredStream = null;
             foreach (var stream in streams.EnumerateArray())
             {
                 if (!stream.TryGetProperty("tags", out var tags) ||
@@ -773,9 +774,21 @@ public sealed partial class FFmpegService(
 
                 if (stream.TryGetProperty("index", out var index) && index.TryGetInt32(out var streamIndex))
                 {
-                    return streamIndex;
+                    var channels = stream.TryGetProperty("channels", out var channelsElement) &&
+                        channelsElement.TryGetInt32(out var channelCount)
+                        ? channelCount
+                        : 0;
+
+                    if (preferredStream is null ||
+                        channels > preferredStream.Value.Channels ||
+                        channels == preferredStream.Value.Channels && streamIndex < preferredStream.Value.Index)
+                    {
+                        preferredStream = (streamIndex, channels);
+                    }
                 }
             }
+
+            return preferredStream?.Index;
         }
         catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception)
         {
@@ -819,12 +832,17 @@ public sealed partial class FFmpegService(
             "-ss", start.ToString(CultureInfo.InvariantCulture),
             "-i", episode.Path,
             "-to", (end - start).ToString(CultureInfo.InvariantCulture),
-            "-map", preferredAudioStreamIndex is int streamIndex ? $"0:{streamIndex}?" : "0:a:0?",
             "-ac", "2",
             "-f", "chromaprint",
             "-fp_format", "raw",
             "-",
         };
+
+        if (preferredAudioStreamIndex is int streamIndex)
+        {
+            args.Insert(6, "-map");
+            args.Insert(7, $"0:{streamIndex}?");
+        }
 
         // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).
         var rawPoints = await GetOutputAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -924,7 +942,7 @@ public sealed partial class FFmpegService(
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to probe audio duration for {File}")]
     private static partial void LogAudioDurationProbeFailed(ILogger logger, Exception ex, string file);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to probe preferred audio language {Language} for {File}; using the first audio stream")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to probe preferred audio language {Language} for {File}; using FFmpeg's default audio stream selection")]
     private static partial void LogPreferredAudioLanguageProbeFailed(ILogger logger, Exception ex, string file, string language);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "ffmpeg process already gone while killing process tree")]

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -816,7 +816,7 @@ public sealed partial class FFmpegService(
             "-ss", start.ToString(CultureInfo.InvariantCulture),
             "-i", episode.Path,
             "-to", (end - start).ToString(CultureInfo.InvariantCulture),
-            "-map", preferredAudioStreamIndex is int streamIndex ? $"0:{streamIndex}" : "0:a:0?",
+            "-map", preferredAudioStreamIndex is int streamIndex ? $"0:{streamIndex}?" : "0:a:0?",
             "-ac", "2",
             "-f", "chromaprint",
             "-fp_format", "raw",

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -840,7 +840,7 @@ public sealed partial class FFmpegService(
         LogFingerprinting(_logger, start, end, episode.Path, episode.EpisodeId);
 
         var configuration = Plugin.Instance?.Configuration;
-        var preferredLanguage = (configuration?.PreferredAudioLanguage ?? string.Empty).Trim();
+        var preferredLanguage = AudioLanguageHelper.Normalize(configuration?.PreferredAudioLanguage);
         var preferredAudioStreamIndex = await FindAudioStreamIndexAsync(
             episode.Path,
             preferredLanguage,
@@ -852,17 +852,21 @@ public sealed partial class FFmpegService(
             "-ss", start.ToString(CultureInfo.InvariantCulture),
             "-i", episode.Path,
             "-to", (end - start).ToString(CultureInfo.InvariantCulture),
-            "-ac", "2",
-            "-f", "chromaprint",
-            "-fp_format", "raw",
-            "-",
         };
 
         if (preferredAudioStreamIndex is int streamIndex)
         {
-            args.Insert(6, "-map");
-            args.Insert(7, $"0:{streamIndex}?");
+            args.Add("-map");
+            args.Add($"0:{streamIndex}?");
         }
+
+        args.AddRange(
+        [
+            "-ac", "2",
+            "-f", "chromaprint",
+            "-fp_format", "raw",
+            "-",
+        ]);
 
         // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).
         var rawPoints = await GetOutputAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -728,13 +728,16 @@ public sealed partial class FFmpegService(
         return Path.Join(Path.GetDirectoryName(ffmpegPath) ?? string.Empty, "ffprobe" + extension);
     }
 
-    private async Task<int?> FindPreferredAudioStreamIndexAsync(
+    private async Task<int?> FindAudioStreamIndexAsync(
         string filePath,
         string preferredLanguage,
+        bool preferMostChannels,
         CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(preferredLanguage))
+        var hasLanguagePreference = !string.IsNullOrWhiteSpace(preferredLanguage);
+        if (!hasLanguagePreference && preferMostChannels)
         {
+            // No explicit map preserves FFmpeg's default selection: most channels, then lowest index.
             return null;
         }
 
@@ -762,33 +765,48 @@ public sealed partial class FFmpegService(
                 return null;
             }
 
-            (int Index, int Channels)? preferredStream = null;
+            var audioStreams = new List<(int Index, int Channels, string? Language)>();
             foreach (var stream in streams.EnumerateArray())
             {
-                if (!stream.TryGetProperty("tags", out var tags) ||
-                    !tags.TryGetProperty("language", out var language) ||
-                    !string.Equals(language.GetString()?.Trim(), preferredLanguage, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
                 if (stream.TryGetProperty("index", out var index) && index.TryGetInt32(out var streamIndex))
                 {
                     var channels = stream.TryGetProperty("channels", out var channelsElement) &&
                         channelsElement.TryGetInt32(out var channelCount)
                         ? channelCount
                         : 0;
+                    var language = stream.TryGetProperty("tags", out var tags) &&
+                        tags.TryGetProperty("language", out var languageElement)
+                        ? languageElement.GetString()?.Trim()
+                        : null;
 
-                    if (preferredStream is null ||
-                        channels > preferredStream.Value.Channels ||
-                        (channels == preferredStream.Value.Channels && streamIndex < preferredStream.Value.Index))
-                    {
-                        preferredStream = (streamIndex, channels);
-                    }
+                    audioStreams.Add((streamIndex, channels, language));
                 }
             }
 
-            return preferredStream?.Index;
+            var candidates = hasLanguagePreference
+                ? audioStreams.Where(stream => string.Equals(stream.Language, preferredLanguage, StringComparison.OrdinalIgnoreCase)).ToList()
+                : audioStreams;
+
+            if (candidates.Count == 0)
+            {
+                if (hasLanguagePreference && preferMostChannels)
+                {
+                    // No match preserves FFmpeg's default most-channel selection.
+                    return null;
+                }
+
+                // With lowest-index selection, an unmatched language preference falls back to all audio streams.
+                candidates = audioStreams;
+            }
+
+            if (candidates.Count == 0)
+            {
+                return null;
+            }
+
+            return preferMostChannels
+                ? candidates.OrderByDescending(stream => stream.Channels).ThenBy(stream => stream.Index).First().Index
+                : candidates.Min(stream => stream.Index);
         }
         catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception)
         {
@@ -821,10 +839,12 @@ public sealed partial class FFmpegService(
 
         LogFingerprinting(_logger, start, end, episode.Path, episode.EpisodeId);
 
-        var preferredLanguage = (Plugin.Instance?.Configuration.PreferredAudioLanguage ?? string.Empty).Trim();
-        var preferredAudioStreamIndex = await FindPreferredAudioStreamIndexAsync(
+        var configuration = Plugin.Instance?.Configuration;
+        var preferredLanguage = (configuration?.PreferredAudioLanguage ?? string.Empty).Trim();
+        var preferredAudioStreamIndex = await FindAudioStreamIndexAsync(
             episode.Path,
             preferredLanguage,
+            configuration?.PreferAudioStreamWithMostChannels ?? true,
             cancellationToken).ConfigureAwait(false);
 
         var args = new List<string>

--- a/IntroSkipper/FFmpeg/IDetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/IDetectionCacheService.cs
@@ -24,6 +24,8 @@ public interface IDetectionCacheService
     /// <param name="start">The start position used as a cache key component.</param>
     /// <param name="end">The end position used as a cache key component.</param>
     /// <param name="result">When this method returns, contains the cached result array, or an empty array if the cache was missed. This parameter is treated as uninitialized.</param>
+    /// <param name="cacheVariant">Optional effective stream identity for stream-sensitive cache entries.</param>
+    /// <param name="legacyConfigHash">Optional legacy hash that is safe to accept for this effective stream.</param>
     /// <returns><see langword="true"/> if a valid cache entry was found; otherwise, <see langword="false"/>.</returns>
     bool TryRead<T>(
         Guid itemId,
@@ -31,7 +33,9 @@ public interface IDetectionCacheService
         CacheEntryType type,
         double start,
         double end,
-        out T[] result);
+        out T[] result,
+        string? cacheVariant = null,
+        string? legacyConfigHash = null);
 
     /// <summary>
     /// Writes a detection result to the SQLite cache.
@@ -43,6 +47,7 @@ public interface IDetectionCacheService
     /// <param name="start">The start position used as a cache key component.</param>
     /// <param name="end">The end position used as a cache key component.</param>
     /// <param name="items">The result array to cache.</param>
+    /// <param name="cacheVariant">Optional effective stream identity for stream-sensitive cache entries.</param>
     /// <returns><see langword="true"/> if the write succeeded; otherwise, <see langword="false"/>.</returns>
     bool Write<T>(
         Guid itemId,
@@ -50,13 +55,15 @@ public interface IDetectionCacheService
         CacheEntryType type,
         double start,
         double end,
-        T[] items);
+        T[] items,
+        string? cacheVariant = null);
 
     /// <summary>
     /// Checks if a fingerprint cache entry exists for the episode.
     /// </summary>
     /// <param name="episode">The queued episode to check.</param>
     /// <param name="mode">One of the enumeration values that specifies the analysis mode.</param>
+    /// <remarks>Stream-scoped entries are considered present here; the fingerprint read validates the exact stream and configuration before reuse.</remarks>
     /// <returns><see langword="true"/> if a fingerprint cache entry exists; otherwise, <see langword="false"/>.</returns>
     bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode);
 }

--- a/IntroSkipper/Helper/AudioLanguageHelper.cs
+++ b/IntroSkipper/Helper/AudioLanguageHelper.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 AbandonedCart
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Helper;
+
+/// <summary>
+/// Normalization for the configured preferred audio language so stream selection
+/// and configuration hashing always agree on how the value is interpreted.
+/// </summary>
+public static class AudioLanguageHelper
+{
+    /// <summary>
+    /// Normalizes a configured audio language code by trimming whitespace and lower-casing it.
+    /// </summary>
+    /// <param name="language">Configured language code.</param>
+    /// <returns>The normalized language code, or an empty string when unset.</returns>
+    public static string Normalize(string? language) => language?.Trim().ToLowerInvariant() ?? string.Empty;
+}

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -73,13 +73,32 @@ public static class ConfigHasher
     /// <param name="mode">Analysis mode.</param>
     /// <returns>A compact hex hash.</returns>
     public static string DetectionCache(PluginConfiguration config, CacheEntryType type, AnalysisMode mode)
+        => DetectionCache(config, type, mode, null);
+
+    /// <summary>
+    /// Computes a hash for a detection cache row, optionally keyed by the effective audio stream selection.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="type">Cache entry type.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="audioStreamIdentity">Effective audio stream identity for Chromaprint entries.</param>
+    /// <returns>A compact hash, or a stream-scoped cache key for Chromaprint entries with an identity.</returns>
+    public static string DetectionCache(
+        PluginConfiguration config,
+        CacheEntryType type,
+        AnalysisMode mode,
+        string? audioStreamIdentity)
     {
         ArgumentNullException.ThrowIfNull(config);
+
+        var streamToken = type == CacheEntryType.Chromaprint && !string.IsNullOrWhiteSpace(audioStreamIdentity)
+            ? FormattableString.Invariant($"|audioStream={audioStreamIdentity}")
+            : ChromaprintStreamToken(config);
 
         var input = type switch
         {
             CacheEntryType.Chromaprint => Invariant(
-                $"cache|v1|{type}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}{ChromaprintStreamToken(config)}"),
+                $"cache|v1|{type}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}{streamToken}"),
 
             CacheEntryType.Silence => Invariant(
                 $"cache|v1|{type}|noise={config.SilenceDetectionMaximumNoise}|dur={config.SilenceDetectionMinimumDuration}"),
@@ -97,8 +116,36 @@ public static class ConfigHasher
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
 
+        var hash = ComputeHash(input);
+        return type == CacheEntryType.Chromaprint && !string.IsNullOrWhiteSpace(audioStreamIdentity)
+            ? FormattableString.Invariant($"audio-stream-v1|{audioStreamIdentity}|{hash}")
+            : hash;
+    }
+
+    /// <summary>
+    /// Computes the pre-stream-selection cache hash used when no language preference was configured.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <returns>The legacy default-selection cache hash.</returns>
+    public static string LegacyChromaprintCacheWithoutLanguage(PluginConfiguration config, AnalysisMode mode)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var input = Invariant(
+            $"cache|v1|{CacheEntryType.Chromaprint}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
+            $"|audioLanguage=|audioMostChannels={config.PreferAudioStreamWithMostChannels}");
+
         return ComputeHash(input);
     }
+
+    /// <summary>
+    /// Gets a value indicating whether a cache hash is scoped to an effective audio stream.
+    /// </summary>
+    /// <param name="cacheHash">Cache hash to inspect.</param>
+    /// <returns><see langword="true"/> when the hash includes an audio stream identity.</returns>
+    public static bool IsStreamScopedDetectionCacheHash(string? cacheHash)
+        => cacheHash?.StartsWith("audio-stream-v1|", StringComparison.Ordinal) == true;
 
     // DetectNonBlackCredits only affects output when the alternative analyzer is active; including it
     // unconditionally would invalidate cached credits on the default BlackFrameAnalyzer path, which

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -110,7 +110,7 @@ public static class ConfigHasher
 
     private static string ChromaprintStreamToken(PluginConfiguration config)
         => FormattableString.Invariant(
-            $"|audioLanguage={config.PreferredAudioLanguage?.Trim().ToLowerInvariant() ?? string.Empty}|audioMostChannels={config.PreferAudioStreamWithMostChannels}");
+            $"|audioLanguage={AudioLanguageHelper.Normalize(config.PreferredAudioLanguage)}|audioMostChannels={config.PreferAudioStreamWithMostChannels}");
 
     // The recap black-frame scan reports every frame (blackframe amount=0) so adaptive threshold
     // normalization can observe the full darkness distribution; the token invalidates truncated

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -32,7 +32,7 @@ public static class ConfigHasher
             AnalysisMode.Introduction => Invariant(
                 $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerIntroductionPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|min={config.MinimumIntroDuration}|max={config.MaximumIntroDuration}",
-                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintLanguageToken(config)}",
+                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
@@ -40,7 +40,7 @@ public static class ConfigHasher
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfaltVersion=2{CreditsNonBlackToken(config)}",
-                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintLanguageToken(config)}",
+                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
                 $"|animePreview={config.AnimePreviewFromCreditsEnd}",
                 $"{AdjustmentHash(config)}"),
 
@@ -48,7 +48,7 @@ public static class ConfigHasher
                 $"analysis|v3|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
                 $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
-                $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintLanguageToken(config)}",
+                $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Preview => Invariant(
@@ -79,7 +79,7 @@ public static class ConfigHasher
         var input = type switch
         {
             CacheEntryType.Chromaprint => Invariant(
-                $"cache|v1|{type}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}{ChromaprintLanguageToken(config)}"),
+                $"cache|v1|{type}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}{ChromaprintStreamToken(config)}"),
 
             CacheEntryType.Silence => Invariant(
                 $"cache|v1|{type}|noise={config.SilenceDetectionMaximumNoise}|dur={config.SilenceDetectionMinimumDuration}"),
@@ -108,9 +108,9 @@ public static class ConfigHasher
             ? FormattableString.Invariant($"|nonblack={config.DetectNonBlackCredits}")
             : string.Empty;
 
-    private static string ChromaprintLanguageToken(PluginConfiguration config)
+    private static string ChromaprintStreamToken(PluginConfiguration config)
         => FormattableString.Invariant(
-            $"|audioLanguage={config.PreferredAudioLanguage?.Trim().ToLowerInvariant() ?? string.Empty}");
+            $"|audioLanguage={config.PreferredAudioLanguage?.Trim().ToLowerInvariant() ?? string.Empty}|audioMostChannels={config.PreferAudioStreamWithMostChannels}");
 
     // The recap black-frame scan reports every frame (blackframe amount=0) so adaptive threshold
     // normalization can observe the full darkness distribution; the token invalidates truncated

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -109,7 +109,8 @@ public static class ConfigHasher
             : string.Empty;
 
     private static string ChromaprintLanguageToken(PluginConfiguration config)
-        => FormattableString.Invariant($"|audioLanguage={config.PreferredAudioLanguage?.Trim() ?? string.Empty}");
+        => FormattableString.Invariant(
+            $"|audioLanguage={config.PreferredAudioLanguage?.Trim().ToLowerInvariant() ?? string.Empty}");
 
     private static string AdjustmentHash(PluginConfiguration config)
         => Invariant(

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -32,7 +32,7 @@ public static class ConfigHasher
             AnalysisMode.Introduction => Invariant(
                 $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerIntroductionPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|min={config.MinimumIntroDuration}|max={config.MaximumIntroDuration}",
-                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
+                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintLanguageToken(config)}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
@@ -40,7 +40,7 @@ public static class ConfigHasher
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfaltVersion=2{CreditsNonBlackToken(config)}",
-                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
+                $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintLanguageToken(config)}",
                 $"|animePreview={config.AnimePreviewFromCreditsEnd}",
                 $"{AdjustmentHash(config)}"),
 
@@ -48,7 +48,7 @@ public static class ConfigHasher
                 $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
                 $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
-                $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
+                $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintLanguageToken(config)}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Preview => Invariant(
@@ -79,7 +79,7 @@ public static class ConfigHasher
         var input = type switch
         {
             CacheEntryType.Chromaprint => Invariant(
-                $"cache|v1|{type}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}"),
+                $"cache|v1|{type}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}{ChromaprintLanguageToken(config)}"),
 
             CacheEntryType.Silence => Invariant(
                 $"cache|v1|{type}|noise={config.SilenceDetectionMaximumNoise}|dur={config.SilenceDetectionMinimumDuration}"),
@@ -107,6 +107,9 @@ public static class ConfigHasher
         => config.UseAlternativeBlackFrameAnalyzer
             ? FormattableString.Invariant($"|nonblack={config.DetectNonBlackCredits}")
             : string.Empty;
+
+    private static string ChromaprintLanguageToken(PluginConfiguration config)
+        => FormattableString.Invariant($"|audioLanguage={config.PreferredAudioLanguage?.Trim() ?? string.Empty}");
 
     private static string AdjustmentHash(PluginConfiguration config)
         => Invariant(

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -50,7 +50,7 @@ export const ffmpegTab: Tab = {
                 label: "Preferred audio language for Chromaprint",
                 placeholder: "eng",
                 description:
-                    "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Leave empty to use the first audio stream; if no matching tag is found, the first audio stream is used.",
+                    "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Leave empty, or use a tag with no match, to preserve FFmpeg's default selection (most channels, then lowest stream index).",
             }),
             selectField({
                 id: "CacheCompressionLevel",

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -47,14 +47,14 @@ export const ffmpegTab: Tab = {
             }),
             textField({
                 id: "PreferredAudioLanguage",
-                label: "Preferred audio language for Chromaprint",
+                label: "Preferred stream audio language",
                 placeholder: "eng",
                 description:
                     "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Empty or unmatched values will use the stream selection policy below.",
             }),
             checkboxField({
                 id: "PreferAudioStreamWithMostChannels",
-                label: "Prefer audio streams with the most channels",
+                label: "Prefer audio channel count",
                 description:
                     "When enabled, Chromaprint selects streams based on channel count, using the lowest index as the tie breaker. When disabled, the first stream is selected.",
             }),

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -56,7 +56,7 @@ export const ffmpegTab: Tab = {
                 id: "PreferAudioStreamWithMostChannels",
                 label: "Prefer audio streams with the most channels",
                 description:
-                    "Controls preferred-language matches, language fallbacks, and selection when no language is configured. When enabled, Chromaprint selects the most-channel stream, using the lowest stream index as the tie breaker. When disabled, it selects the lowest stream index. Defaults to enabled.",
+                    "When enabled, Chromaprint selects the most-channel stream, using the lowest stream index as the tie breaker. When disabled, it selects the lowest stream index.",
             }),
             selectField({
                 id: "CacheCompressionLevel",

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -50,13 +50,13 @@ export const ffmpegTab: Tab = {
                 label: "Preferred audio language for Chromaprint",
                 placeholder: "eng",
                 description:
-                    "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Leave empty, or use a tag with no match, to use the stream selection policy below.",
+                    "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Empty or unmatched values will use the stream selection policy below.",
             }),
             checkboxField({
                 id: "PreferAudioStreamWithMostChannels",
                 label: "Prefer audio streams with the most channels",
                 description:
-                    "When enabled, Chromaprint selects the most-channel stream, using the lowest stream index as the tie breaker. When disabled, it selects the lowest stream index.",
+                    "When enabled, Chromaprint selects streams based on channel count, using the lowest index as the tie breaker. When disabled, the first stream is selected.",
             }),
             selectField({
                 id: "CacheCompressionLevel",

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -2,6 +2,7 @@ import type { Tab } from "../types.ts";
 import { checkboxField } from "../components/checkbox-field.ts";
 import { numberField } from "../components/number-field.ts";
 import { selectField } from "../components/select-field.ts";
+import { textField } from "../components/text-field.ts";
 import { appendTabContent } from "../components/tab-layout.ts";
 
 export const ffmpegTab: Tab = {
@@ -43,6 +44,13 @@ export const ffmpegTab: Tab = {
                 label: "Probe audio duration for credits",
                 description:
                     "Use ffprobe to base credits fingerprinting on the first audio stream duration when container runtime is longer than the audio.",
+            }),
+            textField({
+                id: "PreferredAudioLanguage",
+                label: "Preferred audio language for Chromaprint",
+                placeholder: "eng",
+                description:
+                    "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Leave empty to use the first audio stream; if no matching tag is found, the first audio stream is used.",
             }),
             selectField({
                 id: "CacheCompressionLevel",

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -54,7 +54,7 @@ export const ffmpegTab: Tab = {
             }),
             checkboxField({
                 id: "PreferAudioStreamWithMostChannels",
-                label: "Prefer audio channel count",
+                label: "Prefer highest audio channel count",
                 description:
                     "When enabled, Chromaprint selects streams based on channel count, using the lowest index as the tie breaker. When disabled, the first stream is selected.",
             }),

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -50,7 +50,13 @@ export const ffmpegTab: Tab = {
                 label: "Preferred audio language for Chromaprint",
                 placeholder: "eng",
                 description:
-                    "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Leave empty, or use a tag with no match, to preserve FFmpeg's default selection (most channels, then lowest stream index).",
+                    "Prefer an audio stream with this language tag when generating Chromaprint fingerprints. Leave empty, or use a tag with no match, to use the stream selection policy below.",
+            }),
+            checkboxField({
+                id: "PreferAudioStreamWithMostChannels",
+                label: "Prefer audio streams with the most channels",
+                description:
+                    "Controls preferred-language matches, language fallbacks, and selection when no language is configured. When enabled, Chromaprint selects the most-channel stream, using the lowest stream index as the tie breaker. When disabled, it selects the lowest stream index. Defaults to enabled.",
             }),
             selectField({
                 id: "CacheCompressionLevel",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -40,6 +40,7 @@ export interface PluginConfig {
     ChapterAnalyzerRecapPattern: string;
     ChapterAnalyzerCommercialPattern: string;
     ExcludeSeries: string;
+    PreferredAudioLanguage: string;
     SeriesExclusions: string[];
     MovieExclusions: string[];
     PathExclusions: string[];

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -67,6 +67,7 @@ export interface PluginConfig {
     ScanCommercial: boolean;
     EnableMainMenu: boolean;
     PreferChromaprint: boolean;
+    PreferAudioStreamWithMostChannels: boolean;
     ProbeAudioDuration: boolean;
     SnapToKeyframe: boolean;
     AdjustIntroBasedOnSilence: boolean;


### PR DESCRIPTION
## Summary by Sourcery

Prefer configured audio language and stream selection policy when generating Chromaprint fingerprints, and ensure these options participate in analysis and cache hashing.

New Features:
- Add configuration options for preferred audio language and audio stream selection policy used by Chromaprint.
- Expose preferred audio language and audio stream selection policy in the FFmpeg web configuration tab.

Enhancements:
- Introduce ffprobe-based audio stream selection that honors preferred language and channel-count policy before Chromaprint fingerprinting.
- Extend configuration hashing for Chromaprint analysis and cache entries to account for audio language and stream selection settings.

Tests:
- Add tests validating that Chromaprint-related cache and analysis hashes change with preferred audio language and stream selection policy and ignore language casing.
- Update configuration tests to cover defaults for the new audio language and stream selection options.