### PR TITLE
Abort cache cleanup after incomplete media inventory

### DIFF
--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Manager;
+using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestCleanCacheTask
+{
+    [Fact]
+    public async Task ExecuteAsync_IncompleteInventory_PreservesStoredData()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var dbPath = CreateTempDbPath();
+        using var scope = CreatePluginScope(dbPath);
+        await SeedStoredDataAsync(dbPath, seasonId, episodeId);
+        var task = CreateTask(EntrypointTestHelpers.CreateLibraryManager());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => task.ExecuteAsync(new Progress<double>(), CancellationToken.None));
+
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.True(await db.DbSegment.AnyAsync(s => s.ItemId == episodeId));
+        Assert.True(await db.DbSeasonState.AnyAsync(s => s.SeasonId == seasonId));
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        Assert.True(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == episodeId));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CompleteInventory_RemovesStoredDataForMissingItems()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var dbPath = CreateTempDbPath();
+        using var scope = CreatePluginScope(dbPath);
+        await SeedStoredDataAsync(dbPath, seasonId, episodeId);
+        var libraryManager = InventoryLibraryManager.Create([], []);
+        var progress = new RecordingProgress();
+        var task = CreateTask(libraryManager);
+
+        await task.ExecuteAsync(progress, CancellationToken.None);
+
+        Assert.Equal(100, progress.Value);
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.False(await db.DbSegment.AnyAsync());
+        Assert.False(await db.DbSeasonState.AnyAsync());
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        Assert.False(await cacheDb.DetectionCache.AnyAsync());
+    }
+
+    [Fact]
+    public async Task GetMediaInventory_LibraryQueryFailure_IsIncomplete()
+    {
+        using var scope = CreatePluginScope(CreateTempDbPath());
+        var libraryManager = InventoryLibraryManager.Create(
+            [CreateVirtualFolder()],
+            [],
+            throwOnItemList: true);
+        var queueManager = CreateQueueManager(libraryManager);
+
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true);
+
+        Assert.False(inventory.IsComplete);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetMediaInventory_OmittedSupportedItem_IsIncomplete(bool throwDuringProbe)
+    {
+        using var scope = CreatePluginScope(CreateTempDbPath(), probeAudioDuration: throwDuringProbe);
+        var movie = new Movie
+        {
+            Name = "Movie",
+            Path = throwDuringProbe ? "/tmp/movie.mkv" : string.Empty,
+            RunTimeTicks = TimeSpan.FromMinutes(90).Ticks,
+        };
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", Guid.NewGuid());
+        var libraryManager = InventoryLibraryManager.Create([CreateVirtualFolder()], [movie]);
+        var queueManager = CreateQueueManager(libraryManager);
+
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true);
+
+        Assert.False(inventory.IsComplete);
+    }
+
+    private static CleanCacheTask CreateTask(ILibraryManager libraryManager)
+        => new(
+            NullLogger<CleanCacheTask>.Instance,
+            NullLoggerFactory.Instance,
+            libraryManager,
+            providerManager: null!,
+            fileSystem: null!,
+            new ProbeFailureFfmpegService(),
+            new NullMediaSegmentRefresher());
+
+    private static QueueManager CreateQueueManager(ILibraryManager libraryManager)
+        => new(
+            NullLogger<QueueManager>.Instance,
+            libraryManager,
+            providerManager: null!,
+            fileSystem: null!,
+            new ProbeFailureFfmpegService());
+
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(
+        string dbPath,
+        bool probeAudioDuration = false)
+    {
+        var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration
+        {
+            ProbeAudioDuration = probeAudioDuration,
+            UpdateMediaSegments = false,
+        });
+        return scope;
+    }
+
+    private static async Task SeedStoredDataAsync(string dbPath, Guid seasonId, Guid episodeId)
+    {
+        await using (var db = new IntroSkipperDbContext(dbPath))
+        {
+            await db.Database.EnsureCreatedAsync();
+            db.DbSegment.Add(new DbSegment(
+                new Segment(episodeId, new TimeRange(10, 20)),
+                AnalysisMode.Introduction));
+            db.DbSeasonState.Add(new DbSeasonState(
+                seasonId,
+                AnalysisMode.Introduction,
+                AnalyzerAction.Default,
+                [episodeId]));
+            await db.SaveChangesAsync();
+        }
+
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        cacheDb.DetectionCache.Add(new DbDetectionCache(
+            episodeId,
+            AnalysisMode.Introduction,
+            CacheEntryType.Chromaprint,
+            EntrypointTestHelpers.EmptyJsonArray));
+        await cacheDb.SaveChangesAsync();
+    }
+
+    private static VirtualFolderInfo CreateVirtualFolder()
+        => new()
+        {
+            Name = "Library",
+            ItemId = Guid.NewGuid().ToString("N"),
+        };
+
+    private static string CreateTempDbPath()
+    {
+        var directory = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests", "clean-cache");
+        Directory.CreateDirectory(directory);
+        return Path.Join(directory, Guid.NewGuid().ToString("N") + ".db");
+    }
+
+    private sealed class RecordingProgress : IProgress<double>
+    {
+        public double? Value { get; private set; }
+
+        public void Report(double value) => Value = value;
+    }
+
+    private class InventoryLibraryManager : DispatchProxy
+    {
+        private IReadOnlyList<VirtualFolderInfo> _folders = [];
+        private IReadOnlyList<BaseItem> _items = [];
+        private bool _throwOnItemList;
+
+        public static ILibraryManager Create(
+            IReadOnlyList<VirtualFolderInfo> folders,
+            IReadOnlyList<BaseItem> items,
+            bool throwOnItemList = false)
+        {
+            var proxy = Create<ILibraryManager, InventoryLibraryManager>();
+            var state = (InventoryLibraryManager)(object)proxy;
+            state._folders = folders;
+            state._items = items;
+            state._throwOnItemList = throwOnItemList;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(ILibraryManager.GetVirtualFolders) => _folders.ToList(),
+                nameof(ILibraryManager.GetItemList) when _throwOnItemList => throw new IOException("library unavailable"),
+                nameof(ILibraryManager.GetItemList) => _items.ToList(),
+                nameof(ILibraryManager.GetItemById) => null,
+                _ => throw new NotImplementedException(targetMethod?.Name),
+            };
+        }
+    }
+
+    private sealed class ProbeFailureFfmpegService : IFFmpegService
+    {
+        public Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<uint>());
+
+        public Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<TimeRange>());
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, TimeRange range, int minimum, int threshold, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<BlackFrame>());
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<BlackFrame>());
+
+        public Task<KeyframeVisual[]> DetectKeyframeVisualsAsync(QueuedEpisode episode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<KeyframeVisual>());
+
+        public Task<BlackInterval[]> DetectBlackIntervalsAsync(QueuedEpisode episode, TimeRange range, int threshold, int minimum, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<BlackInterval>());
+
+        public Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<double>());
+
+        public Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
+            => throw new IOException("probe failed");
+
+        public string GetChromaprintLogs() => string.Empty;
+    }
+
+    private sealed class NullMediaSegmentRefresher : IMediaSegmentRefresher
+    {
+        public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -83,6 +83,23 @@ public sealed class TestCleanCacheTask
         Assert.False(inventory.IsComplete);
     }
 
+    [Fact]
+    public async Task GetMediaInventory_InvalidFolderItemId_IsIncomplete()
+    {
+        using var scope = CreatePluginScope(CreateTempDbPath());
+        var folder = new VirtualFolderInfo
+        {
+            Name = "Library",
+            ItemId = "not-a-guid",
+        };
+        var libraryManager = InventoryLibraryManager.Create([folder], []);
+        var queueManager = CreateQueueManager(libraryManager);
+
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true);
+
+        Assert.False(inventory.IsComplete);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -107,6 +107,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 // Some virtual folders don't have a proper item id.
                 if (!Guid.TryParse(folder.ItemId, out var folderId))
                 {
+                    isComplete = false;
+                    LogInvalidFolderId(_logger, folder.Name);
                     continue;
                 }
 
@@ -562,6 +564,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to enumerate virtual folders")]
     private static partial void LogFailedEnumerateLibraries(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping library \"{Name}\": virtual folder does not have a valid item id")]
+    private static partial void LogInvalidFolderId(ILogger logger, string name);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Not analyzing library \"{Name}\": Intro Skipper is disabled in library settings. To enable, check library configuration > Media Segment Providers")]
     private static partial void LogLibraryDisabled(ILogger logger, string name);

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -50,8 +50,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
-    public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
-        => GetMediaItems(includeExcluded: false, cancellationToken);
+    public async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
+        => (await GetMediaInventory(includeExcluded: false, cancellationToken).ConfigureAwait(false)).Items;
 
     internal async Task<bool> GetFfmpegValidAsync(CancellationToken cancellationToken = default)
     {
@@ -66,12 +66,15 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     }
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
+        => (await GetMediaInventory(includeExcluded, cancellationToken).ConfigureAwait(false)).Items;
+
+    internal async Task<MediaInventoryResult> GetMediaInventory(bool includeExcluded, CancellationToken cancellationToken = default)
     {
         var plugin = Plugin.Instance;
         if (plugin is null)
         {
             LogPluginInstanceNull(_logger);
-            return _queuedEpisodes;
+            return new MediaInventoryResult(_queuedEpisodes, false);
         }
 
         if (!includeExcluded)
@@ -81,43 +84,58 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         LoadAnalysisSettings(plugin);
 
-        // For all selected libraries, enqueue all contained episodes.
-        var virtualFolders = _libraryManager.GetVirtualFolders();
-        if (virtualFolders is null)
+        var isComplete = true;
+        try
         {
-            LogLibraryManagerNull(_logger);
-            return _queuedEpisodes;
+            var virtualFolders = _libraryManager.GetVirtualFolders();
+            if (virtualFolders is null)
+            {
+                LogLibraryManagerNull(_logger);
+                return new MediaInventoryResult(_queuedEpisodes, false);
+            }
+
+            foreach (var folder in virtualFolders)
+            {
+                if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true)
+                {
+                    LogLibraryDisabled(_logger, folder.Name);
+                    continue;
+                }
+
+                LogRunningEnqueueLibrary(_logger, folder.Name);
+
+                // Some virtual folders don't have a proper item id.
+                if (!Guid.TryParse(folder.ItemId, out var folderId))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (!await QueueLibraryContents(folderId, includeExcluded, cancellationToken).ConfigureAwait(false))
+                    {
+                        isComplete = false;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    isComplete = false;
+                    LogFailedEnqueueLibrary(_logger, folder.Name, ex);
+                }
+            }
         }
-
-        foreach (var folder in virtualFolders)
+        catch (OperationCanceledException)
         {
-            // If libraries have been selected for analysis, ensure this library was selected.
-            if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true)
-            {
-                LogLibraryDisabled(_logger, folder.Name);
-                continue;
-            }
-
-            LogRunningEnqueueLibrary(_logger, folder.Name);
-
-            // Some virtual folders don't have a proper item id.
-            if (!Guid.TryParse(folder.ItemId, out var folderId))
-            {
-                continue;
-            }
-
-            try
-            {
-                await QueueLibraryContents(folderId, includeExcluded, cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                LogFailedEnqueueLibrary(_logger, folder.Name, ex);
-            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            isComplete = false;
+            LogFailedEnumerateLibraries(_logger, ex);
         }
 
         if (_refreshedEpisodes.Count > 0)
@@ -135,7 +153,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
         }
 
-        return _queuedEpisodes;
+        return new MediaInventoryResult(_queuedEpisodes, isComplete);
     }
 
     /// <summary>
@@ -164,7 +182,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
     }
 
-    private async Task QueueLibraryContents(Guid id, bool includeExcluded, CancellationToken cancellationToken)
+    private async Task<bool> QueueLibraryContents(Guid id, bool includeExcluded, CancellationToken cancellationToken)
     {
         LogConstructingQuery(_logger);
 
@@ -178,20 +196,20 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             IsVirtualItem = false
         };
 
-        var items = _libraryManager.GetItemList(query, false)
-            .DistinctBy(e => e.Id)
-            .ToList();
-
-        if (items is null)
+        var libraryItems = _libraryManager.GetItemList(query, false);
+        if (libraryItems is null)
         {
             LogLibraryQueryNull(_logger);
-            return;
+            return false;
         }
+
+        var items = libraryItems.DistinctBy(e => e.Id).ToList();
 
         // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
 
         var queuedCount = 0;
+        var isComplete = true;
         foreach (var item in items)
         {
             try
@@ -202,12 +220,20 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                     {
                         queuedCount++;
                     }
+                    else if (includeExcluded)
+                    {
+                        isComplete = false;
+                    }
                 }
                 else if (item is Movie movie)
                 {
                     if (await QueueMovieAsync(movie, includeExcluded, cancellationToken).ConfigureAwait(false))
                     {
                         queuedCount++;
+                    }
+                    else if (includeExcluded)
+                    {
+                        isComplete = false;
                     }
                 }
                 else
@@ -221,11 +247,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
             catch (Exception ex)
             {
+                isComplete = false;
                 LogErrorProcessingItem(_logger, ex, item.Name, item.Id);
             }
         }
 
         LogQueuedEpisodes(_logger, queuedCount);
+        return isComplete;
     }
 
     private async Task<bool> QueueEpisode(Episode episode, bool includeExcluded, CancellationToken cancellationToken)
@@ -532,6 +560,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     [LoggerMessage(Level = LogLevel.Error, Message = "Library manager returned null when requesting virtual folders")]
     private static partial void LogLibraryManagerNull(ILogger logger);
 
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to enumerate virtual folders")]
+    private static partial void LogFailedEnumerateLibraries(ILogger logger, Exception exception);
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Not analyzing library \"{Name}\": Intro Skipper is disabled in library settings. To enable, check library configuration > Media Segment Providers")]
     private static partial void LogLibraryDisabled(ILogger logger, string name);
 
@@ -591,4 +622,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping analysis of {Name} ({Id})")]
     private static partial void LogSkippingAnalysisException(ILogger logger, string name, Guid id, Exception exception);
+
+    internal sealed record MediaInventoryResult(
+        IReadOnlyDictionary<Guid, List<QueuedEpisode>> Items,
+        bool IsComplete);
 }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -87,9 +87,15 @@ public partial class CleanCacheTask(
             _fileSystem,
             _ffmpegService);
 
-        // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
+        // QueueManager.GetMediaInventory() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders.
-        var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true, cancellationToken).ConfigureAwait(false);
+        if (!inventory.IsComplete)
+        {
+            throw new InvalidOperationException("Cannot clean the Intro Skipper cache because the media inventory is incomplete");
+        }
+
+        var queue = inventory.Items;
         var enabledLibraryEpisodeIds = queue.Values
             .SelectMany(static episodes => episodes)
             .Select(static episode => episode.EpisodeId)

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -92,6 +92,7 @@ public partial class CleanCacheTask(
         var inventory = await queueManager.GetMediaInventory(includeExcluded: true, cancellationToken).ConfigureAwait(false);
         if (!inventory.IsComplete)
         {
+            LogIncompleteInventory(_logger);
             throw new InvalidOperationException("Cannot clean the Intro Skipper cache because the media inventory is incomplete");
         }
 
@@ -166,6 +167,9 @@ public partial class CleanCacheTask(
     {
         return [];
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Aborting cache cleanup: the media inventory is incomplete, so cached data cannot be safely removed. Check the preceding log entries for the libraries or items that failed to enumerate")]
+    private static partial void LogIncompleteInventory(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting detection cache rows for episode ID: {EpisodeId}")]
     private static partial void LogDeletingDetectionCacheRows(ILogger logger, Guid episodeId);


### PR DESCRIPTION
The cleanup task treated QueueManager's best-effort results as a complete library inventory. A transient library or item failure could therefore make valid timestamps, detection cache entries, and season state look stale and delete them.

- Return an explicit completeness verdict with authoritative media inventories.
- Mark inventory incomplete when virtual-folder enumeration, library queries, item queueing, or supported-item admission fails.
- Treat no-path items as incomplete during cleanup scans because they still exist in the library but cannot be represented safely.
- Abort cleanup before any destructive operation when inventory is incomplete, surfacing the scheduled-task failure for retry.
- Add regression coverage proving incomplete scans preserve all stored data and complete scans still remove genuinely stale records.

## Summary by Sourcery

Protect cache cleanup by requiring a complete authoritative media inventory before removing stale data.

Bug Fixes:
- Prevent cache cleanup from deleting valid stored data when media inventory collection is incomplete.

Enhancements:
- Add explicit media inventory completeness reporting across library enumeration and item admission.
- Abort destructive cleanup and surface scheduled-task failure when any library or supported item cannot be inventoried safely.

Tests:
- Add regression coverage confirming incomplete inventories preserve segments, season state, and detection cache entries, while complete inventories remove stale records.