### PR TITLE
Fix legacy Chromaprint cache hash to match pre-stream-selection rows

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -312,6 +312,25 @@ public sealed class TestCacheOperations
         Assert.Equal(fingerprint, result);
     }
 
+    [Fact]
+    public void LegacyChromaprintCacheHash_MatchesPreStreamSelectionRows()
+    {
+        // Pinned output of the pre-stream-selection Chromaprint cache hash for a default
+        // configuration; rows written by releases without audio stream selection carry exactly
+        // this value. If this changes, upgraded servers refingerprint their entire library.
+        var hash = ConfigHasher.LegacyChromaprintCacheWithoutLanguage(new PluginConfiguration(), AnalysisMode.Introduction);
+
+        Assert.Equal("1CD6171D4F6FA587", hash);
+
+        // The legacy hash predates audio stream selection, so those settings must not affect it.
+        var changedSelection = new PluginConfiguration
+        {
+            PreferredAudioLanguage = "eng",
+            PreferAudioStreamWithMostChannels = false
+        };
+        Assert.Equal(hash, ConfigHasher.LegacyChromaprintCacheWithoutLanguage(changedSelection, AnalysisMode.Introduction));
+    }
+
     [Theory]
     [InlineData(AnalysisMode.Introduction)]
     [InlineData(AnalysisMode.Credits)]

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -62,10 +62,14 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
             var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), type, mode, cacheVariant);
             if (!string.IsNullOrEmpty(entry.ConfigHash)
-                && !string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal)
-                && !string.Equals(entry.ConfigHash, legacyConfigHash, StringComparison.Ordinal))
+                && !string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal))
             {
-                return false;
+                if (!string.Equals(entry.ConfigHash, legacyConfigHash, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                LogLegacyDetectionCacheReused(_logger, itemId, mode, type);
             }
 
             result = DecompressBrotli<T[]>(entry.Data) ?? [];
@@ -186,6 +190,9 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Detection cache hit for {CacheKey}")]
     private static partial void LogDetectionCacheHit(ILogger logger, string cacheKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Reusing pre-stream-selection {Type} cache entry for {ItemId} in {Mode} mode")]
+    private static partial void LogLegacyDetectionCacheReused(ILogger logger, Guid itemId, AnalysisMode mode, CacheEntryType type);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Error reading detection cache from {Path}")]
     private static partial void LogDetectionCacheReadError(ILogger logger, Exception ex, string path);

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -788,7 +788,6 @@ public sealed partial class FFmpegService(
                 return null;
             }
 
-            var fallbackStream = SelectAudioStream(audioStreams, preferMostChannels);
             var defaultStream = SelectAudioStream(audioStreams, preferMostChannels: true);
             var candidates = hasLanguagePreference
                 ? audioStreams.Where(stream => string.Equals(stream.Language, preferredLanguage, StringComparison.OrdinalIgnoreCase)).ToList()
@@ -806,10 +805,12 @@ public sealed partial class FFmpegService(
                 ? "policy=most-channels"
                 : FormattableString.Invariant($"stream-index={selectedStream.Index}");
 
+            // Legacy rows were fingerprinted from FFmpeg's default stream (most channels, then
+            // lowest index), so they are only reusable when that is still the effective stream.
             return new AudioStreamSelection(
                 preferMostChannels && selectsDefaultMostStream ? null : selectedStream.Index,
                 cacheVariant,
-                selectedStream.Index == fallbackStream.Index);
+                selectsDefaultMostStream);
         }
         catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception)
         {

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -123,7 +123,10 @@ public static class ConfigHasher
     }
 
     /// <summary>
-    /// Computes the pre-stream-selection cache hash used when no language preference was configured.
+    /// Computes the cache hash that was written before audio stream selection existed, when
+    /// fingerprints always came from FFmpeg's default stream. It must stay byte-for-byte
+    /// identical to the pre-stream-selection input (no audio tokens), so those rows remain
+    /// readable whenever the effective stream is still FFmpeg's default.
     /// </summary>
     /// <param name="config">Plugin configuration.</param>
     /// <param name="mode">Analysis mode.</param>
@@ -133,8 +136,7 @@ public static class ConfigHasher
         ArgumentNullException.ThrowIfNull(config);
 
         var input = Invariant(
-            $"cache|v1|{CacheEntryType.Chromaprint}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
-            $"|audioLanguage=|audioMostChannels={config.PreferAudioStreamWithMostChannels}");
+            $"cache|v1|{CacheEntryType.Chromaprint}|{mode}|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}");
 
         return ComputeHash(input);
     }

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -128,6 +128,11 @@ public static class ConfigHasher
     /// identical to the pre-stream-selection input (no audio tokens), so those rows remain
     /// readable whenever the effective stream is still FFmpeg's default.
     /// </summary>
+    /// <remarks>
+    /// WARNING: never modify this input string. It is frozen to what older releases wrote;
+    /// any change silently invalidates every fingerprint cached by those releases and forces
+    /// upgraded servers to refingerprint their entire library. A pinned-hash test guards it.
+    /// </remarks>
     /// <param name="config">Plugin configuration.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <returns>The legacy default-selection cache hash.</returns>


### PR DESCRIPTION
## Summary

#879 added a legacy-hash fallback so Chromaprint fingerprints cached before audio stream selection existed stay reusable when the effective stream is still FFmpeg's default. That fallback could never fire:

- `ConfigHasher.LegacyChromaprintCacheWithoutLanguage` appended `|audioLanguage=|audioMostChannels={...}` to the hash input, but rows written before #879 were hashed **without** any audio tokens (`cache|v1|Chromaprint|{mode}|pct=...|probe=...`). The computed "legacy" hash therefore never equals a genuinely old row's hash, and every upgraded server with `CacheFingerprints` enabled silently refingerprints its entire library.
- `AudioStreamSelection.LegacyDefaultCompatible` was anchored on the configured-policy fallback stream (`preferMostChannels` as configured). Legacy rows were produced by FFmpeg's default selection (most channels, then lowest index), so with `PreferAudioStreamWithMostChannels` disabled the flag could mark a legacy fingerprint of a *different* stream as reusable.

## Changes

- `LegacyChromaprintCacheWithoutLanguage` now reproduces the pre-#879 hash input byte-for-byte (no audio tokens), so old rows validate again on the default-stream path.
- `LegacyDefaultCompatible` is now `selectsDefaultMostStream` (selected stream equals FFmpeg's default most-channels stream), matching the stream legacy rows were actually fingerprinted from; the now-unused `fallbackStream` is removed.
- New test pins the legacy hash to the exact value pre-stream-selection releases wrote (`1CD6171D4F6FA587` for a default config, Introduction mode) and asserts the audio selection settings cannot influence it.

## Testing

- `dotnet test` — 487 passed, 0 failed (with jellyfin-ffmpeg 7.1.3 installed as in CI).

## Summary by Sourcery

Restore compatibility with pre-stream-selection Chromaprint cache entries by matching their original hash and FFmpeg default-stream semantics.

Bug Fixes:
- Restore reuse of Chromaprint and detection-cache entries created before audio stream selection by matching their original hash and stream-selection behavior.
- Prevent upgraded servers from unnecessarily refingerprinting libraries when legacy cache entries remain valid.

Enhancements:
- Add debug logging when a pre-stream-selection detection-cache entry is reused.

Tests:
- Add a pinned regression test confirming the legacy Chromaprint hash remains byte-for-byte compatible and independent of audio stream settings.