### PR TITLE
Stop re-analysing the whole library after a settings save

### DIFF
--- a/IntroSkipper.Tests/TestAnalysisConfigHash.cs
+++ b/IntroSkipper.Tests/TestAnalysisConfigHash.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Helper;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+/// <summary>
+/// The per-season config hash is the only thing that retires stale automatic segments, so every
+/// setting an analyzer reads has to change the hash of the mode it affects. These tests cover the
+/// settings that are named for one mode but change the result of another, which is where that
+/// property is easiest to break.
+/// </summary>
+public sealed class TestAnalysisConfigHash
+{
+    private static string Hash(PluginConfiguration config, AnalysisMode mode)
+        => ConfigHasher.Analysis(config, mode, AnalyzerAction.Default, ffmpegValid: true);
+
+    [Theory]
+    [InlineData(AnalysisMode.Introduction)]
+    [InlineData(AnalysisMode.Credits)]
+    public void MinimumIntroDuration_ChangesHash_ForEveryModeChromaprintAppliesItTo(AnalysisMode mode)
+    {
+        // ChromaprintAnalyzer.GetMinimumRegionDuration feeds MinimumIntroDuration to every mode except
+        // Recap, so raising it has to invalidate credits as well as introductions.
+        var before = new PluginConfiguration { MinimumIntroDuration = 15 };
+        var after = new PluginConfiguration { MinimumIntroDuration = 30 };
+
+        Assert.NotEqual(Hash(before, mode), Hash(after, mode));
+    }
+
+    [Fact]
+    public void MinimumIntroDuration_DoesNotChangeRecapHash()
+    {
+        // Recap uses a fixed card duration instead, so folding the setting in would retire recaps for
+        // a change that cannot affect them.
+        var before = new PluginConfiguration { MinimumIntroDuration = 15 };
+        var after = new PluginConfiguration { MinimumIntroDuration = 30 };
+
+        Assert.Equal(Hash(before, AnalysisMode.Recap), Hash(after, AnalysisMode.Recap));
+    }
+
+    [Theory]
+    [InlineData(AnalysisMode.Credits)]
+    [InlineData(AnalysisMode.Preview)]
+    public void AnimePreviewFromCreditsEnd_ChangesHash_ForBothModesItProduces(AnalysisMode mode)
+    {
+        // The setting is read while analyzing Credits but writes a Preview segment, so turning it off
+        // has to invalidate the previews it created.
+        var before = new PluginConfiguration { AnimePreviewFromCreditsEnd = true };
+        var after = new PluginConfiguration { AnimePreviewFromCreditsEnd = false };
+
+        Assert.NotEqual(Hash(before, mode), Hash(after, mode));
+    }
+
+    [Fact]
+    public void AnalyzerAction_ChangesHash()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Chapter, ffmpegValid: true));
+    }
+}

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -139,7 +139,7 @@ public sealed class TestEntrypointEvents
     }
 
     [Fact]
-    public void OnSettingsChanged_UpdatesConfig_AndSetsAnalyzeAgain()
+    public void OnSettingsChanged_UpdatesConfig()
     {
         var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
 
@@ -147,15 +147,11 @@ public sealed class TestEntrypointEvents
 
         using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
         {
-            // Ensure AnalyzeAgain starts false.
-            var plugin = Plugin.Instance!;
-            plugin.AnalyzeAgain = false;
-
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnSettingsChanged", (BasePluginConfiguration)newConfig);
-
-            Assert.True(plugin.AnalyzeAgain);
         }
 
+        // A save records the new configuration and nothing else. Reanalysis is driven by the
+        // per-season config hash, which is durable and therefore survives an interrupted run.
         var storedConfig = (PluginConfiguration)EntrypointTestHelpers.GetPrivateField(entrypoint, "_config");
         Assert.Same(newConfig, storedConfig);
     }

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
@@ -14,6 +15,7 @@ using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -830,6 +832,299 @@ public sealed class TestSeasonReanalysisReset
                 File.Delete(mediaPath);
             }
 
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyQueueAsync_DoesNotRedoSeasonsAlreadyAnalyzedUnderCurrentSettings()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var currentHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true);
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Default,
+                    [episodeId],
+                    "stale-hash"));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+
+                // A settings change leaves the season carrying a stale hash, so it is queued for work.
+                var beforeAnalysis = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+                Assert.Equal(EpisodeState.NotAnalyzed, beforeAnalysis.Single().GetAnalyzed(AnalysisMode.Introduction));
+
+                // The analyzer records the new hash for every season it finishes, so a run interrupted
+                // after this point must not queue the season again.
+                await Plugin.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeId], currentHash);
+
+                var afterAnalysis = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+                Assert.Equal(EpisodeState.NoSegments, afterAnalysis.Single().GetAnalyzed(AnalysisMode.Introduction));
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+    [Fact]
+    public async Task VerifyQueueAsync_IgnoresSettingsSave_WhenStoredHashStillMatches()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var currentHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true);
+
+        // Built before the plugin scope: the constructor requires Plugin.Instance to be null.
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Default,
+                    [episodeId],
+                    currentHash));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                // Saving settings that leave every hash untouched must not requeue anything. This is
+                // the whole-library rescan users reported after changing a cosmetic setting, and the
+                // process-wide flag that caused it is also what made an interrupted run unresumable.
+                EntrypointTestHelpers.InvokePrivate(
+                    entrypoint,
+                    "OnSettingsChanged",
+                    (MediaBrowser.Model.Plugins.BasePluginConfiguration)config);
+
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+
+                var verified = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+
+                Assert.Equal(EpisodeState.NoSegments, verified.Single().GetAnalyzed(AnalysisMode.Introduction));
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyQueueAsync_KeepsChromaprintResults_WhenTheProbeReportsUnavailable()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var withChromaprintHash = ConfigHasher.Analysis(
+            config,
+            AnalysisMode.Introduction,
+            AnalyzerAction.Default,
+            ffmpegValid: true);
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Default,
+                    [episodeId],
+                    withChromaprintHash));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                // The probe reports false for a genuinely incapable ffmpeg and for a one-off failure to
+                // launch it alike, so losing chromaprint must never discard results produced with it.
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: false));
+
+                var verified = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+
+                Assert.Equal(EpisodeState.NoSegments, verified.Single().GetAnalyzed(AnalysisMode.Introduction));
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeItemsAsync_RecordsConfigHash_WhenAnalyzerActionIsNone()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var noneHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.None, ffmpegValid: true);
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                await Plugin.SetAnalyzerActionAsync(
+                    seasonId,
+                    new Dictionary<AnalysisMode, AnalyzerAction>
+                    {
+                        [AnalysisMode.Introduction] = AnalyzerAction.None,
+                    });
+
+                var analyzer = new BaseItemAnalyzerTask(
+                    NullLogger.Instance,
+                    NullLoggerFactory.Instance,
+                    libraryManager: null!,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    mediaSegmentRefresher: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true),
+                    cacheService: null!);
+
+                var episode = CreateQueuedEpisode(episodeId, seasonId);
+                var method = typeof(BaseItemAnalyzerTask).GetMethod(
+                    "AnalyzeItemsAsync",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(method);
+
+                var analyzed = await (Task<int>)method!.Invoke(
+                    analyzer,
+                    [plugin, (IReadOnlyList<QueuedEpisode>)[episode], AnalysisMode.Introduction, true, CancellationToken.None])!;
+                Assert.Equal(0, analyzed);
+            }
+
+            // The action is part of the hash, so a mode switched off must still record the new hash.
+            // Without it the season mismatches on every run forever: queued, skipped, never written.
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var state = await db.DbSeasonState.SingleAsync();
+                Assert.Equal(AnalyzerAction.None, state.Action);
+                Assert.Equal(noneHash, state.ConfigHash);
+                Assert.Equal(new[] { episodeId }, state.EpisodeIds);
+            }
+        }
+        finally
+        {
             DeleteSqliteFiles(dbPath);
         }
     }

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -185,11 +185,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     [HttpPost("Intros/EraseTimestamps")]
     public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false, CancellationToken cancellationToken = default)
     {
-        using var db = Plugin.CreateDbContext();
-        await db.DbSegment
-            .Where(s => s.Type == mode)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        await Plugin.EraseTimestampsForModeAsync(mode, cancellationToken).ConfigureAwait(false);
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {

--- a/IntroSkipper/Data/AnalysisReason.cs
+++ b/IntroSkipper/Data/AnalysisReason.cs
@@ -15,13 +15,6 @@ public enum AnalysisReason
     None,
 
     /// <summary>
-    /// A plugin configuration save set the force-reanalysis flag, which overrides stored state for
-    /// the rest of the server process. Applies to every saved setting, including settings that do
-    /// not affect analysis output.
-    /// </summary>
-    SettingsSaved,
-
-    /// <summary>
     /// The stored analysis configuration hash no longer matches the computed one. Caused by a changed
     /// setting or by a change in Chromaprint availability, which is folded into the hash for the
     /// Introduction, Credits, and Recap modes.

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -19,6 +19,13 @@ public static class ConfigHasher
     /// <param name="config">Plugin configuration.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="action">Analyzer priority/action used for the season.</param>
+    /// <remarks>
+    /// Two settings are folded into a mode other than the one they are named for, because that is where
+    /// they change the result: <see cref="PluginConfiguration.MinimumIntroDuration"/> is the minimum
+    /// shared-region duration Chromaprint applies to Credits as well, and
+    /// <see cref="PluginConfiguration.AnimePreviewFromCreditsEnd"/> is what creates anime Preview
+    /// segments. Leaving either out means turning it off never retires the segments it produced.
+    /// </remarks>
     /// <param name="ffmpegValid">Whether the current FFmpeg build supports Chromaprint. Folded into the
     /// hash for Chromaprint-capable modes so a settled <see cref="EpisodeState.NoSegments"/> season is
     /// re-analyzed once when Chromaprint becomes available instead of being skipped forever.</param>
@@ -36,8 +43,9 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
-                $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v3|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
+                $"|minRegion={config.MinimumIntroDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfaltVersion=2{CreditsNonBlackToken(config)}",
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
@@ -52,7 +60,8 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Preview => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"analysis|v2|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"|animePreview={config.AnimePreviewFromCreditsEnd}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Commercial => Invariant(

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -465,10 +465,22 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 !string.IsNullOrEmpty(savedHash);
             var hashMatches = hasStoredHash && string.Equals(savedHash, expectedHash, StringComparison.Ordinal);
 
-            // Ordered by precedence. The force flag overrides stored state entirely, and a missing
-            // state row is reported instead of the hash comparison it would have lost anyway.
-            var reason = plugin.AnalyzeAgain ? AnalysisReason.SettingsSaved
-                : !hasStoredHash ? AnalysisReason.NoStoredState
+            // Chromaprint availability invalidates upward only. Gaining it reopens seasons that settled
+            // without it, which is why it is in the hash at all. Losing it must not: the probe reports
+            // false for a genuinely incapable build and for a one-off failure to launch ffmpeg alike,
+            // and discarding good results because a probe failed once re-analyzed whole libraries.
+            if (!hashMatches && !ffmpegValid && hasStoredHash)
+            {
+                var withChromaprint = ConfigHasher.Analysis(plugin.Configuration, mode, action, ffmpegValid: true);
+                if (string.Equals(savedHash, withChromaprint, StringComparison.Ordinal))
+                {
+                    hashMatches = true;
+                    expectedHash = withChromaprint;
+                }
+            }
+
+            // A missing state row is reported instead of the hash comparison it would have lost anyway.
+            var reason = !hasStoredHash ? AnalysisReason.NoStoredState
                 : !hashMatches ? AnalysisReason.ConfigHashChanged
                 : AnalysisReason.None;
 
@@ -510,15 +522,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                         var isUserProvided = snapshot.UserProvidedByMode.TryGetValue(mode, out var userProvided) &&
                                              userProvided.Contains(candidate.EpisodeId);
 
-                        // Always preserve user-provided segments. When AnalyzeAgain is true (settings
-                        // changed), leave automatically-analyzed segments as NotAnalyzed so they are
-                        // re-analyzed and their timestamps updated to reflect the new settings.
-                        if (isUserProvided || (!plugin.AnalyzeAgain && hashMatches))
+                        // Always preserve user-provided segments. Automatic ones are reusable only
+                        // while the stored hash still describes the current configuration.
+                        if (isUserProvided || hashMatches)
                         {
                             candidate.SetAnalyzed(mode, isUserProvided ? EpisodeState.UserProvided : EpisodeState.Analyzed);
                         }
                     }
-                    else if (!plugin.AnalyzeAgain && hashMatches &&
+                    else if (hashMatches &&
                              snapshot.EpisodeIdsByMode.TryGetValue(mode, out var ids) &&
                              ids.Contains(candidate.EpisodeId))
                     {
@@ -578,8 +589,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         {
             var state = stateByMode[mode];
 
-            // The analyzer never runs a mode the user switched off for this season, and already says so
-            // itself. Reporting a reason to analyze it would repeat on every run and never come true.
+            // Switching a mode off changes the hash, so the season is queued once to settle its new
+            // state and then skipped. The analyzer logs that skip itself, so announcing analysis that
+            // will not happen would only be confusing.
             if (state.Action == AnalyzerAction.None)
             {
                 continue;
@@ -591,7 +603,6 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             var (reason, level) = state.Reason switch
             {
                 AnalysisReason.None => (AnalysisReason.NotRecorded, LogLevel.Debug),
-                AnalysisReason.SettingsSaved => (AnalysisReason.SettingsSaved, LogLevel.Debug),
                 AnalysisReason.ConfigHashChanged => (AnalysisReason.ConfigHashChanged, LogLevel.Information),
                 _ => (state.Reason, LogLevel.Debug)
             };

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -130,11 +130,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public string CacheDbPath => _cacheDbPath;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to analyze again.
-    /// </summary>
-    public bool AnalyzeAgain { get; set; }
-
-    /// <summary>
     /// Gets the most recent media item queue.
     /// </summary>
     public ConcurrentDictionary<Guid, List<QueuedEpisode>> QueuedMediaItems { get; } = new();
@@ -740,6 +735,50 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             // on this pass or a later one) instead of being stranded as NoSegments.
             var seasonStates = await db.DbSeasonState
                 .Where(s => s.SeasonId == seasonId && modeArray.Contains(s.Type))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var state in seasonStates)
+            {
+                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
+            }
+
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await transaction.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Deletes every stored segment for one analysis mode across the whole library and clears the
+    /// analyzed-episode lists that referenced them.
+    /// </summary>
+    /// <remarks>
+    /// Clearing the lists is what makes the erase recoverable. Leaving them in place would let
+    /// <c>VerifyQueueAsync</c> restore each episode as <see cref="EpisodeState.NoSegments"/> on the
+    /// next run, because the stored config hash still matches, so analysis would skip the mode and the
+    /// erased timestamps would never come back. Mirrors the per-season path in
+    /// <see cref="ResetSeasonForReanalysisAsync"/>.
+    /// </remarks>
+    /// <param name="mode">Analysis mode to erase.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    internal static async Task EraseTimestampsForModeAsync(AnalysisMode mode, CancellationToken cancellationToken = default)
+    {
+        using var db = CreateDbContext();
+        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await db.DbSegment
+                .Where(s => s.Type == mode)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var seasonStates = await db.DbSeasonState
+                .Where(s => s.Type == mode)
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -57,7 +57,13 @@ public partial class BaseItemAnalyzerTask(
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
-    private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+
+    /// <summary>
+    /// Gets the live plugin configuration. Jellyfin replaces the configuration object on save, so a
+    /// snapshot taken when the task was constructed would let this class stamp a hash computed from
+    /// the old settings while <c>VerifyQueueAsync</c> and the analyzers read the new ones.
+    /// </summary>
+    private static PluginConfiguration Config => Plugin.Instance?.Configuration ?? new PluginConfiguration();
 
     /// <summary>
     /// Analyze all media items on the server.
@@ -72,11 +78,11 @@ public partial class BaseItemAnalyzerTask(
         IReadOnlyCollection<Guid>? seasonsToAnalyze = null)
     {
         List<AnalysisMode> modes = [
-            .. _config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
+            .. Config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
         if (seasonsToAnalyze?.Count == 0)
@@ -120,7 +126,7 @@ public partial class BaseItemAnalyzerTask(
         int totalProcessed = 0;
         var options = new ParallelOptions
         {
-            MaxDegreeOfParallelism = Math.Max(1, _config.MaxParallelism),
+            MaxDegreeOfParallelism = Math.Max(1, Config.MaxParallelism),
             CancellationToken = cancellationToken
         };
 
@@ -143,13 +149,13 @@ public partial class BaseItemAnalyzerTask(
             // Reuses the cached fingerprints, so this only re-runs the comparison, not the decode.
             var utcNow = DateTime.UtcNow;
             var episodeIds = episodes.Select(e => e.EpisodeId).ToArray();
-            if (_config.ReanalyzeSettledSeasons &&
-                SeasonReanalysisPlanner.IsSettledForReanalysis(episodes, _config, utcNow))
+            if (Config.ReanalyzeSettledSeasons &&
+                SeasonReanalysisPlanner.IsSettledForReanalysis(episodes, Config, utcNow))
             {
                 settledResetModes = await GetSettleReanalysisModesAsync(first.SeasonId, episodeIds, modes, ffmpegValid, ct).ConfigureAwait(false);
                 if (settledResetModes.Count > 0)
                 {
-                    var resetModes = ExpandSettledResetModesForDerivedSegments(settledResetModes, _config.AnimePreviewFromCreditsEnd);
+                    var resetModes = ExpandSettledResetModesForDerivedSegments(settledResetModes, Config.AnimePreviewFromCreditsEnd);
                     LogReanalyzingSettledSeason(_logger, first.SeasonNumber, first.SeriesName, episodes.Count);
                     await Plugin.ResetSeasonForReanalysisAsync(first.SeasonId, episodeIds, resetModes, ct).ConfigureAwait(false);
                     foreach (var episode in episodes)
@@ -211,7 +217,7 @@ public partial class BaseItemAnalyzerTask(
                 throw;
             }
 
-            if (updateMediaSegments && _config.UpdateMediaSegments)
+            if (updateMediaSegments && Config.UpdateMediaSegments)
             {
                 await _mediaSegmentRefresher.RefreshAsync(episodes.Select(e => e.EpisodeId), ct).ConfigureAwait(false);
             }
@@ -221,7 +227,6 @@ public partial class BaseItemAnalyzerTask(
                 await Plugin.RecordSettleReanalysisAsync(first.SeasonId, completedSettledModes, episodeIds, ct).ConfigureAwait(false);
             }
         }).ConfigureAwait(false);
-        plugin.AnalyzeAgain = false;
     }
 
     private static async Task<IReadOnlyList<AnalysisMode>> GetSettleReanalysisModesAsync(
@@ -314,18 +319,30 @@ public partial class BaseItemAnalyzerTask(
         var isMovie = category == QueuedMediaCategory.Movie;
         var isAnime = category == QueuedMediaCategory.AnimeEpisode;
 
-        if (AnalysisEligibility.IsSeasonZeroOptedOut(first, _config))
+        if (AnalysisEligibility.IsSeasonZeroOptedOut(first, Config))
         {
             return 0;
         }
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
         var action = await Plugin.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
-        var configHash = ConfigHasher.Analysis(_config, mode, action, ffmpegValid);
+        var configHash = ConfigHasher.Analysis(Config, mode, action, ffmpegValid);
 
         if (action == AnalyzerAction.None)
         {
             LogSkippingNoneAction(_logger, mode, first.SeriesName, first.SeasonNumber);
+
+            // The action is part of the hash, so switching a mode off already invalidates the stored
+            // one. Record the new hash even though nothing was analyzed, or the season mismatches on
+            // every run forever: queued, skipped here, never written back. Existing segments stay put;
+            // switching the mode back on changes the hash again and re-analyzes them.
+            await Plugin.SetEpisodeIdsAsync(
+                first.SeasonId,
+                mode,
+                items.Select(i => i.EpisodeId),
+                configHash,
+                cancellationToken).ConfigureAwait(false);
+
             return 0;
         }
 
@@ -405,7 +422,7 @@ public partial class BaseItemAnalyzerTask(
                 PromoteAnalyzer(analyzers, static a => a is BlackFrameAnalyzer or CreditsBlackFrameAnalyzer);
                 break;
             default:
-                if (_config.PreferChromaprint && ffmpegValid)
+                if (Config.PreferChromaprint && ffmpegValid)
                 {
                     PromoteAnalyzer(analyzers, static a => a is ChromaprintAnalyzer);
                 }
@@ -422,7 +439,7 @@ public partial class BaseItemAnalyzerTask(
         }
 
         // For anime, optionally create a Preview segment from the end of credits to the end of the episode.
-        if (mode == AnalysisMode.Credits && isAnime && _config.AnimePreviewFromCreditsEnd)
+        if (mode == AnalysisMode.Credits && isAnime && Config.AnimePreviewFromCreditsEnd)
         {
             await CreateAnimePreviewFromCreditsAsync(plugin, items, cancellationToken).ConfigureAwait(false);
         }
@@ -480,7 +497,7 @@ public partial class BaseItemAnalyzerTask(
     /// Creates the configured black frame analyzer variant.
     /// </summary>
     /// <returns>A <see cref="BlackFrameAnalyzer"/> or <see cref="CreditsBlackFrameAnalyzer"/> based on configuration.</returns>
-    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => _config.UseAlternativeBlackFrameAnalyzer
+    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => Config.UseAlternativeBlackFrameAnalyzer
         ? new CreditsBlackFrameAnalyzer(_loggerFactory.CreateLogger<CreditsBlackFrameAnalyzer>(), _ffmpegService)
         : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>(), _ffmpegService);
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -313,14 +313,11 @@ namespace IntroSkipper.Services
             }
         }
 
+        // Settings that change analysis output are folded into the per-season config hash, so a save
+        // needs no reanalysis trigger of its own. The next run re-analyzes exactly the seasons whose
+        // stored hash no longer matches.
         private void OnSettingsChanged(object? sender, BasePluginConfiguration e)
-        {
-            _config = (PluginConfiguration)e;
-            if (Plugin.Instance is { } plugin)
-            {
-                plugin.AnalyzeAgain = true;
-            }
-        }
+            => _config = (PluginConfiguration)e;
 
         /// <summary>
         /// Start timer to debounce analyzing.


### PR DESCRIPTION
Stacked on #925. Review that first; this PR's diff is only the delta.

Merge #900 before or alongside this one, see Ordering below.

## Problem

Saving any plugin setting set a process-wide `AnalyzeAgain` flag that made the next run ignore every season's stored analysis hash, so a change as small as the skip button colour re-analysed the entire library. Users in #834 reporting "I didn't change any settings" meant they had not changed any *analysis* settings.

It was also cleared only after a fully successful pass, so cancelling the task or restarting mid-run left it set for the life of the process, and every later run redid everything again. That matches the report of stopping the task at 70% and watching it restart from zero.

## Solution

A process-wide boolean cannot represent per-season progress, so there is no correct lifecycle for it: leave it set and runs compound, clear it and pending work is dropped. The per-season config hash already is the durable record, and it is inherently resumable, so the flag is removed and the hash is the only thing that decides. Seasons finished under the new settings carry the new hash and are skipped; seasons not yet reached carry the old one and get picked up.

That makes the hash load-bearing, so this closes the gaps it had:

- `MinimumIntroDuration` is the minimum shared-region duration Chromaprint applies to Credits as well, but only the Introduction hash carried it, so changing it never re-analysed credits.
- `AnimePreviewFromCreditsEnd` creates anime Preview segments but sat only in the Credits hash, so turning it off never retired them.
- Erasing all timestamps for a mode deleted the segments but left the analysed-episode lists, so every episode came back as `NoSegments` on the next run and the timestamps never returned. It now clears the lists in the same transaction, matching the per-season path.
- A season whose analyzer action is `None` never recorded a hash, even though the action is part of it, so it mismatched on every run forever: queued, skipped, never written back.
- The task read a configuration snapshot taken when it was constructed while the queue and the analyzers read the live one, so a save mid-run made it stamp a hash the next run could never match.

Finally, Chromaprint availability now invalidates upward only. Gaining it still reopens seasons that settled without it, which is why it is in the hash, but losing it no longer discards anything. `CheckFFmpegVersionAsync` returns false both for a build without Chromaprint and for `unknown_error`, a failure to launch ffmpeg at all, and treating those alike turned one transient hiccup into two full library re-analyses. This is my leading candidate for #834 itself.

## Upgrade cost

Two hash tokens change, so Credits and Preview are re-analysed once on upgrade. The detection cache is untouched, so that recomputes rather than re-decodes.

## Ordering

Removing the flag takes away the (library-wide-rescan) workaround for episodes stranded by a transient analyzer failure. #900 is the real fix for that and is already green, so it should land before or alongside this.

Refs #834.

## Summary by Sourcery

Replace process-wide forced reanalysis with durable per-season configuration-hash tracking so settings changes reanalyze only affected work and interrupted runs resume correctly.

Bug Fixes:
- Prevent settings saves from triggering unnecessary whole-library reanalysis by relying on durable per-season configuration hashes.
- Ensure analysis hashes invalidate all affected modes, including credits, previews, and analyzer-action changes.
- Preserve valid Chromaprint results when availability checks fail or Chromaprint becomes unavailable.
- Make timestamp erasure clear associated analyzed-episode state so erased segments can be recreated.
- Record configuration hashes for disabled analyzer actions to prevent repeated requeueing.

Enhancements:
- Use the live plugin configuration throughout analysis tasks so settings changes are applied consistently during runs.
- Make analysis progress resumable after cancellation or interruption by removing the process-wide reanalysis flag.

Tests:
- Add coverage for cross-mode configuration hash invalidation, resumable season analysis, disabled analyzer actions, and Chromaprint availability behavior.