### PR TITLE
Restore analyzer selection in the dashboard as a legacy opt-in toggle

### DIFF
--- a/web/src/tabs/black-frame.ts
+++ b/web/src/tabs/black-frame.ts
@@ -23,7 +23,7 @@ export const blackFrameTab: Tab = {
                 id: "UseLegacyBlackFrameAnalyzer",
                 label: "Use legacy black frame analyzer",
                 description:
-                    "If enabled, the legacy black frame analyzer is used instead of the modern credits-focused analyzer. The legacy analyzer does not support refined credits boundaries or non-black credits detection.",
+                    "If enabled, the legacy black frame analyzer is used instead of the modern black frame analyzer. The legacy analyzer does not support refined credits boundaries or non-black credits detection, but can use chapter markers for credits detection.",
             }),
             checkboxField({
                 id: "RefineCreditsBoundary",

--- a/web/src/tabs/black-frame.ts
+++ b/web/src/tabs/black-frame.ts
@@ -20,6 +20,12 @@ export const blackFrameTab: Tab = {
                     "When recap chapter detection fails, mark recap from 0:00 to the latest detected black frame within the detected recap duration limits and before the intro.",
             }),
             checkboxField({
+                id: "UseLegacyBlackFrameAnalyzer",
+                label: "Use legacy black frame analyzer",
+                description:
+                    "If enabled, the legacy black frame analyzer is used instead of the modern credits-focused analyzer. The legacy analyzer does not support refined credits boundaries or non-black credits detection.",
+            }),
+            checkboxField({
                 id: "RefineCreditsBoundary",
                 label: "Refine credits boundary",
                 description:


### PR DESCRIPTION
#907 renamed and inverted the analyzer flag to `UseLegacyBlackFrameAnalyzer`, but removed the dashboard checkbox for the old flag without adding one for the new flag, leaving no UI control for it at all.

This matters because the migration shim preserves each install's previous analyzer: old configs always serialized `UseAlternativeBlackFrameAnalyzer` (default `false`), which inverts to `UseLegacyBlackFrameAnalyzer = true`. So every existing install lands on the legacy analyzer with no way to switch to the modern one from the dashboard — and the Black Frame tab's conditional fields (`RefineCreditsBoundary`, `DetectNonBlackCredits`, `UseChapterMarkersBlackFrame`) hinge on a setting the user can't see or change.

This re-adds a checkbox for `UseLegacyBlackFrameAnalyzer` in the Black Frame tab, in the position the removed checkbox occupied. The existing `bindField` wiring already reacts to store changes, so the dependent fields show/hide live when the toggle changes, and `config-store` normalization already handles the renamed flag on load and save.

No server-side changes. `pnpm build` (tsc + vite) passes; the .NET test suite (493 tests) passes unchanged.

## Summary by Sourcery

New Features:
- Add a configurable checkbox in the Black Frame tab for enabling the legacy black frame analyzer so users can opt in or out from the UI.