### PR TITLE
ci(deps): group codeql-action bumps into a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      # The codeql-action sub-actions (init, autobuild, analyze) must run at the
+      # same version within a workflow; separate bump PRs leave the intermediate
+      # merges with mismatched versions, which fails the CodeQL run outright.
+      codeql-action:
+        patterns:
+          - github/codeql-action*
     labels:
       - dependency
       - github_actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,8 @@ updates:
       # merges with mismatched versions, which fails the CodeQL run outright.
       codeql-action:
         patterns:
-          - github/codeql-action*
+          - github/codeql-action
+          - github/codeql-action/*
     labels:
       - dependency
       - github_actions


### PR DESCRIPTION
Dependabot bumps `github/codeql-action/init`, `autobuild`, and `analyze` in separate PRs (#895, #896, #897). Merging them one at a time leaves the workflow with mismatched sub-action versions between merges, and CodeQL fails hard on that: the push run for 8ffb78e (autobuild at 4.37.6 while init was still 4.37.4) failed with `Loaded a configuration file for version '4.37.4', but running version '4.37.6'` until #896 aligned all three.

This adds a Dependabot `groups` entry so all `github/codeql-action*` updates arrive as one PR, keeping the sub-actions in lockstep and avoiding the transient red CodeQL runs on every bump train.

## Summary by Sourcery

CI:
- Add a Dependabot groups configuration to ensure all github/codeql-action-related bumps are raised together instead of as separate PRs.