### PR TITLE
Enforce FFmpeg process timeouts while output streams are open

### DIFF
--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -138,21 +138,23 @@ public class TestFFmpegService
     [Fact]
     public async Task GetProcessOutputAsync_EnforcesTimeoutBeforeStreamsClose()
     {
-        if (OperatingSystem.IsWindows())
-        {
-            return;
-        }
+        // Spawn a child process that sleeps for ~30 seconds while keeping its
+        // output streams open. "ping -n" is used on Windows because
+        // "timeout.exe" rejects redirected stdin.
+        var (processPath, args) = OperatingSystem.IsWindows()
+            ? ("ping", new[] { "-n", "31", "127.0.0.1" })
+            : ("/bin/sh", new[] { "-c", "sleep 30" });
 
         var ffmpegService = CreateFFmpegService();
         var stopwatch = Stopwatch.StartNew();
 
         await ffmpegService.GetProcessOutputAsync(
-            "/bin/sh",
-            ["-c", "sleep 30"],
+            processPath,
+            args,
             timeout: 100);
 
         Assert.True(
-            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            stopwatch.Elapsed < TimeSpan.FromSeconds(2),
             $"Process timeout took {stopwatch.Elapsed}.");
     }
 

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -158,6 +158,47 @@ public class TestFFmpegService
             $"Process timeout took {stopwatch.Elapsed}.");
     }
 
+    [Fact]
+    public async Task GetProcessOutputAsync_EnforcesTimeoutWhenDescendantKeepsStreamsOpen()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var childPidPath = Path.GetTempFileName();
+        try
+        {
+            var ffmpegService = CreateFFmpegService();
+            var stopwatch = Stopwatch.StartNew();
+
+            await ffmpegService.GetProcessOutputAsync(
+                "/bin/sh",
+                ["-c", $"sleep 30 & echo $! > {childPidPath}"],
+                timeout: 100);
+
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(2),
+                $"Stream timeout took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            if (int.TryParse(await File.ReadAllTextAsync(childPidPath), out var childPid))
+            {
+                try
+                {
+                    Process.GetProcessById(childPid).Kill(entireProcessTree: true);
+                }
+                catch (ArgumentException)
+                {
+                    // The child already exited.
+                }
+            }
+
+            File.Delete(childPidPath);
+        }
+    }
+
     #region Info Query Tests
 
     [FactSkipFFmpegTests]

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -135,6 +135,27 @@ public class TestFFmpegService
         Assert.Equal(1, probeCount);
     }
 
+    [Fact]
+    public async Task GetProcessOutputAsync_EnforcesTimeoutBeforeStreamsClose()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var ffmpegService = CreateFFmpegService();
+        var stopwatch = Stopwatch.StartNew();
+
+        await ffmpegService.GetProcessOutputAsync(
+            "/bin/sh",
+            ["-c", "sleep 30"],
+            timeout: 100);
+
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+            $"Process timeout took {stopwatch.Elapsed}.");
+    }
+
     #region Info Query Tests
 
     [FactSkipFFmpegTests]

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -664,14 +664,14 @@ public sealed partial class FFmpegService(
         using var cancellationRegistration = cancellationToken.Register(() => KillProcessTree(process));
         using var ms = new MemoryStream();
 
-        var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms, cancellationToken);
-        var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null, cancellationToken);
-
         using var timeoutCts = new CancellationTokenSource(timeout);
         using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms, waitCts.Token);
+        var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null, waitCts.Token);
         try
         {
             await process.WaitForExitAsync(waitCts.Token).ConfigureAwait(false);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -682,9 +682,17 @@ public sealed partial class FFmpegService(
         {
             _logger.LogWarning("ffmpeg did not exit within {TimeoutMs}ms; killing process", timeout);
             KillProcessTree(process);
+
+            try
+            {
+                await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            {
+                // The timeout also cancels pipe reads so a failed process-tree kill cannot hang here.
+            }
         }
 
-        await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
         return ms.ToArray();
     }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -609,7 +609,7 @@ public sealed partial class FFmpegService(
             firstArg.StartsWith("-h", StringComparison.Ordinal);
     }
 
-    private async Task<byte[]> GetProcessOutputAsync(
+    internal async Task<byte[]> GetProcessOutputAsync(
         string processPath,
         IReadOnlyList<string> args,
         bool stderr = false,
@@ -655,7 +655,6 @@ public sealed partial class FFmpegService(
 
         var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms, cancellationToken);
         var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null, cancellationToken);
-        await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
 
         using var timeoutCts = new CancellationTokenSource(timeout);
         using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
@@ -674,6 +673,7 @@ public sealed partial class FFmpegService(
             KillProcessTree(process);
         }
 
+        await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
         return ms.ToArray();
     }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -609,6 +609,17 @@ public sealed partial class FFmpegService(
             firstArg.StartsWith("-h", StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Runs a process and returns the bytes it wrote to stdout (or stderr when <paramref name="stderr"/> is true).
+    /// If the process has not exited within <paramref name="timeout"/> milliseconds, its process tree is killed
+    /// and the output captured so far is returned; a timeout does not throw. Internal for testing.
+    /// </summary>
+    /// <param name="processPath">Path of the executable to run.</param>
+    /// <param name="args">Arguments to pass to the executable.</param>
+    /// <param name="stderr">Capture stderr instead of stdout.</param>
+    /// <param name="timeout">Maximum time, in milliseconds, to wait for the process to exit.</param>
+    /// <param name="cancellationToken">Cancellation token; cancellation kills the process tree and throws.</param>
+    /// <returns>The captured output bytes.</returns>
     internal async Task<byte[]> GetProcessOutputAsync(
         string processPath,
         IReadOnlyList<string> args,


### PR DESCRIPTION
The preferred-audio fingerprint path added an ffprobe call with a nominal timeout, but process output was drained before that timeout started, so a stalled child could block the analysis queue indefinitely. Start waiting with the timeout immediately while stdout and stderr are drained concurrently, then finish collecting output after the process exits or is killed.

A regression test runs a child process that keeps its streams open and verifies the configured timeout returns promptly.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/60bb3a32-e66a-421e-939c-9fbf781d1f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-183" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/60bb3a32-e66a-421e-939c-9fbf781d1f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-183&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-183"><img alt="INTRO-183" src="https://capy.ai/api/badge/thread.svg?label=INTRO-183"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Enforce process output timeouts for FFmpeg/ffprobe invocations so stalled child processes cannot block analysis indefinitely.

Bug Fixes:
- Ensure GetProcessOutputAsync enforces the configured timeout while stdout/stderr streams remain open to prevent hangs.
- Prevent long-running child processes from blocking the analysis queue by killing them when the timeout elapses.

Enhancements:
- Expose GetProcessOutputAsync as internal to enable direct testing of process timeout behavior.

Tests:
- Add a regression test that spawns a long-lived child process and verifies GetProcessOutputAsync returns promptly when the timeout is reached.