### PR TITLE
Make season timestamp erasure cancellation-atomic

### DIFF
--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -76,6 +76,34 @@ public sealed class TestVisualizationController
     }
 
     [Fact]
+    public async Task EraseSeasonAsync_CancellationAfterCacheDeletion_LeavesDatabaseConsistent()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var dbPath = CreateTempDbPath();
+        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: true);
+        await SeedSeasonAsync(dbPath, seasonId, episodeIds);
+        await SeedCacheAsync(episodeIds[0], episodeIds[1]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+        var cacheService = new CancelAfterFirstDeleteCacheService(
+            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance),
+            cancellationTokenSource);
+        var controller = CreateController(new RecordingMediaSegmentRefresher(), loggerFactory, cacheService);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: true, cancellationTokenSource.Token));
+
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.False(await db.DbSegment.AnyAsync(s => episodeIds.Contains(s.ItemId)));
+        var seasonStates = await db.DbSeasonState.Where(s => s.SeasonId == seasonId).ToListAsync();
+        Assert.All(seasonStates, state => Assert.Empty(state.EpisodeIds));
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        Assert.False(await cacheDb.DetectionCache.AnyAsync(e => episodeIds.Contains(e.ItemId)));
+    }
+
+    [Fact]
     public async Task ClearExcludedTimestampsAsync_RemovesOnlyCurrentlyExcludedState()
     {
         var seriesId = Guid.NewGuid();
@@ -169,7 +197,10 @@ public sealed class TestVisualizationController
         }
     }
 
-    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory)
+    private static VisualizationController CreateController(
+        RecordingMediaSegmentRefresher refresher,
+        ILoggerFactory loggerFactory,
+        IDetectionCacheService? cacheService = null)
     {
         return new VisualizationController(
             NullLogger<VisualizationController>.Instance,
@@ -179,7 +210,7 @@ public sealed class TestVisualizationController
             fileSystem: null!,
             loggerFactory,
             ffmpegService: null!,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            cacheService ?? new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
@@ -270,6 +301,7 @@ public sealed class TestVisualizationController
 
         public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             RefreshCallCount++;
             CollectionCallCount++;
             LastItemIds = [.. itemIds];
@@ -281,5 +313,34 @@ public sealed class TestVisualizationController
             RemoveCallCount++;
             return RefreshAsync(itemIds, cancellationToken);
         }
+    }
+
+    private sealed class CancelAfterFirstDeleteCacheService(
+        IDetectionCacheService inner,
+        CancellationTokenSource cancellationTokenSource) : IDetectionCacheService
+    {
+        private int _deleteCount;
+
+        public bool IsEnabled => inner.IsEnabled;
+
+        public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
+            => inner.TryRead(itemId, mode, type, start, end, out result);
+
+        public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
+            => inner.Write(itemId, mode, type, start, end, items);
+
+        public void DeleteForItem(Guid itemId)
+        {
+            inner.DeleteForItem(itemId);
+            if (Interlocked.Increment(ref _deleteCount) == 1)
+            {
+                cancellationTokenSource.Cancel();
+            }
+        }
+
+        public void DeleteByMode(AnalysisMode mode) => inner.DeleteByMode(mode);
+
+        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode)
+            => inner.HasCachedFingerprint(episode, mode);
     }
 }

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -173,36 +173,40 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
         {
             using var db = Plugin.CreateDbContext();
 
-            // ExecuteDeleteAsync runs a single server-side DELETE and bypasses the change tracker.
-            // This is safe here because the tracked operations below target DbSeasonState, not DbSegment.
             var episodeIds = episodes.Select(e => e.EpisodeId).ToHashSet();
-            await db.DbSegment
-                .Where(s => episodeIds.Contains(s.ItemId))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await db.DbSegment
+                    .Where(s => episodeIds.Contains(s.ItemId))
+                    .ExecuteDeleteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                var seasonStates = await db.DbSeasonState
+                    .Where(s => s.SeasonId == seasonId)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (var state in seasonStates)
+                {
+                    db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
+                }
+
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                await transaction.DisposeAsync().ConfigureAwait(false);
+            }
 
             if (eraseCache)
             {
-                // Cache deletion must run to completion — the DB rows are already gone,
-                // so aborting here would leave orphaned files with no way to clean them up.
                 foreach (var episode in episodes)
                 {
                     await Task.Run(() => _cacheService.DeleteForItem(episode.EpisodeId), CancellationToken.None).ConfigureAwait(false);
                 }
             }
-
-            // Batch-load season state and clear episode IDs.
-            var seasonStates = await db.DbSeasonState
-                .Where(s => s.SeasonId == seasonId)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            foreach (var state in seasonStates)
-            {
-                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
-            }
-
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             if (Plugin.Instance.Configuration.UpdateMediaSegments)
             {

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -175,7 +175,7 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
             var episodeIds = episodes.Select(e => e.EpisodeId).ToHashSet();
             var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-            try
+            await using (transaction.ConfigureAwait(false))
             {
                 await db.DbSegment
                     .Where(s => episodeIds.Contains(s.ItemId))
@@ -194,10 +194,6 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
                 await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                await transaction.DisposeAsync().ConfigureAwait(false);
             }
 
             if (eraseCache)


### PR DESCRIPTION
`EraseSeasonAsync` could commit segment deletion before a later cancellation interrupted season-state clearing, leaving episodes marked analyzed with no stored segments.

- Execute segment deletion and analyzed-state clearing in one SQLite transaction.
- Commit both database changes before starting the intentionally non-cancellable cache cleanup.
- Preserve request cancellation for the subsequent media-segment refresh without risking database inconsistency.
- Add a regression test that cancels during cache cleanup and verifies segments, season state, and cache entries reach a consistent result.

## Summary by Sourcery

Make season timestamp erasure cancellation-safe by atomically committing database cleanup before cache deletion and media-segment refresh.

Bug Fixes:
- Make season erasure commit segment deletion and analyzed-state clearing atomically to prevent inconsistent database state when cancellation occurs during cache cleanup.

Enhancements:
- Keep cache cleanup non-cancellable after the database transaction commits while preserving cancellation for the subsequent media-segment refresh.

Tests:
- Add regression coverage for cancellation during cache deletion, verifying database segments, season state, and cache entries remain consistent.