### PR TITLE
Filter media queueing by requested seasons and movies

### DIFF
--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -86,7 +86,14 @@ public sealed class TestQueueManager
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
         var plugin = Plugin.Instance!;
         EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration());
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+        var existingSeasonId = Guid.NewGuid();
+        var existingQueue = new ConcurrentDictionary<Guid, List<QueuedEpisode>>
+        {
+            [existingSeasonId] = [new QueuedEpisode { EpisodeId = Guid.NewGuid(), SeasonId = existingSeasonId }]
+        };
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", existingQueue);
+        plugin.TotalQueued = 1;
+        plugin.TotalSeasons = 1;
 
         var seriesId = Guid.NewGuid();
         var targetSeasonId = Guid.NewGuid();
@@ -115,6 +122,10 @@ public sealed class TestQueueManager
         Assert.Equal(targetEpisode.Id, queuedEpisode.EpisodeId);
         Assert.DoesNotContain(otherSeasonId, queue.Keys);
         Assert.DoesNotContain(movie.Id, queue.Keys);
+        Assert.True(plugin.QueuedMediaItems.ContainsKey(existingSeasonId));
+        Assert.DoesNotContain(targetSeasonId, plugin.QueuedMediaItems.Keys);
+        Assert.Equal(1, plugin.TotalQueued);
+        Assert.Equal(1, plugin.TotalSeasons);
     }
 
     private static Episode CreateEpisode(Guid episodeId, Guid seriesId, Guid seasonId)
@@ -172,17 +183,15 @@ public sealed class TestQueueManager
             var query = args?.OfType<InternalItemsQuery>().SingleOrDefault();
             if (query?.AncestorIds is { Length: > 0 })
             {
-                return _items
-                    .Where(item => item is Episode episode && query.AncestorIds.Contains(episode.SeasonId))
-                    .ToList();
+                return [.. _items.Where(item => item is Episode episode && query.AncestorIds.Contains(episode.SeasonId))];
             }
 
             if (query?.ItemIds is { Length: > 0 })
             {
-                return _items.Where(item => query.ItemIds.Contains(item.Id)).ToList();
+                return [.. _items.Where(item => query.ItemIds.Contains(item.Id))];
             }
 
-            return new List<BaseItem>(_items);
+            return [.. _items];
         }
     }
 }

--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -120,6 +120,7 @@ public sealed class TestQueueManager
         var specialsSeasonId = Guid.NewGuid();
         var host = CreateEpisode(Guid.NewGuid(), seriesId, hostSeasonId);
         var special = CreateEpisode(Guid.NewGuid(), seriesId, specialsSeasonId);
+        special.ParentIndexNumber = 0;
         special.AirsBeforeSeasonNumber = 1;
         special.Name = "Special";
 

--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -94,6 +94,7 @@ public sealed class TestQueueManager
         EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", existingQueue);
         plugin.TotalQueued = 1;
         plugin.TotalSeasons = 1;
+        EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
 
         var seriesId = Guid.NewGuid();
         var targetSeasonId = Guid.NewGuid();

--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -109,6 +109,31 @@ public sealed class TestQueueManager
         Assert.Equal(1, plugin.TotalSeasons);
     }
 
+    [Fact]
+    public async Task GetMediaItems_WithSeasonIds_IncludesInSeasonSpecials()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        InitializePlugin();
+
+        var seriesId = Guid.NewGuid();
+        var hostSeasonId = Guid.NewGuid();
+        var specialsSeasonId = Guid.NewGuid();
+        var host = CreateEpisode(Guid.NewGuid(), seriesId, hostSeasonId);
+        var special = CreateEpisode(Guid.NewGuid(), seriesId, specialsSeasonId);
+        special.AirsBeforeSeasonNumber = 1;
+        special.Name = "Special";
+
+        var queueManager = CreateQueueManager(host, special);
+
+        var queue = await queueManager.GetMediaItems([hostSeasonId]);
+
+        var season = Assert.Single(queue);
+        Assert.Equal(hostSeasonId, season.Key);
+        Assert.Equal(2, season.Value.Count);
+        Assert.All(season.Value, episode => Assert.Equal(hostSeasonId, episode.SeasonId));
+        Assert.Contains(season.Value, episode => episode.EpisodeId == special.Id);
+    }
+
     private static Plugin InitializePlugin(
         ConcurrentDictionary<Guid, List<QueuedEpisode>>? queuedMediaItems = null,
         int totalQueued = 0,
@@ -188,6 +213,13 @@ public sealed class TestQueueManager
         private List<BaseItem> GetItems(object?[]? args)
         {
             var query = args?.OfType<InternalItemsQuery>().SingleOrDefault();
+            if (query?.ParentIndexNumber == 0 && query.AncestorIds is { Length: > 0 })
+            {
+                return [.. _items.Where(item => item is Episode episode &&
+                    episode.ParentIndexNumber == query.ParentIndexNumber &&
+                    query.AncestorIds.Contains(episode.SeriesId))];
+            }
+
             if (query?.AncestorIds is { Length: > 0 })
             {
                 return [.. _items.Where(item => item is Episode episode && query.AncestorIds.Contains(episode.SeasonId))];

--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -26,10 +26,7 @@ public sealed class TestQueueManager
     public async Task GetMediaItems_QueuesRegularEpisodeAndMovie_AndPublishesQueueState()
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
-        var plugin = Plugin.Instance!;
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration());
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
-        EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
+        var plugin = InitializePlugin();
 
         var seriesId = Guid.Parse("11111111-1111-1111-1111-111111111111");
         var seasonId = Guid.Parse("22222222-2222-2222-2222-222222222222");
@@ -44,13 +41,7 @@ public sealed class TestQueueManager
             RunTimeTicks = TimeSpan.FromMinutes(4).Ticks,
         };
 
-        var queueManager = new QueueManager(
-            NullLogger<QueueManager>.Instance,
-            QueueLibraryManager.Create([NewFolder("Media")], [episode, movie]),
-            providerManager: null!,
-            fileSystem: null!,
-            ffmpegService: null!,
-            DatabaseTestHelpers.CreateTempSegmentDatabase());
+        var queueManager = CreateQueueManager(episode, movie);
 
         var queue = await queueManager.GetMediaItems();
 
@@ -84,17 +75,12 @@ public sealed class TestQueueManager
     public async Task GetMediaItems_WithSeasonIds_DoesNotQueueUnrelatedItems()
     {
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
-        var plugin = Plugin.Instance!;
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration());
         var existingSeasonId = Guid.NewGuid();
         var existingQueue = new ConcurrentDictionary<Guid, List<QueuedEpisode>>
         {
             [existingSeasonId] = [new QueuedEpisode { EpisodeId = Guid.NewGuid(), SeasonId = existingSeasonId }]
         };
-        EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", existingQueue);
-        plugin.TotalQueued = 1;
-        plugin.TotalSeasons = 1;
-        EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
+        var plugin = InitializePlugin(existingQueue, totalQueued: 1, totalSeasons: 1);
 
         var seriesId = Guid.NewGuid();
         var targetSeasonId = Guid.NewGuid();
@@ -109,13 +95,7 @@ public sealed class TestQueueManager
             RunTimeTicks = TimeSpan.FromMinutes(4).Ticks,
         };
 
-        var queueManager = new QueueManager(
-            NullLogger<QueueManager>.Instance,
-            QueueLibraryManager.Create([NewFolder("Media")], [targetEpisode, otherEpisode, movie]),
-            providerManager: null!,
-            fileSystem: null!,
-            ffmpegService: null!,
-            DatabaseTestHelpers.CreateTempSegmentDatabase());
+        var queueManager = CreateQueueManager(targetEpisode, otherEpisode, movie);
 
         var queue = await queueManager.GetMediaItems([targetSeasonId]);
 
@@ -128,6 +108,32 @@ public sealed class TestQueueManager
         Assert.Equal(1, plugin.TotalQueued);
         Assert.Equal(1, plugin.TotalSeasons);
     }
+
+    private static Plugin InitializePlugin(
+        ConcurrentDictionary<Guid, List<QueuedEpisode>>? queuedMediaItems = null,
+        int totalQueued = 0,
+        int totalSeasons = 0)
+    {
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration());
+        EntrypointTestHelpers.SetPropertyOrField(
+            plugin,
+            "QueuedMediaItems",
+            queuedMediaItems ?? new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+        EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", EntrypointTestHelpers.CreateLibraryManager());
+        plugin.TotalQueued = totalQueued;
+        plugin.TotalSeasons = totalSeasons;
+        return plugin;
+    }
+
+    private static QueueManager CreateQueueManager(params BaseItem[] items)
+        => new(
+            NullLogger<QueueManager>.Instance,
+            QueueLibraryManager.Create([NewFolder("Media")], [.. items]),
+            providerManager: null!,
+            fileSystem: null!,
+            ffmpegService: null!,
+            DatabaseTestHelpers.CreateTempSegmentDatabase());
 
     private static Episode CreateEpisode(Guid episodeId, Guid seriesId, Guid seasonId)
     {

--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -6,6 +6,7 @@ namespace IntroSkipper.Tests;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;

--- a/IntroSkipper.Tests/TestQueueManager.cs
+++ b/IntroSkipper.Tests/TestQueueManager.cs
@@ -79,6 +79,43 @@ public sealed class TestQueueManager
         Assert.Equal(movieId, Assert.Single(plugin.QueuedMediaItems[movieId]).EpisodeId);
     }
 
+    [Fact]
+    public async Task GetMediaItems_WithSeasonIds_DoesNotQueueUnrelatedItems()
+    {
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration());
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "QueuedMediaItems", new ConcurrentDictionary<Guid, List<QueuedEpisode>>());
+
+        var seriesId = Guid.NewGuid();
+        var targetSeasonId = Guid.NewGuid();
+        var otherSeasonId = Guid.NewGuid();
+        var targetEpisode = CreateEpisode(Guid.NewGuid(), seriesId, targetSeasonId);
+        var otherEpisode = CreateEpisode(Guid.NewGuid(), seriesId, otherSeasonId);
+        var movie = new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = "Unrelated feature",
+            Path = "/media/unrelated.mkv",
+            RunTimeTicks = TimeSpan.FromMinutes(4).Ticks,
+        };
+
+        var queueManager = new QueueManager(
+            NullLogger<QueueManager>.Instance,
+            QueueLibraryManager.Create([NewFolder("Media")], [targetEpisode, otherEpisode, movie]),
+            providerManager: null!,
+            fileSystem: null!,
+            ffmpegService: null!,
+            DatabaseTestHelpers.CreateTempSegmentDatabase());
+
+        var queue = await queueManager.GetMediaItems([targetSeasonId]);
+
+        var queuedEpisode = Assert.Single(queue[targetSeasonId]);
+        Assert.Equal(targetEpisode.Id, queuedEpisode.EpisodeId);
+        Assert.DoesNotContain(otherSeasonId, queue.Keys);
+        Assert.DoesNotContain(movie.Id, queue.Keys);
+    }
+
     private static Episode CreateEpisode(Guid episodeId, Guid seriesId, Guid seasonId)
     {
         var episode = new Episode
@@ -123,10 +160,28 @@ public sealed class TestQueueManager
             return targetMethod?.Name switch
             {
                 nameof(ILibraryManager.GetVirtualFolders) => _folders,
-                nameof(ILibraryManager.GetItemList) => new List<BaseItem>(_items),
+                nameof(ILibraryManager.GetItemList) => GetItems(args),
                 nameof(ILibraryManager.GetItemById) => null,
                 _ => throw new NotImplementedException(targetMethod?.Name),
             };
+        }
+
+        private List<BaseItem> GetItems(object?[]? args)
+        {
+            var query = args?.OfType<InternalItemsQuery>().SingleOrDefault();
+            if (query?.AncestorIds is { Length: > 0 })
+            {
+                return _items
+                    .Where(item => item is Episode episode && query.AncestorIds.Contains(episode.SeasonId))
+                    .ToList();
+            }
+
+            if (query?.ItemIds is { Length: > 0 })
+            {
+                return _items.Where(item => query.ItemIds.Contains(item.Id)).ToList();
+            }
+
+            return new List<BaseItem>(_items);
         }
     }
 }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -63,7 +63,18 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
     public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
-        => GetMediaItems(includeExcluded: false, cancellationToken);
+        => GetMediaItems(includeExcluded: false, seasonIds: null, cancellationToken);
+
+    /// <summary>
+    /// Gets media items belonging to the specified seasons or movies.
+    /// </summary>
+    /// <param name="seasonIds">Season IDs and movie IDs to enqueue.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Queued media items.</returns>
+    public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(
+        IReadOnlyCollection<Guid> seasonIds,
+        CancellationToken cancellationToken = default)
+        => GetMediaItems(includeExcluded: false, seasonIds, cancellationToken);
 
     // Per-run memo on top of the service's success-only memoization: while ffmpeg is
     // invalid the service re-probes every call, so cache the verdict here to keep an
@@ -81,6 +92,12 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     }
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
+        => await GetMediaItems(includeExcluded, seasonIds: null, cancellationToken).ConfigureAwait(false);
+
+    private async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(
+        bool includeExcluded,
+        IReadOnlyCollection<Guid>? seasonIds,
+        CancellationToken cancellationToken)
     {
         _enumerationFailures = 0;
 
@@ -98,7 +115,12 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         LoadAnalysisSettings(plugin);
 
-        // For all selected libraries, enqueue all contained episodes.
+        if (seasonIds is { Count: 0 })
+        {
+            return _queuedEpisodes;
+        }
+
+        // For selected libraries, enqueue either all contained items or only the requested seasons/movies.
         var virtualFolders = _libraryManager.GetVirtualFolders();
         if (virtualFolders is null)
         {
@@ -125,7 +147,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
             try
             {
-                await QueueLibraryContents(folderId, includeExcluded, cancellationToken).ConfigureAwait(false);
+                await QueueLibraryContents(folderId, includeExcluded, seasonIds, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -182,7 +204,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
     }
 
-    private async Task QueueLibraryContents(Guid id, bool includeExcluded, CancellationToken cancellationToken)
+    private async Task QueueLibraryContents(
+        Guid id,
+        bool includeExcluded,
+        IReadOnlyCollection<Guid>? seasonIds,
+        CancellationToken cancellationToken)
     {
         LogConstructingQuery(_logger);
 
@@ -196,9 +222,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             IsVirtualItem = false
         };
 
-        var items = _libraryManager.GetItemList(query, false)
-            .DistinctBy(e => e.Id)
-            .ToList();
+        var items = seasonIds is null
+            ? _libraryManager.GetItemList(query, false)
+            : GetScopedLibraryItems(id, seasonIds);
 
         if (items is null)
         {
@@ -206,11 +232,15 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return;
         }
 
+        var distinctItems = items
+            .DistinctBy(e => e.Id)
+            .ToList();
+
         // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
 
         var queuedCount = 0;
-        foreach (var item in items)
+        foreach (var item in distinctItems)
         {
             try
             {
@@ -247,6 +277,34 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
 
         LogQueuedEpisodes(_logger, queuedCount);
+    }
+
+    private IEnumerable<BaseItem> GetScopedLibraryItems(Guid libraryId, IReadOnlyCollection<Guid> seasonIds)
+    {
+        var targetIds = seasonIds.ToArray();
+
+        var episodeQuery = new InternalItemsQuery
+        {
+            ParentId = libraryId,
+            AncestorIds = targetIds,
+            OrderBy = [(ItemSortBy.SeriesSortName, SortOrder.Ascending), (ItemSortBy.ParentIndexNumber, SortOrder.Descending), (ItemSortBy.IndexNumber, SortOrder.Ascending)],
+            IncludeItemTypes = [BaseItemKind.Episode],
+            Recursive = true,
+            IsVirtualItem = false
+        };
+
+        var movieQuery = new InternalItemsQuery
+        {
+            ParentId = libraryId,
+            ItemIds = targetIds,
+            OrderBy = [(ItemSortBy.SeriesSortName, SortOrder.Ascending), (ItemSortBy.ParentIndexNumber, SortOrder.Descending), (ItemSortBy.IndexNumber, SortOrder.Ascending)],
+            IncludeItemTypes = [BaseItemKind.Movie],
+            Recursive = true,
+            IsVirtualItem = false
+        };
+
+        return _libraryManager.GetItemList(episodeQuery, false)
+            .Concat(_libraryManager.GetItemList(movieQuery, false));
     }
 
     private async Task<bool> QueueEpisode(Episode episode, bool includeExcluded, CancellationToken cancellationToken)

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -63,7 +63,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
     public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
-        => GetMediaItems(includeExcluded: false, seasonIds: null, cancellationToken);
+        => GetMediaItems(includeExcluded: false, seasonIds: null, publishQueue: true, cancellationToken);
 
     /// <summary>
     /// Gets media items belonging to the specified seasons or movies.
@@ -74,7 +74,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(
         IReadOnlyCollection<Guid> seasonIds,
         CancellationToken cancellationToken = default)
-        => GetMediaItems(includeExcluded: false, seasonIds, cancellationToken);
+        => GetMediaItems(includeExcluded: false, seasonIds, publishQueue: false, cancellationToken);
 
     // Per-run memo on top of the service's success-only memoization: while ffmpeg is
     // invalid the service re-probes every call, so cache the verdict here to keep an
@@ -92,11 +92,12 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     }
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
-        => await GetMediaItems(includeExcluded, seasonIds: null, cancellationToken).ConfigureAwait(false);
+        => await GetMediaItems(includeExcluded, seasonIds: null, publishQueue: !includeExcluded, cancellationToken).ConfigureAwait(false);
 
     private async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(
         bool includeExcluded,
         IReadOnlyCollection<Guid>? seasonIds,
+        bool publishQueue,
         CancellationToken cancellationToken)
     {
         _enumerationFailures = 0;
@@ -108,7 +109,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return _queuedEpisodes;
         }
 
-        if (!includeExcluded)
+        if (publishQueue)
         {
             plugin.TotalQueued = 0;
         }
@@ -147,7 +148,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
             try
             {
-                await QueueLibraryContents(folderId, includeExcluded, seasonIds, cancellationToken).ConfigureAwait(false);
+                await QueueLibraryContents(folderId, includeExcluded, seasonIds, publishQueue, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -165,7 +166,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             LogRefreshedMetadata(_logger, _refreshedEpisodes.Count);
         }
 
-        if (!includeExcluded)
+        if (publishQueue)
         {
             plugin.TotalSeasons = _queuedEpisodes.Count;
             plugin.QueuedMediaItems.Clear();
@@ -208,6 +209,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         Guid id,
         bool includeExcluded,
         IReadOnlyCollection<Guid>? seasonIds,
+        bool publishQueue,
         CancellationToken cancellationToken)
     {
         LogConstructingQuery(_logger);
@@ -246,14 +248,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             {
                 if (item is Episode episode)
                 {
-                    if (await QueueEpisode(episode, includeExcluded, cancellationToken).ConfigureAwait(false))
+                    if (await QueueEpisode(episode, includeExcluded, publishQueue, cancellationToken).ConfigureAwait(false))
                     {
                         queuedCount++;
                     }
                 }
                 else if (item is Movie movie)
                 {
-                    if (await QueueMovieAsync(movie, includeExcluded, cancellationToken).ConfigureAwait(false))
+                    if (await QueueMovieAsync(movie, includeExcluded, publishQueue, cancellationToken).ConfigureAwait(false))
                     {
                         queuedCount++;
                     }
@@ -307,7 +309,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             .Concat(_libraryManager.GetItemList(movieQuery, false));
     }
 
-    private async Task<bool> QueueEpisode(Episode episode, bool includeExcluded, CancellationToken cancellationToken)
+    private async Task<bool> QueueEpisode(
+        Episode episode,
+        bool includeExcluded,
+        bool publishQueue,
+        CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
@@ -371,7 +377,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             CreditsFingerprintEnd = creditsDuration,
         });
 
-        if (!includeExcluded)
+        if (publishQueue)
         {
             pluginInstance.TotalQueued++;
         }
@@ -400,7 +406,11 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return episode.DateCreated != default ? episode.DateCreated : episode.DateLastSaved;
     }
 
-    private async Task<bool> QueueMovieAsync(Movie movie, bool includeExcluded, CancellationToken cancellationToken)
+    private async Task<bool> QueueMovieAsync(
+        Movie movie,
+        bool includeExcluded,
+        bool publishQueue,
+        CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
@@ -440,7 +450,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             IsExcluded = decision.IsExcluded,
         });
 
-        if (!includeExcluded)
+        if (publishQueue)
         {
             pluginInstance.TotalQueued++;
         }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -234,9 +234,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return;
         }
 
-        var distinctItems = items
-            .DistinctBy(e => e.Id)
-            .ToList();
+        List<BaseItem> distinctItems = [.. items.DistinctBy(e => e.Id)];
 
         // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
@@ -283,7 +281,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     private IEnumerable<BaseItem> GetScopedLibraryItems(Guid libraryId, IReadOnlyCollection<Guid> seasonIds)
     {
-        var targetIds = seasonIds.ToArray();
+        Guid[] targetIds = [.. seasonIds];
 
         var episodeQuery = new InternalItemsQuery
         {
@@ -308,7 +306,40 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         // Match the unscoped path, which treats a null GetItemList result as an empty library.
         var episodes = _libraryManager.GetItemList(episodeQuery, false) ?? [];
         var movies = _libraryManager.GetItemList(movieQuery, false) ?? [];
-        return episodes.Concat(movies);
+
+        // In-season specials are stored beneath their own raw SeasonId, but belong to the season
+        // identified by AirsBefore/AirsAfterSeasonNumber. Query only specials from the series that
+        // supplied the requested season episodes, then filter them to those resolved season keys.
+        HashSet<(Guid SeriesId, int SeasonNumber)> targetSeasonKeys =
+        [
+            .. episodes
+                .OfType<Episode>()
+                .Where(episode => episode.SeriesId != Guid.Empty && episode.AiredSeasonNumber is not null)
+                .Select(episode => (episode.SeriesId, episode.AiredSeasonNumber!.Value))
+        ];
+
+        IEnumerable<BaseItem> specials = [];
+        if (targetSeasonKeys.Count > 0)
+        {
+            Guid[] seriesIds = [.. targetSeasonKeys.Select(key => key.SeriesId).Distinct()];
+            var specialQuery = new InternalItemsQuery
+            {
+                ParentId = libraryId,
+                AncestorIds = seriesIds,
+                ParentIndexNumber = 0,
+                OrderBy = [(ItemSortBy.SeriesSortName, SortOrder.Ascending), (ItemSortBy.ParentIndexNumber, SortOrder.Descending), (ItemSortBy.IndexNumber, SortOrder.Ascending)],
+                IncludeItemTypes = [BaseItemKind.Episode],
+                Recursive = true,
+                IsVirtualItem = false
+            };
+
+            specials = (_libraryManager.GetItemList(specialQuery, false) ?? [])
+                .Where(item => item is Episode episode &&
+                    episode.AiredSeasonNumber is int airedSeasonNumber &&
+                    targetSeasonKeys.Contains((episode.SeriesId, airedSeasonNumber)));
+        }
+
+        return episodes.Concat(specials).Concat(movies);
     }
 
     private async Task<bool> QueueEpisode(

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -305,8 +305,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             IsVirtualItem = false
         };
 
-        return _libraryManager.GetItemList(episodeQuery, false)
-            .Concat(_libraryManager.GetItemList(movieQuery, false));
+        // Match the unscoped path, which treats a null GetItemList result as an empty library.
+        var episodes = _libraryManager.GetItemList(episodeQuery, false) ?? [];
+        var movies = _libraryManager.GetItemList(movieQuery, false) ?? [];
+        return episodes.Concat(movies);
     }
 
     private async Task<bool> QueueEpisode(

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -90,7 +90,9 @@ public partial class BaseItemAnalyzerTask(
         var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var ffmpegValid = await queueManager.GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
 
-        var queue = await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false);
+        var queue = seasonFilter is null
+            ? await queueManager.GetMediaItems(cancellationToken).ConfigureAwait(false)
+            : await queueManager.GetMediaItems(seasonFilter, cancellationToken).ConfigureAwait(false);
 
         if (seasonFilter is not null)
         {


### PR DESCRIPTION
## Summary by Sourcery

Filter scheduled media analysis to the requested seasons and movies without replacing the existing queue.

New Features:
- Support queueing only the requested seasons and movies while including applicable in-season specials.

Bug Fixes:
- Prevent filtered analysis runs from altering the existing published queue state and aggregate counters.

Enhancements:
- Pass season filters through scheduled analysis and distinguish filtered runs from full queue refreshes.

Tests:
- Add coverage for season and movie filtering, queue-state preservation, and in-season specials.