### PR TITLE
Forward-port credits duration limit fix to 12.0 (#885)

### DIFF
--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -36,7 +36,7 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfaltVersion=2{CreditsNonBlackToken(config)}",

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -284,9 +284,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             ? duration
             : await ResolveCreditsFingerprintEndAsync(episode.Path, duration, cancellationToken).ConfigureAwait(false);
 
+        // Credits have their own maximum duration in seconds. Do not apply the general
+        // analysis percentage here, since it can exclude the actual credits boundary.
         var maxCreditsDuration = Math.Min(
-            creditsDuration >= 5 * 60 ? creditsDuration * _analysisPercent : creditsDuration,
-            60 * pluginInstance.Configuration.MaximumCreditsDuration);
+            creditsDuration,
+            pluginInstance.Configuration.MaximumCreditsDuration);
 
         // Queue the episode for analysis.
         seasonEpisodes.Add(new QueuedEpisode


### PR DESCRIPTION
Forward-ports #885 (merged into 10.11) to the 12.0 branch, which still had the original bug.

`QueueManager.VerifyEpisode` capped the credits window at `Math.Min(creditsDuration * AnalysisPercent, 60 * MaximumCreditsDuration)`. `MaximumCreditsDuration` is documented and configured in seconds (default 450), so multiplying by 60 made the configured cap a no-op (27000 s), and applying the general analysis percentage could push `CreditsFingerprintStart` past the actual credits boundary. The movie path already used the seconds value directly.

- Cap the episode credits window at `Math.Min(creditsDuration, MaximumCreditsDuration)`, matching the movie path and the 10.11 fix.
- Bump the credits analysis config hash to `v2` so previously stored credits results computed with the old window are invalidated and re-analyzed.

Full test suite passes (483/483).

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/5df8098f-7129-4add-95a0-4a590578d37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-186" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/5df8098f-7129-4add-95a0-4a590578d37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-186&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-186"><img alt="INTRO-186" src="https://capy.ai/api/badge/thread.svg?label=INTRO-186"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Align episode credits analysis limits with documented configuration and invalidate outdated credits analysis results.

Bug Fixes:
- Correct the episode credits duration cap to respect the configured maximum duration without applying the general analysis percentage.

Enhancements:
- Update the credits analysis configuration hash version so existing cached credits analyses using the old window are re-run.