### PR TITLE
Add missing long-fade regression test for chapter credits detection

### DIFF
--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -156,6 +156,40 @@ public class TestBlackFrames
     }
 
     [Fact]
+    public async Task TryAnalyzeChaptersAsync_AcceptsCreditsChapterWhenPreCreditsFadeExceedsFiveSeconds()
+    {
+        // Fade to black starts 6 seconds before the credits chapter. The historical single-sample
+        // check at [chapterStart - 5, chapterStart - 4] rejected this chapter and fell through to
+        // the earlier act-break chapter at 2274, shifting the outro start minutes too early (#889).
+        var ffmpeg = new RangeBasedBlackFrameService(
+        [
+            new TimeRange(2274, 2276),
+            new TimeRange(2394, 2420)
+        ]);
+        var analyzer = new BlackFrameAnalyzer(NullLogger<BlackFrameAnalyzer>.Instance, ffmpeg);
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPrivateField(plugin, "_chapterRepository", ChapterManagerProxy.Create(
+        [
+            CreateChapterInfo(2274),
+            CreateChapterInfo(2400)
+        ]));
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Duration = 2444.6,
+            CreditsFingerprintStart = 2000,
+        };
+
+        var result = await analyzer.TryAnalyzeChaptersAsync(episode, 85, 28, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(2400, result.Start, 3);
+        Assert.Equal(2444.6, result.End, 3);
+    }
+
+    [Fact]
     public async Task TryAnalyzeChaptersAsync_ReturnsNullWhenChapterCreditsExceedMaximumDuration()
     {
         var ffmpeg = new RangeBasedBlackFrameService(

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -158,9 +158,11 @@ public class TestBlackFrames
     [Fact]
     public async Task TryAnalyzeChaptersAsync_AcceptsCreditsChapterWhenPreCreditsFadeExceedsFiveSeconds()
     {
-        // Fade to black starts 6 seconds before the credits chapter. The historical single-sample
-        // check at [chapterStart - 5, chapterStart - 4] rejected this chapter and fell through to
-        // the earlier act-break chapter at 2274, shifting the outro start minutes too early (#889).
+        // Covers the accept path: a chapter marker is valid whenever it sits within
+        // MaxChapterOffsetFromBlackRunStart of the start of its black run, independent of fade
+        // length (here the fade begins 6s before the marker). The earlier act-break chapter at
+        // 2274 also starts a black run and must not be selected, locking in the rule that only
+        // the latest suitable chapter is ever considered (#889).
         var ffmpeg = new RangeBasedBlackFrameService(
         [
             new TimeRange(2274, 2276),

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -279,7 +279,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
         // Verify the chapter is near the beginning of a black run.
         // Walk backwards to find the first non-black second before the chapter marker.
         var scanStart = Math.Max(0, chapterStart - (MaxChapterOffsetFromBlackRunStart + 1));
-        double? blackRunStart = null;
+        var foundBlackRunStart = false;
         for (var probeStart = chapterStart - 1; probeStart >= scanStart; probeStart -= 1)
         {
             var beforeRange = new TimeRange(probeStart, probeStart + 1);
@@ -293,12 +293,12 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
 
             if (!hasBlackFramesBefore)
             {
-                blackRunStart = probeStart + 1;
+                foundBlackRunStart = true;
                 break;
             }
         }
 
-        if (!blackRunStart.HasValue)
+        if (!foundBlackRunStart)
         {
             return null;
         }


### PR DESCRIPTION
#890 fixed chapter-marker credits detection when the pre-credits fade exceeds 5 seconds (#889), and its description promised a regression test for that accept scenario — but only the two reject-path tests actually landed, leaving the fixed behavior itself uncovered.

- Adds `TryAnalyzeChaptersAsync_AcceptsCreditsChapterWhenPreCreditsFadeExceedsFiveSeconds`: a 6-second fade to black before the credits chapter at 2400s, with an earlier act-break chapter at 2274s present. The test asserts the credits chapter is selected; against the pre-#890 logic it fails by falling through to the act-break chapter, so it locks in the #889 fix.
- Replaces the dead `double? blackRunStart` in the backward scan (assigned but only ever read via `.HasValue`) with a plain `foundBlackRunStart` bool.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/pull/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Add a regression test to cover chapter credits detection when the pre-credits fade exceeds five seconds and simplify the black-run start tracking logic in the analyzer.

Enhancements:
- Replace unused nullable timestamp tracking for black-run start in the backward scan with a simple boolean flag to indicate whether a suitable start was found.

Tests:
- Add a regression test ensuring credits chapters are correctly selected when a long pre-credits fade would previously cause selection of an earlier act-break chapter.