### PR TITLE
Transition to the modern black frame analyzer

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -395,8 +395,8 @@ public sealed class TestCacheOperations
     [Fact]
     public void AnalysisHash_Credits_ChangesWithDetectNonBlackCredits()
     {
-        var baseline = new PluginConfiguration { UseAlternativeBlackFrameAnalyzer = true, DetectNonBlackCredits = true };
-        var changed = new PluginConfiguration { UseAlternativeBlackFrameAnalyzer = true, DetectNonBlackCredits = false };
+        var baseline = new PluginConfiguration { UseLegacyBlackFrameAnalyzer = false, DetectNonBlackCredits = true };
+        var changed = new PluginConfiguration { UseLegacyBlackFrameAnalyzer = false, DetectNonBlackCredits = false };
 
         // Toggling the non-black fallback changes credits output (when its analyzer is active), so it
         // must invalidate stored credits analysis instead of hash-matching a stale result.
@@ -406,12 +406,23 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
-    public void AnalysisHash_Credits_IgnoresDetectNonBlackCredits_WhenAlternativeAnalyzerOff()
+    public void AnalysisHash_Credits_ChangesWhenLegacyAnalyzerIsSelected()
     {
-        var baseline = new PluginConfiguration { UseAlternativeBlackFrameAnalyzer = false, DetectNonBlackCredits = true };
-        var changed = new PluginConfiguration { UseAlternativeBlackFrameAnalyzer = false, DetectNonBlackCredits = false };
+        var defaultAnalyzer = new PluginConfiguration { UseLegacyBlackFrameAnalyzer = false };
+        var legacyAnalyzer = new PluginConfiguration { UseLegacyBlackFrameAnalyzer = true };
 
-        // The default BlackFrameAnalyzer cannot observe DetectNonBlackCredits, so toggling it must not
+        Assert.NotEqual(
+            ConfigHasher.Analysis(defaultAnalyzer, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(legacyAnalyzer, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true));
+    }
+
+    [Fact]
+    public void AnalysisHash_Credits_IgnoresDetectNonBlackCredits_WhenLegacyAnalyzerIsActive()
+    {
+        var baseline = new PluginConfiguration { UseLegacyBlackFrameAnalyzer = true, DetectNonBlackCredits = true };
+        var changed = new PluginConfiguration { UseLegacyBlackFrameAnalyzer = true, DetectNonBlackCredits = false };
+
+        // The legacy BlackFrameAnalyzer cannot observe DetectNonBlackCredits, so toggling it must not
         // invalidate stored credits analysis on that path.
         Assert.Equal(
             ConfigHasher.Analysis(baseline, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true),

--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -25,6 +25,7 @@ public class TestPluginConfiguration
         Assert.Equal(120, config.MaximumRecapDetectionDuration);
         Assert.False(config.DetectRecapUsingBlackFrames);
         Assert.Equal(PluginConfiguration.DefaultSettledSeasonDelayHours, config.SettledSeasonDelayHours);
+        Assert.False(config.UseLegacyBlackFrameAnalyzer);
         Assert.Equal(string.Empty, config.ExcludeSeries);
         Assert.Equal(string.Empty, config.PreferredAudioLanguage);
         Assert.True(config.PreferAudioStreamWithMostChannels);

--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using System.Xml;
 using System.Xml.Serialization;
 using IntroSkipper.Configuration;
 using Xunit;
@@ -129,7 +130,7 @@ public class TestPluginConfiguration
         bool expectedLegacyValue)
     {
         using var reader = new StringReader(
-            $"<PluginConfiguration><UseAlternativeBlackFrameAnalyzer>{oldValue}</UseAlternativeBlackFrameAnalyzer></PluginConfiguration>");
+            $"<PluginConfiguration><UseAlternativeBlackFrameAnalyzer>{XmlConvert.ToString(oldValue)}</UseAlternativeBlackFrameAnalyzer></PluginConfiguration>");
         var config = Assert.IsType<PluginConfiguration>(new XmlSerializer(typeof(PluginConfiguration)).Deserialize(reader));
 
         Assert.Equal(expectedLegacyValue, config.UseLegacyBlackFrameAnalyzer);

--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -98,6 +98,55 @@ public class TestPluginConfiguration
         Assert.Equal(["/mnt/remote"], config.PathExclusions);
     }
 
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void JsonDeserialization_MigratesFormerAlternativeAnalyzerSetting(
+        bool oldValue,
+        bool expectedLegacyValue)
+    {
+        var config = JsonSerializer.Deserialize<PluginConfiguration>(
+            $$"""{"UseAlternativeBlackFrameAnalyzer":{{oldValue.ToString().ToLowerInvariant()}}}""");
+
+        Assert.NotNull(config);
+        Assert.Equal(expectedLegacyValue, config.UseLegacyBlackFrameAnalyzer);
+    }
+
+    [Fact]
+    public void JsonSerialization_DoesNotWriteFormerAlternativeAnalyzerSetting()
+    {
+        var json = JsonSerializer.Serialize(new PluginConfiguration { UseLegacyBlackFrameAnalyzer = true });
+
+        Assert.DoesNotContain("UseAlternativeBlackFrameAnalyzer", json, StringComparison.Ordinal);
+        Assert.Contains("UseLegacyBlackFrameAnalyzer", json, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void XmlDeserialization_MigratesFormerAlternativeAnalyzerSetting(
+        bool oldValue,
+        bool expectedLegacyValue)
+    {
+        using var reader = new StringReader(
+            $"<PluginConfiguration><UseAlternativeBlackFrameAnalyzer>{oldValue}</UseAlternativeBlackFrameAnalyzer></PluginConfiguration>");
+        var config = Assert.IsType<PluginConfiguration>(new XmlSerializer(typeof(PluginConfiguration)).Deserialize(reader));
+
+        Assert.Equal(expectedLegacyValue, config.UseLegacyBlackFrameAnalyzer);
+    }
+
+    [Fact]
+    public void XmlSerialization_DoesNotWriteFormerAlternativeAnalyzerSetting()
+    {
+        using var writer = new StringWriter();
+        new XmlSerializer(typeof(PluginConfiguration)).Serialize(
+            writer,
+            new PluginConfiguration { UseLegacyBlackFrameAnalyzer = true });
+
+        Assert.DoesNotContain("UseAlternativeBlackFrameAnalyzer", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("<UseLegacyBlackFrameAnalyzer>true</UseLegacyBlackFrameAnalyzer>", writer.ToString(), StringComparison.Ordinal);
+    }
+
     [Fact]
     public void JsonSerialization_WritesStructuredExclusionListsAsArrays()
     {

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -11,6 +11,7 @@
 
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 using IntroSkipper.Data;
 using MediaBrowser.Model.Plugins;
@@ -136,6 +137,25 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether to use the legacy black frame analyzer.
     /// </summary>
     public bool UseLegacyBlackFrameAnalyzer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the former alternative analyzer setting for configuration migration.
+    /// The old setting selected the modern analyzer, so its value is inverted when mapped to
+    /// <see cref="UseLegacyBlackFrameAnalyzer"/>.
+    /// </summary>
+    [JsonPropertyName("UseAlternativeBlackFrameAnalyzer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [XmlElement("UseAlternativeBlackFrameAnalyzer")]
+    public bool UseAlternativeBlackFrameAnalyzer
+    {
+        get => false;
+        set => UseLegacyBlackFrameAnalyzer = !value;
+    }
+
+    /// <summary>
+    /// Prevents the former setting from being written back to XML after it has been migrated.
+    /// </summary>
+    public bool ShouldSerializeUseAlternativeBlackFrameAnalyzer() => false;
 
     /// <summary>
     /// Gets or sets a value indicating whether to refine credits boundaries with frame-level analysis.

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -133,13 +133,13 @@ public class PluginConfiguration : BasePluginConfiguration
     public CompressionLevel CacheCompressionLevel { get; set; } = CompressionLevel.Optimal;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to use the alternative black frame analyzer.
+    /// Gets or sets a value indicating whether to use the legacy black frame analyzer.
     /// </summary>
-    public bool UseAlternativeBlackFrameAnalyzer { get; set; }
+    public bool UseLegacyBlackFrameAnalyzer { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to refine credits boundaries with frame-level analysis.
-    /// When enabled, the alternative black frame analyzer probes the gap between keyframes
+    /// When enabled, the black frame analyzer probes the gap between keyframes
     /// to find the exact frame where credits begin. Disable for faster analysis with keyframe-only accuracy.
     /// </summary>
     public bool RefineCreditsBoundary { get; set; } = true;

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -139,7 +139,7 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool UseLegacyBlackFrameAnalyzer { get; set; }
 
     /// <summary>
-    /// Gets or sets the former alternative analyzer setting for configuration migration.
+    /// Gets or sets a value indicating whether the former alternative analyzer was enabled for configuration migration.
     /// The old setting selected the modern analyzer, so its value is inverted when mapped to
     /// <see cref="UseLegacyBlackFrameAnalyzer"/>.
     /// </summary>
@@ -151,11 +151,6 @@ public class PluginConfiguration : BasePluginConfiguration
         get => false;
         set => UseLegacyBlackFrameAnalyzer = !value;
     }
-
-    /// <summary>
-    /// Prevents the former setting from being written back to XML after it has been migrated.
-    /// </summary>
-    public bool ShouldSerializeUseAlternativeBlackFrameAnalyzer() => false;
 
     /// <summary>
     /// Gets or sets a value indicating whether to refine credits boundaries with frame-level analysis.
@@ -509,4 +504,10 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     [XmlIgnore]
     public bool FileTransformationPluginEnabled { get; set; }
+
+    /// <summary>
+    /// Prevents the former setting from being written back to XML after it has been migrated.
+    /// </summary>
+    /// <returns><see langword="false"/> so the former setting is not serialized.</returns>
+    public bool ShouldSerializeUseAlternativeBlackFrameAnalyzer() => false;
 }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -9,8 +9,8 @@
 // SPDX-FileCopyrightText: 2024 CasuallyFilthy
 // SPDX-License-Identifier: GPL-3.0-only
 
-using System.Diagnostics;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json.Serialization;
 using System.Xml.Serialization;

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Diagnostics;
+using System.ComponentModel;
 using System.IO.Compression;
 using System.Text.Json.Serialization;
 using System.Xml.Serialization;
@@ -145,6 +146,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     [JsonPropertyName("UseAlternativeBlackFrameAnalyzer")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [DefaultValue(false)]
     [XmlElement("UseAlternativeBlackFrameAnalyzer")]
     public bool UseAlternativeBlackFrameAnalyzer
     {
@@ -504,10 +506,4 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     [XmlIgnore]
     public bool FileTransformationPluginEnabled { get; set; }
-
-    /// <summary>
-    /// Prevents the former setting from being written back to XML after it has been migrated.
-    /// </summary>
-    /// <returns><see langword="false"/> so the former setting is not serialized.</returns>
-    public bool ShouldSerializeUseAlternativeBlackFrameAnalyzer() => false;
 }

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -39,7 +39,7 @@ public static class ConfigHasher
                 $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
-                $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfaltVersion=2{CreditsNonBlackToken(config)}",
+                $"|bflegacy={config.UseLegacyBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfVersion=3{CreditsNonBlackToken(config)}",
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
                 $"|animePreview={config.AnimePreviewFromCreditsEnd}",
                 $"{AdjustmentHash(config)}"),
@@ -147,11 +147,11 @@ public static class ConfigHasher
     public static bool IsStreamScopedDetectionCacheHash(string? cacheHash)
         => cacheHash?.StartsWith("audio-stream-v1|", StringComparison.Ordinal) == true;
 
-    // DetectNonBlackCredits only affects output when the alternative analyzer is active; including it
-    // unconditionally would invalidate cached credits on the default BlackFrameAnalyzer path, which
+    // DetectNonBlackCredits only affects output when the default analyzer is active; including it
+    // unconditionally would invalidate cached credits on the legacy BlackFrameAnalyzer path, which
     // cannot observe the setting (the UI also hides it there).
     private static string CreditsNonBlackToken(PluginConfiguration config)
-        => config.UseAlternativeBlackFrameAnalyzer
+        => !config.UseLegacyBlackFrameAnalyzer
             ? FormattableString.Invariant($"|nonblack={config.DetectNonBlackCredits}")
             : string.Empty;
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -469,10 +469,10 @@ public partial class BaseItemAnalyzerTask(
     /// <summary>
     /// Creates the configured black frame analyzer variant.
     /// </summary>
-    /// <returns>A <see cref="BlackFrameAnalyzer"/> or <see cref="CreditsBlackFrameAnalyzer"/> based on configuration.</returns>
-    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => _config.UseAlternativeBlackFrameAnalyzer
-        ? new CreditsBlackFrameAnalyzer(_loggerFactory.CreateLogger<CreditsBlackFrameAnalyzer>(), _ffmpegService, _database)
-        : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>(), _ffmpegService, _database);
+    /// <returns>A <see cref="CreditsBlackFrameAnalyzer"/> by default, or the legacy <see cref="BlackFrameAnalyzer"/> when configured.</returns>
+    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => _config.UseLegacyBlackFrameAnalyzer
+        ? new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>(), _ffmpegService, _database)
+        : new CreditsBlackFrameAnalyzer(_loggerFactory.CreateLogger<CreditsBlackFrameAnalyzer>(), _ffmpegService, _database);
 
     /// <summary>
     /// Moves the first analyzer matching <paramref name="predicate"/> to the front of the list,

--- a/web/src/store/config-store.ts
+++ b/web/src/store/config-store.ts
@@ -19,6 +19,19 @@ function normalizeStringList(value: unknown): string[] {
 }
 
 function normalizePluginConfig(loadedConfig: PluginConfig): PluginConfig {
+    const legacyConfig = loadedConfig as PluginConfig & {
+        UseAlternativeBlackFrameAnalyzer?: unknown;
+    };
+
+    // The old flag selected the modern analyzer, so invert it when the renamed flag is absent.
+    if (
+        typeof legacyConfig.UseLegacyBlackFrameAnalyzer !== "boolean" &&
+        typeof legacyConfig.UseAlternativeBlackFrameAnalyzer === "boolean"
+    ) {
+        loadedConfig.UseLegacyBlackFrameAnalyzer = !legacyConfig.UseAlternativeBlackFrameAnalyzer;
+    }
+    delete legacyConfig.UseAlternativeBlackFrameAnalyzer;
+
     loadedConfig.SeriesExclusions = normalizeStringList(loadedConfig.SeriesExclusions);
     loadedConfig.MovieExclusions = normalizeStringList(loadedConfig.MovieExclusions);
     loadedConfig.PathExclusions = normalizeStringList(loadedConfig.PathExclusions);
@@ -121,7 +134,7 @@ export const configStore = {
 
     async save(): Promise<void> {
         await withDashboardLoading(async () => {
-            const serverConfig = await loadPluginConfig();
+            const serverConfig = normalizePluginConfig(await loadPluginConfig());
             Object.assign(serverConfig, config);
             const result = await savePluginConfig(serverConfig);
 

--- a/web/src/tabs/black-frame.ts
+++ b/web/src/tabs/black-frame.ts
@@ -4,6 +4,9 @@ import { checkboxField } from "../components/checkbox-field.ts";
 import { numberField } from "../components/number-field.ts";
 import { appendTabContent } from "../components/tab-layout.ts";
 
+const isLegacyAnalyzerEnabled = (): boolean =>
+    configStore.get("UseLegacyBlackFrameAnalyzer") === true;
+
 export const blackFrameTab: Tab = {
     id: "black-frame",
     label: "Black Frame",
@@ -21,21 +24,21 @@ export const blackFrameTab: Tab = {
                 label: "Refine credits boundary",
                 description:
                     "Use frame-level analysis to find the exact credits boundary. Disable for faster analysis with keyframe-only accuracy.",
-                visible: () => configStore.get("UseLegacyBlackFrameAnalyzer") !== true,
+                visible: () => !isLegacyAnalyzerEnabled(),
             }),
             checkboxField({
                 id: "DetectNonBlackCredits",
                 label: "Detect non-black credits",
                 description:
                     "When the black-frame scan finds nothing, also detect credits shown on a near-uniform card — text over a black, white, grey, or muted-colour background. Vivid, highly saturated backgrounds are not covered. Black-frame detection is unchanged; this only adds matches it would otherwise miss.",
-                visible: () => configStore.get("UseLegacyBlackFrameAnalyzer") !== true,
+                visible: () => !isLegacyAnalyzerEnabled(),
             }),
             checkboxField({
                 id: "UseChapterMarkersBlackFrame",
                 label: "Use chapter markers for credits detection",
                 description:
                     "If enabled, chapter markers will be used to identify credits segments. Tries to detect credits by looking for black frames close to chapter markers.",
-                visible: () => configStore.get("UseLegacyBlackFrameAnalyzer") === true,
+                visible: isLegacyAnalyzerEnabled,
             }),
             numberField({
                 id: "BlackFrameMinimumPercentage",

--- a/web/src/tabs/black-frame.ts
+++ b/web/src/tabs/black-frame.ts
@@ -17,31 +17,25 @@ export const blackFrameTab: Tab = {
                     "When recap chapter detection fails, mark recap from 0:00 to the latest detected black frame within the detected recap duration limits and before the intro.",
             }),
             checkboxField({
-                id: "UseAlternativeBlackFrameAnalyzer",
-                label: "Use alternative black frame analyzer (experimental)",
-                description:
-                    "If enabled, the alternative black frame analyzer will be used. This analyzer is experimental and may not work as expected.",
-            }),
-            checkboxField({
                 id: "RefineCreditsBoundary",
                 label: "Refine credits boundary",
                 description:
                     "Use frame-level analysis to find the exact credits boundary. Disable for faster analysis with keyframe-only accuracy.",
-                visible: () => configStore.get("UseAlternativeBlackFrameAnalyzer") === true,
+                visible: () => configStore.get("UseLegacyBlackFrameAnalyzer") !== true,
             }),
             checkboxField({
                 id: "DetectNonBlackCredits",
                 label: "Detect non-black credits",
                 description:
                     "When the black-frame scan finds nothing, also detect credits shown on a near-uniform card — text over a black, white, grey, or muted-colour background. Vivid, highly saturated backgrounds are not covered. Black-frame detection is unchanged; this only adds matches it would otherwise miss.",
-                visible: () => configStore.get("UseAlternativeBlackFrameAnalyzer") === true,
+                visible: () => configStore.get("UseLegacyBlackFrameAnalyzer") !== true,
             }),
             checkboxField({
                 id: "UseChapterMarkersBlackFrame",
                 label: "Use chapter markers for credits detection",
                 description:
                     "If enabled, chapter markers will be used to identify credits segments. Tries to detect credits by looking for black frames close to chapter markers.",
-                visible: () => configStore.get("UseAlternativeBlackFrameAnalyzer") !== true,
+                visible: () => configStore.get("UseLegacyBlackFrameAnalyzer") === true,
             }),
             numberField({
                 id: "BlackFrameMinimumPercentage",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -50,7 +50,7 @@ export interface PluginConfig {
     ReanalyzeSettledSeasons: boolean;
     AnalyzeSeasonZero: boolean;
     UpdateMediaSegments: boolean;
-    UseAlternativeBlackFrameAnalyzer: boolean;
+    UseLegacyBlackFrameAnalyzer: boolean;
     RefineCreditsBoundary: boolean;
     DetectNonBlackCredits: boolean;
     UseChapterMarkersBlackFrame: boolean;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -51,6 +51,8 @@ export interface PluginConfig {
     AnalyzeSeasonZero: boolean;
     UpdateMediaSegments: boolean;
     UseLegacyBlackFrameAnalyzer: boolean;
+    /** @deprecated Read only for migration of dashboard/server payloads. */
+    UseAlternativeBlackFrameAnalyzer?: boolean;
     RefineCreditsBoundary: boolean;
     DetectNonBlackCredits: boolean;
     UseChapterMarkersBlackFrame: boolean;


### PR DESCRIPTION
## Summary by Sourcery

Rename and invert the black frame analyzer selection to make the modern analyzer the default while retaining a legacy opt-in path and ensuring cache hashes and analysis wiring reflect the new semantics.

New Features:
- Introduce a UseLegacyBlackFrameAnalyzer flag that selects the legacy analyzer while defaulting to the modern credits-focused analyzer.

Bug Fixes:
- Ensure DetectNonBlackCredits only influences cache hashes when the modern analyzer is active and is ignored on the legacy analyzer path.

Enhancements:
- Add JSON/XML migration shims and frontend normalization to transparently map the deprecated UseAlternativeBlackFrameAnalyzer setting onto UseLegacyBlackFrameAnalyzer and clean up payloads.
- Update UI visibility logic so modern-only options (refined credits boundary and non-black credits) are hidden when the legacy analyzer is selected and legacy-only chapter-marker detection is shown instead.

Tests:
- Extend plugin configuration and cache hashing tests to cover migration from the old analyzer flag, serialization behavior of the deprecated setting, and analyzer-dependent hash changes.