### PR TITLE
ci: Apply grouped Dependabot updates for the codeql-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,14 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      # The codeql-action sub-actions (init, autobuild, analyze) must run at the
+      # same version within a workflow; separate bump PRs leave the intermediate
+      # merges with mismatched versions, which fails the CodeQL run outright.
+      codeql-action:
+        patterns:
+          - github/codeql-action
+          - github/codeql-action/*
     labels:
       - dependency
       - github_actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,13 +35,13 @@ jobs:
         uses: ./.github/actions/setup-build-env
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION
Aligns the CodeQL action pins on `12.0` with the dependabot bumps merged to `10.11` (#895, #896, #897). Dependabot only tracks the default branch, but the CodeQL workflow runs on pushes to every branch, so `12.0` was still analyzing with v4.37.0. Pins `init`, `autobuild`, and `analyze` to the same `5595ccaf` SHA (v4.37.6), which also picks up the 4.37.5 fallback fix for network errors while streaming the CodeQL bundle download.

Also cherry-picks #903 so the `codeql-action` sub-actions arrive as a single grouped Dependabot PR on this branch too, keeping init/autobuild/analyze in lockstep.

## Summary by Sourcery

CI:
- Bump github/codeql-action init, autobuild, and analyze steps in the CodeQL workflow to v4.37.6 with a unified SHA pin.
- Cherry-pick the Dependabot `groups` entry from #903 so all github/codeql-action bumps arrive as one PR.