### PR TITLE
Accept legacy pre-stream-selection rows in HasCachedFingerprint

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -655,6 +655,40 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
+    public void HasCachedFingerprint_ReturnsTrueForLegacyPreStreamSelectionEntry()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            IntroFingerprintEnd = 600,
+        };
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(cacheDir);
+
+        using (var db = new DetectionCacheDbContext(scope.CacheDbPath))
+        {
+            // Row written by a release without audio stream selection: its ConfigHash carries
+            // no audio tokens. It must still count as a cached fingerprint so already-analyzed
+            // episodes can rejoin the Chromaprint comparison pool after an upgrade.
+            db.DetectionCache.Add(new DbDetectionCache(
+                episode.EpisodeId,
+                AnalysisMode.Introduction,
+                CacheEntryType.Chromaprint,
+                EntrypointTestHelpers.EmptyJsonArray,
+                0,
+                600,
+                ConfigHasher.LegacyChromaprintCacheWithoutLanguage(new PluginConfiguration(), AnalysisMode.Introduction)));
+            db.SaveChanges();
+        }
+
+        using (var cachingScope = new CachingPluginScope(cacheDir, scope.CacheDbPath))
+        {
+            Assert.True(cachingScope.CacheService.HasCachedFingerprint(episode, AnalysisMode.Introduction));
+        }
+    }
+
+    [Fact]
     public void HasCachedFingerprint_Credits_ReturnsTrueForMatchingEntry()
     {
         var episode = new QueuedEpisode

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -144,9 +144,15 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
                 return false;
             }
 
-            var expectedHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), CacheEntryType.Chromaprint, mode);
+            var config = Plugin.Instance?.Configuration ?? new();
+            var expectedHash = ConfigHasher.DetectionCache(config, CacheEntryType.Chromaprint, mode);
+
+            // Pre-stream-selection rows are accepted optimistically, like stream-scoped hashes:
+            // whether the effective stream still matches is only decided at read time, and a
+            // mismatch there just refingerprints the episode.
             return string.IsNullOrEmpty(entry.ConfigHash)
                 || string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal)
+                || string.Equals(entry.ConfigHash, ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, mode), StringComparison.Ordinal)
                 || ConfigHasher.IsStreamScopedDetectionCacheHash(entry.ConfigHash);
         }
         catch (DbException ex)


### PR DESCRIPTION
## Summary

Follow-up to #904. That fix made `TryRead` accept pre-stream-selection Chromaprint rows on the default-stream path, but `HasCachedFingerprint` still rejected them: a legacy `ConfigHash` (no audio tokens) matches neither the current expected hash nor the `audio-stream-v1|` prefix, so it returned `false`.

`ChromaprintAnalyzer.AnalyzeMediaFiles` uses `HasCachedFingerprint` to decide which already-analyzed episodes rejoin the comparison pool. On an upgraded server whose cache predates audio stream selection, every analyzed episode was excluded, so a newly added episode could only be compared against its ±1-number neighbors instead of the whole cached season — the exact reuse #904 set out to restore.

## Changes

- `HasCachedFingerprint` now also accepts `ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, mode)`. Acceptance is optimistic, mirroring the existing stream-scoped (`audio-stream-v1|`) handling: whether the effective stream still matches is decided at read time by `TryRead`, and a mismatch there just refingerprints the episode.
- Regression test inserting a row with the legacy hash and asserting `HasCachedFingerprint` returns `true`.

## Testing

- `dotnet test` — 495 passed, 0 failed.

## Summary by Sourcery

Preserve reuse of legacy Chromaprint fingerprints when checking cached analysis results.

Bug Fixes:
- Allow HasCachedFingerprint to recognize legacy pre-stream-selection Chromaprint cache entries so previously analyzed episodes remain eligible for comparison after upgrades.

Tests:
- Add regression coverage for legacy pre-stream-selection cache entries.