### PR TITLE
Route interactive segment writes through Segment Change

### DIFF
--- a/IntroSkipper.Tests/ControllerSegmentChangeTestHelpers.cs
+++ b/IntroSkipper.Tests/ControllerSegmentChangeTestHelpers.cs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.Manager;
+using IntroSkipper.SegmentChanges;
+using MediaBrowser.Model.MediaSegments;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+internal static class ControllerSegmentChangeTestHelpers
+{
+    internal static SegmentChange Create(
+        IntroSkipperDatabase database,
+        FakeJellyfinSegmentStore store,
+        bool projectionEnabled = true)
+        => Create(database, new StoreProjectionAdapter(store), projectionEnabled);
+
+    internal static SegmentChange Create(
+        IntroSkipperDatabase database,
+        ISegmentProjectionAdapter adapter,
+        bool projectionEnabled = true)
+    {
+        var factory = (IDbContextFactory<IntroSkipperDbContext>)typeof(IntroSkipperDatabase)
+            .GetFields(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            .Single(field => typeof(IDbContextFactory<IntroSkipperDbContext>).IsAssignableFrom(field.FieldType))
+            .GetValue(database)!;
+        return new SegmentChange(
+            factory,
+            database,
+            adapter,
+            new ProjectionConfiguration(projectionEnabled),
+            TimeProvider.System,
+            NullLogger<SegmentChange>.Instance);
+    }
+
+    private sealed class StoreProjectionAdapter(FakeJellyfinSegmentStore store) : ISegmentProjectionAdapter
+    {
+        public Task<ExternalSegmentTarget?> ResolveExternalTargetAsync(Guid itemId, Guid externalSegmentId, CancellationToken cancellationToken)
+        {
+            var segment = store.ExistingSegments.FirstOrDefault(value => value.Id == externalSegmentId);
+            return Task.FromResult(segment is null
+                ? null
+                : new ExternalSegmentTarget(segment.Id, segment.ItemId, segment.Type, segment.StartTicks, segment.EndTicks));
+        }
+
+        public async Task ApplyAsync(SegmentProjectionPlan plan, CancellationToken cancellationToken)
+        {
+            foreach (var operation in plan.ExternalOperations)
+            {
+                await store.DeleteSegmentAsync(plan.ItemId, operation.ExternalSegmentId, cancellationToken).ConfigureAwait(false);
+            }
+
+            await store.ReplaceSegmentsAsync(
+                plan.ItemId,
+                plan.Segments.Select(value => new MediaSegmentDto
+                {
+                    Id = value.Id,
+                    ItemId = plan.ItemId,
+                    Type = value.Type,
+                    StartTicks = value.StartTicks,
+                    EndTicks = value.EndTicks
+                }).ToList(),
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class ProjectionConfiguration(bool enabled) : ISegmentProjectionConfiguration
+    {
+        public event EventHandler<bool>? EnabledChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public bool Enabled { get; } = enabled;
+    }
+}

--- a/IntroSkipper.Tests/DatabaseTestHelpers.cs
+++ b/IntroSkipper.Tests/DatabaseTestHelpers.cs
@@ -5,12 +5,14 @@ namespace IntroSkipper.Tests;
 
 using System;
 using System.IO;
-using IntroSkipper.Controllers;
+using System.Threading;
+using System.Threading.Tasks;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
 using IntroSkipper.Providers;
+using IntroSkipper.SegmentChanges;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -48,12 +50,17 @@ internal static class DatabaseTestHelpers
     internal static MediaSegmentEditorService CreateEditorService(IJellyfinSegmentStore store, IIntroSkipperDatabase database)
         => new(CreateMirror(store, database), database, NullLogger<MediaSegmentEditorService>.Instance);
 
-    /// <summary>
-    /// Composes the editor controller over the standard editor-service wiring, the
-    /// single test home of the controller composition chain.
-    /// </summary>
-    internal static SegmentEditorController CreateSegmentEditorController(IJellyfinSegmentStore store, IIntroSkipperDatabase database)
-        => new(CreateEditorService(store, database), database, store);
+    internal static SegmentChange CreateSegmentChange(string dbPath)
+    {
+        var factory = new TestDbContextFactory<IntroSkipperDbContext>(() => new IntroSkipperDbContext(dbPath));
+        return new SegmentChange(
+            factory,
+            CreateSegmentDatabase(dbPath),
+            new NoOpProjectionAdapter(),
+            new EnabledProjectionConfiguration(),
+            TimeProvider.System,
+            NullLogger<SegmentChange>.Instance);
+    }
 
     /// <summary>
     /// Converts seconds to ticks for test fixtures; shared so per-file shims are unneeded.
@@ -114,5 +121,24 @@ internal static class DatabaseTestHelpers
                 File.Delete(path);
             }
         }
+    }
+
+    private sealed class NoOpProjectionAdapter : ISegmentProjectionAdapter
+    {
+        public Task<ExternalSegmentTarget?> ResolveExternalTargetAsync(Guid itemId, Guid externalSegmentId, CancellationToken cancellationToken)
+            => Task.FromResult<ExternalSegmentTarget?>(null);
+
+        public Task ApplyAsync(SegmentProjectionPlan plan, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    private sealed class EnabledProjectionConfiguration : ISegmentProjectionConfiguration
+    {
+        public event EventHandler<bool>? EnabledChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public bool Enabled => true;
     }
 }

--- a/IntroSkipper.Tests/RecordingSegmentChange.cs
+++ b/IntroSkipper.Tests/RecordingSegmentChange.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.SegmentChanges;
+
+internal sealed class RecordingSegmentChange : ISegmentChange
+{
+    internal Func<SegmentChangeIntent, SegmentChangeOutcome> Outcome { get; set; }
+        = _ => new Accepted(Guid.NewGuid(), [], [new SegmentProjectionResult(Guid.NewGuid(), ProjectionState.Applied)]);
+
+    internal List<SegmentChangeIntent> Intents { get; } = [];
+
+    public Task<SegmentChangeOutcome> ApplyAsync(SegmentChangeIntent intent, CancellationToken cancellationToken = default)
+    {
+        Intents.Add(intent);
+        return Task.FromResult(Outcome(intent));
+    }
+
+    public Task<ProjectionStatus> GetProjectionStatusAsync(ProjectionScope scope, CancellationToken cancellationToken = default)
+        => Task.FromResult(new ProjectionStatus(scope, []));
+
+    public Task<ProjectionRetryOutcome> RetryProjectionAsync(ProjectionScope scope, CancellationToken cancellationToken = default)
+        => Task.FromResult(new ProjectionRetryOutcome(scope, 0, new ProjectionStatus(scope, [])));
+
+    internal static Accepted Accepted(Guid itemId, ProjectionState state, params SegmentValue[] values)
+        => new(Guid.NewGuid(), values, [new SegmentProjectionResult(itemId, state)]);
+}

--- a/IntroSkipper.Tests/TestSegmentChange.cs
+++ b/IntroSkipper.Tests/TestSegmentChange.cs
@@ -493,6 +493,70 @@ public sealed class TestSegmentChange : IDisposable
         Assert.Single(await verify.ProjectionHeads.ToListAsync());
     }
 
+    [Fact]
+    public async Task EditorDelete_CorrelatedId_TombstonesAutomaticWithExactTicks()
+    {
+        var itemId = Guid.NewGuid();
+        var row = new DbSegment(itemId, AnalysisMode.Introduction, 123456789, 987654321, SegmentSource.Chapter, "hash");
+        await SeedAsync(row);
+        var adapter = new RecordingProjectionAdapter { ResolveException = new InvalidOperationException("correlated delete must not resolve externally") };
+
+        var accepted = Assert.IsType<Accepted>(await CreateService(adapter).ApplyAsync(
+            new EditorDeleteSegmentIntent(itemId, row.Id, MediaSegmentType.Intro)));
+
+        var affected = Assert.Single(accepted.AffectedValues);
+        Assert.Equal(row.Id, affected.Id);
+        Assert.Equal(123456789, affected.StartTicks);
+        Assert.Equal(987654321, affected.EndTicks);
+        Assert.Equal(SegmentState.Suppressed, affected.State);
+        Assert.Empty(Assert.Single(adapter.Plans).ExternalOperations);
+        await using var db = CreateContext();
+        Assert.Equal(SegmentState.Suppressed, Assert.Single(await db.Segments.ToListAsync()).State);
+    }
+
+    [Fact]
+    public async Task EditorDelete_UncorrelatedId_UsesExactTickFallbackAndDurableExternalDelete()
+    {
+        var itemId = Guid.NewGuid();
+        var externalId = Guid.NewGuid();
+        var row = new DbSegment(itemId, AnalysisMode.Credits, 111111111, 222222222, SegmentSource.User);
+        await SeedAsync(row);
+        var adapter = new RecordingProjectionAdapter
+        {
+            ExternalTarget = new ExternalSegmentTarget(externalId, itemId, MediaSegmentType.Outro, row.StartTicks, row.EndTicks)
+        };
+
+        var accepted = Assert.IsType<Accepted>(await CreateService(adapter).ApplyAsync(
+            new EditorDeleteSegmentIntent(itemId, externalId, MediaSegmentType.Outro)));
+
+        Assert.Equal(row.Id, Assert.Single(accepted.AffectedValues).Id);
+        var operation = Assert.Single(Assert.Single(adapter.Plans).ExternalOperations);
+        Assert.Equal(externalId, operation.ExternalSegmentId);
+        await using var db = CreateContext();
+        Assert.Empty(await db.Segments.ToListAsync());
+    }
+
+    [Fact]
+    public async Task EditorDelete_RejectsResolvedTargetMismatchWithoutMutation()
+    {
+        var itemId = Guid.NewGuid();
+        var externalId = Guid.NewGuid();
+        var row = new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.Chapter);
+        await SeedAsync(row);
+        var adapter = new RecordingProjectionAdapter
+        {
+            ExternalTarget = new ExternalSegmentTarget(externalId, itemId, MediaSegmentType.Outro, row.StartTicks, row.EndTicks)
+        };
+
+        var rejected = Assert.IsType<Rejected>(await CreateService(adapter).ApplyAsync(
+            new EditorDeleteSegmentIntent(itemId, externalId, MediaSegmentType.Intro)));
+
+        Assert.Equal(SegmentChangeRejectedReason.ExternalTypeMismatch, rejected.Reason);
+        await using var db = CreateContext();
+        Assert.Equal(SegmentState.Active, Assert.Single(await db.Segments.ToListAsync()).State);
+        Assert.Empty(await db.ProjectionPlans.ToListAsync());
+    }
+
     /// <inheritdoc />
     public void Dispose() => DatabaseTestHelpers.DeleteSqliteFiles(_dbPath);
 

--- a/IntroSkipper.Tests/TestSegmentChangeHttp.cs
+++ b/IntroSkipper.Tests/TestSegmentChangeHttp.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using IntroSkipper.Controllers;
+using IntroSkipper.Data;
+using IntroSkipper.SegmentChanges;
+using Xunit;
+
+public sealed class TestSegmentChangeHttp
+{
+    [Fact]
+    public void Accepted_UsesStructuredStableProjectionTokens()
+    {
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var result = SegmentChangeHttp.Accepted(new Accepted(
+            Guid.NewGuid(),
+            [],
+            [
+                new SegmentProjectionResult(firstId, ProjectionState.Applied),
+                new SegmentProjectionResult(secondId, ProjectionState.Pending)
+            ]));
+
+        var response = Assert.IsType<SegmentChangeAcceptedResponse>(result.Value);
+        Assert.Equal("Applied", response.Projections[0].Status);
+        Assert.Equal("Pending", response.Projections[1].Status);
+        Assert.Equal(firstId, response.Projections[0].ItemId);
+        Assert.Equal(secondId, response.Projections[1].ItemId);
+    }
+}

--- a/IntroSkipper.Tests/TestSegmentEditorController.cs
+++ b/IntroSkipper.Tests/TestSegmentEditorController.cs
@@ -10,6 +10,7 @@ using IntroSkipper.Controllers;
 using IntroSkipper.Data;
 using IntroSkipper.Manager;
 using IntroSkipper.Providers;
+using IntroSkipper.SegmentChanges;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Model.MediaSegments;
 using Microsoft.AspNetCore.Mvc;
@@ -18,15 +19,13 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 /// <summary>
-/// Tests for <see cref="SegmentEditorController.DeleteSegmentAsync"/> validation and rollback behavior:
-/// the plugin DB row is deleted before the Jellyfin-side delete (tombstoning automatic rows,
-/// hard-deleting user rows), so a Jellyfin failure must restore the exact row — via the
-/// shared-id fast path or the exact-ticks fallback for uncorrelated Jellyfin ids.
+/// Tests for <see cref="SegmentEditorController.DeleteSegmentAsync"/> validation and
+/// accepted-plus-pending projection behavior.
 /// </summary>
 public sealed class SegmentEditorControllerTests
 {
     [Fact]
-    public async Task DeleteSegment_RestoresPluginRow_WhenJellyfinDeleteFails_AndJellyfinSegmentAlreadyGone()
+    public async Task DeleteSegment_CorrelatedProjectionFailure_KeepsAuthoritativeDeletePending()
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var itemId = Guid.NewGuid();
@@ -34,28 +33,17 @@ public sealed class SegmentEditorControllerTests
         var original = await database.AddUserSegmentAsync(
             itemId, AnalysisMode.Introduction, TickConversions.FromSeconds(100), TickConversions.FromSeconds(160));
 
-        // Jellyfin has no segment with this id, and its delete throws: the already
-        // hard-deleted user row must be re-inserted verbatim by the rollback.
-        var store = new FakeJellyfinSegmentStore { DeleteSegmentException = new InvalidOperationException("jellyfin down") };
+        var store = new FakeJellyfinSegmentStore { WriteException = new InvalidOperationException("jellyfin down") };
         var controller = CreateController(store, database);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            controller.DeleteSegmentAsync(original.Id, itemId, "intro", CancellationToken.None));
+        var result = await controller.DeleteSegmentAsync(original.Id, itemId, "intro", CancellationToken.None);
 
-        var rows = await database.GetSegmentsAsync(itemId);
-        var restored = Assert.Single(rows);
-        Assert.Equal(original.Id, restored.Id);
-        Assert.Equal(AnalysisMode.Introduction, restored.Type);
-        Assert.Equal(TickConversions.FromSeconds(100), restored.StartTicks);
-        Assert.Equal(TickConversions.FromSeconds(160), restored.EndTicks);
-        Assert.Equal(SegmentSource.User, restored.Source);
-        Assert.Equal(SegmentState.Active, restored.State);
-        Assert.Equal(original.ConfigHash, restored.ConfigHash);
-        Assert.Equal(original.CreatedAt, restored.CreatedAt);
+        Assert.IsType<AcceptedResult>(result);
+        Assert.Empty(await database.GetSegmentsAsync(itemId, includeSuppressed: true));
     }
 
     [Fact]
-    public async Task DeleteSegment_RestoresPluginRow_WhenJellyfinDeleteFails_WithKnownJellyfinSegment()
+    public async Task DeleteSegment_UncorrelatedProjectionFailure_KeepsAuthoritativeTombstonePending()
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var itemId = Guid.NewGuid();
@@ -89,17 +77,13 @@ public sealed class SegmentEditorControllerTests
         };
         var controller = CreateController(store, database);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            controller.DeleteSegmentAsync(jellyfinSegmentId, itemId, "intro", CancellationToken.None));
+        var result = await controller.DeleteSegmentAsync(jellyfinSegmentId, itemId, "intro", CancellationToken.None);
 
-        var restored = Assert.Single(await database.GetSegmentsAsync(itemId));
-        Assert.Equal(original.Id, restored.Id);
-        Assert.Equal(original.StartTicks, restored.StartTicks);
-        Assert.Equal(original.EndTicks, restored.EndTicks);
-        Assert.Equal(SegmentSource.Chapter, restored.Source);
-        Assert.Equal(SegmentState.Active, restored.State);
-        Assert.Equal("cfg-2", restored.ConfigHash);
-        Assert.Equal(original.CreatedAt, restored.CreatedAt);
+        Assert.IsType<AcceptedResult>(result);
+        var tombstone = Assert.Single(await database.GetSegmentsAsync(itemId, includeSuppressed: true));
+        Assert.Equal(original.Id, tombstone.Id);
+        Assert.Equal(SegmentState.Suppressed, tombstone.State);
+        Assert.Equal("cfg-2", tombstone.ConfigHash);
     }
 
     [Theory]
@@ -199,7 +183,7 @@ public sealed class SegmentEditorControllerTests
 
         Assert.IsType<OkResult>(result);
         Assert.Empty(await database.GetSegmentsAsync(itemId, includeSuppressed: true));
-        Assert.Equal([(itemId, row.Id)], store.DeletedSegments);
+        Assert.DoesNotContain(store.ReplacedItems[^1].Segments, segment => segment.Id == row.Id);
     }
 
     [Fact]
@@ -225,7 +209,7 @@ public sealed class SegmentEditorControllerTests
         Assert.Equal(row.Id, tombstone.Id);
         Assert.Equal(SegmentState.Suppressed, tombstone.State);
         Assert.Equal(SegmentSource.Chapter, tombstone.Source);
-        Assert.Equal([(itemId, row.Id)], store.DeletedSegments);
+        Assert.DoesNotContain(store.ReplacedItems[^1].Segments, segment => segment.Id == row.Id);
 
         // Deleting the already-suppressed row again reports not-found.
         var second = await controller.DeleteSegmentAsync(row.Id, itemId, "intro", CancellationToken.None);
@@ -262,7 +246,7 @@ public sealed class SegmentEditorControllerTests
 
         Assert.IsType<OkResult>(result);
         Assert.Empty(await database.GetSegmentsAsync(itemId, includeSuppressed: true));
-        Assert.Equal([(itemId, row.Id)], store.DeletedSegments);
+        Assert.DoesNotContain(store.ReplacedItems[^1].Segments, segment => segment.Id == row.Id);
     }
 
     [Fact]
@@ -271,7 +255,9 @@ public sealed class SegmentEditorControllerTests
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
         using var jellyfinDb = new TempJellyfinDb();
-        var store = new JellyfinSegmentStore(jellyfinDb.Factory, NullLogger<JellyfinSegmentStore>.Instance);
+        var adapter = new JellyfinSegmentProjectionAdapter(
+            jellyfinDb.Factory,
+            NullLogger<JellyfinSegmentProjectionAdapter>.Instance);
         var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
 
         var itemA = Guid.NewGuid();
@@ -298,7 +284,8 @@ public sealed class SegmentEditorControllerTests
             await context.SaveChangesAsync();
         }
 
-        var controller = CreateController(store, database);
+        var controller = new SegmentEditorController(
+            ControllerSegmentChangeTestHelpers.Create(database, adapter));
 
         // Item B's id paired with item A's segment id: the item mismatch skips the shared-id
         // fast path, the Jellyfin lookup is scoped to item B and finds nothing, and neither
@@ -377,5 +364,7 @@ public sealed class SegmentEditorControllerTests
     private static SegmentEditorController CreateController(
         IJellyfinSegmentStore store,
         IntroSkipper.Db.IIntroSkipperDatabase database)
-        => DatabaseTestHelpers.CreateSegmentEditorController(store, database);
+        => new(ControllerSegmentChangeTestHelpers.Create(
+            (IntroSkipper.Db.IntroSkipperDatabase)database,
+            (FakeJellyfinSegmentStore)store));
 }

--- a/IntroSkipper.Tests/TestSegmentsApiController.cs
+++ b/IntroSkipper.Tests/TestSegmentsApiController.cs
@@ -136,7 +136,7 @@ public sealed class TestSegmentsApiController
                 new CreateSegmentRequest(AnalysisMode.Introduction, 5, 30),
                 CancellationToken.None);
 
-            Assert.IsType<CreatedAtActionResult>(response.Result);
+            Assert.IsType<AcceptedResult>(response.Result);
             Assert.Empty(store.ReplacedItems);
         }
         finally
@@ -269,7 +269,7 @@ public sealed class TestSegmentsApiController
             Assert.IsType<NoContentResult>(await controller.DeleteSegment(itemId, autoRow.Id, CancellationToken.None));
             var tombstone = Assert.Single(await database.GetSegmentsAsync(itemId, includeSuppressed: true), s => s.Id == autoRow.Id);
             Assert.Equal(SegmentState.Suppressed, tombstone.State);
-            Assert.Contains((itemId, autoRow.Id), store.DeletedSegments);
+            Assert.DoesNotContain(store.ReplacedItems[^1].Segments, segment => segment.Id == autoRow.Id);
 
             Assert.IsType<NoContentResult>(await controller.DeleteSegment(itemId, userRow.Id, CancellationToken.None));
             Assert.DoesNotContain(await database.GetSegmentsAsync(itemId, includeSuppressed: true), s => s.Id == userRow.Id);
@@ -296,7 +296,7 @@ public sealed class TestSegmentsApiController
             var row = Assert.Single(await database.GetSegmentsAsync(itemId));
             var controller = CreateController(database, out var store);
 
-            Assert.IsType<NoContentResult>(await controller.DeleteSegment(itemId, row.Id, CancellationToken.None));
+            Assert.IsType<AcceptedResult>(await controller.DeleteSegment(itemId, row.Id, CancellationToken.None));
 
             // Plugin-side delete happened; Jellyfin stays untouched, consistent with
             // how create/update/restore honor the UpdateMediaSegments flag.
@@ -312,7 +312,7 @@ public sealed class TestSegmentsApiController
     }
 
     [Fact]
-    public async Task DeleteSegment_RollsBackPluginDelete_WhenJellyfinDeleteFails()
+    public async Task DeleteSegment_JellyfinFailure_ReturnsAcceptedPendingWithoutRollingBack()
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
@@ -324,13 +324,13 @@ public sealed class TestSegmentsApiController
             var row = Assert.Single(await database.GetSegmentsAsync(itemId));
             var controller = CreateController(database, out _, new InvalidOperationException("Jellyfin unavailable"));
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                () => controller.DeleteSegment(itemId, row.Id, CancellationToken.None));
+            Assert.IsType<AcceptedResult>(
+                await controller.DeleteSegment(itemId, row.Id, CancellationToken.None));
 
-            // The tombstone was rolled back — the row is active again with its metadata.
-            var restored = Assert.Single(await database.GetSegmentsAsync(itemId));
-            Assert.Equal(row.Id, restored.Id);
-            Assert.Equal("cfg", restored.ConfigHash);
+            var tombstone = Assert.Single(await database.GetSegmentsAsync(itemId, includeSuppressed: true));
+            Assert.Equal(row.Id, tombstone.Id);
+            Assert.Equal(SegmentState.Suppressed, tombstone.State);
+            Assert.Equal("cfg", tombstone.ConfigHash);
         }
         finally
         {
@@ -370,11 +370,15 @@ public sealed class TestSegmentsApiController
     private static SegmentsController CreateController(
         IIntroSkipperDatabase database,
         out FakeJellyfinSegmentStore store,
-        Exception? deleteException = null)
+        Exception? projectionException = null)
     {
-        store = new FakeJellyfinSegmentStore { DeleteSegmentException = deleteException };
-        var editorService = DatabaseTestHelpers.CreateEditorService(store, database);
-        return new SegmentsController(database, editorService);
+        store = new FakeJellyfinSegmentStore { WriteException = projectionException };
+        return new SegmentsController(
+            database,
+            ControllerSegmentChangeTestHelpers.Create(
+                (IntroSkipperDatabase)database,
+                store,
+                Plugin.Instance!.Configuration.UpdateMediaSegments));
     }
 
     private static string CreateTempDbPath()

--- a/IntroSkipper.Tests/TestSkipIntroController.cs
+++ b/IntroSkipper.Tests/TestSkipIntroController.cs
@@ -15,7 +15,7 @@ namespace IntroSkipper.Tests;
 public sealed class TestSkipIntroController
 {
     [Fact]
-    public async Task UpdateTimestampsAsync_AwaitsMirrorWrite_BeforeReturningNoContent()
+    public async Task UpdateTimestampsAsync_AwaitsProjectionBeforeReturningNoContent()
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
@@ -28,7 +28,12 @@ public sealed class TestSkipIntroController
             WriteGate = writeGate,
             BlockedItemId = itemId
         };
+        // Pre-warm the facade's init gate so the action below runs synchronously up to the
+        // projection await (its single pending point). With a cold gate, initialization
+        // completes on the thread pool and the pre-completion assertions race it. This
+        // mirrors production, where the hosted initializer warms the gate before traffic.
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+        await database.InitializeAsync();
         var controller = CreateController(store, database, pluginScope.CacheDbPath);
         var timestamps = new TimeStamps
         {
@@ -41,6 +46,7 @@ public sealed class TestSkipIntroController
         // still has to wait for that write to finish.
         await writeEntered.Task;
         Assert.False(actionTask.IsCompleted);
+        Assert.Equal(1, store.WriteCallCount);
 
         writeGate.SetResult();
         var result = await actionTask;
@@ -55,14 +61,14 @@ public sealed class TestSkipIntroController
     }
 
     [Fact]
-    public async Task UpdateTimestampsAsync_MirrorDisabled_StoresSegmentWithoutJellyfinWrite()
+    public async Task UpdateTimestampsAsync_ProjectionDisabled_ReturnsAcceptedSkipped()
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
         using var pluginScope = EntrypointTestHelpers.CreateMoviePluginScope(itemId, updateMediaSegments: false, out _);
         var store = new FakeJellyfinSegmentStore();
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
-        var controller = CreateController(store, database, pluginScope.CacheDbPath);
+        var controller = CreateController(store, database, pluginScope.CacheDbPath, projectionEnabled: false);
         var timestamps = new TimeStamps
         {
             Introduction = new Segment(itemId, new TimeRange(10, 20))
@@ -70,15 +76,14 @@ public sealed class TestSkipIntroController
 
         var result = await controller.UpdateTimestampsAsync(itemId, timestamps, CancellationToken.None);
 
-        // The controller does not gate on UpdateMediaSegments; the mirror itself no-ops.
-        Assert.IsType<NoContentResult>(result);
+        Assert.IsType<AcceptedResult>(result);
         Assert.Equal(0, store.WriteCallCount);
         var segment = Assert.Single(await database.GetSegmentsAsync(itemId));
         Assert.Equal(SegmentSource.User, segment.Source);
     }
 
     [Fact]
-    public async Task UpdateTimestampsAsync_MirrorFailure_PropagatesAndKeepsStoredSegment()
+    public async Task UpdateTimestampsAsync_MirrorFailure_ReturnsAcceptedAndKeepsStoredSegment()
     {
         var itemId = Guid.NewGuid();
         var dbPath = CreateTempDbPath();
@@ -94,11 +99,11 @@ public sealed class TestSkipIntroController
             Introduction = new Segment(itemId, new TimeRange(10, 20))
         };
 
-        // Like every editor write: the failure reaches the caller instead of a 204, and
-        // the committed plugin row stays (the next sync converges the mirror).
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => controller.UpdateTimestampsAsync(itemId, timestamps, CancellationToken.None));
+        // The mirror failure no longer reaches the caller: the committed plugin row stays,
+        // the projection plan stays pending for retry, and the response reports 202.
+        var result = await controller.UpdateTimestampsAsync(itemId, timestamps, CancellationToken.None);
 
+        Assert.IsType<AcceptedResult>(result);
         Assert.Equal(1, store.WriteCallCount);
         var segment = Assert.Single(await database.GetSegmentsAsync(itemId));
         Assert.Equal(SegmentSource.User, segment.Source);
@@ -121,7 +126,7 @@ public sealed class TestSkipIntroController
             AnalysisMode.Introduction,
             [new Segment(itemId, new TimeRange(10, 20))],
             SegmentSource.Chapter);
-        var controller = CreateController(new FakeJellyfinSegmentStore(), database, pluginScope.CacheDbPath);
+        var controller = CreateController(new FakeJellyfinSegmentStore(), database, pluginScope.CacheDbPath, projectionEnabled: false);
         var timestamps = new TimeStamps
         {
             Commercial = new Segment(itemId, new TimeRange(400, 430))
@@ -131,7 +136,7 @@ public sealed class TestSkipIntroController
 
         // The deprecated singular endpoint replaces every stored commercial with the one
         // posted user segment (no more append), while other modes stay untouched.
-        Assert.IsType<NoContentResult>(result);
+        Assert.IsType<AcceptedResult>(result);
         var rows = await database.GetSegmentsAsync(itemId);
         var commercial = Assert.Single(rows, row => row.Type == AnalysisMode.Commercial);
         Assert.Equal(TickConversions.FromSeconds(400), commercial.StartTicks);
@@ -174,15 +179,16 @@ public sealed class TestSkipIntroController
     }
 
     private static SkipIntroController CreateController(
-        IJellyfinSegmentStore store,
+        FakeJellyfinSegmentStore store,
         IntroSkipperDatabase database,
         string cacheDbPath,
-        IMediaSegmentRefresher? refresher = null)
+        IMediaSegmentRefresher? refresher = null,
+        bool projectionEnabled = true)
         => new(
-            DatabaseTestHelpers.CreateEditorService(store, database),
             refresher ?? new RecordingMediaSegmentRefresher(),
             DatabaseTestHelpers.CreateCacheDatabase(cacheDbPath),
-            database);
+            database,
+            ControllerSegmentChangeTestHelpers.Create(database, store, projectionEnabled));
 
     private static string CreateTempDbPath()
         => DatabaseTestHelpers.CreateTempDbPath(Guid.NewGuid().ToString("N") + "-skip-controller.db");

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -11,6 +11,7 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Manager;
+using IntroSkipper.SegmentChanges;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.AspNetCore.Http;
@@ -232,7 +233,7 @@ public sealed class TestVisualizationController
         using var loggerFactory = LoggerFactory.Create(builder => { });
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
         var controller = CreateController(
-            refresher, loggerFactory, database, pluginScope.CacheDbPath, DatabaseTestHelpers.CreateEditorService(store, database));
+            refresher, loggerFactory, database, pluginScope.CacheDbPath, ControllerSegmentChangeTestHelpers.Create(database, store));
 
         var putResult = await controller.DisableItem(episodeIds[0], CancellationToken.None);
 
@@ -273,7 +274,7 @@ public sealed class TestVisualizationController
         using var loggerFactory = LoggerFactory.Create(builder => { });
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
         var controller = CreateController(
-            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, DatabaseTestHelpers.CreateEditorService(store, database));
+            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, ControllerSegmentChangeTestHelpers.Create(database, store));
 
         var unknown = await controller.DisableItem(Guid.NewGuid(), CancellationToken.None);
 
@@ -283,7 +284,7 @@ public sealed class TestVisualizationController
     }
 
     [Fact]
-    public async Task DisabledItems_RefreshFailureRollsBackDisable_AndReports500()
+    public async Task DisabledItems_ProjectionFailure_KeepsDisablePending()
     {
         var seriesId = Guid.NewGuid();
         var seasonId = Guid.NewGuid();
@@ -301,19 +302,16 @@ public sealed class TestVisualizationController
         using var loggerFactory = LoggerFactory.Create(builder => { });
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
         var controller = CreateController(
-            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, DatabaseTestHelpers.CreateEditorService(store, database));
+            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, ControllerSegmentChangeTestHelpers.Create(database, store));
 
         var result = await controller.DisableItem(episodeIds[0], CancellationToken.None);
 
-        // The mirror kept its old rows, so the response must not be a success and
-        // the flag write must be rolled back.
-        var problem = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(StatusCodes.Status500InternalServerError, problem.StatusCode);
-        Assert.Empty(await database.GetDisabledItemIdsAsync(seasonId));
+        Assert.IsType<AcceptedResult>(result);
+        Assert.Equal([episodeIds[0]], await database.GetDisabledItemIdsAsync(seasonId));
     }
 
     [Fact]
-    public async Task DisabledItems_RefreshFailureRollsBackEnable_AndReports500()
+    public async Task DisabledItems_ProjectionFailure_KeepsEnablePending()
     {
         var seriesId = Guid.NewGuid();
         var seasonId = Guid.NewGuid();
@@ -332,18 +330,16 @@ public sealed class TestVisualizationController
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
         await database.SetItemDisabledAsync(seasonId, episodeIds[0], disabled: true);
         var controller = CreateController(
-            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, DatabaseTestHelpers.CreateEditorService(store, database));
+            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, ControllerSegmentChangeTestHelpers.Create(database, store));
 
         var result = await controller.EnableItem(episodeIds[0], CancellationToken.None);
 
-        // Jellyfin still withholds the rows, so the stored flag must stay disabled.
-        var problem = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(StatusCodes.Status500InternalServerError, problem.StatusCode);
-        Assert.Equal([episodeIds[0]], await database.GetDisabledItemIdsAsync(seasonId));
+        Assert.IsType<AcceptedResult>(result);
+        Assert.Empty(await database.GetDisabledItemIdsAsync(seasonId));
     }
 
     [Fact]
-    public async Task DisabledItems_ConcurrentMutationSerializesBehindFailingRollback()
+    public async Task DisabledItems_ConcurrentDuplicateSerializesBehindPendingProjection()
     {
         var seriesId = Guid.NewGuid();
         var seasonId = Guid.NewGuid();
@@ -366,34 +362,29 @@ public sealed class TestVisualizationController
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
         await database.InitializeAsync();
         var controller = CreateController(
-            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, DatabaseTestHelpers.CreateEditorService(store, database));
+            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, ControllerSegmentChangeTestHelpers.Create(database, store));
 
         // Request A writes the flag, then parks inside its strict mirror write.
         var requestA = controller.DisableItem(episodeIds[0], CancellationToken.None);
         await writeEntered.Task;
 
-        // Request B mutates the same item while A is in flight. It must serialize
-        // behind A's whole mutation instead of observing A's uncommitted flag: if it
-        // ran now it would see `previous == true` and no-op, and A's rollback would
-        // then silently clobber B's "successful" disable.
+        // Request B waits behind A's in-flight projection, then observes the committed flag.
         var requestB = controller.DisableItem(episodeIds[0], CancellationToken.None);
         Assert.NotSame(requestB, await Task.WhenAny(requestB, Task.Delay(250)));
         Assert.Equal(1, store.WriteCallCount);
 
-        // A's mirror write now fails; the rollback must complete before B proceeds.
+        // A's projection fails but its authoritative flag remains; B becomes an idempotent no-op.
         writeGate.SetException(new InvalidOperationException("mirror write failed"));
 
-        var problem = Assert.IsType<ObjectResult>(await requestA);
-        Assert.Equal(StatusCodes.Status500InternalServerError, problem.StatusCode);
+        Assert.IsType<AcceptedResult>(await requestA);
         Assert.IsType<NoContentResult>(await requestB);
 
-        // B reported success after A's rollback, so the item must end up disabled.
-        Assert.Equal(2, store.WriteCallCount);
+        Assert.Equal(1, store.WriteCallCount);
         Assert.Equal([episodeIds[0]], await database.GetDisabledItemIdsAsync(seasonId));
     }
 
     [Fact]
-    public async Task DisabledItems_ConcurrentSegmentCreateSerializesBehindFailingRollback()
+    public async Task DisabledItems_ConcurrentSegmentCreate_ProjectsInAcceptedOrder()
     {
         var seriesId = Guid.NewGuid();
         var seasonId = Guid.NewGuid();
@@ -416,37 +407,33 @@ public sealed class TestVisualizationController
         var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
         await database.ReplaceAutoSegmentsAsync(
             episodeIds[0], AnalysisMode.Introduction, [new Segment(episodeIds[0], new TimeRange(10, 20))], SegmentSource.Chapter);
-        var editorService = DatabaseTestHelpers.CreateEditorService(store, database);
+        var segmentChange = ControllerSegmentChangeTestHelpers.Create(database, store);
         var controller = CreateController(
-            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, editorService);
-        var segmentsController = new SegmentsController(database, editorService);
+            new RecordingMediaSegmentRefresher(), loggerFactory, database, pluginScope.CacheDbPath, segmentChange);
+        var segmentsController = new SegmentsController(database, segmentChange);
 
         // Request A writes the disable flag, then parks inside its strict mirror write.
         var requestA = controller.DisableItem(episodeIds[0], CancellationToken.None);
         await writeEntered.Task;
 
-        // A segment create for the same item must serialize behind A's whole mutation:
-        // syncing now would read A's uncommitted disabled flag and strip the automatic
-        // rows, a state A's rollback would leave baked into the mirror.
+        // A segment create for the same item waits behind A's in-flight projection.
         var requestB = segmentsController.CreateSegment(
             episodeIds[0], new CreateSegmentRequest(AnalysisMode.Commercial, 100, 120), CancellationToken.None);
         Assert.NotSame(requestB, await Task.WhenAny(requestB, Task.Delay(250)));
         Assert.Equal(1, store.WriteCallCount);
 
-        // A's mirror write now fails and rolls the flag back; only then does B proceed.
+        // A becomes pending; B retries A's plan, then applies its own image.
         writeGate.SetException(new InvalidOperationException("mirror write failed"));
 
-        var problem = Assert.IsType<ObjectResult>(await requestA);
-        Assert.Equal(StatusCodes.Status500InternalServerError, problem.StatusCode);
+        Assert.IsType<AcceptedResult>(await requestA);
         Assert.IsType<CreatedAtActionResult>((await requestB).Result);
 
-        // B's sync ran after the rollback: the flag is enabled again, so the final
-        // mirror push carries the automatic segment alongside the new user segment.
-        Assert.Empty(await database.GetDisabledItemIdsAsync(seasonId));
-        Assert.Equal(2, store.WriteCallCount);
+        Assert.Equal([episodeIds[0]], await database.GetDisabledItemIdsAsync(seasonId));
+        Assert.Equal(3, store.WriteCallCount);
         var finalPush = store.ReplacedItems[^1];
         Assert.Equal(episodeIds[0], finalPush.ItemId);
-        Assert.Equal(2, finalPush.Segments.Count);
+        var projected = Assert.Single(finalPush.Segments);
+        Assert.Equal(Jellyfin.Database.Implementations.Enums.MediaSegmentType.Commercial, projected.Type);
     }
 
     [Fact]
@@ -486,12 +473,12 @@ public sealed class TestVisualizationController
     private static VisualizationController CreateController(IMediaSegmentRefresher refresher, ILoggerFactory loggerFactory, string dbPath, string cacheDbPath)
         => CreateController(refresher, loggerFactory, DatabaseTestHelpers.CreateSegmentDatabase(dbPath), cacheDbPath);
 
-    private static VisualizationController CreateController(IMediaSegmentRefresher refresher, ILoggerFactory loggerFactory, IntroSkipperDatabase database, string cacheDbPath, MediaSegmentEditorService? editorService = null)
+    private static VisualizationController CreateController(IMediaSegmentRefresher refresher, ILoggerFactory loggerFactory, IntroSkipperDatabase database, string cacheDbPath, ISegmentChange? segmentChange = null)
     {
         return new VisualizationController(
             NullLogger<VisualizationController>.Instance,
             refresher,
-            editorService ?? DatabaseTestHelpers.CreateEditorService(new FakeJellyfinSegmentStore(), database),
+            segmentChange ?? ControllerSegmentChangeTestHelpers.Create(database, new FakeJellyfinSegmentStore()),
             libraryManager: null!,
             new AnalyzerTaskFactory(
                 loggerFactory,

--- a/IntroSkipper.Tests/TestVisualizationControllerSeams.cs
+++ b/IntroSkipper.Tests/TestVisualizationControllerSeams.cs
@@ -169,7 +169,7 @@ public sealed class TestVisualizationControllerSeams
         => new(
             NullLogger<VisualizationController>.Instance,
             new NoOpMediaSegmentRefresher(),
-            DatabaseTestHelpers.CreateEditorService(new FakeJellyfinSegmentStore(), database),
+            new RecordingSegmentChange(),
             libraryManager!,
             new AnalyzerTaskFactory(
                 NullLoggerFactory.Instance,

--- a/IntroSkipper/Controllers/SegmentChangeHttp.cs
+++ b/IntroSkipper/Controllers/SegmentChangeHttp.cs
@@ -14,10 +14,16 @@ internal static class SegmentChangeHttp
 
     internal static AcceptedResult Accepted(Accepted accepted)
     {
-        var projection = accepted.Projections.Count == 1
-            ? accepted.Projections[0].State.ToString()
-            : string.Join(",", accepted.Projections.Select(value => value.State).Distinct());
-        return new AcceptedResult((string?)null, new SegmentChangeAcceptedResponse(accepted.ChangeId, "Accepted", projection));
+        var projections = accepted.Projections.Select(projection => new SegmentProjectionAcceptedResponse(
+            projection.ItemId,
+            projection.State switch
+            {
+                ProjectionState.Applied => "Applied",
+                ProjectionState.Pending => "Pending",
+                ProjectionState.Skipped => "Skipped",
+                _ => throw new ArgumentOutOfRangeException(nameof(accepted), projection.State, "Unknown projection state.")
+            })).ToList();
+        return new AcceptedResult((string?)null, new SegmentChangeAcceptedResponse(accepted.ChangeId, "Accepted", projections));
     }
 
     internal static ActionResult Rejected(Rejected rejected)

--- a/IntroSkipper/Controllers/SegmentChangeHttp.cs
+++ b/IntroSkipper/Controllers/SegmentChangeHttp.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Data;
+using IntroSkipper.SegmentChanges;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IntroSkipper.Controllers;
+
+internal static class SegmentChangeHttp
+{
+    internal static bool IsApplied(Accepted accepted)
+        => accepted.Projections.All(projection => projection.State == ProjectionState.Applied);
+
+    internal static AcceptedResult Accepted(Accepted accepted)
+    {
+        var projection = accepted.Projections.Count == 1
+            ? accepted.Projections[0].State.ToString()
+            : string.Join(",", accepted.Projections.Select(value => value.State).Distinct());
+        return new AcceptedResult((string?)null, new SegmentChangeAcceptedResponse(accepted.ChangeId, "Accepted", projection));
+    }
+
+    internal static ActionResult Rejected(Rejected rejected)
+        => rejected.Reason switch
+        {
+            SegmentChangeRejectedReason.SegmentMissingOrSuppressed or
+            SegmentChangeRejectedReason.ExternalSegmentNotFound or
+            SegmentChangeRejectedReason.ExternalItemMismatch => new NotFoundResult(),
+            SegmentChangeRejectedReason.ExternalIdMismatch or
+            SegmentChangeRejectedReason.ExternalTypeMismatch => new BadRequestObjectResult(rejected.Message),
+            _ => new BadRequestObjectResult(rejected.Message)
+        };
+
+    internal static SegmentDto ToDto(SegmentValue value) => new(
+        value.Id,
+        value.Mode,
+        TickConversions.ToSeconds(value.StartTicks),
+        TickConversions.ToSeconds(value.EndTicks),
+        value.Source,
+        value.State == SegmentState.Suppressed);
+}

--- a/IntroSkipper/Controllers/SegmentEditorController.cs
+++ b/IntroSkipper/Controllers/SegmentEditorController.cs
@@ -6,9 +6,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.Net.Mime;
 using IntroSkipper.Data;
-using IntroSkipper.Db;
 using IntroSkipper.Helper;
-using IntroSkipper.Manager;
+using IntroSkipper.SegmentChanges;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Model.MediaSegments;
 using MediaBrowser.Model.Querying;
@@ -24,21 +23,14 @@ namespace IntroSkipper.Controllers;
 /// <remarks>
 /// Initializes a new instance of the <see cref="SegmentEditorController"/> class.
 /// </remarks>
-/// <param name="mediaSegmentEditorService">Media segment editor service; owns every mutation end-to-end.</param>
-/// <param name="database">Segment database facade.</param>
-/// <param name="segmentStore">Direct store for Jellyfin's media segments, for reads outside the mutation path.</param>
+/// <param name="segmentChange">Durable segment change coordinator.</param>
 [Authorize(Policy = Policies.RequiresElevation)]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("MediaSegmentsApi")]
-public class SegmentEditorController(
-    MediaSegmentEditorService mediaSegmentEditorService,
-    IIntroSkipperDatabase database,
-    IJellyfinSegmentStore segmentStore) : ControllerBase
+public class SegmentEditorController(ISegmentChange segmentChange) : ControllerBase
 {
-    private readonly MediaSegmentEditorService _mediaSegmentEditorService = mediaSegmentEditorService;
-    private readonly IIntroSkipperDatabase _database = database;
-    private readonly IJellyfinSegmentStore _segmentStore = segmentStore;
+    private readonly ISegmentChange _segmentChange = segmentChange;
 
     /// <summary>
     /// Plugin meta endpoint.
@@ -66,6 +58,7 @@ public class SegmentEditorController(
     /// <returns>The created segment.</returns>
     [HttpPost("{itemId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<QueryResult<MediaSegmentDto>>> CreateSegmentAsync(
@@ -91,11 +84,16 @@ public class SegmentEditorController(
             return BadRequest($"Unknown segment type '{segment.Type}'.");
         }
 
-        await _mediaSegmentEditorService
-            .CreateUserSegmentAsync(itemId, mode, segment.StartTicks, segment.EndTicks, cancellationToken)
-            .ConfigureAwait(false);
-
-        return Ok();
+        var outcome = await _segmentChange.ApplyAsync(
+            new AddUserSegmentIntent(itemId, mode, segment.StartTicks, segment.EndTicks), cancellationToken).ConfigureAwait(false);
+        return outcome switch
+        {
+            Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+            Accepted _ => Ok(),
+            Ignored { Reason: SegmentChangeIgnoredReason.UserSegmentAlreadyExists } => Ok(),
+            Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+            _ => Conflict()
+        };
     }
 
     /// <summary>
@@ -112,6 +110,7 @@ public class SegmentEditorController(
     /// </returns>
     [HttpDelete("{segmentId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteSegmentAsync(
@@ -129,49 +128,15 @@ public class SegmentEditorController(
             return BadRequest($"Unknown segment type '{type}'.");
         }
 
-        // Fast path: the plugin row shares the Jellyfin row's id.
-        var pluginRow = await _database.GetSegmentAsync(segmentId, cancellationToken).ConfigureAwait(false);
-        if (pluginRow is not null && pluginRow.ItemId == itemId)
+        var outcome = await _segmentChange.ApplyAsync(
+            new EditorDeleteSegmentIntent(itemId, segmentId, AnalysisHelpers.ModeToSegmentType[requestedMode]), cancellationToken).ConfigureAwait(false);
+        return outcome switch
         {
-            if (pluginRow.Type != requestedMode)
-            {
-                return BadRequest($"Segment '{segmentId}' is {AnalysisHelpers.ModeToSegmentType[pluginRow.Type]}, not requested type '{type}'.");
-            }
-
-            // Deletability (unknown, vanished, or suppressed rows → 404) is the cascade's
-            // call, derived from its result exactly like the plural DELETE endpoint.
-            var deleted = await _mediaSegmentEditorService
-                .DeleteSegmentAsync(itemId, segmentId, cancellationToken)
-                .ConfigureAwait(false);
-            if (deleted is null)
-            {
-                return NotFound();
-            }
-        }
-        else
-        {
-            // Fallback for uncorrelated ids: rows Jellyfin materialized before the shared-id
-            // scheme, or foreign-provider rows. The cascade matches the plugin-side
-            // counterpart by exact ticks; without one, only the Jellyfin row is removed
-            // and the state still resets.
-            var existingSegment = await _segmentStore
-                .GetSegmentAsync(itemId, segmentId, cancellationToken)
-                .ConfigureAwait(false);
-            if (existingSegment is null)
-            {
-                return NotFound();
-            }
-
-            if (existingSegment.Type != AnalysisHelpers.ModeToSegmentType[requestedMode])
-            {
-                return BadRequest($"Segment '{segmentId}' is {existingSegment.Type}, not requested type '{type}'.");
-            }
-
-            await _mediaSegmentEditorService
-                .DeleteUncorrelatedSegmentAsync(itemId, requestedMode, existingSegment, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return Ok();
+            Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+            Accepted _ => Ok(),
+            Ignored { Reason: SegmentChangeIgnoredReason.SegmentMissingOrDeleted } => NotFound(),
+            Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+            _ => Conflict()
+        };
     }
 }

--- a/IntroSkipper/Controllers/SegmentsController.cs
+++ b/IntroSkipper/Controllers/SegmentsController.cs
@@ -5,7 +5,7 @@ using System.Net.Mime;
 using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Helper;
-using IntroSkipper.Manager;
+using IntroSkipper.SegmentChanges;
 using MediaBrowser.Common.Api;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -24,16 +24,16 @@ namespace IntroSkipper.Controllers;
 /// Initializes a new instance of the <see cref="SegmentsController"/> class.
 /// </remarks>
 /// <param name="database">Segment database facade.</param>
-/// <param name="mediaSegmentEditorService">Media segment editor service; owns every mutation end-to-end.</param>
+/// <param name="segmentChange">Durable segment change coordinator.</param>
 [Authorize]
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 public class SegmentsController(
     IIntroSkipperDatabase database,
-    MediaSegmentEditorService mediaSegmentEditorService) : ControllerBase
+    ISegmentChange segmentChange) : ControllerBase
 {
     private readonly IIntroSkipperDatabase _database = database;
-    private readonly MediaSegmentEditorService _mediaSegmentEditorService = mediaSegmentEditorService;
+    private readonly ISegmentChange _segmentChange = segmentChange;
 
     /// <summary>
     /// Gets all stored segments of an item, ordered by type and start time.
@@ -76,6 +76,7 @@ public class SegmentsController(
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPost("Episode/{itemId}/Segments")]
     [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<SegmentDto>> CreateSegment(
@@ -102,10 +103,16 @@ public class SegmentsController(
             return BadRequest("Start must be non-negative and End must be after Start.");
         }
 
-        var row = await _mediaSegmentEditorService
-            .CreateUserSegmentAsync(itemId, request.Type, startTicks, endTicks, cancellationToken)
-            .ConfigureAwait(false);
-        return CreatedAtAction(nameof(GetSegments), new { itemId }, SegmentDto.FromDbSegment(row));
+        var outcome = await _segmentChange.ApplyAsync(
+            new AddUserSegmentIntent(itemId, request.Type, startTicks, endTicks), cancellationToken).ConfigureAwait(false);
+        return outcome switch
+        {
+            Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+            Accepted accepted => CreatedAtAction(nameof(GetSegments), new { itemId }, SegmentChangeHttp.ToDto(AssertSingle(accepted.AffectedValues))),
+            Ignored { Reason: SegmentChangeIgnoredReason.UserSegmentAlreadyExists } ignored => CreatedAtAction(nameof(GetSegments), new { itemId }, SegmentChangeHttp.ToDto(AssertSingle(ignored.AffectedValues))),
+            Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+            _ => Conflict()
+        };
     }
 
     /// <summary>
@@ -124,6 +131,7 @@ public class SegmentsController(
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPut("Episode/{itemId}/Segments/{segmentId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<SegmentDto>> UpdateSegment(
@@ -144,15 +152,16 @@ public class SegmentsController(
             return BadRequest("Start must be non-negative and End must be after Start.");
         }
 
-        var updated = await _mediaSegmentEditorService
-            .UpdateSegmentAsync(itemId, segmentId, startTicks, endTicks, cancellationToken)
-            .ConfigureAwait(false);
-        if (updated is null)
+        var outcome = await _segmentChange.ApplyAsync(
+            new UpdateSegmentIntent(itemId, segmentId, startTicks, endTicks), cancellationToken).ConfigureAwait(false);
+        return outcome switch
         {
-            return NotFound();
-        }
-
-        return Ok(SegmentDto.FromDbSegment(updated));
+            Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+            Accepted accepted => Ok(SegmentChangeHttp.ToDto(AssertSingle(accepted.AffectedValues))),
+            Ignored { Reason: SegmentChangeIgnoredReason.SegmentAlreadyHasValues } ignored => Ok(SegmentChangeHttp.ToDto(AssertSingle(ignored.AffectedValues))),
+            Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+            _ => Conflict()
+        };
     }
 
     /// <summary>
@@ -168,6 +177,7 @@ public class SegmentsController(
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpDelete("Episode/{itemId}/Segments/{segmentId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteSegment(
         [FromRoute] Guid itemId,
@@ -179,19 +189,15 @@ public class SegmentsController(
             return NotFound();
         }
 
-        // The cascade owns the whole delete workflow: item-scoped plugin delete, targeted
-        // Jellyfin delete with rollback, mirror re-sync when the shared id found no
-        // Jellyfin row, and the season-state reset (mode comes from the deleted row).
-        // The Jellyfin row shares the segment id.
-        var deleted = await _mediaSegmentEditorService
-            .DeleteSegmentAsync(itemId, segmentId, cancellationToken)
-            .ConfigureAwait(false);
-        if (deleted is null)
+        var outcome = await _segmentChange.ApplyAsync(new DeleteSegmentIntent(itemId, segmentId), cancellationToken).ConfigureAwait(false);
+        return outcome switch
         {
-            return NotFound();
-        }
-
-        return NoContent();
+            Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+            Accepted _ => NoContent(),
+            Ignored { Reason: SegmentChangeIgnoredReason.SegmentMissingOrDeleted } => NotFound(),
+            Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+            _ => Conflict()
+        };
     }
 
     /// <summary>
@@ -206,6 +212,7 @@ public class SegmentsController(
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPost("Episode/{itemId}/Segments/{segmentId}/Restore")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<SegmentDto>> RestoreSegment(
         [FromRoute] Guid itemId,
@@ -217,14 +224,17 @@ public class SegmentsController(
             return NotFound();
         }
 
-        var restored = await _mediaSegmentEditorService
-            .RestoreSegmentAsync(itemId, segmentId, cancellationToken)
-            .ConfigureAwait(false);
-        if (restored is null)
+        var outcome = await _segmentChange.ApplyAsync(new RestoreSegmentIntent(itemId, segmentId), cancellationToken).ConfigureAwait(false);
+        return outcome switch
         {
-            return NotFound();
-        }
-
-        return Ok(SegmentDto.FromDbSegment(restored));
+            Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+            Accepted accepted => Ok(SegmentChangeHttp.ToDto(AssertSingle(accepted.AffectedValues))),
+            Ignored { Reason: SegmentChangeIgnoredReason.SegmentMissingOrNotSuppressed } => NotFound(),
+            Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+            _ => Conflict()
+        };
     }
+
+    private static SegmentValue AssertSingle(IReadOnlyList<SegmentValue> values)
+        => values.Count == 1 ? values[0] : throw new InvalidOperationException("A single affected segment was expected.");
 }

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -12,8 +12,10 @@ using IntroSkipper.Data;
 using IntroSkipper.Db;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
+using IntroSkipper.SegmentChanges;
 using MediaBrowser.Common.Api;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace IntroSkipper.Controllers;
@@ -25,15 +27,15 @@ namespace IntroSkipper.Controllers;
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 public partial class SkipIntroController(
-    MediaSegmentEditorService editorService,
     IMediaSegmentRefresher mediaSegmentRefresher,
     IDetectionCacheDatabase cacheDatabase,
-    IIntroSkipperDatabase database) : ControllerBase
+    IIntroSkipperDatabase database,
+    ISegmentChange segmentChange) : ControllerBase
 {
-    private readonly MediaSegmentEditorService _editorService = editorService;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IDetectionCacheDatabase _cacheDatabase = cacheDatabase;
     private readonly IIntroSkipperDatabase _database = database;
+    private readonly ISegmentChange _segmentChange = segmentChange;
 
     /// <summary>
     /// Updates the timestamps for the provided episode.
@@ -52,6 +54,8 @@ public partial class SkipIntroController(
     /// <returns>No content.</returns>
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPost("Episode/{Id}/Timestamps")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     public async Task<ActionResult> UpdateTimestampsAsync([FromRoute] Guid id, [FromBody] TimeStamps timestamps, CancellationToken cancellationToken = default)
     {
         // only update existing episodes
@@ -74,19 +78,25 @@ public partial class SkipIntroController(
             (AnalysisMode.Commercial, timestamps.Commercial)
         };
 
-        var segmentsByMode = new Dictionary<AnalysisMode, (long StartTicks, long EndTicks)>();
+        var valid = new List<UserTimestamp>();
         foreach (var (mode, segment) in segmentTypes)
         {
             // An empty or degenerate slot (end not after start) is skipped, not stored.
             if (TickConversions.TryFromSecondsRange(segment.Start, segment.End, out var startTicks, out var endTicks))
             {
-                segmentsByMode[mode] = (startTicks, endTicks);
+                valid.Add(new UserTimestamp(mode, startTicks, endTicks));
             }
         }
 
-        await _editorService.ReplaceUserSegmentsAsync(id, segmentsByMode, cancellationToken).ConfigureAwait(false);
-
-        return NoContent();
+        var outcome = await _segmentChange.ApplyAsync(new WriteUserTimestampsIntent(id, valid), cancellationToken).ConfigureAwait(false);
+        return outcome switch
+        {
+            Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+            Accepted _ => NoContent(),
+            Ignored { Reason: SegmentChangeIgnoredReason.NoValidUserTimestamps } => NoContent(),
+            Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+            _ => Conflict()
+        };
     }
 
     /// <summary>

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -13,6 +13,7 @@ using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
+using IntroSkipper.SegmentChanges;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
@@ -33,7 +34,7 @@ namespace IntroSkipper.Controllers;
 /// </remarks>
 /// <param name="logger">Logger.</param>
 /// <param name="mediaSegmentRefresher">Media segment refresher.</param>
-/// <param name="mediaSegmentEditorService">Media segment editor service; owns the disable-flag mutation end-to-end.</param>
+/// <param name="segmentChange">Durable segment change coordinator.</param>
 /// <param name="libraryManager">libraryManager.</param>
 /// <param name="analyzerFactory">Factory for per-run queue managers and analyzer tasks.</param>
 /// <param name="database">Segment database facade.</param>
@@ -42,11 +43,11 @@ namespace IntroSkipper.Controllers;
 [ApiController]
 [Produces(MediaTypeNames.Application.Json)]
 [Route("Intros")]
-public partial class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentRefresher mediaSegmentRefresher, MediaSegmentEditorService mediaSegmentEditorService, ILibraryManager libraryManager, AnalyzerTaskFactory analyzerFactory, IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase) : ControllerBase
+public partial class VisualizationController(ILogger<VisualizationController> logger, IMediaSegmentRefresher mediaSegmentRefresher, ISegmentChange segmentChange, ILibraryManager libraryManager, AnalyzerTaskFactory analyzerFactory, IIntroSkipperDatabase database, IDetectionCacheDatabase cacheDatabase) : ControllerBase
 {
     private readonly ILogger<VisualizationController> _logger = logger;
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
-    private readonly MediaSegmentEditorService _mediaSegmentEditorService = mediaSegmentEditorService;
+    private readonly ISegmentChange _segmentChange = segmentChange;
     private readonly ILibraryManager _libraryManager = libraryManager;
     private readonly AnalyzerTaskFactory _analyzerFactory = analyzerFactory;
     private readonly IIntroSkipperDatabase _database = database;
@@ -242,11 +243,12 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     /// <returns>No content.</returns>
     [HttpPut("DisabledItems/{ItemId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public Task<ActionResult> DisableItem([FromRoute] Guid itemId, CancellationToken cancellationToken = default)
     {
-        return SetItemDisabledAsync(itemId, disabled: true, cancellationToken);
+        return SetItemVisibilityAsync(itemId, disabled: true, cancellationToken);
     }
 
     /// <summary>
@@ -257,14 +259,15 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     /// <returns>No content.</returns>
     [HttpDelete("DisabledItems/{ItemId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType<SegmentChangeAcceptedResponse>(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public Task<ActionResult> EnableItem([FromRoute] Guid itemId, CancellationToken cancellationToken = default)
     {
-        return SetItemDisabledAsync(itemId, disabled: false, cancellationToken);
+        return SetItemVisibilityAsync(itemId, disabled: false, cancellationToken);
     }
 
-    private async Task<ActionResult> SetItemDisabledAsync(Guid itemId, bool disabled, CancellationToken cancellationToken)
+    private async Task<ActionResult> SetItemVisibilityAsync(Guid itemId, bool disabled, CancellationToken cancellationToken)
     {
         if (MediaItemHelper.FindSupported(itemId) is not { } item)
         {
@@ -273,9 +276,16 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
 
         try
         {
-            // The editor service owns the whole mutation as one per-item linearized
-            // unit: flag write, strict mirror resync, and flag rollback on failure.
-            await _mediaSegmentEditorService.SetItemDisabledAsync(item, disabled, cancellationToken).ConfigureAwait(false);
+            var outcome = await _segmentChange.ApplyAsync(
+                new SegmentVisibilityChangeIntent(itemId, SeasonStateKeyResolver.Resolve(item), Visible: !disabled), cancellationToken).ConfigureAwait(false);
+            return outcome switch
+            {
+                Accepted accepted when !SegmentChangeHttp.IsApplied(accepted) => SegmentChangeHttp.Accepted(accepted),
+                Accepted _ => NoContent(),
+                Ignored { Reason: SegmentChangeIgnoredReason.AlreadyHidden or SegmentChangeIgnoredReason.AlreadyVisible } => NoContent(),
+                Rejected rejected => SegmentChangeHttp.Rejected(rejected),
+                _ => Conflict()
+            };
         }
         catch (OperationCanceledException)
         {
@@ -283,14 +293,9 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
         }
         catch (Exception ex)
         {
-            // The service rolls the flag back on a mirror failure, but a failing rollback
-            // is logged there rather than thrown; do not promise a state the response
-            // cannot know.
             LogFailedToSetItemDisabled(_logger, ex, itemId, disabled);
-            return Problem("The media segment mirror could not be refreshed; the request was not applied. See the server log for the item's current state.", statusCode: StatusCodes.Status500InternalServerError);
+            return Problem("The segment visibility change could not be committed.", statusCode: StatusCodes.Status500InternalServerError);
         }
-
-        return NoContent();
     }
 
     private async Task<IReadOnlyList<QueuedEpisode>> GetExcludedInventoryAsync(Plugin plugin, CancellationToken cancellationToken)
@@ -402,6 +407,6 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
     [LoggerMessage(Level = LogLevel.Error, Message = "Error during manual season rescan for {SeasonId}")]
     private static partial void LogRescanError(ILogger logger, Exception ex, Guid seasonId);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to refresh media segments while setting item {ItemId} disabled={Disabled}")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to commit segment visibility for item {ItemId} disabled={Disabled}")]
     private static partial void LogFailedToSetItemDisabled(ILogger logger, Exception ex, Guid itemId, bool disabled);
 }

--- a/IntroSkipper/Data/SegmentChangeAcceptedResponse.cs
+++ b/IntroSkipper/Data/SegmentChangeAcceptedResponse.cs
@@ -6,5 +6,5 @@ namespace IntroSkipper.Data;
 /// <summary>Wire response for an authoritative change whose projection did not apply synchronously.</summary>
 /// <param name="ChangeId">Durable change identifier.</param>
 /// <param name="ChangeStatus">Authoritative change status.</param>
-/// <param name="ProjectionStatus">Projection status at response time.</param>
-public sealed record SegmentChangeAcceptedResponse(Guid ChangeId, string ChangeStatus, string ProjectionStatus);
+/// <param name="Projections">Per-item projection status at response time.</param>
+public sealed record SegmentChangeAcceptedResponse(Guid ChangeId, string ChangeStatus, IReadOnlyList<SegmentProjectionAcceptedResponse> Projections);

--- a/IntroSkipper/Data/SegmentChangeAcceptedResponse.cs
+++ b/IntroSkipper/Data/SegmentChangeAcceptedResponse.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Data;
+
+/// <summary>Wire response for an authoritative change whose projection did not apply synchronously.</summary>
+/// <param name="ChangeId">Durable change identifier.</param>
+/// <param name="ChangeStatus">Authoritative change status.</param>
+/// <param name="ProjectionStatus">Projection status at response time.</param>
+public sealed record SegmentChangeAcceptedResponse(Guid ChangeId, string ChangeStatus, string ProjectionStatus);

--- a/IntroSkipper/Data/SegmentProjectionAcceptedResponse.cs
+++ b/IntroSkipper/Data/SegmentProjectionAcceptedResponse.cs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Data;
+
+/// <summary>Wire projection status for one accepted item.</summary>
+/// <param name="ItemId">Projected item ID.</param>
+/// <param name="Status">Stable projection status token.</param>
+public sealed record SegmentProjectionAcceptedResponse(Guid ItemId, string Status);

--- a/IntroSkipper/SegmentChanges/EditorDeleteSegmentIntent.cs
+++ b/IntroSkipper/SegmentChanges/EditorDeleteSegmentIntent.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Intro-Skipper contributors <intro-skipper.org>
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Database.Implementations.Enums;
+
+namespace IntroSkipper.SegmentChanges;
+
+/// <summary>Deletes an editor-addressed segment using shared-id or exact external fallback semantics.</summary>
+/// <param name="ItemId">Owning item ID.</param>
+/// <param name="SegmentId">Editor-visible segment ID.</param>
+/// <param name="ExpectedType">Type supplied by the editor.</param>
+public sealed record EditorDeleteSegmentIntent(Guid ItemId, Guid SegmentId, MediaSegmentType ExpectedType) : SegmentChangeIntent(ItemId);

--- a/IntroSkipper/SegmentChanges/Ignored.cs
+++ b/IntroSkipper/SegmentChanges/Ignored.cs
@@ -6,4 +6,14 @@ namespace IntroSkipper.SegmentChanges;
 /// <summary>The intent already held and no transaction was needed.</summary>
 /// <param name="Reason">Typed no-change reason.</param>
 /// <param name="Message">Human-readable reason.</param>
-public sealed record Ignored(SegmentChangeIgnoredReason Reason, string Message) : SegmentChangeOutcome;
+/// <param name="AffectedValues">Existing authoritative values relevant to the no-op.</param>
+public sealed record Ignored(SegmentChangeIgnoredReason Reason, string Message, IReadOnlyList<SegmentValue> AffectedValues) : SegmentChangeOutcome
+{
+    /// <summary>Initializes a new instance of the <see cref="Ignored"/> class without a response value.</summary>
+    /// <param name="reason">Typed no-change reason.</param>
+    /// <param name="message">Human-readable reason.</param>
+    public Ignored(SegmentChangeIgnoredReason reason, string message)
+        : this(reason, message, [])
+    {
+    }
+}

--- a/IntroSkipper/SegmentChanges/MutationResult.cs
+++ b/IntroSkipper/SegmentChanges/MutationResult.cs
@@ -9,7 +9,8 @@ namespace IntroSkipper.SegmentChanges;
 /// <param name="ExternalOperations">Exact external operations to journal.</param>
 internal sealed record MutationResult(SegmentChangeOutcome? Outcome, IReadOnlyList<SegmentValue> Affected, IReadOnlyList<ProjectedExternalOperation> ExternalOperations)
 {
-    internal static MutationResult Ignore(SegmentChangeIgnoredReason reason, string message) => new(new Ignored(reason, message), [], []);
+    internal static MutationResult Ignore(SegmentChangeIgnoredReason reason, string message, IReadOnlyList<SegmentValue>? affected = null)
+        => new(new Ignored(reason, message, affected ?? []), [], []);
 
     internal static MutationResult Reject(SegmentChangeRejectedReason reason, string message) => new(new Rejected(reason, message), [], []);
 }

--- a/IntroSkipper/SegmentChanges/SegmentChange.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChange.cs
@@ -35,6 +35,11 @@ internal sealed partial class SegmentChange(
             return new Rejected(SegmentChangeRejectedReason.EmptyItemId, "Item ID must not be empty.");
         }
 
+        if (Validate(intent) is { } rejection)
+        {
+            return rejection;
+        }
+
         ExternalSegmentTarget? externalTarget = null;
         if (intent is DeleteExternalSegmentIntent external)
         {
@@ -43,6 +48,11 @@ internal sealed partial class SegmentChange(
             if (externalTarget is null)
             {
                 return new Rejected(SegmentChangeRejectedReason.ExternalSegmentNotFound, "External segment was not found.");
+            }
+
+            if (externalTarget.Id != external.ExternalSegmentId)
+            {
+                return new Rejected(SegmentChangeRejectedReason.ExternalIdMismatch, "Resolved external segment does not match the addressed ID.");
             }
 
             if (externalTarget.ItemId != external.ItemId)
@@ -56,16 +66,24 @@ internal sealed partial class SegmentChange(
             }
         }
 
-        if (Validate(intent) is { } rejection)
-        {
-            return rejection;
-        }
-
         await database.InitializeAsync().ConfigureAwait(false);
         var changeId = Guid.CreateVersion7();
         IReadOnlyList<SegmentValue> affected;
         {
             using var itemLock = await _locks.AcquireAsync(intent.ItemId, cancellationToken).ConfigureAwait(false);
+            if (intent is EditorDeleteSegmentIntent editorDelete)
+            {
+                using var lookup = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+                var correlated = await lookup.Segments.AsNoTracking().AnyAsync(
+                    value => value.ItemId == editorDelete.ItemId && value.Id == editorDelete.SegmentId,
+                    cancellationToken).ConfigureAwait(false);
+                if (!correlated)
+                {
+                    externalTarget = await adapter.ResolveExternalTargetAsync(
+                        editorDelete.ItemId, editorDelete.SegmentId, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
             using (var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false))
             {
                 var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -472,7 +490,8 @@ internal sealed partial class SegmentChange(
             DeleteSegmentIntent value when value.SegmentId == Guid.Empty => new(SegmentChangeRejectedReason.EmptySegmentId, "Segment ID must not be empty."),
             RestoreSegmentIntent value when value.SegmentId == Guid.Empty => new(SegmentChangeRejectedReason.EmptySegmentId, "Segment ID must not be empty."),
             DeleteExternalSegmentIntent value when value.ExternalSegmentId == Guid.Empty || AnalysisHelpers.TryMapSegmentTypeToMode(value.ExpectedType) is null => new(SegmentChangeRejectedReason.InvalidExternalIdOrType, "Invalid external segment ID or type."),
-            WriteUserTimestampsIntent value when value.Timestamps is null || value.Timestamps.Count == 0 || value.Timestamps.Any(timestamp => !ValidMode(timestamp.Mode) || !ValidRange(timestamp.StartTicks, timestamp.EndTicks)) || value.Timestamps.Select(timestamp => timestamp.Mode).Distinct().Count() != value.Timestamps.Count => new(SegmentChangeRejectedReason.InvalidUserTimestamps, "User timestamps must contain unique supported modes and valid ranges."),
+            EditorDeleteSegmentIntent value when value.SegmentId == Guid.Empty || AnalysisHelpers.TryMapSegmentTypeToMode(value.ExpectedType) is null => new(SegmentChangeRejectedReason.InvalidExternalIdOrType, "Invalid segment ID or type."),
+            WriteUserTimestampsIntent value when value.Timestamps is null || value.Timestamps.Any(timestamp => !ValidMode(timestamp.Mode) || !ValidRange(timestamp.StartTicks, timestamp.EndTicks)) || value.Timestamps.Select(timestamp => timestamp.Mode).Distinct().Count() != value.Timestamps.Count => new(SegmentChangeRejectedReason.InvalidUserTimestamps, "User timestamps must contain unique supported modes and valid ranges."),
             SegmentVisibilityChangeIntent value when value.SeasonId == Guid.Empty => new(SegmentChangeRejectedReason.EmptySeasonId, "Season ID must not be empty."),
             _ => null
         };
@@ -491,7 +510,7 @@ internal sealed partial class SegmentChange(
                     var exact = rows.FirstOrDefault(row => row.Type == value.Mode && row.StartTicks == value.StartTicks && row.EndTicks == value.EndTicks);
                     if (exact is { Source: SegmentSource.User, State: SegmentState.Active })
                     {
-                        return MutationResult.Ignore(SegmentChangeIgnoredReason.UserSegmentAlreadyExists, "The user segment already exists.");
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.UserSegmentAlreadyExists, "The user segment already exists.", [ToValue(exact)]);
                     }
 
                     exact ??= new DbSegment(value.ItemId, value.Mode, value.StartTicks, value.EndTicks, SegmentSource.User);
@@ -513,7 +532,7 @@ internal sealed partial class SegmentChange(
                     var active = rows.Where(row => row.Type == value.Mode && row.State == SegmentState.Active).ToList();
                     if (active.Count == requested.Count && active.All(row => row.Source == SegmentSource.User && requested.Contains(new SegmentRange(row.StartTicks, row.EndTicks))))
                     {
-                        return MutationResult.Ignore(SegmentChangeIgnoredReason.UserImageAlreadyExists, "The requested user image already exists.");
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.UserImageAlreadyExists, "The requested user image already exists.", active.Select(ToValue).ToList());
                     }
 
                     db.Segments.RemoveRange(active);
@@ -546,7 +565,7 @@ internal sealed partial class SegmentChange(
 
                     if (row.StartTicks == value.StartTicks && row.EndTicks == value.EndTicks && row.Source == SegmentSource.User)
                     {
-                        return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentAlreadyHasValues, "The segment already has the requested values.");
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentAlreadyHasValues, "The segment already has the requested values.", [ToValue(row)]);
                     }
 
                     var occupant = rows.FirstOrDefault(item => item.Id != row.Id && item.Type == row.Type && item.StartTicks == value.StartTicks && item.EndTicks == value.EndTicks);
@@ -632,8 +651,86 @@ internal sealed partial class SegmentChange(
                     break;
                 }
 
+            case EditorDeleteSegmentIntent value:
+                {
+                    var mode = AnalysisHelpers.TryMapSegmentTypeToMode(value.ExpectedType)!.Value;
+                    var correlated = rows.FirstOrDefault(row => row.Id == value.SegmentId);
+                    if (correlated is not null)
+                    {
+                        if (correlated.State != SegmentState.Active)
+                        {
+                            return MutationResult.Ignore(SegmentChangeIgnoredReason.SegmentMissingOrDeleted, "Segment was already deleted.");
+                        }
+
+                        if (correlated.Type != mode)
+                        {
+                            return MutationResult.Reject(SegmentChangeRejectedReason.ExternalTypeMismatch, "Segment type does not match the expected type.");
+                        }
+
+                        if (correlated.Source == SegmentSource.User)
+                        {
+                            db.Segments.Remove(correlated);
+                        }
+                        else
+                        {
+                            correlated.State = SegmentState.Suppressed;
+                        }
+
+                        affected.Add(ToValue(correlated));
+                        await DeriveAnalyzedItemAsync(db, rows, value.ItemId, mode, cancellationToken).ConfigureAwait(false);
+                        break;
+                    }
+
+                    if (externalTarget is null)
+                    {
+                        return MutationResult.Reject(SegmentChangeRejectedReason.ExternalSegmentNotFound, "External segment was not found.");
+                    }
+
+                    if (externalTarget.Id != value.SegmentId)
+                    {
+                        return MutationResult.Reject(SegmentChangeRejectedReason.ExternalIdMismatch, "Resolved external segment does not match the addressed ID.");
+                    }
+
+                    if (externalTarget.ItemId != value.ItemId)
+                    {
+                        return MutationResult.Reject(SegmentChangeRejectedReason.ExternalItemMismatch, "External segment belongs to another item.");
+                    }
+
+                    if (externalTarget.Type != value.ExpectedType)
+                    {
+                        return MutationResult.Reject(SegmentChangeRejectedReason.ExternalTypeMismatch, "External segment type does not match the expected type.");
+                    }
+
+                    var match = rows.FirstOrDefault(row => row.Type == mode
+                        && row.StartTicks == externalTarget.StartTicks
+                        && row.EndTicks == externalTarget.EndTicks
+                        && row.State == SegmentState.Active);
+                    if (match is not null)
+                    {
+                        if (match.Source == SegmentSource.User)
+                        {
+                            db.Segments.Remove(match);
+                        }
+                        else
+                        {
+                            match.State = SegmentState.Suppressed;
+                        }
+
+                        affected.Add(ToValue(match));
+                    }
+
+                    externalOperations.Add(new ProjectedExternalOperation(value.SegmentId, value.ExpectedType, ProjectionExternalOperationKind.Delete));
+                    await DeriveAnalyzedItemAsync(db, rows, value.ItemId, mode, cancellationToken).ConfigureAwait(false);
+                    break;
+                }
+
             case WriteUserTimestampsIntent value:
                 {
+                    if (value.Timestamps.Count == 0)
+                    {
+                        return MutationResult.Ignore(SegmentChangeIgnoredReason.NoValidUserTimestamps, "The payload contained no valid timestamp slots.");
+                    }
+
                     foreach (var timestamp in value.Timestamps)
                     {
                         var active = rows.Where(row => row.Type == timestamp.Mode && row.State == SegmentState.Active).ToList();

--- a/IntroSkipper/SegmentChanges/SegmentChangeIgnoredReason.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChangeIgnoredReason.cs
@@ -25,5 +25,8 @@ public enum SegmentChangeIgnoredReason
     AlreadyVisible,
 
     /// <summary>The item is already hidden.</summary>
-    AlreadyHidden
+    AlreadyHidden,
+
+    /// <summary>The timestamp payload contained no valid slots.</summary>
+    NoValidUserTimestamps
 }

--- a/IntroSkipper/SegmentChanges/SegmentChangeRejectedReason.cs
+++ b/IntroSkipper/SegmentChanges/SegmentChangeRejectedReason.cs
@@ -33,6 +33,9 @@ public enum SegmentChangeRejectedReason
     /// <summary>The external segment has another type.</summary>
     ExternalTypeMismatch,
 
+    /// <summary>The resolved external target is not the exact addressed row.</summary>
+    ExternalIdMismatch,
+
     /// <summary>The user timestamp set is invalid.</summary>
     InvalidUserTimestamps,
 

--- a/web/src/store/api.ts
+++ b/web/src/store/api.ts
@@ -10,6 +10,7 @@ import type {
     LibraryStorage,
     SystemStorageInfo,
     ClearExcludedTimestampsResponse,
+    SegmentChangeAcceptedResponse,
 } from "../types.ts";
 
 const PLUGIN_ID = "c83d86bb-a1e0-4c35-a113-e2101cf4ee6b";
@@ -116,24 +117,24 @@ export function getEpisodeSegments(
 export function createEpisodeSegment(
     itemId: string,
     body: SegmentCreateRequest,
-): Promise<ApiResult<SegmentDto>> {
-    return request<SegmentDto>(`Episode/${encodeURIComponent(itemId)}/Segments`, "POST", body);
+): Promise<ApiResult<SegmentDto | SegmentChangeAcceptedResponse>> {
+    return request<SegmentDto | SegmentChangeAcceptedResponse>(`Episode/${encodeURIComponent(itemId)}/Segments`, "POST", body);
 }
 
 export function updateEpisodeSegment(
     itemId: string,
     segmentId: string,
     body: SegmentUpdateRequest,
-): Promise<ApiResult<SegmentDto>> {
-    return request<SegmentDto>(
+): Promise<ApiResult<SegmentDto | SegmentChangeAcceptedResponse>> {
+    return request<SegmentDto | SegmentChangeAcceptedResponse>(
         `Episode/${encodeURIComponent(itemId)}/Segments/${encodeURIComponent(segmentId)}`,
         "PUT",
         body,
     );
 }
 
-export function deleteEpisodeSegment(itemId: string, segmentId: string): Promise<ApiResult<null>> {
-    return request<null>(
+export function deleteEpisodeSegment(itemId: string, segmentId: string): Promise<ApiResult<null | SegmentChangeAcceptedResponse>> {
+    return request<null | SegmentChangeAcceptedResponse>(
         `Episode/${encodeURIComponent(itemId)}/Segments/${encodeURIComponent(segmentId)}`,
         "DELETE",
     );
@@ -142,8 +143,8 @@ export function deleteEpisodeSegment(itemId: string, segmentId: string): Promise
 export function restoreEpisodeSegment(
     itemId: string,
     segmentId: string,
-): Promise<ApiResult<SegmentDto>> {
-    return request<SegmentDto>(
+): Promise<ApiResult<SegmentDto | SegmentChangeAcceptedResponse>> {
+    return request<SegmentDto | SegmentChangeAcceptedResponse>(
         `Episode/${encodeURIComponent(itemId)}/Segments/${encodeURIComponent(segmentId)}/Restore`,
         "POST",
     );
@@ -170,8 +171,8 @@ export function getDisabledItems(seasonId: string): Promise<ApiResult<string[]>>
     return getJson<string[]>(`Intros/DisabledItems/${encodeURIComponent(seasonId)}`);
 }
 
-export function setItemDisabled(itemId: string, disabled: boolean): Promise<ApiResult<null>> {
-    return request<null>(
+export function setItemDisabled(itemId: string, disabled: boolean): Promise<ApiResult<null | SegmentChangeAcceptedResponse>> {
+    return request<null | SegmentChangeAcceptedResponse>(
         `Intros/DisabledItems/${encodeURIComponent(itemId)}`,
         disabled ? "PUT" : "DELETE",
     );

--- a/web/src/tabs/timestamp-data.ts
+++ b/web/src/tabs/timestamp-data.ts
@@ -54,6 +54,6 @@ export async function getDisabledItemIds(seasonId: string): Promise<string[] | n
     return result.ok && result.data ? result.data : null;
 }
 
-export function setItemDisabled(itemId: string, disabled: boolean): Promise<ApiResult<null>> {
+export function setItemDisabled(itemId: string, disabled: boolean): ReturnType<typeof api.setItemDisabled> {
     return api.setItemDisabled(itemId, disabled);
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -122,6 +122,12 @@ export type SegmentUpdateRequest = {
     End: number;
 };
 
+export type SegmentChangeAcceptedResponse = {
+    ChangeId: string;
+    ChangeStatus: "Accepted";
+    ProjectionStatus: "Pending" | "Skipped";
+};
+
 export type ScanStatus = {
     isRunning: boolean;
 };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -125,7 +125,10 @@ export type SegmentUpdateRequest = {
 export type SegmentChangeAcceptedResponse = {
     ChangeId: string;
     ChangeStatus: "Accepted";
-    ProjectionStatus: "Pending" | "Skipped";
+    Projections: Array<{
+        ItemId: string;
+        Status: "Applied" | "Pending" | "Skipped";
+    }>;
 };
 
 export type ScanStatus = {


### PR DESCRIPTION
## Summary

- route plural segment CRUD, the external Segment Editor wire contract, singular timestamp writes, and per-item visibility changes through `ISegmentChange`
- add one semantic editor-delete intent that handles correlated stable IDs and exact uncorrelated fallback without controller-side database/Jellyfin choreography
- preserve existing applied response shapes while returning a typed `202 Accepted` payload when authority commits but projection is pending or intentionally skipped
- replace visibility and deletion rollback behavior with authoritative accepted-plus-pending semantics
- expose typed rejection/no-change reasons to transport adapters and update dashboard request types for 202 responses

## Stack discipline

This PR cuts over interactive callers only. Analyzer, reset, cleanup, and scheduled-task writers remain on their current paths for the next stack layer.

## Testing

- `dotnet test --no-restore --verbosity minimal` — 608 passed
- restored controller regression suites — 48 passed
- web build through the normal project target
- `git diff --check`
- controller mutation static gate

## Summary by Sourcery

Route interactive segment mutations through the durable change coordinator and report authoritative commits separately from projection completion.

New Features:
- Route interactive segment creation, updates, deletion, restoration, timestamp writes, and item visibility changes through the durable segment-change workflow.
- Add a unified editor-delete intent supporting correlated IDs and validated exact-match external fallbacks.
- Expose structured accepted responses with per-item applied, pending, or skipped projection status.

Bug Fixes:
- Preserve authoritative segment and visibility changes when external projection fails instead of rolling them back.
- Return typed rejection and no-change outcomes for invalid, missing, mismatched, or duplicate segment mutations.

Enhancements:
- Centralize controller mutation behavior behind ISegmentChange while preserving existing synchronous response shapes.
- Update dashboard API types to support accepted asynchronous mutation responses.

Tests:
- Expand controller and segment-change coverage for correlated and uncorrelated deletes, projection failures, pending mutations, visibility changes, and structured HTTP responses.

Chores:
- Keep analyzer, reset, cleanup, and scheduled-task writers on their existing mutation paths for the next migration layer.