### PR TITLE
Fix credits analysis duration hashing and limit

### DIFF
--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -36,7 +36,7 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfaltVersion=2{CreditsNonBlackToken(config)}",

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -263,9 +263,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             ? duration
             : await ResolveCreditsFingerprintEndAsync(episode.Path, duration, cancellationToken).ConfigureAwait(false);
 
+        // Credits have their own maximum duration in seconds. Do not apply the general
+        // analysis percentage here, since it can exclude the actual credits boundary.
         var maxCreditsDuration = Math.Min(
-            creditsDuration >= 5 * 60 ? creditsDuration * _analysisPercent : creditsDuration,
-            60 * pluginInstance.Configuration.MaximumCreditsDuration);
+            creditsDuration,
+            pluginInstance.Configuration.MaximumCreditsDuration);
 
         // Queue the episode for analysis.
         seasonEpisodes.Add(new QueuedEpisode


### PR DESCRIPTION
## Summary by Sourcery

Adjust credits analysis duration handling and update configuration hashing for credits analysis.

Bug Fixes:
- Prevent credits analysis from using the general analysis percentage when limiting credits duration, ensuring the actual credits boundary is not excluded.

Enhancements:
- Bump the credits analysis configuration hash version to v2 so changes to credits-related settings invalidate previous analysis results.