### PR TITLE
Keep transient credit-analysis failures retriable

### DIFF
--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1185,19 +1185,64 @@ public class TestBlackFrames
     [Fact]
     public async Task TestAnalyzeMediaFiles_DetectionException_Continues()
     {
-        var episode = CreateQueuedCreditsEpisode();
+        var failedEpisode = CreateQueuedCreditsEpisode();
+        var noCreditsEpisode = CreateQueuedCreditsEpisode();
         var ffmpeg = new FakeFFmpegService([])
         {
             CreditsScanException = new InvalidOperationException("test failure"),
+            CreditsScanExceptionOnCall = 1,
         };
         var analyzer = CreateCreditsBlackFrameAnalyzer(ffmpeg);
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
 
-        var result = await analyzer.AnalyzeMediaFiles([episode], AnalysisMode.Credits, CancellationToken.None);
+        var result = await analyzer.AnalyzeMediaFiles([failedEpisode, noCreditsEpisode], AnalysisMode.Credits, CancellationToken.None);
 
-        Assert.Same(episode, result[0]);
+        Assert.Same(failedEpisode, result[0]);
+        Assert.Equal(EpisodeState.AnalysisFailed, failedEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.True(failedEpisode.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.Equal(EpisodeState.NotAnalyzed, noCreditsEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.Equal(2, ffmpeg.CreditsScanCalls);
+    }
+
+    [Fact]
+    public async Task TestBlackFrameAnalyzer_BinarySearchException_MarksFailureAndContinues()
+    {
+        var failedEpisode = CreateQueuedCreditsEpisode();
+        var noCreditsEpisode = CreateQueuedCreditsEpisode();
+        var ffmpeg = new FakeFFmpegService([])
+        {
+            RangeScanException = new InvalidOperationException("test failure"),
+            RangeScanExceptionOnCall = 2,
+        };
+        var analyzer = new BlackFrameAnalyzer(NullLogger<BlackFrameAnalyzer>.Instance, ffmpeg);
+        var config = (PluginConfiguration)EntrypointTestHelpers.GetPrivateField(analyzer, "_config");
+        config.UseChapterMarkersBlackFrame = false;
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        await analyzer.AnalyzeMediaFiles([failedEpisode, noCreditsEpisode], AnalysisMode.Credits, CancellationToken.None);
+
+        Assert.Equal(EpisodeState.AnalysisFailed, failedEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.True(failedEpisode.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.Equal(EpisodeState.NotAnalyzed, noCreditsEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.True(ffmpeg.RangeScanCalls > 2);
+    }
+
+    [Fact]
+    public async Task TestAnalyzeMediaFiles_OptionalIntervalException_RemainsDegradable()
+    {
+        var episode = CreateQueuedCreditsEpisode();
+        var ffmpeg = new FakeFFmpegService(CreateLowDensitySingleCandidateFrames())
+        {
+            IntervalScanException = new InvalidOperationException("test failure"),
+        };
+        var analyzer = CreateCreditsBlackFrameAnalyzer(ffmpeg);
+        SetDetectNonBlackCredits(analyzer, value: false);
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        await analyzer.AnalyzeMediaFiles([episode], AnalysisMode.Credits, CancellationToken.None);
+
         Assert.Equal(EpisodeState.NotAnalyzed, episode.GetAnalyzed(AnalysisMode.Credits));
-        Assert.Equal(1, ffmpeg.CreditsScanCalls);
+        Assert.Equal(1, ffmpeg.IntervalScanCalls);
     }
 
     // ── Non-black (entropy/saturation) credit fallback ───────────────────
@@ -1991,6 +2036,12 @@ public class TestBlackFrames
 
         public Exception? CreditsScanException { get; init; }
 
+        public int? CreditsScanExceptionOnCall { get; init; }
+
+        public Exception? RangeScanException { get; init; }
+
+        public int? RangeScanExceptionOnCall { get; init; }
+
         public Exception? IntervalScanException { get; init; }
 
         public int CreditsScanCalls { get; private set; }
@@ -2036,6 +2087,12 @@ public class TestBlackFrames
             LastProbeThreshold = threshold;
             LastProbeMode = mode;
             cancellationToken.ThrowIfCancellationRequested();
+            if (RangeScanException is not null &&
+                (RangeScanExceptionOnCall is null || RangeScanCalls == RangeScanExceptionOnCall))
+            {
+                throw RangeScanException;
+            }
+
             return Task.FromResult(_probeFrames);
         }
 
@@ -2043,7 +2100,8 @@ public class TestBlackFrames
         {
             CreditsScanCalls++;
             cancellationToken.ThrowIfCancellationRequested();
-            if (CreditsScanException is not null)
+            if (CreditsScanException is not null &&
+                (CreditsScanExceptionOnCall is null || CreditsScanCalls == CreditsScanExceptionOnCall))
             {
                 throw CreditsScanException;
             }

--- a/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
+++ b/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Data;
+using IntroSkipper.FFmpeg;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestChromaprintFailureHandling
+{
+    [Fact]
+    public async Task AnalyzeMediaFiles_FingerprintException_MarksFailureAndContinues()
+    {
+        var episodes = new[] { CreateEpisode(1), CreateEpisode(2) };
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            new ThrowingFingerprintService(),
+            new NoOpDetectionCacheService());
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        var result = await analyzer.AnalyzeMediaFiles(episodes, AnalysisMode.Introduction, CancellationToken.None);
+
+        // A fingerprint that could not be produced is a failed attempt, not a "nothing found" verdict.
+        // Left as NotAnalyzed the episode is persisted in the season's analyzed-episode list and cached
+        // as NoSegments on the next run, so a one-off ffmpeg failure becomes permanent.
+        Assert.Same(episodes, result);
+        Assert.All(episodes, e => Assert.Equal(EpisodeState.AnalysisFailed, e.GetAnalyzed(AnalysisMode.Introduction)));
+    }
+
+    private static QueuedEpisode CreateEpisode(int number) => new()
+    {
+        EpisodeId = Guid.NewGuid(),
+        SeasonId = Guid.Empty,
+        SeriesName = "Rick and Morty",
+        SeasonNumber = 1,
+        EpisodeNumber = number,
+        Name = $"S01E0{number}",
+        Duration = 1800,
+        IntroFingerprintEnd = 600,
+    };
+
+    private sealed class ThrowingFingerprintService : IFFmpegService
+    {
+        public Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new FingerprintException("chromaprint output was malformed");
+
+        public Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, TimeRange range, int minimum, int threshold, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<KeyframeVisual[]> DetectKeyframeVisualsAsync(QueuedEpisode episode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackInterval[]> DetectBlackIntervalsAsync(QueuedEpisode episode, TimeRange range, int threshold, int minimum, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public FFmpegCheckResult GetCheckResult() => FFmpegCheckResult.NotRun;
+    }
+
+    private sealed class NoOpDetectionCacheService : IDetectionCacheService
+    {
+        public bool IsEnabled => false;
+
+        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode) => false;
+
+        public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
+        {
+            result = [];
+            return false;
+        }
+
+        public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items) => false;
+
+        public void DeleteForItem(Guid itemId)
+        {
+        }
+
+        public void DeleteByMode(AnalysisMode mode)
+        {
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -331,6 +331,106 @@ public sealed class TestSeasonReanalysisPlanner
 public sealed class TestSeasonReanalysisReset
 {
     [Fact]
+    public async Task PersistableEpisodeIds_ExcludeFailuresWithoutDiscardingNegativeCacheResults()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var failedMediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+        var noSegmentsMediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+        var seasonId = Guid.NewGuid();
+        var failedId = Guid.NewGuid();
+        var noSegmentsId = Guid.NewGuid();
+        var analyzedId = Guid.NewGuid();
+        var userProvidedId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var configHash = ConfigHasher.Analysis(
+            config,
+            AnalysisMode.Credits,
+            AnalyzerAction.Default,
+            ffmpegValid: true);
+
+        var failed = CreateQueuedEpisode(failedId, seasonId);
+        failed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
+        var noSegments = CreateQueuedEpisode(noSegmentsId, seasonId);
+        var analyzed = CreateQueuedEpisode(analyzedId, seasonId);
+        analyzed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
+        Assert.True(analyzed.NeedsAnalysis(AnalysisMode.Credits));
+        analyzed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.Analyzed);
+        var userProvided = CreateQueuedEpisode(userProvidedId, seasonId);
+        userProvided.SetAnalyzed(AnalysisMode.Credits, EpisodeState.UserProvided);
+
+        var persistableIds = BaseItemAnalyzerTask.GetPersistableEpisodeIds(
+            [failed, noSegments, analyzed, userProvided],
+            AnalysisMode.Credits);
+
+        Assert.Equal([noSegmentsId, analyzedId, userProvidedId], persistableIds);
+        Assert.True(failed.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.False(analyzed.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.False(userProvided.NeedsAnalysis(AnalysisMode.Credits));
+
+        try
+        {
+            await File.WriteAllTextAsync(failedMediaPath, string.Empty);
+            await File.WriteAllTextAsync(noSegmentsMediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var failedItem = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(failedItem, "Id", failedId);
+                EntrypointTestHelpers.SetPropertyOrField(failedItem, "Path", failedMediaPath);
+                var noSegmentsItem = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(noSegmentsItem, "Id", noSegmentsId);
+                EntrypointTestHelpers.SetPropertyOrField(noSegmentsItem, "Path", noSegmentsMediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(failedItem, noSegmentsItem);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                await Plugin.SetEpisodeIdsAsync(
+                    seasonId,
+                    AnalysisMode.Credits,
+                    persistableIds,
+                    configHash);
+
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+                var nextRun = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(failedId, seasonId), CreateQueuedEpisode(noSegmentsId, seasonId)],
+                    [AnalysisMode.Credits]);
+
+                Assert.Equal(EpisodeState.NotAnalyzed, nextRun[0].GetAnalyzed(AnalysisMode.Credits));
+                Assert.Equal(EpisodeState.NoSegments, nextRun[1].GetAnalyzed(AnalysisMode.Credits));
+            }
+        }
+        finally
+        {
+            if (File.Exists(failedMediaPath))
+            {
+                File.Delete(failedMediaPath);
+            }
+
+            if (File.Exists(noSegmentsMediaPath))
+            {
+                File.Delete(noSegmentsMediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task SettleReanalysisGuard_PersistsCompletedEpisodeSet()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -119,6 +119,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
             }
             catch (Exception ex)
             {
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
                 LogErrorAnalyzingCredits(_logger, ex, episode.Name);
             }
         }
@@ -214,6 +215,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
         }
         catch (Exception ex)
         {
+            episode.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
             LogErrorDuringAnalysis(_logger, ex, episode.Name);
             return null;
         }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -81,8 +81,11 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
                 LogCaughtFingerprintError(ex);
                 WarningManager.SetFlag(PluginWarning.InvalidChromaprintFingerprint);
 
-                // Fallback to an empty fingerprint on any error
+                // Fallback to an empty fingerprint on any error, and record the failure so the episode
+                // is retried on the next run. Without this it is persisted as a completed no-segment
+                // result, and an ffmpeg hiccup on one episode becomes a permanent verdict.
                 fingerprintCache[episode.EpisodeId] = [];
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
             }
         }
 

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -82,6 +82,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
             }
             catch (Exception ex)
             {
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
                 LogErrorAnalyzingCredits(ex, episode.Name);
             }
         }

--- a/IntroSkipper/Data/EpisodeState.cs
+++ b/IntroSkipper/Data/EpisodeState.cs
@@ -30,4 +30,9 @@ public enum EpisodeState
     /// Episode segment was provided externally via the segment editor and must not be overwritten by automatic analysis.
     /// </summary>
     UserProvided,
+
+    /// <summary>
+    /// Episode analysis failed and must not be cached as a completed no-segment result.
+    /// </summary>
+    AnalysisFailed,
 }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -428,10 +428,21 @@ public partial class BaseItemAnalyzerTask(
         }
 
         // Set the episode IDs for the analyzed items
-        await Plugin.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), configHash, cancellationToken).ConfigureAwait(false);
+        await Plugin.SetEpisodeIdsAsync(first.SeasonId, mode, GetPersistableEpisodeIds(items, mode), configHash, cancellationToken).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
     }
+
+    /// <summary>
+    /// Gets episode IDs whose analysis result can be persisted for the current configuration.
+    /// </summary>
+    /// <param name="items">Episodes in the current season pass.</param>
+    /// <param name="mode">Analysis mode being processed.</param>
+    /// <returns>Episode IDs excluding transient analysis failures.</returns>
+    internal static IReadOnlyList<Guid> GetPersistableEpisodeIds(IReadOnlyList<QueuedEpisode> items, AnalysisMode mode)
+        => [.. items
+            .Where(item => item.GetAnalyzed(mode) != EpisodeState.AnalysisFailed)
+            .Select(item => item.EpisodeId)];
 
     /// <summary>
     /// Decide whether an anime Preview segment needs to be written for an episode, and build it.


### PR DESCRIPTION
Per-episode FFmpeg failures in the black-frame analyzers were logged and swallowed, after which the season pass persisted those episodes as completed. On the next scan they became cached `NoSegments` results instead of being retried.

- Add a transient `AnalysisFailed` episode state for hard per-item analyzer failures.
- Mark failures from both black-frame analyzer variants, including the default analyzer's inner binary-search path.
- Keep failed episodes eligible for later analyzers in the same chain and allow a later success to replace the failure state.
- Exclude unresolved failures from persisted analyzed episode IDs while retaining legitimate negative-cache results and protected user segments.
- Add coverage for analyzer isolation, optional degraded fallback, and the database-to-next-queue persistence boundary.

## Summary by Sourcery

Preserve transient analyzer failures as retriable episode states across analysis and persistence boundaries.

Bug Fixes:
- Keep per-episode analyzer failures transient so affected episodes remain eligible for retry instead of being cached as completed no-segment results.
- Mark failures from black-frame and Chromaprint analyzers, including failures during black-frame binary search, while preserving optional degraded fallback behavior.
- Exclude unresolved analysis failures from persisted season episode IDs while retaining valid negative-cache and user-provided results.

Enhancements:
- Allow later analyzers in the same chain to process failed episodes and replace a failure state with a successful result.

Tests:
- Add coverage for analyzer isolation, binary-search failures, optional fallback behavior, Chromaprint failures, and persistence-to-next-queue retry behavior.