### PR TITLE
Add durable Segment Change projection foundation

### DIFF
--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -361,8 +361,10 @@ public sealed class TestDbSegmentStorage
 
                 // The whole v2 schema comes from one baseline migration; anything added
                 // after the first release lands as a plain EF migration on top.
-                var appliedMigration = Assert.Single(await db.Database.GetAppliedMigrationsAsync());
-                Assert.EndsWith("_InitialCreate", appliedMigration, StringComparison.Ordinal);
+                string[] appliedMigrations = [.. await db.Database.GetAppliedMigrationsAsync()];
+                Assert.Equal(2, appliedMigrations.Length);
+                Assert.EndsWith("_InitialCreate", appliedMigrations[0], StringComparison.Ordinal);
+                Assert.EndsWith("_AddSegmentProjectionJournal", appliedMigrations[1], StringComparison.Ordinal);
 
                 db.SeasonStates.Add(new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default));
                 db.AnalyzedItems.Add(new DbAnalyzedItem(episodeId, AnalysisMode.Introduction, "season-config"));

--- a/IntroSkipper.Tests/TestJellyfinSegmentProjectionAdapter.cs
+++ b/IntroSkipper.Tests/TestJellyfinSegmentProjectionAdapter.cs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Data;
+using IntroSkipper.Manager;
+using IntroSkipper.SegmentChanges;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Database.Implementations.Locking;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+/// <summary>Contract tests for atomic application of durable Jellyfin plans.</summary>
+public sealed class TestJellyfinSegmentProjectionAdapter
+{
+    [Fact]
+    public async Task ApplyAsync_DeletesExactTargetThenReplacesOwnProviderRows()
+    {
+        using var db = new TempJellyfinDb();
+        var itemId = Guid.NewGuid();
+        var target = Row(itemId, MediaSegmentType.Intro, 1, 2, "foreign");
+        var survivor = Row(itemId, MediaSegmentType.Outro, 3, 4, "foreign");
+        await SeedAsync(db, target, survivor, Row(itemId, MediaSegmentType.Intro, 5, 6, JellyfinSegmentStore.ProviderId));
+        var projectedId = Guid.NewGuid();
+
+        await Create(db).ApplyAsync(new SegmentProjectionPlan(
+            Guid.NewGuid(),
+            itemId,
+            1,
+            [new ProjectedSegment(projectedId, MediaSegmentType.Recap, 10, 20, SegmentSource.User)],
+            [new ProjectedExternalOperation(target.Id, target.Type, ProjectionExternalOperationKind.Delete)]),
+            CancellationToken.None);
+
+        await using var verify = db.Factory.CreateDbContext();
+        var rows = await verify.MediaSegments.AsNoTracking().ToListAsync();
+        Assert.DoesNotContain(rows, row => row.Id == target.Id);
+        Assert.Contains(rows, row => row.Id == survivor.Id);
+        var own = Assert.Single(rows, row => row.SegmentProviderId == JellyfinSegmentStore.ProviderId);
+        Assert.Equal(projectedId, own.Id);
+        Assert.Equal(MediaSegmentType.Recap, own.Type);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_IsIdempotentAfterJellyfinCommit()
+    {
+        using var db = new TempJellyfinDb();
+        var itemId = Guid.NewGuid();
+        var target = Row(itemId, MediaSegmentType.Intro, 1, 2, "foreign");
+        await SeedAsync(db, target);
+        var plan = new SegmentProjectionPlan(
+            Guid.NewGuid(),
+            itemId,
+            1,
+            [new ProjectedSegment(Guid.NewGuid(), MediaSegmentType.Intro, 10, 20, SegmentSource.User)],
+            [new ProjectedExternalOperation(target.Id, target.Type, ProjectionExternalOperationKind.Delete)]);
+        var adapter = Create(db);
+
+        await adapter.ApplyAsync(plan, CancellationToken.None);
+        await adapter.ApplyAsync(plan, CancellationToken.None);
+
+        await using var verify = db.Factory.CreateDbContext();
+        Assert.Equal(plan.Segments[0].Id, Assert.Single(await verify.MediaSegments.AsNoTracking().ToListAsync()).Id);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_EmptyImageDeletesOwnRowsOnly()
+    {
+        using var db = new TempJellyfinDb();
+        var itemId = Guid.NewGuid();
+        var foreign = Row(itemId, MediaSegmentType.Intro, 1, 2, "foreign");
+        await SeedAsync(db, foreign, Row(itemId, MediaSegmentType.Outro, 3, 4, JellyfinSegmentStore.ProviderId));
+
+        await Create(db).ApplyAsync(new SegmentProjectionPlan(Guid.NewGuid(), itemId, 1, [], []), CancellationToken.None);
+
+        await using var verify = db.Factory.CreateDbContext();
+        Assert.Equal(foreign.Id, Assert.Single(await verify.MediaSegments.AsNoTracking().ToListAsync()).Id);
+    }
+
+    [Fact]
+    public async Task ResolveExternalTargetAsync_ReturnsActualOwnerAndType()
+    {
+        using var db = new TempJellyfinDb();
+        var row = Row(Guid.NewGuid(), MediaSegmentType.Commercial, 10, 20, "foreign");
+        await SeedAsync(db, row);
+
+        var target = await Create(db).ResolveExternalTargetAsync(Guid.NewGuid(), row.Id, CancellationToken.None);
+
+        Assert.NotNull(target);
+        Assert.Equal(row.ItemId, target.ItemId);
+        Assert.Equal(row.Type, target.Type);
+        Assert.Equal(row.StartTicks, target.StartTicks);
+        Assert.Equal(row.EndTicks, target.EndTicks);
+    }
+
+    [Fact]
+    public async Task FailedApply_RollsBackEveryOperationAndReleasesWriteLock()
+    {
+        using var db = new TempJellyfinDb(new PessimisticLockBehavior(
+            NullLogger<PessimisticLockBehavior>.Instance,
+            NullLoggerFactory.Instance));
+        var itemId = Guid.NewGuid();
+        var target = Row(itemId, MediaSegmentType.Intro, 1, 2, "foreign");
+        var collision = Row(itemId, MediaSegmentType.Outro, 3, 4, "foreign");
+        var own = Row(itemId, MediaSegmentType.Recap, 5, 6, JellyfinSegmentStore.ProviderId);
+        await SeedAsync(db, target, collision, own);
+        var adapter = Create(db);
+        var failingPlan = new SegmentProjectionPlan(
+            Guid.NewGuid(),
+            itemId,
+            1,
+            [new ProjectedSegment(collision.Id, MediaSegmentType.Commercial, 10, 20, SegmentSource.User)],
+            [new ProjectedExternalOperation(target.Id, target.Type, ProjectionExternalOperationKind.Delete)]);
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => adapter.ApplyAsync(failingPlan, CancellationToken.None));
+        await adapter.ApplyAsync(new SegmentProjectionPlan(Guid.NewGuid(), itemId, 2, [], []), CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(10));
+
+        await using var verify = db.Factory.CreateDbContext();
+        var rows = await verify.MediaSegments.AsNoTracking().ToListAsync();
+        Assert.Contains(rows, row => row.Id == target.Id);
+        Assert.Contains(rows, row => row.Id == collision.Id);
+        Assert.DoesNotContain(rows, row => row.Id == own.Id);
+    }
+
+    private static JellyfinSegmentProjectionAdapter Create(TempJellyfinDb db)
+        => new(db.Factory, NullLogger<JellyfinSegmentProjectionAdapter>.Instance);
+
+    private static MediaSegment Row(Guid itemId, MediaSegmentType type, long start, long end, string provider)
+        => new() { Id = Guid.NewGuid(), ItemId = itemId, Type = type, StartTicks = start, EndTicks = end, SegmentProviderId = provider };
+
+    private static async Task SeedAsync(TempJellyfinDb db, params MediaSegment[] rows)
+    {
+        await using var context = db.Factory.CreateDbContext();
+        context.MediaSegments.AddRange(rows);
+        await context.SaveChangesAsync();
+    }
+}

--- a/IntroSkipper.Tests/TestSegmentChange.cs
+++ b/IntroSkipper.Tests/TestSegmentChange.cs
@@ -1,0 +1,559 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.Manager;
+using IntroSkipper.SegmentChanges;
+using Jellyfin.Database.Implementations.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+/// <summary>Durability and ordering tests for the segment change coordinator.</summary>
+public sealed class TestSegmentChange : IDisposable
+{
+    private readonly string _dbPath = DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-changes.db");
+
+    [Fact]
+    public async Task AddUserSegment_CommitsImageAndCompactsAppliedPlan()
+    {
+        var adapter = new RecordingProjectionAdapter();
+        var service = CreateService(adapter);
+        var itemId = Guid.NewGuid();
+
+        var outcome = Assert.IsType<Accepted>(await service.ApplyAsync(
+            new AddUserSegmentIntent(itemId, AnalysisMode.Introduction, 10, 20)));
+
+        Assert.Equal(ProjectionState.Applied, Assert.Single(outcome.Projections).State);
+        var affected = Assert.Single(outcome.AffectedValues);
+        var plan = Assert.Single(adapter.Plans);
+        Assert.Equal(affected.Id, Assert.Single(plan.Segments).Id);
+        Assert.Equal(SegmentSource.User, Assert.Single(plan.Segments).Source);
+
+        await using var db = CreateContext();
+        Assert.Empty(await db.ProjectionPlans.ToListAsync());
+        Assert.Empty(await db.ProjectionAttempts.ToListAsync());
+        var head = Assert.Single(await db.ProjectionHeads.ToListAsync());
+        Assert.Equal(1, head.LastAcceptedSequence);
+        Assert.Equal(1, head.LastAppliedSequence);
+        Assert.Equal(ProjectionState.Applied, head.Status);
+    }
+
+    [Fact]
+    public async Task ProjectionFailure_DoesNotRollBackAuthoritativeMutation_AndManualRetryConverges()
+    {
+        var adapter = new RecordingProjectionAdapter { FailuresRemaining = 1 };
+        var service = CreateService(adapter);
+        var itemId = Guid.NewGuid();
+
+        var outcome = Assert.IsType<Accepted>(await service.ApplyAsync(
+            new AddUserSegmentIntent(itemId, AnalysisMode.Credits, 30, 40)));
+        Assert.Equal(ProjectionState.Pending, Assert.Single(outcome.Projections).State);
+
+        await using (var db = CreateContext())
+        {
+            Assert.Single(await db.Segments.ToListAsync());
+            Assert.Single(await db.ProjectionPlans.ToListAsync());
+            var attempt = Assert.Single(await db.ProjectionAttempts.ToListAsync());
+            Assert.Equal(1, attempt.AttemptCount);
+            Assert.NotNull(attempt.Failure);
+        }
+
+        Assert.Equal(1, (await service.RetryProjectionAsync(ProjectionScope.ForItem(itemId))).RetriedCount);
+        Assert.Equal(2, adapter.Attempts.Count);
+        Assert.Equal(ProjectionState.Applied, Assert.Single((await service.GetProjectionStatusAsync(ProjectionScope.ForItem(itemId))).Items).State);
+    }
+
+    [Fact]
+    public async Task FailedEarlierPlan_BlocksLaterPlanForSameItem()
+    {
+        var adapter = new RecordingProjectionAdapter { FailuresRemaining = 2 };
+        var service = CreateService(adapter);
+        var itemId = Guid.NewGuid();
+
+        await service.ApplyAsync(new AddUserSegmentIntent(itemId, AnalysisMode.Introduction, 10, 20));
+        await service.ApplyAsync(new AddUserSegmentIntent(itemId, AnalysisMode.Credits, 30, 40));
+
+        Assert.Equal(new long[] { 1, 1 }, adapter.Attempts.Select(plan => plan.Sequence));
+        Assert.All(adapter.Attempts, plan => Assert.Single(plan.Segments));
+        adapter.FailuresRemaining = 0;
+        Assert.Equal(2, (await service.RetryProjectionAsync(ProjectionScope.ForItem(itemId))).RetriedCount);
+        Assert.Equal(new long[] { 1, 1, 1, 2 }, adapter.Attempts.Select(plan => plan.Sequence));
+        Assert.Single(adapter.Attempts[2].Segments);
+        Assert.Equal(2, adapter.Attempts[3].Segments.Count);
+        Assert.Equal(2, Assert.Single((await service.GetProjectionStatusAsync(ProjectionScope.ForItem(itemId))).Items).LastAppliedSequence);
+    }
+
+    [Fact]
+    public async Task DeleteAutomaticSegment_PersistsTombstoneAndProjectsEmptyImage()
+    {
+        var itemId = Guid.NewGuid();
+        var automatic = new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter);
+        await SeedAsync(automatic);
+        var adapter = new RecordingProjectionAdapter();
+        var service = CreateService(adapter);
+
+        var outcome = Assert.IsType<Accepted>(await service.ApplyAsync(new DeleteSegmentIntent(itemId, automatic.Id)));
+
+        Assert.Equal(SegmentState.Suppressed, Assert.Single(outcome.AffectedValues).State);
+        Assert.Empty(Assert.Single(adapter.Plans).Segments);
+        await using var db = CreateContext();
+        Assert.Equal(SegmentState.Suppressed, Assert.Single(await db.Segments.ToListAsync()).State);
+    }
+
+    [Fact]
+    public async Task ExternalDelete_RejectsCrossItemAndTypeBeforeCommit()
+    {
+        var itemId = Guid.NewGuid();
+        var adapter = new RecordingProjectionAdapter
+        {
+            ExternalTarget = new ExternalSegmentTarget(Guid.NewGuid(), Guid.NewGuid(), MediaSegmentType.Intro, 10, 20)
+        };
+        var service = CreateService(adapter);
+
+        Assert.IsType<Rejected>(await service.ApplyAsync(
+            new DeleteExternalSegmentIntent(itemId, adapter.ExternalTarget.Id, MediaSegmentType.Intro)));
+
+        adapter.ExternalTarget = adapter.ExternalTarget with { ItemId = itemId };
+        Assert.IsType<Rejected>(await service.ApplyAsync(
+            new DeleteExternalSegmentIntent(itemId, adapter.ExternalTarget.Id, MediaSegmentType.Outro)));
+        await using var db = CreateContext();
+        await db.ApplyMigrationsAsync();
+        Assert.Empty(await db.ProjectionPlans.ToListAsync());
+    }
+
+    [Fact]
+    public async Task VisibilityFailure_KeepsDisabledFlagAndPendingFilteredImage()
+    {
+        var itemId = Guid.NewGuid();
+        await SeedAsync(
+            new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter),
+            new DbSegment(itemId, AnalysisMode.Credits, 30, 40, SegmentSource.User));
+        var adapter = new RecordingProjectionAdapter { FailuresRemaining = 1 };
+        var service = CreateService(adapter);
+
+        var outcome = Assert.IsType<Accepted>(await service.ApplyAsync(
+            new SegmentVisibilityChangeIntent(itemId, Guid.NewGuid(), Visible: false)));
+
+        Assert.Equal(ProjectionState.Pending, Assert.Single(outcome.Projections).State);
+        Assert.Equal(SegmentSource.User, Assert.Single(Assert.Single(adapter.Attempts).Segments).Source);
+        await using var db = CreateContext();
+        Assert.True(await db.DisabledItems.AnyAsync(item => item.ItemId == itemId));
+    }
+
+    [Fact]
+    public async Task MultiModeTimestampWrite_IsAtomicAndUsesUserPrecedence()
+    {
+        var itemId = Guid.NewGuid();
+        await SeedAsync(new DbSegment(itemId, AnalysisMode.Introduction, 1, 2, SegmentSource.Chapter));
+        var service = CreateService(new RecordingProjectionAdapter());
+
+        var outcome = Assert.IsType<Accepted>(await service.ApplyAsync(new WriteUserTimestampsIntent(
+            itemId,
+            [new UserTimestamp(AnalysisMode.Introduction, 10, 20), new UserTimestamp(AnalysisMode.Credits, 30, 40)])));
+
+        Assert.Equal(2, outcome.AffectedValues.Count);
+        await using var db = CreateContext();
+        var rows = await db.Segments.OrderBy(row => row.Type).ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.All(rows, row => Assert.Equal(SegmentSource.User, row.Source));
+        Assert.Equal(2, await db.AnalyzedStates.CountAsync(state => state.State == EpisodeState.UserProvided));
+    }
+
+    [Fact]
+    public async Task AddPromotion_UpsertsUserProvidedAnalyzedState()
+    {
+        var itemId = Guid.NewGuid();
+        var automatic = new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter, "automatic-hash");
+        await SeedAsync(automatic);
+        await SeedAnalyzedStateAsync(new DbAnalyzedState(itemId, AnalysisMode.Introduction, EpisodeState.Analyzed, "automatic-hash"));
+
+        var accepted = Assert.IsType<Accepted>(await CreateService(new RecordingProjectionAdapter()).ApplyAsync(
+            new AddUserSegmentIntent(itemId, AnalysisMode.Introduction, 10, 20)));
+
+        Assert.Equal(automatic.Id, Assert.Single(accepted.AffectedValues).Id);
+        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Introduction, EpisodeState.UserProvided, string.Empty);
+    }
+
+    [Fact]
+    public async Task ReplaceUserSegments_UpsertsUserProvidedAnalyzedState()
+    {
+        var itemId = Guid.NewGuid();
+        await SeedAsync(new DbSegment(itemId, AnalysisMode.Credits, 1, 2, SegmentSource.BlackFrame, "old-hash"));
+
+        await CreateService(new RecordingProjectionAdapter()).ApplyAsync(new ReplaceUserSegmentsForModeIntent(
+            itemId,
+            AnalysisMode.Credits,
+            [new SegmentRange(30, 40), new SegmentRange(50, 60)]));
+
+        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Credits, EpisodeState.UserProvided, string.Empty);
+    }
+
+    [Fact]
+    public async Task ReplaceUserSegments_EmptyImage_RemovesAnalyzedState()
+    {
+        var itemId = Guid.NewGuid();
+        await SeedAsync(new DbSegment(itemId, AnalysisMode.Commercial, 10, 20, SegmentSource.User));
+        await SeedAnalyzedStateAsync(new DbAnalyzedState(itemId, AnalysisMode.Commercial, EpisodeState.UserProvided));
+
+        Assert.IsType<Accepted>(await CreateService(new RecordingProjectionAdapter()).ApplyAsync(
+            new ReplaceUserSegmentsForModeIntent(itemId, AnalysisMode.Commercial, [])));
+
+        await using var db = CreateContext();
+        Assert.Empty(await db.AnalyzedStates.ToListAsync());
+        Assert.Empty(await db.Segments.Where(row => row.State == SegmentState.Active).ToListAsync());
+    }
+
+    [Fact]
+    public async Task UpdateCollision_UpsertsUserProvidedAnalyzedState()
+    {
+        var itemId = Guid.NewGuid();
+        var moved = new DbSegment(itemId, AnalysisMode.Preview, 10, 20, SegmentSource.Chapter, "one");
+        var occupant = new DbSegment(itemId, AnalysisMode.Preview, 30, 40, SegmentSource.BlackFrame, "two");
+        await SeedAsync(moved, occupant);
+
+        var accepted = Assert.IsType<Accepted>(await CreateService(new RecordingProjectionAdapter()).ApplyAsync(
+            new UpdateSegmentIntent(itemId, moved.Id, occupant.StartTicks, occupant.EndTicks)));
+
+        Assert.Equal(occupant.Id, Assert.Single(accepted.AffectedValues).Id);
+        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Preview, EpisodeState.UserProvided, string.Empty);
+    }
+
+    [Fact]
+    public async Task Delete_DerivesStateFromRemainingUserAndAutomaticRows()
+    {
+        var userItemId = Guid.NewGuid();
+        var deletedUser = new DbSegment(userItemId, AnalysisMode.Commercial, 10, 20, SegmentSource.User);
+        await SeedAsync(deletedUser, new DbSegment(userItemId, AnalysisMode.Commercial, 30, 40, SegmentSource.User));
+        var service = CreateService(new RecordingProjectionAdapter());
+
+        await service.ApplyAsync(new DeleteSegmentIntent(userItemId, deletedUser.Id));
+        await AssertAnalyzedStateAsync(userItemId, AnalysisMode.Commercial, EpisodeState.UserProvided, string.Empty);
+
+        var autoItemId = Guid.NewGuid();
+        var deletedAuto = new DbSegment(autoItemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter, "deleted");
+        await SeedAsync(
+            deletedAuto,
+            new DbSegment(autoItemId, AnalysisMode.Introduction, 30, 40, SegmentSource.Chapter, "hash-a"),
+            new DbSegment(autoItemId, AnalysisMode.Introduction, 50, 60, SegmentSource.BlackFrame, "hash-b"));
+
+        await service.ApplyAsync(new DeleteSegmentIntent(autoItemId, deletedAuto.Id));
+        await AssertAnalyzedStateAsync(autoItemId, AnalysisMode.Introduction, EpisodeState.Analyzed, string.Empty);
+    }
+
+    [Fact]
+    public async Task Delete_WithSoleRemainingAutomaticHash_PreservesHash()
+    {
+        var itemId = Guid.NewGuid();
+        var deleted = new DbSegment(itemId, AnalysisMode.Recap, 10, 20, SegmentSource.Chromaprint, "old");
+        await SeedAsync(deleted, new DbSegment(itemId, AnalysisMode.Recap, 30, 40, SegmentSource.Chromaprint, "remaining"));
+
+        await CreateService(new RecordingProjectionAdapter()).ApplyAsync(new DeleteSegmentIntent(itemId, deleted.Id));
+
+        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Recap, EpisodeState.Analyzed, "remaining");
+    }
+
+    [Fact]
+    public async Task RestoreAutomatic_UpsertsAnalyzedWithPreservedHash()
+    {
+        var itemId = Guid.NewGuid();
+        var tombstone = new DbSegment(itemId, AnalysisMode.Credits, 10, 20, SegmentSource.BlackFrame, "restore-hash")
+        {
+            State = SegmentState.Suppressed
+        };
+        await SeedAsync(tombstone);
+
+        await CreateService(new RecordingProjectionAdapter()).ApplyAsync(new RestoreSegmentIntent(itemId, tombstone.Id));
+
+        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Credits, EpisodeState.Analyzed, "restore-hash");
+    }
+
+    [Fact]
+    public async Task RestoreAutomatic_WithActiveUserSegment_KeepsUserProvidedState()
+    {
+        var itemId = Guid.NewGuid();
+        var automatic = new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter, "restored-hash")
+        {
+            State = SegmentState.Suppressed
+        };
+        await SeedAsync(
+            automatic,
+            new DbSegment(itemId, AnalysisMode.Introduction, 30, 40, SegmentSource.User));
+
+        Assert.IsType<Accepted>(await CreateService(new RecordingProjectionAdapter()).ApplyAsync(
+            new RestoreSegmentIntent(itemId, automatic.Id)));
+
+        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Introduction, EpisodeState.UserProvided, string.Empty);
+    }
+
+    [Fact]
+    public async Task ExternalResolutionInfrastructureFailure_PropagatesWithoutMutation()
+    {
+        await using (var db = CreateContext())
+        {
+            await db.ApplyMigrationsAsync();
+        }
+
+        var adapter = new RecordingProjectionAdapter { ResolveException = new InvalidOperationException("resolver unavailable") };
+        var service = CreateService(adapter);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.ApplyAsync(
+            new DeleteExternalSegmentIntent(Guid.NewGuid(), Guid.NewGuid(), MediaSegmentType.Intro)));
+
+        await using var verify = CreateContext();
+        Assert.Empty(await verify.Segments.ToListAsync());
+        Assert.Empty(await verify.AnalyzedStates.ToListAsync());
+        Assert.Empty(await verify.ProjectionPlans.ToListAsync());
+        Assert.Empty(await verify.ProjectionHeads.ToListAsync());
+    }
+
+    [Fact]
+    public async Task DisabledProjection_IsSkippedThenReconciledWithEmptyImageOnEnable()
+    {
+        var adapter = new RecordingProjectionAdapter();
+        var configuration = new TestProjectionConfiguration { Enabled = false };
+        var service = CreateService(adapter, configuration);
+        var itemId = Guid.NewGuid();
+
+        var accepted = Assert.IsType<Accepted>(await service.ApplyAsync(
+            new AddUserSegmentIntent(itemId, AnalysisMode.Introduction, 10, 20)));
+        Assert.Equal(ProjectionState.Skipped, Assert.Single(accepted.Projections).State);
+        Assert.Empty(adapter.Attempts);
+
+        Assert.IsType<Accepted>(await service.ApplyAsync(new DeleteSegmentIntent(itemId, accepted.AffectedValues[0].Id)));
+        await service.StartAsync(CancellationToken.None);
+        configuration.SetEnabled(true);
+        var reconciled = await adapter.Applied.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal(itemId, reconciled.ItemId);
+        Assert.Empty(reconciled.Segments);
+    }
+
+    [Fact]
+    public async Task ExactOperation_RemainsDurableWhileDisabled_AndRunsOnEnable()
+    {
+        var itemId = Guid.NewGuid();
+        var externalId = Guid.NewGuid();
+        var adapter = new RecordingProjectionAdapter
+        {
+            ExternalTarget = new ExternalSegmentTarget(externalId, itemId, MediaSegmentType.Intro, 10, 20)
+        };
+        var configuration = new TestProjectionConfiguration { Enabled = false };
+        var service = CreateService(adapter, configuration);
+
+        var accepted = Assert.IsType<Accepted>(await service.ApplyAsync(
+            new DeleteExternalSegmentIntent(itemId, externalId, MediaSegmentType.Intro)));
+        Assert.Equal(ProjectionState.Skipped, Assert.Single(accepted.Projections).State);
+        await using (var db = CreateContext())
+        {
+            Assert.Single(await db.ProjectionExternalOperations.ToListAsync());
+        }
+
+        await service.StartAsync(CancellationToken.None);
+        configuration.SetEnabled(true);
+        var reconciled = await adapter.Applied.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal(externalId, Assert.Single(reconciled.ExternalOperations).ExternalSegmentId);
+        await using var verify = CreateContext();
+        Assert.Empty(await verify.ProjectionExternalOperations.ToListAsync());
+    }
+
+    [Fact]
+    public async Task SkippedExactOperations_ReplayInAcceptedSequence_WithoutAdvancingAppliedHead()
+    {
+        var itemId = Guid.NewGuid();
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var adapter = new RecordingProjectionAdapter();
+        adapter.ExternalTargets[firstId] = new ExternalSegmentTarget(firstId, itemId, MediaSegmentType.Intro, 10, 20);
+        adapter.ExternalTargets[secondId] = new ExternalSegmentTarget(secondId, itemId, MediaSegmentType.Outro, 30, 40);
+        var configuration = new TestProjectionConfiguration { Enabled = false };
+        var service = CreateService(adapter, configuration);
+
+        await service.ApplyAsync(new DeleteExternalSegmentIntent(itemId, firstId, MediaSegmentType.Intro));
+        await service.ApplyAsync(new DeleteExternalSegmentIntent(itemId, secondId, MediaSegmentType.Outro));
+
+        var skipped = Assert.Single((await service.GetProjectionStatusAsync(ProjectionScope.ForItem(itemId))).Items);
+        Assert.Equal(2, skipped.LastAcceptedSequence);
+        Assert.Equal(0, skipped.LastAppliedSequence);
+        Assert.Equal(ProjectionState.Skipped, skipped.State);
+        await using (var db = CreateContext())
+        {
+            Assert.Equal(new long[] { 1, 2 }, await db.ProjectionExternalOperations.OrderBy(operation => operation.Sequence).Select(operation => operation.Sequence).ToArrayAsync());
+        }
+
+        await service.StartAsync(CancellationToken.None);
+        configuration.SetEnabled(true);
+        var replay = await adapter.Applied.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await service.RetryProjectionAsync(ProjectionScope.ForItem(itemId));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { firstId, secondId }, replay.ExternalOperations.Select(operation => operation.ExternalSegmentId));
+        var applied = Assert.Single((await service.GetProjectionStatusAsync(ProjectionScope.ForItem(itemId))).Items);
+        Assert.Equal(3, applied.LastAcceptedSequence);
+        Assert.Equal(3, applied.LastAppliedSequence);
+        Assert.Equal(ProjectionState.Applied, applied.State);
+    }
+
+    [Fact]
+    public async Task StartupRecovery_AppliesPendingPlan()
+    {
+        var itemId = Guid.NewGuid();
+        var failing = new RecordingProjectionAdapter { FailuresRemaining = 1 };
+        await CreateService(failing).ApplyAsync(new AddUserSegmentIntent(itemId, AnalysisMode.Preview, 10, 20));
+        var recovering = new RecordingProjectionAdapter();
+        var service = CreateService(recovering);
+
+        await service.StartAsync(CancellationToken.None);
+        var plan = await recovering.Applied.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await service.RetryProjectionAsync(ProjectionScope.ForItem(itemId));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal(itemId, plan.ItemId);
+        Assert.Equal(ProjectionState.Applied, Assert.Single((await service.GetProjectionStatusAsync(ProjectionScope.ForItem(itemId))).Items).State);
+    }
+
+    [Fact]
+    public async Task FailureForOneItem_DoesNotBlockAnotherItem()
+    {
+        var blockedItem = Guid.NewGuid();
+        var progressingItem = Guid.NewGuid();
+        var adapter = new RecordingProjectionAdapter();
+        adapter.FailingItems.Add(blockedItem);
+        var service = CreateService(adapter);
+
+        var blocked = Assert.IsType<Accepted>(await service.ApplyAsync(
+            new AddUserSegmentIntent(blockedItem, AnalysisMode.Introduction, 10, 20)));
+        var progressed = Assert.IsType<Accepted>(await service.ApplyAsync(
+            new AddUserSegmentIntent(progressingItem, AnalysisMode.Credits, 30, 40)));
+
+        Assert.Equal(ProjectionState.Pending, Assert.Single(blocked.Projections).State);
+        Assert.Equal(ProjectionState.Applied, Assert.Single(progressed.Projections).State);
+        Assert.Contains(adapter.Plans, plan => plan.ItemId == progressingItem);
+    }
+
+    [Fact]
+    public async Task Rebuild_RetainsPendingPlansAttemptsAndHeads()
+    {
+        var itemId = Guid.NewGuid();
+        var service = CreateService(new RecordingProjectionAdapter { FailuresRemaining = 1 });
+        await service.ApplyAsync(new AddUserSegmentIntent(itemId, AnalysisMode.Commercial, 10, 20));
+
+        await using (var db = CreateContext())
+        {
+            await db.RebuildDatabaseAsync(CreateContext);
+        }
+
+        await using var verify = CreateContext();
+        Assert.Single(await verify.ProjectionPlans.ToListAsync());
+        Assert.Single(await verify.ProjectionPlanSegments.ToListAsync());
+        Assert.Single(await verify.ProjectionAttempts.ToListAsync());
+        Assert.Single(await verify.ProjectionHeads.ToListAsync());
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => DatabaseTestHelpers.DeleteSqliteFiles(_dbPath);
+
+    private SegmentChange CreateService(RecordingProjectionAdapter adapter, TestProjectionConfiguration? configuration = null)
+    {
+        var factory = new TestDbContextFactory<IntroSkipperDbContext>(() => new IntroSkipperDbContext(_dbPath));
+        var database = new IntroSkipperDatabase(factory, NullLogger<IntroSkipperDatabase>.Instance);
+        return new SegmentChange(factory, database, adapter, configuration ?? new TestProjectionConfiguration(), TimeProvider.System, NullLogger<SegmentChange>.Instance);
+    }
+
+    private IntroSkipperDbContext CreateContext() => new(_dbPath);
+
+    private async Task SeedAsync(params DbSegment[] segments)
+    {
+        await using var db = CreateContext();
+        await db.ApplyMigrationsAsync();
+        db.Segments.AddRange(segments);
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SeedAnalyzedStateAsync(params DbAnalyzedState[] states)
+    {
+        await using var db = CreateContext();
+        await db.ApplyMigrationsAsync();
+        db.AnalyzedStates.AddRange(states);
+        await db.SaveChangesAsync();
+    }
+
+    private async Task AssertAnalyzedStateAsync(Guid itemId, AnalysisMode mode, EpisodeState expectedState, string expectedHash)
+    {
+        await using var db = CreateContext();
+        var state = await db.AnalyzedStates.SingleAsync(value => value.ItemId == itemId && value.Type == mode);
+        Assert.Equal(expectedState, state.State);
+        Assert.Equal(expectedHash, state.ConfigHash);
+    }
+
+    private sealed class TestProjectionConfiguration : ISegmentProjectionConfiguration
+    {
+        public event EventHandler<bool>? EnabledChanged;
+
+        public bool Enabled { get; set; } = true;
+
+        internal void SetEnabled(bool enabled)
+        {
+            Enabled = enabled;
+            EnabledChanged?.Invoke(this, enabled);
+        }
+    }
+
+    private sealed class RecordingProjectionAdapter : ISegmentProjectionAdapter
+    {
+        public int FailuresRemaining { get; set; }
+
+        public ExternalSegmentTarget? ExternalTarget { get; set; }
+
+        public Exception? ResolveException { get; set; }
+
+        public Dictionary<Guid, ExternalSegmentTarget> ExternalTargets { get; } = [];
+
+        public HashSet<Guid> FailingItems { get; } = [];
+
+        public TaskCompletionSource<SegmentProjectionPlan> Applied { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<SegmentProjectionPlan> Attempts { get; } = [];
+
+        public List<SegmentProjectionPlan> Plans { get; } = [];
+
+        public Task<ExternalSegmentTarget?> ResolveExternalTargetAsync(Guid itemId, Guid externalSegmentId, CancellationToken cancellationToken)
+        {
+            if (ResolveException is not null)
+            {
+                throw ResolveException;
+            }
+
+            return Task.FromResult(ExternalTargets.TryGetValue(externalSegmentId, out var target) ? target : ExternalTarget);
+        }
+
+        public Task ApplyAsync(SegmentProjectionPlan plan, CancellationToken cancellationToken)
+        {
+            var snapshot = plan with
+            {
+                Segments = plan.Segments.ToArray(),
+                ExternalOperations = plan.ExternalOperations.ToArray()
+            };
+            Attempts.Add(snapshot);
+            if (FailuresRemaining-- > 0 || FailingItems.Contains(plan.ItemId))
+            {
+                throw new InvalidOperationException("synthetic projection failure");
+            }
+
+            Plans.Add(snapshot);
+            Applied.TrySetResult(snapshot);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestSegmentChange.cs
+++ b/IntroSkipper.Tests/TestSegmentChange.cs
@@ -165,26 +165,26 @@ public sealed class TestSegmentChange : IDisposable
         var rows = await db.Segments.OrderBy(row => row.Type).ToListAsync();
         Assert.Equal(2, rows.Count);
         Assert.All(rows, row => Assert.Equal(SegmentSource.User, row.Source));
-        Assert.Equal(2, await db.AnalyzedStates.CountAsync(state => state.State == EpisodeState.UserProvided));
+        Assert.Empty(await db.AnalyzedItems.ToListAsync());
     }
 
     [Fact]
-    public async Task AddPromotion_UpsertsUserProvidedAnalyzedState()
+    public async Task AddPromotion_ClearsPriorAnalysisRecord()
     {
         var itemId = Guid.NewGuid();
         var automatic = new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter, "automatic-hash");
         await SeedAsync(automatic);
-        await SeedAnalyzedStateAsync(new DbAnalyzedState(itemId, AnalysisMode.Introduction, EpisodeState.Analyzed, "automatic-hash"));
+        await SeedAnalyzedItemAsync(new DbAnalyzedItem(itemId, AnalysisMode.Introduction, "automatic-hash"));
 
         var accepted = Assert.IsType<Accepted>(await CreateService(new RecordingProjectionAdapter()).ApplyAsync(
             new AddUserSegmentIntent(itemId, AnalysisMode.Introduction, 10, 20)));
 
         Assert.Equal(automatic.Id, Assert.Single(accepted.AffectedValues).Id);
-        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Introduction, EpisodeState.UserProvided, string.Empty);
+        await AssertNoAnalyzedItemAsync(itemId, AnalysisMode.Introduction);
     }
 
     [Fact]
-    public async Task ReplaceUserSegments_UpsertsUserProvidedAnalyzedState()
+    public async Task ReplaceUserSegments_ClearsPriorAnalysisRecord()
     {
         var itemId = Guid.NewGuid();
         await SeedAsync(new DbSegment(itemId, AnalysisMode.Credits, 1, 2, SegmentSource.BlackFrame, "old-hash"));
@@ -194,7 +194,7 @@ public sealed class TestSegmentChange : IDisposable
             AnalysisMode.Credits,
             [new SegmentRange(30, 40), new SegmentRange(50, 60)]));
 
-        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Credits, EpisodeState.UserProvided, string.Empty);
+        await AssertNoAnalyzedItemAsync(itemId, AnalysisMode.Credits);
     }
 
     [Fact]
@@ -202,18 +202,18 @@ public sealed class TestSegmentChange : IDisposable
     {
         var itemId = Guid.NewGuid();
         await SeedAsync(new DbSegment(itemId, AnalysisMode.Commercial, 10, 20, SegmentSource.User));
-        await SeedAnalyzedStateAsync(new DbAnalyzedState(itemId, AnalysisMode.Commercial, EpisodeState.UserProvided));
+        await SeedAnalyzedItemAsync(new DbAnalyzedItem(itemId, AnalysisMode.Commercial, "old"));
 
         Assert.IsType<Accepted>(await CreateService(new RecordingProjectionAdapter()).ApplyAsync(
             new ReplaceUserSegmentsForModeIntent(itemId, AnalysisMode.Commercial, [])));
 
         await using var db = CreateContext();
-        Assert.Empty(await db.AnalyzedStates.ToListAsync());
+        Assert.Empty(await db.AnalyzedItems.ToListAsync());
         Assert.Empty(await db.Segments.Where(row => row.State == SegmentState.Active).ToListAsync());
     }
 
     [Fact]
-    public async Task UpdateCollision_UpsertsUserProvidedAnalyzedState()
+    public async Task UpdateCollision_ClearsPriorAnalysisRecord()
     {
         var itemId = Guid.NewGuid();
         var moved = new DbSegment(itemId, AnalysisMode.Preview, 10, 20, SegmentSource.Chapter, "one");
@@ -224,7 +224,7 @@ public sealed class TestSegmentChange : IDisposable
             new UpdateSegmentIntent(itemId, moved.Id, occupant.StartTicks, occupant.EndTicks)));
 
         Assert.Equal(occupant.Id, Assert.Single(accepted.AffectedValues).Id);
-        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Preview, EpisodeState.UserProvided, string.Empty);
+        await AssertNoAnalyzedItemAsync(itemId, AnalysisMode.Preview);
     }
 
     [Fact]
@@ -236,7 +236,7 @@ public sealed class TestSegmentChange : IDisposable
         var service = CreateService(new RecordingProjectionAdapter());
 
         await service.ApplyAsync(new DeleteSegmentIntent(userItemId, deletedUser.Id));
-        await AssertAnalyzedStateAsync(userItemId, AnalysisMode.Commercial, EpisodeState.UserProvided, string.Empty);
+        await AssertNoAnalyzedItemAsync(userItemId, AnalysisMode.Commercial);
 
         var autoItemId = Guid.NewGuid();
         var deletedAuto = new DbSegment(autoItemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter, "deleted");
@@ -246,7 +246,7 @@ public sealed class TestSegmentChange : IDisposable
             new DbSegment(autoItemId, AnalysisMode.Introduction, 50, 60, SegmentSource.BlackFrame, "hash-b"));
 
         await service.ApplyAsync(new DeleteSegmentIntent(autoItemId, deletedAuto.Id));
-        await AssertAnalyzedStateAsync(autoItemId, AnalysisMode.Introduction, EpisodeState.Analyzed, string.Empty);
+        await AssertAnalyzedItemAsync(autoItemId, AnalysisMode.Introduction, string.Empty);
     }
 
     [Fact]
@@ -258,7 +258,7 @@ public sealed class TestSegmentChange : IDisposable
 
         await CreateService(new RecordingProjectionAdapter()).ApplyAsync(new DeleteSegmentIntent(itemId, deleted.Id));
 
-        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Recap, EpisodeState.Analyzed, "remaining");
+        await AssertAnalyzedItemAsync(itemId, AnalysisMode.Recap, "remaining");
     }
 
     [Fact]
@@ -273,11 +273,11 @@ public sealed class TestSegmentChange : IDisposable
 
         await CreateService(new RecordingProjectionAdapter()).ApplyAsync(new RestoreSegmentIntent(itemId, tombstone.Id));
 
-        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Credits, EpisodeState.Analyzed, "restore-hash");
+        await AssertAnalyzedItemAsync(itemId, AnalysisMode.Credits, "restore-hash");
     }
 
     [Fact]
-    public async Task RestoreAutomatic_WithActiveUserSegment_KeepsUserProvidedState()
+    public async Task RestoreAutomatic_WithActiveUserSegment_ClearsAnalysisRecord()
     {
         var itemId = Guid.NewGuid();
         var automatic = new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter, "restored-hash")
@@ -291,7 +291,7 @@ public sealed class TestSegmentChange : IDisposable
         Assert.IsType<Accepted>(await CreateService(new RecordingProjectionAdapter()).ApplyAsync(
             new RestoreSegmentIntent(itemId, automatic.Id)));
 
-        await AssertAnalyzedStateAsync(itemId, AnalysisMode.Introduction, EpisodeState.UserProvided, string.Empty);
+        await AssertNoAnalyzedItemAsync(itemId, AnalysisMode.Introduction);
     }
 
     [Fact]
@@ -310,7 +310,7 @@ public sealed class TestSegmentChange : IDisposable
 
         await using var verify = CreateContext();
         Assert.Empty(await verify.Segments.ToListAsync());
-        Assert.Empty(await verify.AnalyzedStates.ToListAsync());
+        Assert.Empty(await verify.AnalyzedItems.ToListAsync());
         Assert.Empty(await verify.ProjectionPlans.ToListAsync());
         Assert.Empty(await verify.ProjectionHeads.ToListAsync());
     }
@@ -513,20 +513,25 @@ public sealed class TestSegmentChange : IDisposable
         await db.SaveChangesAsync();
     }
 
-    private async Task SeedAnalyzedStateAsync(params DbAnalyzedState[] states)
+    private async Task SeedAnalyzedItemAsync(params DbAnalyzedItem[] items)
     {
         await using var db = CreateContext();
         await db.ApplyMigrationsAsync();
-        db.AnalyzedStates.AddRange(states);
+        db.AnalyzedItems.AddRange(items);
         await db.SaveChangesAsync();
     }
 
-    private async Task AssertAnalyzedStateAsync(Guid itemId, AnalysisMode mode, EpisodeState expectedState, string expectedHash)
+    private async Task AssertAnalyzedItemAsync(Guid itemId, AnalysisMode mode, string expectedHash)
     {
         await using var db = CreateContext();
-        var state = await db.AnalyzedStates.SingleAsync(value => value.ItemId == itemId && value.Type == mode);
-        Assert.Equal(expectedState, state.State);
-        Assert.Equal(expectedHash, state.ConfigHash);
+        var item = await db.AnalyzedItems.SingleAsync(value => value.ItemId == itemId && value.Type == mode);
+        Assert.Equal(expectedHash, item.ConfigHash);
+    }
+
+    private async Task AssertNoAnalyzedItemAsync(Guid itemId, AnalysisMode mode)
+    {
+        await using var db = CreateContext();
+        Assert.False(await db.AnalyzedItems.AnyAsync(value => value.ItemId == itemId && value.Type == mode));
     }
 
     private sealed class TestProjectionConfiguration : ISegmentProjectionConfiguration

--- a/IntroSkipper.Tests/TestSegmentChange.cs
+++ b/IntroSkipper.Tests/TestSegmentChange.cs
@@ -424,6 +424,38 @@ public sealed class TestSegmentChange : IDisposable
     }
 
     [Fact]
+    public async Task RecoveryPoll_DoesNotReconcilePendingExternalOperation()
+    {
+        var itemId = Guid.NewGuid();
+        var externalId = Guid.NewGuid();
+        await SeedAsync(
+            new DbSegment(Guid.NewGuid(), AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter),
+            new DbSegment(Guid.NewGuid(), AnalysisMode.Credits, 30, 40, SegmentSource.BlackFrame));
+        var adapter = new RecordingProjectionAdapter
+        {
+            ExternalTarget = new ExternalSegmentTarget(externalId, itemId, MediaSegmentType.Intro, 10, 20),
+            FailuresRemaining = 1
+        };
+        var service = CreateService(adapter);
+
+        await service.ApplyAsync(new DeleteExternalSegmentIntent(itemId, externalId, MediaSegmentType.Intro));
+        adapter.FailuresRemaining = 1;
+        await service.StartAsync(CancellationToken.None);
+        var reconciled = await Task.WhenAny(adapter.Applied.Task, Task.Delay(TimeSpan.FromSeconds(1))) == adapter.Applied.Task;
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.False(reconciled);
+        Assert.Equal(new long[] { 1, 1 }, adapter.Attempts.Select(plan => plan.Sequence));
+        Assert.All(adapter.Attempts, plan => Assert.Equal(externalId, Assert.Single(plan.ExternalOperations).ExternalSegmentId));
+        await using var db = CreateContext();
+        Assert.Equal(1, Assert.Single(await db.ProjectionPlans.ToListAsync()).Sequence);
+        Assert.Equal(1, Assert.Single(await db.ProjectionExternalOperations.ToListAsync()).Sequence);
+        var head = Assert.Single(await db.ProjectionHeads.ToListAsync());
+        Assert.Equal(1, head.LastAcceptedSequence);
+        Assert.Equal(ProjectionState.Pending, head.Status);
+    }
+
+    [Fact]
     public async Task FailureForOneItem_DoesNotBlockAnotherItem()
     {
         var blockedItem = Guid.NewGuid();

--- a/IntroSkipper/Db/DbProjectionAttempt.cs
+++ b/IntroSkipper/Db/DbProjectionAttempt.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.SegmentChanges;
+
+namespace IntroSkipper.Db;
+
+/// <summary>Mutable retry metadata for one pending item plan.</summary>
+internal sealed class DbProjectionAttempt
+{
+    public Guid ChangeId { get; set; }
+
+    public Guid ItemId { get; set; }
+
+    public ProjectionState Status { get; set; }
+
+    public int AttemptCount { get; set; }
+
+    public DateTime? LastAttemptAt { get; set; }
+
+    public DateTime? NextAttemptAt { get; set; }
+
+    public string? Failure { get; set; }
+}

--- a/IntroSkipper/Db/DbProjectionExternalOperation.cs
+++ b/IntroSkipper/Db/DbProjectionExternalOperation.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.SegmentChanges;
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.Db;
+
+/// <summary>One ordered exact external operation in an immutable plan.</summary>
+internal sealed class DbProjectionExternalOperation
+{
+    public Guid ChangeId { get; set; }
+
+    public Guid ItemId { get; set; }
+
+    public long Sequence { get; set; }
+
+    public int Position { get; set; }
+
+    public Guid ExternalSegmentId { get; set; }
+
+    public MediaSegmentType ExpectedType { get; set; }
+
+    public ProjectionExternalOperationKind Kind { get; set; }
+}

--- a/IntroSkipper/Db/DbProjectionHead.cs
+++ b/IntroSkipper/Db/DbProjectionHead.cs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.SegmentChanges;
+
+namespace IntroSkipper.Db;
+
+/// <summary>Compacted projection progress for one item.</summary>
+internal sealed class DbProjectionHead
+{
+    public Guid ItemId { get; set; }
+
+    public long LastAcceptedSequence { get; set; }
+
+    public long LastAppliedSequence { get; set; }
+
+    public ProjectionState Status { get; set; }
+}

--- a/IntroSkipper/Db/DbProjectionPlan.cs
+++ b/IntroSkipper/Db/DbProjectionPlan.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Db;
+
+/// <summary>Immutable durable projection plan header.</summary>
+internal sealed class DbProjectionPlan
+{
+    public Guid ChangeId { get; set; }
+
+    public Guid ItemId { get; set; }
+
+    public long Sequence { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+}

--- a/IntroSkipper/Db/DbProjectionPlanSegment.cs
+++ b/IntroSkipper/Db/DbProjectionPlanSegment.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.Db;
+
+/// <summary>One row in a plan's immutable full own-row image.</summary>
+internal sealed class DbProjectionPlanSegment
+{
+    public Guid ChangeId { get; set; }
+
+    public Guid ItemId { get; set; }
+
+    public int Position { get; set; }
+
+    public Guid SegmentId { get; set; }
+
+    public MediaSegmentType Type { get; set; }
+
+    public long StartTicks { get; set; }
+
+    public long EndTicks { get; set; }
+
+    public SegmentSource Source { get; set; }
+}

--- a/IntroSkipper/Db/IntroSkipperDbContext.cs
+++ b/IntroSkipper/Db/IntroSkipperDbContext.cs
@@ -37,6 +37,11 @@ public class IntroSkipperDbContext : DbContext
         AnalyzedItems = Set<DbAnalyzedItem>();
         ImportHistory = Set<DbImportRecord>();
         DisabledItems = Set<DbDisabledItem>();
+        ProjectionPlans = Set<DbProjectionPlan>();
+        ProjectionPlanSegments = Set<DbProjectionPlanSegment>();
+        ProjectionExternalOperations = Set<DbProjectionExternalOperation>();
+        ProjectionAttempts = Set<DbProjectionAttempt>();
+        ProjectionHeads = Set<DbProjectionHead>();
     }
 
     /// <summary>
@@ -58,6 +63,11 @@ public class IntroSkipperDbContext : DbContext
         AnalyzedItems = Set<DbAnalyzedItem>();
         ImportHistory = Set<DbImportRecord>();
         DisabledItems = Set<DbDisabledItem>();
+        ProjectionPlans = Set<DbProjectionPlan>();
+        ProjectionPlanSegments = Set<DbProjectionPlanSegment>();
+        ProjectionExternalOperations = Set<DbProjectionExternalOperation>();
+        ProjectionAttempts = Set<DbProjectionAttempt>();
+        ProjectionHeads = Set<DbProjectionHead>();
     }
 
     /// <summary>
@@ -85,6 +95,21 @@ public class IntroSkipperDbContext : DbContext
     /// segments are withheld from Jellyfin.
     /// </summary>
     public DbSet<DbDisabledItem> DisabledItems { get; set; }
+
+    /// <summary>Gets or sets immutable projection plan headers.</summary>
+    internal DbSet<DbProjectionPlan> ProjectionPlans { get; set; }
+
+    /// <summary>Gets or sets immutable projection plan segment images.</summary>
+    internal DbSet<DbProjectionPlanSegment> ProjectionPlanSegments { get; set; }
+
+    /// <summary>Gets or sets immutable exact external operations.</summary>
+    internal DbSet<DbProjectionExternalOperation> ProjectionExternalOperations { get; set; }
+
+    /// <summary>Gets or sets mutable projection retry attempts.</summary>
+    internal DbSet<DbProjectionAttempt> ProjectionAttempts { get; set; }
+
+    /// <summary>Gets or sets compacted per-item projection heads.</summary>
+    internal DbSet<DbProjectionHead> ProjectionHeads { get; set; }
 
     /// <inheritdoc/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -170,6 +195,41 @@ public class IntroSkipperDbContext : DbContext
             entity.HasIndex(e => e.SeasonId);
         });
 
+        modelBuilder.Entity<DbProjectionPlan>(entity =>
+        {
+            entity.ToTable("ProjectionPlans");
+            entity.HasKey(e => new { e.ChangeId, e.ItemId });
+            entity.HasIndex(e => new { e.ItemId, e.Sequence }).IsUnique();
+            entity.Property(e => e.CreatedAt).HasConversion(_utcDateTimeConverter);
+        });
+
+        modelBuilder.Entity<DbProjectionPlanSegment>(entity =>
+        {
+            entity.ToTable("ProjectionPlanSegments");
+            entity.HasKey(e => new { e.ChangeId, e.ItemId, e.Position });
+        });
+
+        modelBuilder.Entity<DbProjectionExternalOperation>(entity =>
+        {
+            entity.ToTable("ProjectionExternalOperations");
+            entity.HasKey(e => new { e.ChangeId, e.ItemId, e.Position });
+            entity.HasIndex(e => new { e.ItemId, e.ExternalSegmentId });
+        });
+
+        modelBuilder.Entity<DbProjectionAttempt>(entity =>
+        {
+            entity.ToTable("ProjectionAttempts");
+            entity.HasKey(e => new { e.ChangeId, e.ItemId });
+            entity.Property(e => e.LastAttemptAt).HasConversion(_utcDateTimeConverter);
+            entity.Property(e => e.NextAttemptAt).HasConversion(_utcDateTimeConverter);
+        });
+
+        modelBuilder.Entity<DbProjectionHead>(entity =>
+        {
+            entity.ToTable("ProjectionHeads");
+            entity.HasKey(e => e.ItemId);
+        });
+
         base.OnModelCreating(modelBuilder);
     }
 
@@ -217,6 +277,11 @@ public class IntroSkipperDbContext : DbContext
         var analyzedItems = new List<DbAnalyzedItem>();
         var importRecords = new List<DbImportRecord>();
         var disabledItems = new List<DbDisabledItem>();
+        var projectionPlans = new List<DbProjectionPlan>();
+        var projectionPlanSegments = new List<DbProjectionPlanSegment>();
+        var projectionExternalOperations = new List<DbProjectionExternalOperation>();
+        var projectionAttempts = new List<DbProjectionAttempt>();
+        var projectionHeads = new List<DbProjectionHead>();
         var backupFailed = false;
 
         // Best-effort backup — a corrupted DB will fail here, and that's fine.
@@ -238,6 +303,11 @@ public class IntroSkipperDbContext : DbContext
                 analyzedItems = await db.AnalyzedItems.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
                 importRecords = await db.ImportHistory.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
                 disabledItems = await db.DisabledItems.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+                projectionPlans = await db.ProjectionPlans.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+                projectionPlanSegments = await db.ProjectionPlanSegments.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+                projectionExternalOperations = await db.ProjectionExternalOperations.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+                projectionAttempts = await db.ProjectionAttempts.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
+                projectionHeads = await db.ProjectionHeads.AsNoTracking().ToListAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -291,6 +361,11 @@ public class IntroSkipperDbContext : DbContext
                 await AddInBatchesAsync(db, db.SeasonStates, seasonStates, cancellationToken).ConfigureAwait(false);
                 await AddInBatchesAsync(db, db.AnalyzedItems, analyzedItems, cancellationToken).ConfigureAwait(false);
                 await AddInBatchesAsync(db, db.DisabledItems, disabledItems, cancellationToken).ConfigureAwait(false);
+                await AddInBatchesAsync(db, db.ProjectionPlans, projectionPlans, cancellationToken).ConfigureAwait(false);
+                await AddInBatchesAsync(db, db.ProjectionPlanSegments, projectionPlanSegments, cancellationToken).ConfigureAwait(false);
+                await AddInBatchesAsync(db, db.ProjectionExternalOperations, projectionExternalOperations, cancellationToken).ConfigureAwait(false);
+                await AddInBatchesAsync(db, db.ProjectionAttempts, projectionAttempts, cancellationToken).ConfigureAwait(false);
+                await AddInBatchesAsync(db, db.ProjectionHeads, projectionHeads, cancellationToken).ConfigureAwait(false);
                 await AddInBatchesAsync(db, db.ImportHistory, importRecords, cancellationToken).ConfigureAwait(false);
 
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Migrations/20260823080000_AddSegmentProjectionJournal.Designer.cs
+++ b/IntroSkipper/Migrations/20260823080000_AddSegmentProjectionJournal.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IntroSkipper.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,14 +11,16 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace IntroSkipper.Migrations
 {
     [DbContext(typeof(IntroSkipperDbContext))]
-    partial class IntroSkipperDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823080000_AddSegmentProjectionJournal")]
+    partial class AddSegmentProjectionJournal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.10");
 
-            modelBuilder.Entity("IntroSkipper.Db.DbAnalyzedItem", b =>
+            modelBuilder.Entity("IntroSkipper.Db.DbAnalyzedState", b =>
                 {
                     b.Property<Guid>("ItemId")
                         .HasColumnType("TEXT");
@@ -29,9 +32,12 @@ namespace IntroSkipper.Migrations
                         .IsRequired()
                         .HasColumnType("TEXT");
 
+                    b.Property<int>("State")
+                        .HasColumnType("INTEGER");
+
                     b.HasKey("ItemId", "Type");
 
-                    b.ToTable("AnalyzedItems", (string)null);
+                    b.ToTable("AnalyzedStates", (string)null);
                 });
 
             modelBuilder.Entity("IntroSkipper.Db.DbDisabledItem", b =>
@@ -270,10 +276,7 @@ namespace IntroSkipper.Migrations
                         .IsUnique()
                         .HasDatabaseName("IX_Segments_ItemId_Type_StartTicks_EndTicks");
 
-                    b.ToTable("Segments", null, t =>
-                        {
-                            t.HasCheckConstraint("CK_Segments_Range", "\"EndTicks\" > \"StartTicks\" AND \"StartTicks\" >= 0");
-                        });
+                    b.ToTable("Segments", (string)null);
                 });
 #pragma warning restore 612, 618
         }

--- a/IntroSkipper/Migrations/20260823080000_AddSegmentProjectionJournal.cs
+++ b/IntroSkipper/Migrations/20260823080000_AddSegmentProjectionJournal.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IntroSkipper.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSegmentProjectionJournal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProjectionAttempts",
+                columns: table => new
+                {
+                    ChangeId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false),
+                    AttemptCount = table.Column<int>(type: "INTEGER", nullable: false),
+                    LastAttemptAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    NextAttemptAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    Failure = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectionAttempts", x => new { x.ChangeId, x.ItemId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectionExternalOperations",
+                columns: table => new
+                {
+                    ChangeId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Sequence = table.Column<long>(type: "INTEGER", nullable: false),
+                    Position = table.Column<int>(type: "INTEGER", nullable: false),
+                    ExternalSegmentId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ExpectedType = table.Column<int>(type: "INTEGER", nullable: false),
+                    Kind = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectionExternalOperations", x => new { x.ChangeId, x.ItemId, x.Position });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectionHeads",
+                columns: table => new
+                {
+                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    LastAcceptedSequence = table.Column<long>(type: "INTEGER", nullable: false),
+                    LastAppliedSequence = table.Column<long>(type: "INTEGER", nullable: false),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectionHeads", x => x.ItemId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectionPlans",
+                columns: table => new
+                {
+                    ChangeId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Sequence = table.Column<long>(type: "INTEGER", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectionPlans", x => new { x.ChangeId, x.ItemId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProjectionPlanSegments",
+                columns: table => new
+                {
+                    ChangeId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Position = table.Column<int>(type: "INTEGER", nullable: false),
+                    SegmentId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Type = table.Column<int>(type: "INTEGER", nullable: false),
+                    StartTicks = table.Column<long>(type: "INTEGER", nullable: false),
+                    EndTicks = table.Column<long>(type: "INTEGER", nullable: false),
+                    Source = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectionPlanSegments", x => new { x.ChangeId, x.ItemId, x.Position });
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectionExternalOperations_ItemId_ExternalSegmentId",
+                table: "ProjectionExternalOperations",
+                columns: new[] { "ItemId", "ExternalSegmentId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectionPlans_ItemId_Sequence",
+                table: "ProjectionPlans",
+                columns: new[] { "ItemId", "Sequence" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProjectionAttempts");
+
+            migrationBuilder.DropTable(
+                name: "ProjectionExternalOperations");
+
+            migrationBuilder.DropTable(
+                name: "ProjectionHeads");
+
+            migrationBuilder.DropTable(
+                name: "ProjectionPlans");
+
+            migrationBuilder.DropTable(
+                name: "ProjectionPlanSegments");
+        }
+    }
+}

--- a/IntroSkipper/PluginServiceRegistrator.cs
+++ b/IntroSkipper/PluginServiceRegistrator.cs
@@ -8,6 +8,7 @@ using IntroSkipper.FFmpeg;
 using IntroSkipper.Filters;
 using IntroSkipper.Manager;
 using IntroSkipper.Providers;
+using IntroSkipper.SegmentChanges;
 using IntroSkipper.Services;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
@@ -16,6 +17,7 @@ using MediaBrowser.Controller.Plugins;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace IntroSkipper
 {
@@ -43,6 +45,15 @@ namespace IntroSkipper
             // service; the facades' internal gate still guarantees ordering for any
             // request that arrives earlier.
             serviceCollection.AddHostedService<IntroSkipperDatabaseInitializer>();
+
+            serviceCollection.AddSingleton(TimeProvider.System);
+            serviceCollection.AddSingleton<ISegmentProjectionAdapter, JellyfinSegmentProjectionAdapter>();
+            serviceCollection.AddSingleton<SegmentProjectionConfiguration>();
+            serviceCollection.AddSingleton<ISegmentProjectionConfiguration>(serviceProvider => serviceProvider.GetRequiredService<SegmentProjectionConfiguration>());
+            serviceCollection.AddSingleton<IHostedService>(serviceProvider => serviceProvider.GetRequiredService<SegmentProjectionConfiguration>());
+            serviceCollection.AddSingleton<SegmentChange>();
+            serviceCollection.AddSingleton<ISegmentChange>(serviceProvider => serviceProvider.GetRequiredService<SegmentChange>());
+            serviceCollection.AddSingleton<IHostedService>(serviceProvider => serviceProvider.GetRequiredService<SegmentChange>());
 
             serviceCollection.AddHostedService<Entrypoint>();
             // Owns the shared dependency set of the per-run analysis objects

--- a/IntroSkipper/SegmentChanges/Accepted.cs
+++ b/IntroSkipper/SegmentChanges/Accepted.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>The authoritative transaction committed and projection was journaled.</summary>
+/// <param name="ChangeId">Durable change ID.</param>
+/// <param name="AffectedValues">Affected authoritative segment values.</param>
+/// <param name="Projections">Per-item projection disposition.</param>
+public sealed record Accepted(Guid ChangeId, IReadOnlyList<SegmentValue> AffectedValues, IReadOnlyList<SegmentProjectionResult> Projections) : SegmentChangeOutcome;

--- a/IntroSkipper/SegmentChanges/AddUserSegmentIntent.cs
+++ b/IntroSkipper/SegmentChanges/AddUserSegmentIntent.cs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Adds or promotes one user segment.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="Mode">Analysis mode.</param>
+/// <param name="StartTicks">Start ticks.</param>
+/// <param name="EndTicks">End ticks.</param>
+public sealed record AddUserSegmentIntent(Guid ItemId, AnalysisMode Mode, long StartTicks, long EndTicks) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/DeleteExternalSegmentIntent.cs
+++ b/IntroSkipper/SegmentChanges/DeleteExternalSegmentIntent.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Deletes one exactly validated Jellyfin segment and any exact counterpart.</summary>
+/// <param name="ItemId">Expected owning item ID.</param>
+/// <param name="ExternalSegmentId">External row ID.</param>
+/// <param name="ExpectedType">Expected Jellyfin type.</param>
+public sealed record DeleteExternalSegmentIntent(Guid ItemId, Guid ExternalSegmentId, MediaSegmentType ExpectedType) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/DeleteSegmentIntent.cs
+++ b/IntroSkipper/SegmentChanges/DeleteSegmentIntent.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Deletes one stored segment, preserving automatic intent as a tombstone.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="SegmentId">Segment ID.</param>
+public sealed record DeleteSegmentIntent(Guid ItemId, Guid SegmentId) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/ExternalSegmentTarget.cs
+++ b/IntroSkipper/SegmentChanges/ExternalSegmentTarget.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>An exactly resolved Jellyfin segment.</summary>
+/// <param name="Id">External row ID.</param>
+/// <param name="ItemId">Owning item ID.</param>
+/// <param name="Type">Jellyfin segment type.</param>
+/// <param name="StartTicks">Start ticks.</param>
+/// <param name="EndTicks">End ticks.</param>
+internal sealed record ExternalSegmentTarget(Guid Id, Guid ItemId, MediaSegmentType Type, long StartTicks, long EndTicks);

--- a/IntroSkipper/SegmentChanges/ISegmentChange.cs
+++ b/IntroSkipper/SegmentChanges/ISegmentChange.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>
+/// Commits authoritative segment changes and durably projects their resulting images.
+/// </summary>
+public interface ISegmentChange
+{
+    /// <summary>Applies one closed segment-change intent.</summary>
+    /// <param name="intent">Closed domain intent.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The typed domain and projection outcome.</returns>
+    Task<SegmentChangeOutcome> ApplyAsync(SegmentChangeIntent intent, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets aggregate pending and compacted projection state.</summary>
+    /// <param name="scope">All items or one item.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Aggregate status with per-item details and counts.</returns>
+    Task<ProjectionStatus> GetProjectionStatusAsync(ProjectionScope scope, CancellationToken cancellationToken = default);
+
+    /// <summary>Immediately retries pending projections in the requested scope.</summary>
+    /// <param name="scope">All items or one item.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Retry counts and resulting aggregate status.</returns>
+    Task<ProjectionRetryOutcome> RetryProjectionAsync(ProjectionScope scope, CancellationToken cancellationToken = default);
+}

--- a/IntroSkipper/SegmentChanges/ISegmentProjectionAdapter.cs
+++ b/IntroSkipper/SegmentChanges/ISegmentProjectionAdapter.cs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Plan-level seam between the durable journal and Jellyfin's database.</summary>
+internal interface ISegmentProjectionAdapter
+{
+    /// <summary>Resolves an exact external target before authoritative commit.</summary>
+    /// <param name="itemId">Expected owning item.</param>
+    /// <param name="externalSegmentId">External segment ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The actual target, or <see langword="null"/> when absent.</returns>
+    Task<ExternalSegmentTarget?> ResolveExternalTargetAsync(Guid itemId, Guid externalSegmentId, CancellationToken cancellationToken);
+
+    /// <summary>Atomically applies one immutable item plan.</summary>
+    /// <param name="plan">Immutable item plan.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the operation.</returns>
+    Task ApplyAsync(SegmentProjectionPlan plan, CancellationToken cancellationToken);
+}

--- a/IntroSkipper/SegmentChanges/ISegmentProjectionConfiguration.cs
+++ b/IntroSkipper/SegmentChanges/ISegmentProjectionConfiguration.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Exposes projection enablement and host configuration transitions.</summary>
+internal interface ISegmentProjectionConfiguration
+{
+    /// <summary>Raised when projection enablement changes.</summary>
+    event EventHandler<bool>? EnabledChanged;
+
+    /// <summary>Gets a value indicating whether Jellyfin projection is enabled.</summary>
+    bool Enabled { get; }
+}

--- a/IntroSkipper/SegmentChanges/Ignored.cs
+++ b/IntroSkipper/SegmentChanges/Ignored.cs
@@ -4,5 +4,6 @@
 namespace IntroSkipper.SegmentChanges;
 
 /// <summary>The intent already held and no transaction was needed.</summary>
-/// <param name="Reason">Domain reason.</param>
-public sealed record Ignored(string Reason) : SegmentChangeOutcome;
+/// <param name="Reason">Typed no-change reason.</param>
+/// <param name="Message">Human-readable reason.</param>
+public sealed record Ignored(SegmentChangeIgnoredReason Reason, string Message) : SegmentChangeOutcome;

--- a/IntroSkipper/SegmentChanges/Ignored.cs
+++ b/IntroSkipper/SegmentChanges/Ignored.cs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>The intent already held and no transaction was needed.</summary>
+/// <param name="Reason">Domain reason.</param>
+public sealed record Ignored(string Reason) : SegmentChangeOutcome;

--- a/IntroSkipper/SegmentChanges/ItemProjectionStatus.cs
+++ b/IntroSkipper/SegmentChanges/ItemProjectionStatus.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Current durable projection status for one item.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="LastAcceptedSequence">Last accepted sequence.</param>
+/// <param name="LastAppliedSequence">Last sequence applied to Jellyfin.</param>
+/// <param name="State">Current state.</param>
+/// <param name="AttemptCount">Attempts for the earliest pending plan.</param>
+/// <param name="NextAttemptAt">Next due time.</param>
+/// <param name="Failure">Sanitized latest failure.</param>
+public sealed record ItemProjectionStatus(Guid ItemId, long LastAcceptedSequence, long LastAppliedSequence, ProjectionState State, int AttemptCount, DateTime? NextAttemptAt, string? Failure);

--- a/IntroSkipper/SegmentChanges/JellyfinSegmentProjectionAdapter.cs
+++ b/IntroSkipper/SegmentChanges/JellyfinSegmentProjectionAdapter.cs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Manager;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Applies durable item plans directly to Jellyfin's media segment table.</summary>
+internal sealed partial class JellyfinSegmentProjectionAdapter(
+    IDbContextFactory<JellyfinDbContext> contextFactory,
+    ILogger<JellyfinSegmentProjectionAdapter> logger) : ISegmentProjectionAdapter
+{
+    /// <inheritdoc />
+    public async Task<ExternalSegmentTarget?> ResolveExternalTargetAsync(Guid itemId, Guid externalSegmentId, CancellationToken cancellationToken)
+    {
+        var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            var row = await db.MediaSegments.AsNoTracking()
+                .FirstOrDefaultAsync(segment => segment.Id == externalSegmentId, cancellationToken)
+                .ConfigureAwait(false);
+            return row is null ? null : new ExternalSegmentTarget(row.Id, row.ItemId, row.Type, row.StartTicks, row.EndTicks);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ApplyAsync(SegmentProjectionPlan plan, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        var entities = plan.Segments.Select(segment => new MediaSegment
+        {
+            Id = segment.Id,
+            ItemId = plan.ItemId,
+            Type = segment.Type,
+            StartTicks = segment.StartTicks,
+            EndTicks = segment.EndTicks,
+            SegmentProviderId = JellyfinSegmentStore.ProviderId
+        }).ToList();
+
+        if (entities.Any(segment => segment.Id == Guid.Empty || segment.EndTicks <= segment.StartTicks))
+        {
+            throw new InvalidOperationException("Projection plans must contain stable IDs and valid tick ranges.");
+        }
+
+        var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (db.ConfigureAwait(false))
+        {
+            var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            await using (transaction.ConfigureAwait(false))
+            {
+                try
+                {
+                    foreach (var operation in plan.ExternalOperations)
+                    {
+                        if (operation.Kind != ProjectionExternalOperationKind.Delete)
+                        {
+                            throw new InvalidOperationException("Unsupported projection operation.");
+                        }
+
+                        var deleted = await db.MediaSegments
+                            .Where(segment => segment.Id == operation.ExternalSegmentId
+                                && segment.ItemId == plan.ItemId
+                                && segment.Type == operation.ExpectedType)
+                            .ExecuteDeleteAsync(cancellationToken)
+                            .ConfigureAwait(false);
+                        if (deleted == 0)
+                        {
+                            var mismatched = await db.MediaSegments.AsNoTracking()
+                                .AnyAsync(segment => segment.Id == operation.ExternalSegmentId, cancellationToken)
+                                .ConfigureAwait(false);
+                            if (mismatched)
+                            {
+                                throw new InvalidOperationException("The external segment no longer matches its validated owner and type.");
+                            }
+                        }
+                    }
+
+                    await db.MediaSegments
+                        .Where(segment => segment.ItemId == plan.ItemId && segment.SegmentProviderId == JellyfinSegmentStore.ProviderId)
+                        .ExecuteDeleteAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    if (entities.Count > 0)
+                    {
+                        db.MediaSegments.AddRange(entities);
+                        var written = await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                        if (written != entities.Count)
+                        {
+                            LogUnexpectedWriteCount(logger, plan.ItemId, entities.Count, written);
+                            throw new InvalidOperationException($"Expected {entities.Count} projection writes but Jellyfin reported {written}.");
+                        }
+                    }
+
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    try
+                    {
+                        await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogRollbackFailed(logger, ex);
+                    }
+
+                    throw;
+                }
+            }
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Projection for item {ItemId} expected {ExpectedWrites} writes but Jellyfin reported {Written}.")]
+    private static partial void LogUnexpectedWriteCount(ILogger logger, Guid itemId, int expectedWrites, int written);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to roll back a Jellyfin projection transaction.")]
+    private static partial void LogRollbackFailed(ILogger logger, Exception exception);
+}

--- a/IntroSkipper/SegmentChanges/MutationResult.cs
+++ b/IntroSkipper/SegmentChanges/MutationResult.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Internal authoritative mutation result before plan creation.</summary>
+/// <param name="Outcome">Ignored or rejected outcome, if no plan should be created.</param>
+/// <param name="Affected">Affected authoritative segment values.</param>
+/// <param name="ExternalOperations">Exact external operations to journal.</param>
+internal sealed record MutationResult(SegmentChangeOutcome? Outcome, IReadOnlyList<SegmentValue> Affected, IReadOnlyList<ProjectedExternalOperation> ExternalOperations)
+{
+    internal static MutationResult Ignore(string reason) => new(new Ignored(reason), [], []);
+
+    internal static MutationResult Reject(string reason) => new(new Rejected(reason), [], []);
+}

--- a/IntroSkipper/SegmentChanges/MutationResult.cs
+++ b/IntroSkipper/SegmentChanges/MutationResult.cs
@@ -9,7 +9,7 @@ namespace IntroSkipper.SegmentChanges;
 /// <param name="ExternalOperations">Exact external operations to journal.</param>
 internal sealed record MutationResult(SegmentChangeOutcome? Outcome, IReadOnlyList<SegmentValue> Affected, IReadOnlyList<ProjectedExternalOperation> ExternalOperations)
 {
-    internal static MutationResult Ignore(string reason) => new(new Ignored(reason), [], []);
+    internal static MutationResult Ignore(SegmentChangeIgnoredReason reason, string message) => new(new Ignored(reason, message), [], []);
 
-    internal static MutationResult Reject(string reason) => new(new Rejected(reason), [], []);
+    internal static MutationResult Reject(SegmentChangeRejectedReason reason, string message) => new(new Rejected(reason, message), [], []);
 }

--- a/IntroSkipper/SegmentChanges/ProjectedExternalOperation.cs
+++ b/IntroSkipper/SegmentChanges/ProjectedExternalOperation.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>One ordered exact external operation.</summary>
+/// <param name="ExternalSegmentId">External row ID.</param>
+/// <param name="ExpectedType">Validated Jellyfin type.</param>
+/// <param name="Kind">Operation kind.</param>
+internal sealed record ProjectedExternalOperation(Guid ExternalSegmentId, MediaSegmentType ExpectedType, ProjectionExternalOperationKind Kind);

--- a/IntroSkipper/SegmentChanges/ProjectedSegment.cs
+++ b/IntroSkipper/SegmentChanges/ProjectedSegment.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>One complete Intro Skipper row image for Jellyfin.</summary>
+/// <param name="Id">Stable segment ID.</param>
+/// <param name="Type">Jellyfin segment type.</param>
+/// <param name="StartTicks">Start ticks.</param>
+/// <param name="EndTicks">End ticks.</param>
+/// <param name="Source">Segment provenance.</param>
+internal sealed record ProjectedSegment(Guid Id, MediaSegmentType Type, long StartTicks, long EndTicks, SegmentSource Source);

--- a/IntroSkipper/SegmentChanges/ProjectionExternalOperationKind.cs
+++ b/IntroSkipper/SegmentChanges/ProjectionExternalOperationKind.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Kind of an exact external projection operation.</summary>
+public enum ProjectionExternalOperationKind
+{
+    /// <summary>Delete the exact validated Jellyfin row.</summary>
+    Delete
+}

--- a/IntroSkipper/SegmentChanges/ProjectionRetryOutcome.cs
+++ b/IntroSkipper/SegmentChanges/ProjectionRetryOutcome.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Result of a manual retry request.</summary>
+/// <param name="Scope">Requested scope.</param>
+/// <param name="RetriedCount">Number of plans compacted by the retry.</param>
+/// <param name="Status">Aggregate status after retrying.</param>
+public sealed record ProjectionRetryOutcome(ProjectionScope Scope, int RetriedCount, ProjectionStatus Status);

--- a/IntroSkipper/SegmentChanges/ProjectionScope.cs
+++ b/IntroSkipper/SegmentChanges/ProjectionScope.cs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Selects all item projections or one item.</summary>
+public sealed record ProjectionScope
+{
+    private ProjectionScope(Guid? itemId)
+    {
+        ItemId = itemId;
+    }
+
+    /// <summary>Gets the item ID, or <see langword="null"/> for all items.</summary>
+    public Guid? ItemId { get; }
+
+    /// <summary>Gets the all-items scope.</summary>
+    public static ProjectionScope All { get; } = new((Guid?)null);
+
+    /// <summary>Creates a one-item scope.</summary>
+    /// <param name="itemId">Non-empty item ID.</param>
+    /// <returns>The item scope.</returns>
+    public static ProjectionScope ForItem(Guid itemId)
+    {
+        ArgumentOutOfRangeException.ThrowIfEqual(itemId, Guid.Empty);
+        return new(itemId);
+    }
+}

--- a/IntroSkipper/SegmentChanges/ProjectionState.cs
+++ b/IntroSkipper/SegmentChanges/ProjectionState.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Durable projection lifecycle.</summary>
+public enum ProjectionState
+{
+    /// <summary>The immutable plan is waiting to be applied.</summary>
+    Pending,
+
+    /// <summary>The immutable plan was applied and compacted.</summary>
+    Applied,
+
+    /// <summary>Projection was disabled, so the image was durably skipped.</summary>
+    Skipped
+}

--- a/IntroSkipper/SegmentChanges/ProjectionStatus.cs
+++ b/IntroSkipper/SegmentChanges/ProjectionStatus.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Aggregate projection status with per-item detail and counts.</summary>
+/// <param name="Scope">Requested scope.</param>
+/// <param name="Items">Per-item statuses.</param>
+public sealed record ProjectionStatus(ProjectionScope Scope, IReadOnlyList<ItemProjectionStatus> Items)
+{
+    /// <summary>Gets the item count.</summary>
+    public int ItemCount => Items.Count;
+
+    /// <summary>Gets the number of applied items.</summary>
+    public int AppliedCount => Items.Count(item => item.State == ProjectionState.Applied);
+
+    /// <summary>Gets the number of pending items.</summary>
+    public int PendingCount => Items.Count(item => item.State == ProjectionState.Pending);
+
+    /// <summary>Gets the number of skipped items.</summary>
+    public int SkippedCount => Items.Count(item => item.State == ProjectionState.Skipped);
+}

--- a/IntroSkipper/SegmentChanges/Rejected.cs
+++ b/IntroSkipper/SegmentChanges/Rejected.cs
@@ -4,5 +4,6 @@
 namespace IntroSkipper.SegmentChanges;
 
 /// <summary>The intent was invalid or did not own its addressed target.</summary>
-/// <param name="Reason">Domain reason.</param>
-public sealed record Rejected(string Reason) : SegmentChangeOutcome;
+/// <param name="Reason">Typed rejection reason.</param>
+/// <param name="Message">Human-readable reason.</param>
+public sealed record Rejected(SegmentChangeRejectedReason Reason, string Message) : SegmentChangeOutcome;

--- a/IntroSkipper/SegmentChanges/Rejected.cs
+++ b/IntroSkipper/SegmentChanges/Rejected.cs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>The intent was invalid or did not own its addressed target.</summary>
+/// <param name="Reason">Domain reason.</param>
+public sealed record Rejected(string Reason) : SegmentChangeOutcome;

--- a/IntroSkipper/SegmentChanges/ReplaceUserSegmentsForModeIntent.cs
+++ b/IntroSkipper/SegmentChanges/ReplaceUserSegmentsForModeIntent.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Replaces active segments for one mode with user segments.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="Mode">Analysis mode.</param>
+/// <param name="Segments">Complete user range set.</param>
+public sealed record ReplaceUserSegmentsForModeIntent(Guid ItemId, AnalysisMode Mode, IReadOnlyList<SegmentRange> Segments) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/RestoreSegmentIntent.cs
+++ b/IntroSkipper/SegmentChanges/RestoreSegmentIntent.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Restores one automatic tombstone.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="SegmentId">Segment ID.</param>
+public sealed record RestoreSegmentIntent(Guid ItemId, Guid SegmentId) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/SegmentChange.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChange.cs
@@ -1,0 +1,805 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.Helper;
+using IntroSkipper.Manager;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>EF-backed durable segment change coordinator and retry worker.</summary>
+internal sealed partial class SegmentChange(
+    IDbContextFactory<IntroSkipperDbContext> contextFactory,
+    IIntroSkipperDatabase database,
+    ISegmentProjectionAdapter adapter,
+    ISegmentProjectionConfiguration configuration,
+    TimeProvider timeProvider,
+    ILogger<SegmentChange> logger) : BackgroundService, ISegmentChange
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(10);
+    private readonly StripedAsyncLock _locks = new();
+    private readonly SemaphoreSlim _reconcileLock = new(1, 1);
+    private int _reconcileRequested;
+
+    /// <inheritdoc />
+    public async Task<SegmentChangeOutcome> ApplyAsync(SegmentChangeIntent intent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(intent);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (intent.ItemId == Guid.Empty)
+        {
+            return new Rejected("Item ID must not be empty.");
+        }
+
+        ExternalSegmentTarget? externalTarget = null;
+        if (intent is DeleteExternalSegmentIntent external)
+        {
+            externalTarget = await adapter.ResolveExternalTargetAsync(external.ItemId, external.ExternalSegmentId, cancellationToken).ConfigureAwait(false);
+
+            if (externalTarget is null)
+            {
+                return new Rejected("External segment was not found.");
+            }
+
+            if (externalTarget.ItemId != external.ItemId)
+            {
+                return new Rejected("External segment belongs to another item.");
+            }
+
+            if (externalTarget.Type != external.ExpectedType)
+            {
+                return new Rejected("External segment type does not match the expected type.");
+            }
+        }
+
+        if (Validate(intent) is { } rejection)
+        {
+            return rejection;
+        }
+
+        await database.InitializeAsync().ConfigureAwait(false);
+        var changeId = Guid.CreateVersion7();
+        IReadOnlyList<SegmentValue> affected;
+        {
+            using var itemLock = await _locks.AcquireAsync(intent.ItemId, cancellationToken).ConfigureAwait(false);
+            using (var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+                await using (transaction.ConfigureAwait(false))
+                {
+                    var mutation = await MutateAsync(db, intent, externalTarget, cancellationToken).ConfigureAwait(false);
+                    if (mutation.Outcome is not null)
+                    {
+                        await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                        return mutation.Outcome;
+                    }
+
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    affected = mutation.Affected;
+                    await AddPlanAsync(db, changeId, intent.ItemId, mutation.ExternalOperations, cancellationToken).ConfigureAwait(false);
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        var projected = await ProjectAcceptedChangeAsync(intent.ItemId, changeId).ConfigureAwait(false);
+        return new Accepted(changeId, affected, [new SegmentProjectionResult(intent.ItemId, projected)]);
+    }
+
+    /// <inheritdoc />
+    public async Task<ProjectionStatus> GetProjectionStatusAsync(ProjectionScope scope, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        await database.InitializeAsync().ConfigureAwait(false);
+        using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var heads = db.ProjectionHeads.AsNoTracking();
+        if (scope.ItemId.HasValue)
+        {
+            heads = heads.Where(head => head.ItemId == scope.ItemId.Value);
+        }
+
+        var values = await heads.OrderBy(head => head.ItemId).ToListAsync(cancellationToken).ConfigureAwait(false);
+        var results = new List<ItemProjectionStatus>(values.Count);
+        foreach (var head in values)
+        {
+            var attempt = await db.ProjectionAttempts.AsNoTracking()
+                .Where(value => value.ItemId == head.ItemId)
+                .OrderBy(value => value.NextAttemptAt)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+            results.Add(new ItemProjectionStatus(
+                head.ItemId,
+                head.LastAcceptedSequence,
+                head.LastAppliedSequence,
+                head.Status,
+                attempt?.AttemptCount ?? 0,
+                attempt?.NextAttemptAt,
+                attempt?.Failure));
+        }
+
+        return new ProjectionStatus(scope, results);
+    }
+
+    /// <inheritdoc />
+    public async Task<ProjectionRetryOutcome> RetryProjectionAsync(ProjectionScope scope, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        await database.InitializeAsync().ConfigureAwait(false);
+        IReadOnlyList<Guid> itemIds;
+        if (scope.ItemId.HasValue)
+        {
+            itemIds = [scope.ItemId.Value];
+        }
+        else
+        {
+            using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            itemIds = await db.ProjectionPlans.AsNoTracking().Select(plan => plan.ItemId).Distinct().ToListAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var applied = 0;
+        foreach (var id in itemIds)
+        {
+            while (await ProjectItemAsync(id, force: true, cancellationToken).ConfigureAwait(false) is ProjectionState.Applied or ProjectionState.Skipped)
+            {
+                applied++;
+                using var verify = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+                if (!await verify.ProjectionPlans.AnyAsync(plan => plan.ItemId == id, cancellationToken).ConfigureAwait(false))
+                {
+                    break;
+                }
+            }
+        }
+
+        return new ProjectionRetryOutcome(scope, applied, await GetProjectionStatusAsync(scope, cancellationToken).ConfigureAwait(false));
+    }
+
+    /// <inheritdoc />
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        configuration.EnabledChanged += OnEnabledChanged;
+        return base.StartAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        _reconcileLock.Dispose();
+        base.Dispose();
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            try
+            {
+                await RetryProjectionAsync(ProjectionScope.All, stoppingToken).ConfigureAwait(false);
+                await RetryDueAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogRecoveryCycleFailed(logger, ex);
+            }
+
+            using var timer = new PeriodicTimer(PollInterval, timeProvider);
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    await RetryDueAsync(stoppingToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    LogRecoveryCycleFailed(logger, ex);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            configuration.EnabledChanged -= OnEnabledChanged;
+        }
+    }
+
+    private void OnEnabledChanged(object? sender, bool enabled)
+    {
+        if (enabled)
+        {
+            Interlocked.Exchange(ref _reconcileRequested, 1);
+            _ = ReconcileAfterEnableAsync();
+        }
+    }
+
+    private async Task ReconcileAfterEnableAsync()
+    {
+        await _reconcileLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (Volatile.Read(ref _reconcileRequested) == 0 || !configuration.Enabled)
+            {
+                return;
+            }
+
+            await database.InitializeAsync().ConfigureAwait(false);
+            using var db = await contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+            var itemIds = await db.Segments.Select(value => value.ItemId)
+                .Union(db.DisabledItems.Select(value => value.ItemId))
+                .Union(db.AnalyzedStates.Select(value => value.ItemId))
+                .Union(db.ProjectionHeads.Select(value => value.ItemId))
+                .Union(db.ProjectionExternalOperations.Select(value => value.ItemId))
+                .Distinct()
+                .ToListAsync()
+                .ConfigureAwait(false);
+
+            foreach (var itemId in itemIds)
+            {
+                {
+                    using var itemLock = await _locks.AcquireAsync(itemId, CancellationToken.None).ConfigureAwait(false);
+                    using var writeDb = await contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+                    var transaction = await writeDb.Database.BeginTransactionAsync().ConfigureAwait(false);
+                    await using (transaction.ConfigureAwait(false))
+                    {
+                        var retained = await writeDb.ProjectionExternalOperations
+                            .Where(operation => operation.ItemId == itemId)
+                            .OrderBy(operation => operation.Sequence).ThenBy(operation => operation.Position)
+                            .ToListAsync().ConfigureAwait(false);
+                        var operations = retained.Select(value => new ProjectedExternalOperation(value.ExternalSegmentId, value.ExpectedType, value.Kind)).ToList();
+                        await AddPlanAsync(writeDb, Guid.CreateVersion7(), itemId, operations, CancellationToken.None).ConfigureAwait(false);
+                        writeDb.ProjectionExternalOperations.RemoveRange(retained);
+                        await writeDb.SaveChangesAsync().ConfigureAwait(false);
+                        await transaction.CommitAsync().ConfigureAwait(false);
+                    }
+                }
+
+                await ProjectItemAsync(itemId, force: true, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            Interlocked.Exchange(ref _reconcileRequested, 0);
+        }
+        catch (Exception ex)
+        {
+            LogReconciliationFailed(logger, ex);
+        }
+        finally
+        {
+            _reconcileLock.Release();
+        }
+    }
+
+    private async Task RetryDueAsync(CancellationToken cancellationToken)
+    {
+        await database.InitializeAsync().ConfigureAwait(false);
+        if (configuration.Enabled && Volatile.Read(ref _reconcileRequested) != 0)
+        {
+            await ReconcileAfterEnableAsync().ConfigureAwait(false);
+        }
+
+        using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        if (configuration.Enabled
+            && Volatile.Read(ref _reconcileRequested) == 0
+            && (await db.ProjectionHeads.AnyAsync(head => head.Status == ProjectionState.Skipped, cancellationToken).ConfigureAwait(false)
+                || await db.ProjectionExternalOperations.AnyAsync(cancellationToken).ConfigureAwait(false)))
+        {
+            Interlocked.Exchange(ref _reconcileRequested, 1);
+            await ReconcileAfterEnableAsync().ConfigureAwait(false);
+        }
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var itemIds = await db.ProjectionPlans.AsNoTracking()
+            .Where(plan => !db.ProjectionAttempts.Any(attempt => attempt.ChangeId == plan.ChangeId && attempt.ItemId == plan.ItemId && attempt.NextAttemptAt > now))
+            .Select(plan => plan.ItemId).Distinct().ToListAsync(cancellationToken).ConfigureAwait(false);
+        await Task.WhenAll(itemIds.Select(id => ProjectItemAsync(id, force: false, cancellationToken))).ConfigureAwait(false);
+    }
+
+    private async Task<ProjectionState> ProjectAcceptedChangeAsync(Guid itemId, Guid changeId)
+    {
+        while (true)
+        {
+            using var db = await contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+            var target = await db.ProjectionPlans.AsNoTracking()
+                .FirstOrDefaultAsync(plan => plan.ChangeId == changeId && plan.ItemId == itemId)
+                .ConfigureAwait(false);
+            if (target is null)
+            {
+                var head = await db.ProjectionHeads.AsNoTracking().FirstAsync(value => value.ItemId == itemId).ConfigureAwait(false);
+                return head.Status == ProjectionState.Skipped ? ProjectionState.Skipped : ProjectionState.Applied;
+            }
+
+            var state = await ProjectItemAsync(itemId, force: true, CancellationToken.None).ConfigureAwait(false);
+            if (state == ProjectionState.Pending)
+            {
+                return state;
+            }
+
+            using var verify = await contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+            if (!await verify.ProjectionPlans.AnyAsync(plan => plan.ChangeId == changeId && plan.ItemId == itemId).ConfigureAwait(false))
+            {
+                return state;
+            }
+        }
+    }
+
+    private async Task<ProjectionState> ProjectItemAsync(Guid itemId, bool force, CancellationToken cancellationToken)
+    {
+        using var itemLock = await _locks.AcquireAsync(itemId, cancellationToken).ConfigureAwait(false);
+        using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var planRow = await db.ProjectionPlans.AsNoTracking().Where(plan => plan.ItemId == itemId)
+            .OrderBy(plan => plan.Sequence).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+        if (planRow is null)
+        {
+            var head = await db.ProjectionHeads.AsNoTracking().FirstOrDefaultAsync(value => value.ItemId == itemId, cancellationToken).ConfigureAwait(false);
+            return head?.Status ?? ProjectionState.Applied;
+        }
+
+        var attempt = await db.ProjectionAttempts.FirstAsync(value => value.ChangeId == planRow.ChangeId && value.ItemId == itemId, cancellationToken).ConfigureAwait(false);
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        if (!force && attempt.NextAttemptAt > now)
+        {
+            return ProjectionState.Pending;
+        }
+
+        if (!configuration.Enabled)
+        {
+            await CompactAsync(db, planRow, ProjectionState.Skipped, retainExternalOperations: true, cancellationToken).ConfigureAwait(false);
+            return ProjectionState.Skipped;
+        }
+
+        var segments = await db.ProjectionPlanSegments.AsNoTracking()
+            .Where(value => value.ChangeId == planRow.ChangeId && value.ItemId == itemId)
+            .OrderBy(value => value.Position).ToListAsync(cancellationToken).ConfigureAwait(false);
+        var operations = await db.ProjectionExternalOperations.AsNoTracking()
+            .Where(value => value.ChangeId == planRow.ChangeId && value.ItemId == itemId)
+            .OrderBy(value => value.Position).ToListAsync(cancellationToken).ConfigureAwait(false);
+        var plan = new SegmentProjectionPlan(
+            planRow.ChangeId,
+            itemId,
+            planRow.Sequence,
+            segments.Select(value => new ProjectedSegment(value.SegmentId, value.Type, value.StartTicks, value.EndTicks, value.Source)).ToList(),
+            operations.Select(value => new ProjectedExternalOperation(value.ExternalSegmentId, value.ExpectedType, value.Kind)).ToList());
+
+        try
+        {
+            await adapter.ApplyAsync(plan, cancellationToken).ConfigureAwait(false);
+            await CompactAsync(db, planRow, ProjectionState.Applied, retainExternalOperations: false, cancellationToken).ConfigureAwait(false);
+            return ProjectionState.Applied;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            attempt.AttemptCount++;
+            attempt.LastAttemptAt = now;
+            attempt.NextAttemptAt = now + TimeSpan.FromSeconds(Math.Min(3600, 5 * Math.Pow(2, Math.Min(10, attempt.AttemptCount - 1))));
+            attempt.Failure = Sanitize(ex);
+            attempt.Status = ProjectionState.Pending;
+            var head = await db.ProjectionHeads.FirstAsync(value => value.ItemId == itemId, cancellationToken).ConfigureAwait(false);
+            head.Status = ProjectionState.Pending;
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            LogProjectionFailed(logger, ex, itemId, planRow.Sequence);
+            return ProjectionState.Pending;
+        }
+    }
+
+    private static async Task CompactAsync(IntroSkipperDbContext db, DbProjectionPlan plan, ProjectionState state, bool retainExternalOperations, CancellationToken cancellationToken)
+    {
+        var head = await db.ProjectionHeads.FirstAsync(value => value.ItemId == plan.ItemId, cancellationToken).ConfigureAwait(false);
+        if (state == ProjectionState.Applied)
+        {
+            head.LastAppliedSequence = plan.Sequence;
+        }
+
+        head.Status = await db.ProjectionPlans.AnyAsync(
+            value => value.ItemId == plan.ItemId && (value.ChangeId != plan.ChangeId || value.ItemId != plan.ItemId),
+            cancellationToken).ConfigureAwait(false)
+            ? ProjectionState.Pending
+            : state;
+        await db.ProjectionPlanSegments.Where(value => value.ChangeId == plan.ChangeId && value.ItemId == plan.ItemId).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        if (!retainExternalOperations)
+        {
+            await db.ProjectionExternalOperations.Where(value => value.ChangeId == plan.ChangeId && value.ItemId == plan.ItemId).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await db.ProjectionAttempts.Where(value => value.ChangeId == plan.ChangeId && value.ItemId == plan.ItemId).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        await db.ProjectionPlans.Where(value => value.ChangeId == plan.ChangeId && value.ItemId == plan.ItemId).ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task AddPlanAsync(IntroSkipperDbContext db, Guid changeId, Guid itemId, IReadOnlyList<ProjectedExternalOperation> externalOperations, CancellationToken cancellationToken)
+    {
+        var head = await db.ProjectionHeads.FirstOrDefaultAsync(value => value.ItemId == itemId, cancellationToken).ConfigureAwait(false);
+        var sequence = head?.LastAcceptedSequence + 1 ?? 1;
+        if (head is null)
+        {
+            head = new DbProjectionHead { ItemId = itemId };
+            db.ProjectionHeads.Add(head);
+        }
+
+        head.LastAcceptedSequence = sequence;
+        head.Status = ProjectionState.Pending;
+        db.ProjectionPlans.Add(new DbProjectionPlan { ChangeId = changeId, ItemId = itemId, Sequence = sequence, CreatedAt = timeProvider.GetUtcNow().UtcDateTime });
+        db.ProjectionAttempts.Add(new DbProjectionAttempt { ChangeId = changeId, ItemId = itemId, Status = ProjectionState.Pending, NextAttemptAt = timeProvider.GetUtcNow().UtcDateTime });
+
+        var disabled = await db.DisabledItems.AnyAsync(value => value.ItemId == itemId, cancellationToken).ConfigureAwait(false);
+        var image = await db.Segments.Where(value => value.ItemId == itemId && value.State == SegmentState.Active && (!disabled || value.Source == SegmentSource.User))
+            .OrderBy(value => value.Type).ThenBy(value => value.StartTicks).ThenBy(value => value.Id)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        db.ProjectionPlanSegments.AddRange(image.Select((value, index) => new DbProjectionPlanSegment
+        {
+            ChangeId = changeId,
+            ItemId = itemId,
+            Position = index,
+            SegmentId = value.Id,
+            Type = AnalysisHelpers.ModeToSegmentType[value.Type],
+            StartTicks = value.StartTicks,
+            EndTicks = value.EndTicks,
+            Source = value.Source
+        }));
+        db.ProjectionExternalOperations.AddRange(externalOperations.Select((externalOperation, index) => new DbProjectionExternalOperation
+            {
+                ChangeId = changeId,
+                ItemId = itemId,
+                Sequence = sequence,
+                Position = index,
+                ExternalSegmentId = externalOperation.ExternalSegmentId,
+                ExpectedType = externalOperation.ExpectedType,
+                Kind = externalOperation.Kind
+            }));
+    }
+
+    private static Rejected? Validate(SegmentChangeIntent intent)
+    {
+        static bool ValidMode(AnalysisMode mode) => AnalysisHelpers.IsSupported(mode);
+        static bool ValidRange(long start, long end) => start >= 0 && end > start;
+
+        return intent switch
+        {
+            AddUserSegmentIntent value when !ValidMode(value.Mode) || !ValidRange(value.StartTicks, value.EndTicks) => new("Invalid mode or tick range."),
+            ReplaceUserSegmentsForModeIntent value when value.Segments is null || !ValidMode(value.Mode) || value.Segments.Any(range => !ValidRange(range.StartTicks, range.EndTicks)) => new("Invalid mode or tick range."),
+            UpdateSegmentIntent value when value.SegmentId == Guid.Empty || !ValidRange(value.StartTicks, value.EndTicks) => new("Invalid segment ID or tick range."),
+            DeleteSegmentIntent value when value.SegmentId == Guid.Empty => new("Segment ID must not be empty."),
+            RestoreSegmentIntent value when value.SegmentId == Guid.Empty => new("Segment ID must not be empty."),
+            DeleteExternalSegmentIntent value when value.ExternalSegmentId == Guid.Empty || AnalysisHelpers.TryMapSegmentTypeToMode(value.ExpectedType) is null => new("Invalid external segment ID or type."),
+            WriteUserTimestampsIntent value when value.Timestamps is null || value.Timestamps.Count == 0 || value.Timestamps.Any(timestamp => !ValidMode(timestamp.Mode) || !ValidRange(timestamp.StartTicks, timestamp.EndTicks)) || value.Timestamps.Select(timestamp => timestamp.Mode).Distinct().Count() != value.Timestamps.Count => new("User timestamps must contain unique supported modes and valid ranges."),
+            SegmentVisibilityChangeIntent value when value.SeasonId == Guid.Empty => new("Season ID must not be empty."),
+            _ => null
+        };
+    }
+
+    private static async Task<MutationResult> MutateAsync(IntroSkipperDbContext db, SegmentChangeIntent intent, ExternalSegmentTarget? externalTarget, CancellationToken cancellationToken)
+    {
+        var rows = await db.Segments.Where(value => value.ItemId == intent.ItemId).ToListAsync(cancellationToken).ConfigureAwait(false);
+        var affected = new List<SegmentValue>();
+        var externalOperations = new List<ProjectedExternalOperation>();
+
+        switch (intent)
+        {
+            case AddUserSegmentIntent value:
+                {
+                    var exact = rows.FirstOrDefault(row => row.Type == value.Mode && row.StartTicks == value.StartTicks && row.EndTicks == value.EndTicks);
+                    if (exact is { Source: SegmentSource.User, State: SegmentState.Active })
+                    {
+                        if (await HasAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
+                        {
+                            return MutationResult.Ignore("The user segment already exists.");
+                        }
+
+                        affected.Add(ToValue(exact));
+                        await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+
+                    exact ??= new DbSegment(value.ItemId, value.Mode, value.StartTicks, value.EndTicks, SegmentSource.User);
+                    if (exact.Id == Guid.Empty || !rows.Contains(exact))
+                    {
+                        db.Segments.Add(exact);
+                    }
+
+                    exact.Source = SegmentSource.User;
+                    exact.State = SegmentState.Active;
+                    affected.Add(ToValue(exact));
+                    await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+
+            case ReplaceUserSegmentsForModeIntent value:
+                {
+                    var requested = value.Segments.Distinct().OrderBy(range => range.StartTicks).ThenBy(range => range.EndTicks).ToList();
+                    var active = rows.Where(row => row.Type == value.Mode && row.State == SegmentState.Active).ToList();
+                    if (active.Count == requested.Count && active.All(row => row.Source == SegmentSource.User && requested.Contains(new SegmentRange(row.StartTicks, row.EndTicks))))
+                    {
+                        if (await HasAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
+                        {
+                            return MutationResult.Ignore("The requested user image already exists.");
+                        }
+
+                        affected.AddRange(active.Select(ToValue));
+                        await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+
+                    db.Segments.RemoveRange(active);
+                    foreach (var range in requested)
+                    {
+                        var tombstone = rows.FirstOrDefault(row => row.Type == value.Mode && row.State == SegmentState.Suppressed && row.StartTicks == range.StartTicks && row.EndTicks == range.EndTicks);
+                        var row = tombstone ?? new DbSegment(value.ItemId, value.Mode, range.StartTicks, range.EndTicks, SegmentSource.User);
+                        row.State = SegmentState.Active;
+                        row.Source = SegmentSource.User;
+                        if (tombstone is null)
+                        {
+                            db.Segments.Add(row);
+                        }
+
+                        affected.Add(ToValue(row));
+                    }
+
+                    if (requested.Count > 0)
+                    {
+                        await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await DeriveAnalyzedStateAsync(db, rows, value.ItemId, value.Mode, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                }
+
+            case UpdateSegmentIntent value:
+                {
+                    var row = rows.FirstOrDefault(item => item.Id == value.SegmentId && item.State == SegmentState.Active);
+                    if (row is null)
+                    {
+                        return MutationResult.Reject("Segment was not found on the item or is suppressed.");
+                    }
+
+                    if (row.StartTicks == value.StartTicks && row.EndTicks == value.EndTicks && row.Source == SegmentSource.User)
+                    {
+                        if (await HasAnalyzedStateAsync(db, value.ItemId, row.Type, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
+                        {
+                            return MutationResult.Ignore("The segment already has the requested values.");
+                        }
+
+                        affected.Add(ToValue(row));
+                        await UpsertAnalyzedStateAsync(db, value.ItemId, row.Type, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+
+                    var occupant = rows.FirstOrDefault(item => item.Id != row.Id && item.Type == row.Type && item.StartTicks == value.StartTicks && item.EndTicks == value.EndTicks);
+                    if (occupant is { State: SegmentState.Active })
+                    {
+                        db.Segments.Remove(row);
+                        occupant.Source = SegmentSource.User;
+                        affected.Add(ToValue(occupant));
+                    }
+                    else
+                    {
+                        if (occupant is not null)
+                        {
+                            db.Segments.Remove(occupant);
+                        }
+
+                        row.StartTicks = value.StartTicks;
+                        row.EndTicks = value.EndTicks;
+                        row.Source = SegmentSource.User;
+                        affected.Add(ToValue(row));
+                    }
+
+                    await UpsertAnalyzedStateAsync(db, value.ItemId, row.Type, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+
+            case DeleteSegmentIntent value:
+                {
+                    var row = rows.FirstOrDefault(item => item.Id == value.SegmentId && item.State == SegmentState.Active);
+                    if (row is null)
+                    {
+                        return MutationResult.Ignore("Segment was not found on the item or was already deleted.");
+                    }
+
+                    if (row.Source == SegmentSource.User)
+                    {
+                        db.Segments.Remove(row);
+                    }
+                    else
+                    {
+                        row.State = SegmentState.Suppressed;
+                    }
+
+                    affected.Add(ToValue(row));
+                    await DeriveAnalyzedStateAsync(db, rows, value.ItemId, row.Type, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+
+            case RestoreSegmentIntent value:
+                {
+                    var row = rows.FirstOrDefault(item => item.Id == value.SegmentId && item.State == SegmentState.Suppressed);
+                    if (row is null)
+                    {
+                        return MutationResult.Ignore("Segment was not found on the item or was not suppressed.");
+                    }
+
+                    row.State = SegmentState.Active;
+                    affected.Add(ToValue(row));
+                    await DeriveAnalyzedStateAsync(db, rows, value.ItemId, row.Type, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+
+            case DeleteExternalSegmentIntent value:
+                {
+                    var mode = AnalysisHelpers.TryMapSegmentTypeToMode(value.ExpectedType)!.Value;
+                    var match = rows.FirstOrDefault(row => row.Type == mode && row.StartTicks == externalTarget!.StartTicks && row.EndTicks == externalTarget.EndTicks && row.State == SegmentState.Active);
+                    if (match is not null)
+                    {
+                        if (match.Source == SegmentSource.User)
+                        {
+                            db.Segments.Remove(match);
+                        }
+                        else
+                        {
+                            match.State = SegmentState.Suppressed;
+                        }
+
+                        affected.Add(ToValue(match));
+                    }
+
+                    externalOperations.Add(new ProjectedExternalOperation(value.ExternalSegmentId, value.ExpectedType, ProjectionExternalOperationKind.Delete));
+                    await DeriveAnalyzedStateAsync(db, rows, value.ItemId, mode, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+
+            case WriteUserTimestampsIntent value:
+                {
+                    foreach (var timestamp in value.Timestamps)
+                    {
+                        var active = rows.Where(row => row.Type == timestamp.Mode && row.State == SegmentState.Active).ToList();
+                        db.Segments.RemoveRange(active);
+                        var tombstone = rows.FirstOrDefault(row => row.Type == timestamp.Mode && row.State == SegmentState.Suppressed && row.StartTicks == timestamp.StartTicks && row.EndTicks == timestamp.EndTicks);
+                        var row = tombstone ?? new DbSegment(value.ItemId, timestamp.Mode, timestamp.StartTicks, timestamp.EndTicks, SegmentSource.User);
+                        row.Source = SegmentSource.User;
+                        row.State = SegmentState.Active;
+                        if (tombstone is null)
+                        {
+                            db.Segments.Add(row);
+                        }
+
+                        affected.Add(ToValue(row));
+                        await UpsertAnalyzedStateAsync(db, value.ItemId, timestamp.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    break;
+                }
+
+            case SegmentVisibilityChangeIntent value:
+                {
+                    var disabled = await db.DisabledItems.FirstOrDefaultAsync(item => item.ItemId == value.ItemId, cancellationToken).ConfigureAwait(false);
+                    if (value.Visible && disabled is null)
+                    {
+                        return MutationResult.Ignore("The item is already visible.");
+                    }
+
+                    if (!value.Visible && disabled is not null && disabled.SeasonId == value.SeasonId)
+                    {
+                        return MutationResult.Ignore("The item is already hidden.");
+                    }
+
+                    if (value.Visible)
+                    {
+                        db.DisabledItems.Remove(disabled!);
+                    }
+                    else if (disabled is null)
+                    {
+                        db.DisabledItems.Add(new DbDisabledItem(value.SeasonId, value.ItemId));
+                    }
+                    else
+                    {
+                        disabled.SeasonId = value.SeasonId;
+                    }
+
+                    affected.AddRange(rows.Where(row => row.State == SegmentState.Active && (value.Visible || row.Source == SegmentSource.User)).Select(ToValue));
+                    break;
+                }
+
+            default:
+                return MutationResult.Reject("Unsupported segment change intent.");
+        }
+
+        return new MutationResult(null, affected, externalOperations);
+    }
+
+    private static SegmentValue ToValue(DbSegment row) => new(row.Id, row.ItemId, row.Type, row.StartTicks, row.EndTicks, row.Source, row.State);
+
+    private static async Task DeriveAnalyzedStateAsync(
+        IntroSkipperDbContext db,
+        IReadOnlyList<DbSegment> itemRows,
+        Guid itemId,
+        AnalysisMode mode,
+        CancellationToken cancellationToken)
+    {
+        var remaining = itemRows
+            .Where(row => row.Type == mode && row.State == SegmentState.Active && db.Entry(row).State != EntityState.Deleted)
+            .ToList();
+        if (remaining.Any(row => row.Source == SegmentSource.User))
+        {
+            await UpsertAnalyzedStateAsync(db, itemId, mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (remaining.Count > 0)
+        {
+            var hashes = remaining.Select(row => row.ConfigHash).Distinct(StringComparer.Ordinal).ToList();
+            await UpsertAnalyzedStateAsync(
+                db,
+                itemId,
+                mode,
+                EpisodeState.Analyzed,
+                hashes.Count == 1 ? hashes[0] : string.Empty,
+                cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var existing = await db.AnalyzedStates.FirstOrDefaultAsync(
+            value => value.ItemId == itemId && value.Type == mode,
+            cancellationToken).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            db.AnalyzedStates.Remove(existing);
+        }
+    }
+
+    private static async Task UpsertAnalyzedStateAsync(
+        IntroSkipperDbContext db,
+        Guid itemId,
+        AnalysisMode mode,
+        EpisodeState state,
+        string configHash,
+        CancellationToken cancellationToken)
+    {
+        var existing = await db.AnalyzedStates.FirstOrDefaultAsync(
+            value => value.ItemId == itemId && value.Type == mode,
+            cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            db.AnalyzedStates.Add(new DbAnalyzedState(itemId, mode, state, configHash));
+            return;
+        }
+
+        db.Entry(existing).Property(value => value.State).CurrentValue = state;
+        db.Entry(existing).Property(value => value.ConfigHash).CurrentValue = configHash;
+    }
+
+    private static async Task<bool> HasAnalyzedStateAsync(
+        IntroSkipperDbContext db,
+        Guid itemId,
+        AnalysisMode mode,
+        EpisodeState state,
+        string configHash,
+        CancellationToken cancellationToken)
+        => await db.AnalyzedStates.AnyAsync(
+            value => value.ItemId == itemId && value.Type == mode && value.State == state && value.ConfigHash == configHash,
+            cancellationToken).ConfigureAwait(false);
+
+    private static string Sanitize(Exception exception)
+    {
+        var value = exception.Message.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        return value.Length <= 1024 ? value : value[..1024];
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Projection failed for item {ItemId} sequence {Sequence}; it remains pending.")]
+    private static partial void LogProjectionFailed(ILogger logger, Exception exception, Guid itemId, long sequence);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to reconcile segment projections after mirroring was enabled.")]
+    private static partial void LogReconciliationFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Segment projection recovery cycle failed; pending work will be retried.")]
+    private static partial void LogRecoveryCycleFailed(ILogger logger, Exception exception);
+}

--- a/IntroSkipper/SegmentChanges/SegmentChange.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChange.cs
@@ -286,7 +286,10 @@ internal sealed partial class SegmentChange(
         if (configuration.Enabled
             && Volatile.Read(ref _reconcileRequested) == 0
             && (await db.ProjectionHeads.AnyAsync(head => head.Status == ProjectionState.Skipped, cancellationToken).ConfigureAwait(false)
-                || await db.ProjectionExternalOperations.AnyAsync(cancellationToken).ConfigureAwait(false)))
+                || await db.ProjectionExternalOperations.AnyAsync(
+                    operation => !db.ProjectionPlans.Any(
+                        plan => plan.ChangeId == operation.ChangeId && plan.ItemId == operation.ItemId),
+                    cancellationToken).ConfigureAwait(false)))
         {
             Interlocked.Exchange(ref _reconcileRequested, 1);
             await ReconcileAfterEnableAsync().ConfigureAwait(false);

--- a/IntroSkipper/SegmentChanges/SegmentChange.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChange.cs
@@ -32,7 +32,7 @@ internal sealed partial class SegmentChange(
         cancellationToken.ThrowIfCancellationRequested();
         if (intent.ItemId == Guid.Empty)
         {
-            return new Rejected("Item ID must not be empty.");
+            return new Rejected(SegmentChangeRejectedReason.EmptyItemId, "Item ID must not be empty.");
         }
 
         ExternalSegmentTarget? externalTarget = null;
@@ -42,17 +42,17 @@ internal sealed partial class SegmentChange(
 
             if (externalTarget is null)
             {
-                return new Rejected("External segment was not found.");
+                return new Rejected(SegmentChangeRejectedReason.ExternalSegmentNotFound, "External segment was not found.");
             }
 
             if (externalTarget.ItemId != external.ItemId)
             {
-                return new Rejected("External segment belongs to another item.");
+                return new Rejected(SegmentChangeRejectedReason.ExternalItemMismatch, "External segment belongs to another item.");
             }
 
             if (externalTarget.Type != external.ExpectedType)
             {
-                return new Rejected("External segment type does not match the expected type.");
+                return new Rejected(SegmentChangeRejectedReason.ExternalTypeMismatch, "External segment type does not match the expected type.");
             }
         }
 
@@ -463,14 +463,14 @@ internal sealed partial class SegmentChange(
 
         return intent switch
         {
-            AddUserSegmentIntent value when !ValidMode(value.Mode) || !ValidRange(value.StartTicks, value.EndTicks) => new("Invalid mode or tick range."),
-            ReplaceUserSegmentsForModeIntent value when value.Segments is null || !ValidMode(value.Mode) || value.Segments.Any(range => !ValidRange(range.StartTicks, range.EndTicks)) => new("Invalid mode or tick range."),
-            UpdateSegmentIntent value when value.SegmentId == Guid.Empty || !ValidRange(value.StartTicks, value.EndTicks) => new("Invalid segment ID or tick range."),
-            DeleteSegmentIntent value when value.SegmentId == Guid.Empty => new("Segment ID must not be empty."),
-            RestoreSegmentIntent value when value.SegmentId == Guid.Empty => new("Segment ID must not be empty."),
-            DeleteExternalSegmentIntent value when value.ExternalSegmentId == Guid.Empty || AnalysisHelpers.TryMapSegmentTypeToMode(value.ExpectedType) is null => new("Invalid external segment ID or type."),
-            WriteUserTimestampsIntent value when value.Timestamps is null || value.Timestamps.Count == 0 || value.Timestamps.Any(timestamp => !ValidMode(timestamp.Mode) || !ValidRange(timestamp.StartTicks, timestamp.EndTicks)) || value.Timestamps.Select(timestamp => timestamp.Mode).Distinct().Count() != value.Timestamps.Count => new("User timestamps must contain unique supported modes and valid ranges."),
-            SegmentVisibilityChangeIntent value when value.SeasonId == Guid.Empty => new("Season ID must not be empty."),
+            AddUserSegmentIntent value when !ValidMode(value.Mode) || !ValidRange(value.StartTicks, value.EndTicks) => new(SegmentChangeRejectedReason.InvalidModeOrRange, "Invalid mode or tick range."),
+            ReplaceUserSegmentsForModeIntent value when value.Segments is null || !ValidMode(value.Mode) || value.Segments.Any(range => !ValidRange(range.StartTicks, range.EndTicks)) => new(SegmentChangeRejectedReason.InvalidModeOrRange, "Invalid mode or tick range."),
+            UpdateSegmentIntent value when value.SegmentId == Guid.Empty || !ValidRange(value.StartTicks, value.EndTicks) => new(SegmentChangeRejectedReason.InvalidSegmentIdOrRange, "Invalid segment ID or tick range."),
+            DeleteSegmentIntent value when value.SegmentId == Guid.Empty => new(SegmentChangeRejectedReason.EmptySegmentId, "Segment ID must not be empty."),
+            RestoreSegmentIntent value when value.SegmentId == Guid.Empty => new(SegmentChangeRejectedReason.EmptySegmentId, "Segment ID must not be empty."),
+            DeleteExternalSegmentIntent value when value.ExternalSegmentId == Guid.Empty || AnalysisHelpers.TryMapSegmentTypeToMode(value.ExpectedType) is null => new(SegmentChangeRejectedReason.InvalidExternalIdOrType, "Invalid external segment ID or type."),
+            WriteUserTimestampsIntent value when value.Timestamps is null || value.Timestamps.Count == 0 || value.Timestamps.Any(timestamp => !ValidMode(timestamp.Mode) || !ValidRange(timestamp.StartTicks, timestamp.EndTicks)) || value.Timestamps.Select(timestamp => timestamp.Mode).Distinct().Count() != value.Timestamps.Count => new(SegmentChangeRejectedReason.InvalidUserTimestamps, "User timestamps must contain unique supported modes and valid ranges."),
+            SegmentVisibilityChangeIntent value when value.SeasonId == Guid.Empty => new(SegmentChangeRejectedReason.EmptySeasonId, "Season ID must not be empty."),
             _ => null
         };
     }
@@ -490,7 +490,7 @@ internal sealed partial class SegmentChange(
                     {
                         if (await HasAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
                         {
-                            return MutationResult.Ignore("The user segment already exists.");
+                            return MutationResult.Ignore(SegmentChangeIgnoredReason.UserSegmentAlreadyExists, "The user segment already exists.");
                         }
 
                         affected.Add(ToValue(exact));
@@ -519,7 +519,7 @@ internal sealed partial class SegmentChange(
                     {
                         if (await HasAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
                         {
-                            return MutationResult.Ignore("The requested user image already exists.");
+                            return MutationResult.Ignore(SegmentChangeIgnoredReason.UserImageAlreadyExists, "The requested user image already exists.");
                         }
 
                         affected.AddRange(active.Select(ToValue));
@@ -559,14 +559,14 @@ internal sealed partial class SegmentChange(
                     var row = rows.FirstOrDefault(item => item.Id == value.SegmentId && item.State == SegmentState.Active);
                     if (row is null)
                     {
-                        return MutationResult.Reject("Segment was not found on the item or is suppressed.");
+                        return MutationResult.Reject(SegmentChangeRejectedReason.SegmentMissingOrSuppressed, "Segment was not found on the item or is suppressed.");
                     }
 
                     if (row.StartTicks == value.StartTicks && row.EndTicks == value.EndTicks && row.Source == SegmentSource.User)
                     {
                         if (await HasAnalyzedStateAsync(db, value.ItemId, row.Type, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
                         {
-                            return MutationResult.Ignore("The segment already has the requested values.");
+                            return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentAlreadyHasValues, "The segment already has the requested values.");
                         }
 
                         affected.Add(ToValue(row));
@@ -603,7 +603,7 @@ internal sealed partial class SegmentChange(
                     var row = rows.FirstOrDefault(item => item.Id == value.SegmentId && item.State == SegmentState.Active);
                     if (row is null)
                     {
-                        return MutationResult.Ignore("Segment was not found on the item or was already deleted.");
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentMissingOrDeleted, "Segment was not found on the item or was already deleted.");
                     }
 
                     if (row.Source == SegmentSource.User)
@@ -625,7 +625,7 @@ internal sealed partial class SegmentChange(
                     var row = rows.FirstOrDefault(item => item.Id == value.SegmentId && item.State == SegmentState.Suppressed);
                     if (row is null)
                     {
-                        return MutationResult.Ignore("Segment was not found on the item or was not suppressed.");
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentMissingOrNotSuppressed, "Segment was not found on the item or was not suppressed.");
                     }
 
                     row.State = SegmentState.Active;
@@ -684,12 +684,12 @@ internal sealed partial class SegmentChange(
                     var disabled = await db.DisabledItems.FirstOrDefaultAsync(item => item.ItemId == value.ItemId, cancellationToken).ConfigureAwait(false);
                     if (value.Visible && disabled is null)
                     {
-                        return MutationResult.Ignore("The item is already visible.");
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.AlreadyVisible, "The item is already visible.");
                     }
 
                     if (!value.Visible && disabled is not null && disabled.SeasonId == value.SeasonId)
                     {
-                        return MutationResult.Ignore("The item is already hidden.");
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.AlreadyHidden, "The item is already hidden.");
                     }
 
                     if (value.Visible)
@@ -710,7 +710,7 @@ internal sealed partial class SegmentChange(
                 }
 
             default:
-                return MutationResult.Reject("Unsupported segment change intent.");
+                return MutationResult.Reject(SegmentChangeRejectedReason.UnsupportedIntent, "Unsupported segment change intent.");
         }
 
         return new MutationResult(null, affected, externalOperations);

--- a/IntroSkipper/SegmentChanges/SegmentChange.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChange.cs
@@ -232,7 +232,7 @@ internal sealed partial class SegmentChange(
             using var db = await contextFactory.CreateDbContextAsync().ConfigureAwait(false);
             var itemIds = await db.Segments.Select(value => value.ItemId)
                 .Union(db.DisabledItems.Select(value => value.ItemId))
-                .Union(db.AnalyzedStates.Select(value => value.ItemId))
+                .Union(db.AnalyzedItems.Select(value => value.ItemId))
                 .Union(db.ProjectionHeads.Select(value => value.ItemId))
                 .Union(db.ProjectionExternalOperations.Select(value => value.ItemId))
                 .Distinct()
@@ -491,14 +491,7 @@ internal sealed partial class SegmentChange(
                     var exact = rows.FirstOrDefault(row => row.Type == value.Mode && row.StartTicks == value.StartTicks && row.EndTicks == value.EndTicks);
                     if (exact is { Source: SegmentSource.User, State: SegmentState.Active })
                     {
-                        if (await HasAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
-                        {
-                            return MutationResult.Ignore(SegmentChangeIgnoredReason.UserSegmentAlreadyExists, "The user segment already exists.");
-                        }
-
-                        affected.Add(ToValue(exact));
-                        await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
-                        break;
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.UserSegmentAlreadyExists, "The user segment already exists.");
                     }
 
                     exact ??= new DbSegment(value.ItemId, value.Mode, value.StartTicks, value.EndTicks, SegmentSource.User);
@@ -510,7 +503,7 @@ internal sealed partial class SegmentChange(
                     exact.Source = SegmentSource.User;
                     exact.State = SegmentState.Active;
                     affected.Add(ToValue(exact));
-                    await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                    await ClearAnalyzedItemAsync(db, value.ItemId, value.Mode, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 
@@ -520,14 +513,7 @@ internal sealed partial class SegmentChange(
                     var active = rows.Where(row => row.Type == value.Mode && row.State == SegmentState.Active).ToList();
                     if (active.Count == requested.Count && active.All(row => row.Source == SegmentSource.User && requested.Contains(new SegmentRange(row.StartTicks, row.EndTicks))))
                     {
-                        if (await HasAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
-                        {
-                            return MutationResult.Ignore(SegmentChangeIgnoredReason.UserImageAlreadyExists, "The requested user image already exists.");
-                        }
-
-                        affected.AddRange(active.Select(ToValue));
-                        await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
-                        break;
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.UserImageAlreadyExists, "The requested user image already exists.");
                     }
 
                     db.Segments.RemoveRange(active);
@@ -545,14 +531,7 @@ internal sealed partial class SegmentChange(
                         affected.Add(ToValue(row));
                     }
 
-                    if (requested.Count > 0)
-                    {
-                        await UpsertAnalyzedStateAsync(db, value.ItemId, value.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await DeriveAnalyzedStateAsync(db, rows, value.ItemId, value.Mode, cancellationToken).ConfigureAwait(false);
-                    }
+                    await DeriveAnalyzedItemAsync(db, rows, value.ItemId, value.Mode, cancellationToken).ConfigureAwait(false);
 
                     break;
                 }
@@ -567,14 +546,7 @@ internal sealed partial class SegmentChange(
 
                     if (row.StartTicks == value.StartTicks && row.EndTicks == value.EndTicks && row.Source == SegmentSource.User)
                     {
-                        if (await HasAnalyzedStateAsync(db, value.ItemId, row.Type, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false))
-                        {
-                            return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentAlreadyHasValues, "The segment already has the requested values.");
-                        }
-
-                        affected.Add(ToValue(row));
-                        await UpsertAnalyzedStateAsync(db, value.ItemId, row.Type, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
-                        break;
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentAlreadyHasValues, "The segment already has the requested values.");
                     }
 
                     var occupant = rows.FirstOrDefault(item => item.Id != row.Id && item.Type == row.Type && item.StartTicks == value.StartTicks && item.EndTicks == value.EndTicks);
@@ -597,7 +569,7 @@ internal sealed partial class SegmentChange(
                         affected.Add(ToValue(row));
                     }
 
-                    await UpsertAnalyzedStateAsync(db, value.ItemId, row.Type, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                    await ClearAnalyzedItemAsync(db, value.ItemId, row.Type, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 
@@ -619,7 +591,7 @@ internal sealed partial class SegmentChange(
                     }
 
                     affected.Add(ToValue(row));
-                    await DeriveAnalyzedStateAsync(db, rows, value.ItemId, row.Type, cancellationToken).ConfigureAwait(false);
+                    await DeriveAnalyzedItemAsync(db, rows, value.ItemId, row.Type, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 
@@ -633,7 +605,7 @@ internal sealed partial class SegmentChange(
 
                     row.State = SegmentState.Active;
                     affected.Add(ToValue(row));
-                    await DeriveAnalyzedStateAsync(db, rows, value.ItemId, row.Type, cancellationToken).ConfigureAwait(false);
+                    await DeriveAnalyzedItemAsync(db, rows, value.ItemId, row.Type, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 
@@ -656,7 +628,7 @@ internal sealed partial class SegmentChange(
                     }
 
                     externalOperations.Add(new ProjectedExternalOperation(value.ExternalSegmentId, value.ExpectedType, ProjectionExternalOperationKind.Delete));
-                    await DeriveAnalyzedStateAsync(db, rows, value.ItemId, mode, cancellationToken).ConfigureAwait(false);
+                    await DeriveAnalyzedItemAsync(db, rows, value.ItemId, mode, cancellationToken).ConfigureAwait(false);
                     break;
                 }
 
@@ -676,7 +648,7 @@ internal sealed partial class SegmentChange(
                         }
 
                         affected.Add(ToValue(row));
-                        await UpsertAnalyzedStateAsync(db, value.ItemId, timestamp.Mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+                        await ClearAnalyzedItemAsync(db, value.ItemId, timestamp.Mode, cancellationToken).ConfigureAwait(false);
                     }
 
                     break;
@@ -721,7 +693,7 @@ internal sealed partial class SegmentChange(
 
     private static SegmentValue ToValue(DbSegment row) => new(row.Id, row.ItemId, row.Type, row.StartTicks, row.EndTicks, row.Source, row.State);
 
-    private static async Task DeriveAnalyzedStateAsync(
+    private static async Task DeriveAnalyzedItemAsync(
         IntroSkipperDbContext db,
         IReadOnlyList<DbSegment> itemRows,
         Guid itemId,
@@ -733,63 +705,53 @@ internal sealed partial class SegmentChange(
             .ToList();
         if (remaining.Any(row => row.Source == SegmentSource.User))
         {
-            await UpsertAnalyzedStateAsync(db, itemId, mode, EpisodeState.UserProvided, string.Empty, cancellationToken).ConfigureAwait(false);
+            await ClearAnalyzedItemAsync(db, itemId, mode, cancellationToken).ConfigureAwait(false);
             return;
         }
 
         if (remaining.Count > 0)
         {
             var hashes = remaining.Select(row => row.ConfigHash).Distinct(StringComparer.Ordinal).ToList();
-            await UpsertAnalyzedStateAsync(
-                db,
-                itemId,
-                mode,
-                EpisodeState.Analyzed,
-                hashes.Count == 1 ? hashes[0] : string.Empty,
-                cancellationToken).ConfigureAwait(false);
+            await UpsertAnalyzedItemAsync(db, itemId, mode, hashes.Count == 1 ? hashes[0] : string.Empty, cancellationToken).ConfigureAwait(false);
             return;
         }
 
-        var existing = await db.AnalyzedStates.FirstOrDefaultAsync(
-            value => value.ItemId == itemId && value.Type == mode,
-            cancellationToken).ConfigureAwait(false);
-        if (existing is not null)
-        {
-            db.AnalyzedStates.Remove(existing);
-        }
+        await ClearAnalyzedItemAsync(db, itemId, mode, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task UpsertAnalyzedStateAsync(
+    private static async Task UpsertAnalyzedItemAsync(
         IntroSkipperDbContext db,
         Guid itemId,
         AnalysisMode mode,
-        EpisodeState state,
         string configHash,
         CancellationToken cancellationToken)
     {
-        var existing = await db.AnalyzedStates.FirstOrDefaultAsync(
+        var existing = await db.AnalyzedItems.FirstOrDefaultAsync(
             value => value.ItemId == itemId && value.Type == mode,
             cancellationToken).ConfigureAwait(false);
         if (existing is null)
         {
-            db.AnalyzedStates.Add(new DbAnalyzedState(itemId, mode, state, configHash));
+            db.AnalyzedItems.Add(new DbAnalyzedItem(itemId, mode, configHash));
             return;
         }
 
-        db.Entry(existing).Property(value => value.State).CurrentValue = state;
         db.Entry(existing).Property(value => value.ConfigHash).CurrentValue = configHash;
     }
 
-    private static async Task<bool> HasAnalyzedStateAsync(
+    private static async Task ClearAnalyzedItemAsync(
         IntroSkipperDbContext db,
         Guid itemId,
         AnalysisMode mode,
-        EpisodeState state,
-        string configHash,
         CancellationToken cancellationToken)
-        => await db.AnalyzedStates.AnyAsync(
-            value => value.ItemId == itemId && value.Type == mode && value.State == state && value.ConfigHash == configHash,
+    {
+        var existing = await db.AnalyzedItems.FirstOrDefaultAsync(
+            value => value.ItemId == itemId && value.Type == mode,
             cancellationToken).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            db.AnalyzedItems.Remove(existing);
+        }
+    }
 
     private static string Sanitize(Exception exception)
     {

--- a/IntroSkipper/SegmentChanges/SegmentChangeIgnoredReason.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChangeIgnoredReason.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Expected reasons why a valid intent made no authoritative change.</summary>
+public enum SegmentChangeIgnoredReason
+{
+    /// <summary>The requested user segment already exists.</summary>
+    UserSegmentAlreadyExists,
+
+    /// <summary>The requested user segment image already exists.</summary>
+    UserImageAlreadyExists,
+
+    /// <summary>The segment already has the requested values.</summary>
+    SegmentAlreadyHasValues,
+
+    /// <summary>The segment is absent or was already deleted.</summary>
+    SegmentMissingOrDeleted,
+
+    /// <summary>The segment is absent or is not suppressed.</summary>
+    SegmentMissingOrNotSuppressed,
+
+    /// <summary>The item is already visible.</summary>
+    AlreadyVisible,
+
+    /// <summary>The item is already hidden.</summary>
+    AlreadyHidden
+}

--- a/IntroSkipper/SegmentChanges/SegmentChangeIntent.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChangeIntent.cs
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Base type of every closed authoritative segment mutation.</summary>
+/// <param name="ItemId">Item ID.</param>
+public abstract record SegmentChangeIntent(Guid ItemId);

--- a/IntroSkipper/SegmentChanges/SegmentChangeOutcome.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChangeOutcome.cs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Base type of typed change outcomes.</summary>
+public abstract record SegmentChangeOutcome;

--- a/IntroSkipper/SegmentChanges/SegmentChangeRejectedReason.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChangeRejectedReason.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Domain reasons why an intent was rejected before authoritative commit.</summary>
+public enum SegmentChangeRejectedReason
+{
+    /// <summary>The item ID is empty.</summary>
+    EmptyItemId,
+
+    /// <summary>The mode or tick range is invalid.</summary>
+    InvalidModeOrRange,
+
+    /// <summary>The segment ID or tick range is invalid.</summary>
+    InvalidSegmentIdOrRange,
+
+    /// <summary>The segment ID is empty.</summary>
+    EmptySegmentId,
+
+    /// <summary>The addressed segment is absent or suppressed.</summary>
+    SegmentMissingOrSuppressed,
+
+    /// <summary>The external segment ID or type is invalid.</summary>
+    InvalidExternalIdOrType,
+
+    /// <summary>The external segment does not exist.</summary>
+    ExternalSegmentNotFound,
+
+    /// <summary>The external segment belongs to another item.</summary>
+    ExternalItemMismatch,
+
+    /// <summary>The external segment has another type.</summary>
+    ExternalTypeMismatch,
+
+    /// <summary>The user timestamp set is invalid.</summary>
+    InvalidUserTimestamps,
+
+    /// <summary>The season ID is empty.</summary>
+    EmptySeasonId,
+
+    /// <summary>The intent type is not supported.</summary>
+    UnsupportedIntent
+}

--- a/IntroSkipper/SegmentChanges/SegmentProjectionConfiguration.cs
+++ b/IntroSkipper/SegmentChanges/SegmentProjectionConfiguration.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Manager;
+using MediaBrowser.Model.Plugins;
+using Microsoft.Extensions.Hosting;
+
+namespace IntroSkipper.SegmentChanges;
+
+internal sealed class SegmentProjectionConfiguration : IHostedService, ISegmentProjectionConfiguration
+{
+    private bool _enabled = MediaSegmentMirrorPolicy.Enabled;
+
+    /// <inheritdoc />
+    public event EventHandler<bool>? EnabledChanged;
+
+    /// <inheritdoc />
+    public bool Enabled => _enabled;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (Plugin.Instance is { } plugin)
+        {
+            _enabled = plugin.Configuration.UpdateMediaSegments;
+            plugin.ConfigurationChanged += OnConfigurationChanged;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (Plugin.Instance is { } plugin)
+        {
+            plugin.ConfigurationChanged -= OnConfigurationChanged;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OnConfigurationChanged(object? sender, BasePluginConfiguration configuration)
+    {
+        var enabled = ((Configuration.PluginConfiguration)configuration).UpdateMediaSegments;
+        if (_enabled == enabled)
+        {
+            return;
+        }
+
+        _enabled = enabled;
+        EnabledChanged?.Invoke(this, enabled);
+    }
+}

--- a/IntroSkipper/SegmentChanges/SegmentProjectionPlan.cs
+++ b/IntroSkipper/SegmentChanges/SegmentProjectionPlan.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>An immutable item projection plan passed to the adapter.</summary>
+/// <param name="ChangeId">Change ID.</param>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="Sequence">Per-item sequence.</param>
+/// <param name="Segments">Complete own-row image.</param>
+/// <param name="ExternalOperations">Ordered exact external operations.</param>
+internal sealed record SegmentProjectionPlan(Guid ChangeId, Guid ItemId, long Sequence, IReadOnlyList<ProjectedSegment> Segments, IReadOnlyList<ProjectedExternalOperation> ExternalOperations);

--- a/IntroSkipper/SegmentChanges/SegmentProjectionResult.cs
+++ b/IntroSkipper/SegmentChanges/SegmentProjectionResult.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Projection disposition for one accepted item.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="State">Projection state.</param>
+public sealed record SegmentProjectionResult(Guid ItemId, ProjectionState State);

--- a/IntroSkipper/SegmentChanges/SegmentRange.cs
+++ b/IntroSkipper/SegmentChanges/SegmentRange.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>An immutable tick range.</summary>
+/// <param name="StartTicks">Start ticks.</param>
+/// <param name="EndTicks">End ticks.</param>
+public sealed record SegmentRange(long StartTicks, long EndTicks);

--- a/IntroSkipper/SegmentChanges/SegmentValue.cs
+++ b/IntroSkipper/SegmentChanges/SegmentValue.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>An authoritative segment value affected by a change.</summary>
+/// <param name="Id">Stable segment ID.</param>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="Mode">Analysis mode.</param>
+/// <param name="StartTicks">Start ticks.</param>
+/// <param name="EndTicks">End ticks.</param>
+/// <param name="Source">Segment provenance.</param>
+/// <param name="State">Segment lifecycle state.</param>
+public sealed record SegmentValue(Guid Id, Guid ItemId, AnalysisMode Mode, long StartTicks, long EndTicks, SegmentSource Source, SegmentState State);

--- a/IntroSkipper/SegmentChanges/SegmentVisibilityChangeIntent.cs
+++ b/IntroSkipper/SegmentChanges/SegmentVisibilityChangeIntent.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Changes whether automatic segments are visible for one item.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="SeasonId">Owning season-state key.</param>
+/// <param name="Visible">Whether automatic output is visible.</param>
+public sealed record SegmentVisibilityChangeIntent(Guid ItemId, Guid SeasonId, bool Visible) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/UpdateSegmentIntent.cs
+++ b/IntroSkipper/SegmentChanges/UpdateSegmentIntent.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Updates one segment and promotes the surviving row to user provenance.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="SegmentId">Segment ID.</param>
+/// <param name="StartTicks">Start ticks.</param>
+/// <param name="EndTicks">End ticks.</param>
+public sealed record UpdateSegmentIntent(Guid ItemId, Guid SegmentId, long StartTicks, long EndTicks) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/UserTimestamp.cs
+++ b/IntroSkipper/SegmentChanges/UserTimestamp.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>A user-provided range for one analysis mode.</summary>
+/// <param name="Mode">Analysis mode.</param>
+/// <param name="StartTicks">Start ticks.</param>
+/// <param name="EndTicks">End ticks.</param>
+public sealed record UserTimestamp(AnalysisMode Mode, long StartTicks, long EndTicks);

--- a/IntroSkipper/SegmentChanges/WriteUserTimestampsIntent.cs
+++ b/IntroSkipper/SegmentChanges/WriteUserTimestampsIntent.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Atomically writes user timestamps and analyzed state for several modes.</summary>
+/// <param name="ItemId">Item ID.</param>
+/// <param name="Timestamps">Unique mode timestamps.</param>
+public sealed record WriteUserTimestampsIntent(Guid ItemId, IReadOnlyList<UserTimestamp> Timestamps) : SegmentChangeIntent(ItemId);


### PR DESCRIPTION
## Summary

- introduce the three-method `ISegmentChange` interface, typed user/output intents and outcomes, and authoritative item-state transitions without cutting over production callers yet
- persist immutable per-item projection images, ordered exact external operations, retry attempts, and compacted projection heads in a new EF migration
- add a plan-level Jellyfin adapter with provider-scoped full replacement, exact validated deletes, atomic transactions, stable IDs, and idempotent replay
- add immediate projection, ordered same-item retry, cross-item progress, startup recovery, bounded backoff, manual retry, disabled projection, and full reconciliation on re-enable
- make per-item visibility changes commit their flag and filtered projection image atomically; projection failure remains pending and never rolls authority back

## Stack discipline

This PR is intentionally foundation-only. Existing controllers, analyzers, and scheduled tasks do not call `ISegmentChange`; production cutover is the next stacked PR.

## Testing

- `dotnet test --no-restore --verbosity minimal` — 604 passed
- focused Segment Change and Jellyfin adapter contracts — 27 passed
- `git diff --check`
- no-production-caller static gate

## Summary by Sourcery

Establish the durable Segment Change and Jellyfin projection foundation for reliable authoritative mutations and recoverable external synchronization.

New Features:
- Introduce the public segment-change contract with typed intents, outcomes, projection status, and manual retry support.
- Add durable per-item projection plans, full segment images, exact external operations, retry metadata, and compacted progress heads.
- Add atomic Jellyfin projection of provider-owned segment images with validated external deletes and idempotent replay.
- Support immediate projection, ordered per-item retries, cross-item progress, startup recovery, disabled projection, and reconciliation when re-enabled.
- Atomically persist visibility changes with filtered projection images while keeping authoritative changes committed when projection fails.

Enhancements:
- Centralize authoritative segment mutations and analyzed-state transitions behind the new coordinator without migrating existing production callers.

Tests:
- Add durability, ordering, failure recovery, disabled-mode, reconciliation, atomicity, and Jellyfin adapter contract coverage.

Chores:
- Preserve projection journal data during database rebuilds and add the projection journal EF migration.