### PR TITLE
Add a global warning when chromaprint is unsupported

### DIFF
--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -2,6 +2,7 @@ import { validator } from "../validation/validator.ts";
 import { configStore } from "../store/config-store.ts";
 import * as api from "../store/api.ts";
 import { el } from "./dom.ts";
+import { isChromaprintUnavailable, parseSupportBundle } from "./support-bundle.ts";
 
 /** How long the "Changes saved" message stays visible (ms). */
 const STATUS_CLEAR_MS = 3000;
@@ -23,27 +24,24 @@ export function createAppShell(rootEl: HTMLElement): {
         className: "app-header-warning",
         role: "status",
         "aria-label": "Chromaprint Unavailable",
+        "aria-live": "polite",
+        "aria-atomic": "true",
     });
     const warningIcon = el("span", {
         className: "app-header-warning-icon",
         "aria-hidden": "true",
     }, "\u26a0");
-    chromaprintWarning.append(warningIcon, el("span", {}, "Chromaprint Unavailable"));
-    chromaprintWarning.style.display = "none";
+    const warningText = el("span");
+    chromaprintWarning.append(warningIcon, warningText);
 
     header.append(title, chromaprintWarning);
 
     void api
         .getSupportBundle()
         .then((supportBundle) => {
-            const warnings = /^\* Warnings: `([^`]*)`$/m.exec(supportBundle)?.[1] ?? "";
-            const ffmpegStatus = /^\* FFmpeg: `([^`]*)`$/m.exec(supportBundle)?.[1];
-            const hasIncompatibleBuildWarning = warnings
-                .split(", ")
-                .includes("IncompatibleFFmpegBuild");
-
-            if (hasIncompatibleBuildWarning && ffmpegStatus === "chromaprint_not_supported") {
-                chromaprintWarning.style.display = "flex";
+            if (isChromaprintUnavailable(parseSupportBundle(supportBundle))) {
+                warningText.textContent = "Chromaprint Unavailable";
+                chromaprintWarning.classList.add("is-visible");
             }
         })
         .catch(() => {

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -7,6 +7,27 @@ import { isChromaprintUnavailable, parseSupportBundle } from "./support-bundle.t
 /** How long the "Changes saved" message stays visible (ms). */
 const STATUS_CLEAR_MS = 3000;
 
+/** Fetch the support bundle and reveal the header warning if Chromaprint is unavailable. */
+function announceChromaprintWarning(chromaprintWarning: HTMLElement, warningText: HTMLElement): void {
+    void api
+        .getSupportBundle()
+        .then((supportBundle) => {
+            if (isChromaprintUnavailable(parseSupportBundle(supportBundle))) {
+                warningText.textContent = "Chromaprint Unavailable";
+                chromaprintWarning.setAttribute("role", "status");
+                chromaprintWarning.setAttribute("aria-label", "Chromaprint Unavailable");
+                chromaprintWarning.setAttribute("aria-live", "polite");
+                chromaprintWarning.setAttribute("aria-atomic", "true");
+                chromaprintWarning.classList.add("is-visible");
+                chromaprintWarning.removeAttribute("aria-hidden");
+            }
+        })
+        .catch(() => {
+            // The header warning is advisory; the information tab still reports
+            // support-bundle errors through its normal status message.
+        });
+}
+
 export function createAppShell(rootEl: HTMLElement): {
     navEl: HTMLElement;
     contentEl: HTMLElement;
@@ -33,23 +54,7 @@ export function createAppShell(rootEl: HTMLElement): {
 
     header.append(title, chromaprintWarning);
 
-    void api
-        .getSupportBundle()
-        .then((supportBundle) => {
-            if (isChromaprintUnavailable(parseSupportBundle(supportBundle))) {
-                warningText.textContent = "Chromaprint Unavailable";
-                chromaprintWarning.setAttribute("role", "status");
-                chromaprintWarning.setAttribute("aria-label", "Chromaprint Unavailable");
-                chromaprintWarning.setAttribute("aria-live", "polite");
-                chromaprintWarning.setAttribute("aria-atomic", "true");
-                chromaprintWarning.classList.add("is-visible");
-                chromaprintWarning.removeAttribute("aria-hidden");
-            }
-        })
-        .catch(() => {
-            // The header warning is advisory; the information tab still reports
-            // support-bundle errors through its normal status message.
-        });
+    announceChromaprintWarning(chromaprintWarning, warningText);
 
     const sidebar = el("nav", { className: "app-sidebar", "aria-label": "Settings Sections" });
 

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -22,10 +22,7 @@ export function createAppShell(rootEl: HTMLElement): {
     const header = el("header", { className: "app-header", "aria-labelledby": titleId });
     const chromaprintWarning = el("div", {
         className: "app-header-warning",
-        role: "status",
-        "aria-label": "Chromaprint Unavailable",
-        "aria-live": "polite",
-        "aria-atomic": "true",
+        "aria-hidden": "true",
     });
     const warningIcon = el("span", {
         className: "app-header-warning-icon",
@@ -41,7 +38,12 @@ export function createAppShell(rootEl: HTMLElement): {
         .then((supportBundle) => {
             if (isChromaprintUnavailable(parseSupportBundle(supportBundle))) {
                 warningText.textContent = "Chromaprint Unavailable";
+                chromaprintWarning.setAttribute("role", "status");
+                chromaprintWarning.setAttribute("aria-label", "Chromaprint Unavailable");
+                chromaprintWarning.setAttribute("aria-live", "polite");
+                chromaprintWarning.setAttribute("aria-atomic", "true");
                 chromaprintWarning.classList.add("is-visible");
+                chromaprintWarning.removeAttribute("aria-hidden");
             }
         })
         .catch(() => {

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -1,5 +1,6 @@
 import { validator } from "../validation/validator.ts";
 import { configStore } from "../store/config-store.ts";
+import * as api from "../store/api.ts";
 import { el } from "./dom.ts";
 
 /** How long the "Changes saved" message stays visible (ms). */
@@ -18,7 +19,37 @@ export function createAppShell(rootEl: HTMLElement): {
     const title = el("h1", { className: "app-title", id: titleId }, "Intro Skipper Configuration");
 
     const header = el("header", { className: "app-header", "aria-labelledby": titleId });
-    header.append(title);
+    const chromaprintWarning = el("div", {
+        className: "app-header-warning",
+        role: "status",
+        "aria-label": "Chromaprint Unavailable",
+    });
+    const warningIcon = el("span", {
+        className: "app-header-warning-icon",
+        "aria-hidden": "true",
+    }, "\u26a0");
+    chromaprintWarning.append(warningIcon, el("span", {}, "Chromaprint Unavailable"));
+    chromaprintWarning.style.display = "none";
+
+    header.append(title, chromaprintWarning);
+
+    void api
+        .getSupportBundle()
+        .then((supportBundle) => {
+            const warnings = /^\* Warnings: `([^`]*)`$/m.exec(supportBundle)?.[1] ?? "";
+            const ffmpegStatus = /^\* FFmpeg: `([^`]*)`$/m.exec(supportBundle)?.[1];
+            const hasIncompatibleBuildWarning = warnings
+                .split(", ")
+                .includes("IncompatibleFFmpegBuild");
+
+            if (hasIncompatibleBuildWarning && ffmpegStatus === "chromaprint_not_supported") {
+                chromaprintWarning.style.display = "flex";
+            }
+        })
+        .catch(() => {
+            // The header warning is advisory; the information tab still reports
+            // support-bundle errors through its normal status message.
+        });
 
     const sidebar = el("nav", { className: "app-sidebar", "aria-label": "Settings Sections" });
 

--- a/web/src/components/support-bundle.ts
+++ b/web/src/components/support-bundle.ts
@@ -1,0 +1,38 @@
+/** Parsed status fields from the Markdown support bundle. */
+export interface SupportBundleInfo {
+    warnings: ReadonlySet<string>;
+    ffmpegStatus: string | null;
+}
+
+const STATUS_FIELD_PATTERN = /^\s*\*\s+([^:]+):\s*`([^`]*)`\s*$/gm;
+
+/** Parse the structured status fields emitted by the support-bundle endpoint. */
+export function parseSupportBundle(bundle: string): SupportBundleInfo {
+    const fields = new Map<string, string>();
+    for (const match of bundle.matchAll(STATUS_FIELD_PATTERN)) {
+        const fieldName = match[1]?.trim();
+        const fieldValue = match[2]?.trim();
+        if (fieldName && fieldValue !== undefined) {
+            fields.set(fieldName, fieldValue);
+        }
+    }
+
+    const warnings = new Set(
+        (fields.get("Warnings") ?? "")
+            .split(",")
+            .map((warning) => warning.trim())
+            .filter(Boolean),
+    );
+
+    return {
+        warnings,
+        ffmpegStatus: fields.get("FFmpeg") ?? null,
+    };
+}
+
+export function isChromaprintUnavailable(bundle: SupportBundleInfo): boolean {
+    return (
+        bundle.warnings.has("IncompatibleFFmpegBuild") &&
+        bundle.ffmpegStatus === "chromaprint_not_supported"
+    );
+}

--- a/web/src/components/support-bundle.ts
+++ b/web/src/components/support-bundle.ts
@@ -1,3 +1,15 @@
+/** Support-bundle field holding the comma-separated plugin warning flags. */
+const WARNINGS_FIELD = "Warnings";
+
+/** Support-bundle field holding the FFmpeg feature-detection status. */
+const FFMPEG_FIELD = "FFmpeg";
+
+/** Warning flag raised by the server when the FFmpeg build lacks required features. */
+const INCOMPATIBLE_FFMPEG_BUILD_WARNING = "IncompatibleFFmpegBuild";
+
+/** FFmpeg status reported when the build has no chromaprint (fingerprinting) support. */
+const CHROMAPRINT_NOT_SUPPORTED_STATUS = "chromaprint_not_supported";
+
 /** Parsed status fields from the Markdown support bundle. */
 export interface SupportBundleInfo {
     warnings: ReadonlySet<string>;
@@ -18,7 +30,7 @@ export function parseSupportBundle(bundle: string): SupportBundleInfo {
     }
 
     const warnings = new Set(
-        (fields.get("Warnings") ?? "")
+        (fields.get(WARNINGS_FIELD) ?? "")
             .split(",")
             .map((warning) => warning.trim())
             .filter(Boolean),
@@ -26,13 +38,13 @@ export function parseSupportBundle(bundle: string): SupportBundleInfo {
 
     return {
         warnings,
-        ffmpegStatus: fields.get("FFmpeg") ?? null,
+        ffmpegStatus: fields.get(FFMPEG_FIELD) ?? null,
     };
 }
 
 export function isChromaprintUnavailable(bundle: SupportBundleInfo): boolean {
     return (
-        bundle.warnings.has("IncompatibleFFmpegBuild") &&
-        bundle.ffmpegStatus === "chromaprint_not_supported"
+        bundle.warnings.has(INCOMPATIBLE_FFMPEG_BUILD_WARNING) &&
+        bundle.ffmpegStatus === CHROMAPRINT_NOT_SUPPORTED_STATUS
     );
 }

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -41,13 +41,32 @@
 }
 
 .app-header-warning {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    color: var(--is-warning);
+    white-space: nowrap;
+    border: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+}
+
+.app-header-warning.is-visible {
+    position: static;
+    display: flex;
     align-items: center;
     gap: 8px;
+    width: auto;
+    height: auto;
     margin-left: auto;
-    color: var(--is-warning);
+    overflow: visible;
     font-size: 0.85em;
     font-weight: 600;
-    white-space: nowrap;
+    clip: auto;
+    clip-path: none;
 }
 
 .app-header-warning-icon {

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -40,6 +40,20 @@
     border-bottom: 1px solid var(--is-border);
 }
 
+.app-header-warning {
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+    color: var(--is-warning);
+    font-size: 0.85em;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.app-header-warning-icon {
+    font-size: 1.25em;
+}
+
 .app-sidebar {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary by Sourcery

Add a header-level accessibility-friendly warning when Chromaprint support is unavailable, based on data from the support bundle.

New Features:
- Surface a global warning in the app header when Chromaprint is not supported by the underlying FFmpeg build.

Enhancements:
- Introduce a support-bundle parser and helper to detect Chromaprint availability from structured status fields.
- Style the header warning so it is visually hidden by default and becomes a visible, prominent alert when active.