### PR TITLE
Forward-port long-fade regression test for chapter credits detection (12.0)

### DIFF
--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -159,6 +159,45 @@ public class TestBlackFrames
     }
 
     [Fact]
+    public async Task TryAnalyzeChaptersAsync_AcceptsCreditsChapterWhenPreCreditsFadeExceedsFiveSeconds()
+    {
+        // Covers the accept path: a chapter marker is valid whenever it sits within
+        // MaxChapterOffsetFromBlackRunStart of the start of its black run, independent of fade
+        // length (here the fade begins 6s before the marker). The earlier act-break chapter at
+        // 2274 also starts a black run and must not be selected, locking in the rule that only
+        // the latest suitable chapter is ever considered (#889).
+        var ffmpeg = new RangeBasedBlackFrameService(
+        [
+            new TimeRange(2274, 2276),
+            new TimeRange(2394, 2420)
+        ]);
+        var analyzer = new BlackFrameAnalyzer(
+            NullLogger<BlackFrameAnalyzer>.Instance,
+            ffmpeg,
+            DatabaseTestHelpers.CreateTempSegmentDatabase());
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPrivateField(plugin, "_chapterRepository", ChapterManagerProxy.Create(
+        [
+            CreateChapterInfo(2274),
+            CreateChapterInfo(2400)
+        ]));
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Duration = 2444.6,
+            CreditsFingerprintStart = 2000,
+        };
+
+        var result = await analyzer.TryAnalyzeChaptersAsync(episode, 85, 28, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(2400, result.Start, 3);
+        Assert.Equal(2444.6, result.End, 3);
+    }
+
+    [Fact]
     public async Task TryAnalyzeChaptersAsync_ReturnsNullWhenChapterCreditsExceedMaximumDuration()
     {
         var ffmpeg = new RangeBasedBlackFrameService(

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -163,13 +163,21 @@ public class TestBlackFrames
     {
         // Covers the accept path: a chapter marker is valid whenever it sits within
         // MaxChapterOffsetFromBlackRunStart of the start of its black run, independent of fade
-        // length (here the fade begins 6s before the marker). The earlier act-break chapter at
-        // 2274 also starts a black run and must not be selected, locking in the rule that only
-        // the latest suitable chapter is ever considered (#889).
+        // length. The earlier act-break chapter also starts a black run and must not be
+        // selected, locking in the rule that only the latest suitable chapter is ever
+        // considered (#889).
+        const double ActBreakChapterStart = 2274;
+        const double ActBreakBlackRunEnd = 2276;
+        const double PreCreditsFadeStart = 2394; // fade begins 6s before the credits chapter
+        const double CreditsChapterStart = 2400;
+        const double CreditsBlackRunEnd = 2420;
+        const double FingerprintStart = 2000;
+        const double EpisodeDuration = 2444.6;
+
         var ffmpeg = new RangeBasedBlackFrameService(
         [
-            new TimeRange(2274, 2276),
-            new TimeRange(2394, 2420)
+            new TimeRange(ActBreakChapterStart, ActBreakBlackRunEnd),
+            new TimeRange(PreCreditsFadeStart, CreditsBlackRunEnd)
         ]);
         var analyzer = new BlackFrameAnalyzer(
             NullLogger<BlackFrameAnalyzer>.Instance,
@@ -180,21 +188,21 @@ public class TestBlackFrames
         var plugin = Plugin.Instance!;
         EntrypointTestHelpers.SetPrivateField(plugin, "_chapterRepository", ChapterManagerProxy.Create(
         [
-            CreateChapterInfo(2274),
-            CreateChapterInfo(2400)
+            CreateChapterInfo(ActBreakChapterStart),
+            CreateChapterInfo(CreditsChapterStart)
         ]));
         var episode = new QueuedEpisode
         {
             EpisodeId = Guid.NewGuid(),
-            Duration = 2444.6,
-            CreditsFingerprintStart = 2000,
+            Duration = EpisodeDuration,
+            CreditsFingerprintStart = FingerprintStart,
         };
 
         var result = await analyzer.TryAnalyzeChaptersAsync(episode, 85, 28, CancellationToken.None);
 
         Assert.NotNull(result);
-        Assert.Equal(2400, result.Start, 3);
-        Assert.Equal(2444.6, result.End, 3);
+        Assert.Equal(CreditsChapterStart, result.Start, 3);
+        Assert.Equal(EpisodeDuration, result.End, 3);
     }
 
     [Fact]

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -279,8 +279,11 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
             return null;
         }
 
-        // Verify the chapter is near the beginning of a black run.
-        // Walk backwards to find the first non-black second before the chapter marker.
+        // Verify the chapter is near the beginning of a black run. The scan window is bounded
+        // by MaxChapterOffsetFromBlackRunStart, so encountering any non-black second inside it
+        // proves the run started within the allowed offset of the marker. Only that existence
+        // matters, not the exact start position, hence the boolean flag. If the whole window is
+        // black, the run began too far before the chapter and it is rejected.
         var scanStart = Math.Max(0, chapterStart - (MaxChapterOffsetFromBlackRunStart + 1));
         var foundBlackRunStart = false;
         for (var probeStart = chapterStart - 1; probeStart >= scanStart; probeStart -= 1)

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -282,7 +282,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
         // Verify the chapter is near the beginning of a black run.
         // Walk backwards to find the first non-black second before the chapter marker.
         var scanStart = Math.Max(0, chapterStart - (MaxChapterOffsetFromBlackRunStart + 1));
-        double? blackRunStart = null;
+        var foundBlackRunStart = false;
         for (var probeStart = chapterStart - 1; probeStart >= scanStart; probeStart -= 1)
         {
             var beforeRange = new TimeRange(probeStart, probeStart + 1);
@@ -296,12 +296,12 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
 
             if (!hasBlackFramesBefore)
             {
-                blackRunStart = probeStart + 1;
+                foundBlackRunStart = true;
                 break;
             }
         }
 
-        if (!blackRunStart.HasValue)
+        if (!foundBlackRunStart)
         {
             return null;
         }


### PR DESCRIPTION
Forward-ports #893 from 10.11: the #890 fix for chapter-marker credits detection with pre-credits fades longer than 5s landed on 12.0 (aba9322) with only the two reject-path tests, leaving the fixed accept behavior uncovered here as well.

- Adds `TryAnalyzeChaptersAsync_AcceptsCreditsChapterWhenPreCreditsFadeExceedsFiveSeconds`: a 6-second fade to black before the credits chapter at 2400s, with an earlier act-break chapter at 2274s present. The test asserts the credits chapter is selected; against the pre-#890 logic it would fall through to the act-break chapter, locking in the #889 fix.
- Replaces the dead `double? blackRunStart` in the backward scan (assigned but only ever read via `.HasValue`) with a plain `foundBlackRunStart` bool, matching 10.11.

The test is adapted to the 12.0 `BlackFrameAnalyzer` constructor, which takes the segment database facade.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/d9584df7-07d0-4401-b3f5-f8c5b41535bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open INTRO-192" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/2c3251e5-86f4-430e-af58-b8f9661d8408/thread/d9584df7-07d0-4401-b3f5-f8c5b41535bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-192&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=INTRO-192"><img alt="INTRO-192" src="https://capy.ai/api/badge/thread.svg?label=INTRO-192"></picture></a>
<!-- capy-pr-badge:end -->

## Summary by Sourcery

Add a regression test and minor analyzer cleanup to ensure credits chapter selection behaves correctly with long pre-credits fades.

New Features:
- Add a test case verifying that credits chapters are selected when preceded by a black-frame fade longer than five seconds, even when an earlier act-break chapter exists.

Enhancements:
- Simplify the backward black-run detection in BlackFrameAnalyzer by replacing an unused nullable start timestamp with a boolean flag.

Tests:
- Extend chapter analysis tests to cover the accept path for long pre-credits fades, locking in the rule that the latest suitable chapter marker is chosen.