### PR TITLE
Allow intro start offset when snapping to episode start

### DIFF
--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -716,8 +716,8 @@ public sealed class TestDbSegmentStorage
             {
                 await db.Database.EnsureCreatedAsync();
                 db.DbSegment.AddRange(
-                    new DbSegment(new Segment(itemId, new TimeRange(0, 10)), AnalysisMode.Introduction),
-                    new DbSegment(new Segment(itemId, new TimeRange(20, 30)), AnalysisMode.Introduction, true));
+                    new DbSegment(new Segment(itemId, new TimeRange(0, 10)), AnalysisMode.Commercial),
+                    new DbSegment(new Segment(itemId, new TimeRange(20, 30)), AnalysisMode.Commercial, true));
                 await db.SaveChangesAsync();
             }
 
@@ -725,7 +725,7 @@ public sealed class TestDbSegmentStorage
             {
                 ConfigurePluginLogger(Plugin.Instance!);
                 EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
-                await Plugin.DeleteAutomaticTimestampAsync(itemId, AnalysisMode.Introduction);
+                await Plugin.DeleteAutomaticTimestampAsync(itemId, AnalysisMode.Commercial);
             }
 
             using (var db = new IntroSkipperDbContext(dbPath))

--- a/IntroSkipper.Tests/TestDbSegmentStorage.cs
+++ b/IntroSkipper.Tests/TestDbSegmentStorage.cs
@@ -701,6 +701,47 @@ public sealed class TestDbSegmentStorage
         }
     }
 
+    [Fact]
+    public async Task DeleteAutomaticTimestampAsync_PreservesUserProvidedSegments()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        var dbFileName = Guid.NewGuid().ToString("N") + ".db";
+        var dbPath = Path.Join(tempDir, dbFileName);
+        var itemId = Guid.NewGuid();
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSegment.AddRange(
+                    new DbSegment(new Segment(itemId, new TimeRange(0, 10)), AnalysisMode.Introduction),
+                    new DbSegment(new Segment(itemId, new TimeRange(20, 30)), AnalysisMode.Introduction, true));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                ConfigurePluginLogger(Plugin.Instance!);
+                EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
+                await Plugin.DeleteAutomaticTimestampAsync(itemId, AnalysisMode.Introduction);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var remaining = await db.DbSegment.SingleAsync();
+                Assert.True(remaining.IsUserProvided);
+                Assert.Equal(20, remaining.Start);
+                Assert.Equal(30, remaining.End);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
     private static async Task<bool> TableExistsAsync(IntroSkipperDbContext db, string tableName)
     {
         var connection = db.Database.GetDbConnection();

--- a/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
+++ b/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
@@ -80,6 +80,23 @@ public class TestTimeAdjustmentHelper
     }
 
     [Fact]
+    public async Task OffsetThatConsumesSnappedIntro_ReturnsInvalidSegment()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2;
+        cfg.IncludeIntroStartOffsetWhenSnapping = true;
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 1, End = 2 };
+
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
+
+        Assert.False(adjusted.Valid);
+        Assert.Equal(0, adjusted.Start);
+        Assert.Equal(0, adjusted.End);
+    }
+
+    [Fact]
     public async Task StartOffset_IsApplied_When_NotSnapping()
     {
         var (helper, cfg) = CreateHelper();

--- a/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
+++ b/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
@@ -33,13 +33,45 @@ public class TestTimeAdjustmentHelper
     }
 
     [Fact]
-    public async Task StartOffset_IsIgnored_When_SnappingToEpisodeStart()
+    public async Task StartOffset_IsApplied_When_SnappingToEpisodeStart()
     {
         var (helper, cfg) = CreateHelper();
         cfg.IntroStartOffset = 2; // user-configured offset
+        cfg.IncludeIntroStartOffsetWhenSnapping = true;
 
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
         var original = new Segment(episode.EpisodeId) { Start = 1.2, End = 10 };
+
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
+
+        Assert.Equal(2, adjusted.Start);
+        Assert.Equal(10, adjusted.End);
+    }
+
+    [Fact]
+    public async Task StartOffset_IsApplied_When_IntroStartsAtZero()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2;
+        cfg.IncludeIntroStartOffsetWhenSnapping = true;
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 0, End = 10 };
+
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
+
+        Assert.Equal(2, adjusted.Start);
+        Assert.Equal(10, adjusted.End);
+    }
+
+    [Fact]
+    public async Task StartOffset_IsNotApplied_When_SnappingAndOptionIsDisabled()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2;
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 0, End = 10 };
 
         var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
 

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -125,6 +125,11 @@ public partial class ChapterAnalyzer(
             // The helper is initialized with the current mode, so recap fallback segments
             // still receive the same mode-specific boundary adjustments as chapter matches.
             skipRange = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, skipRange, false, cancellationToken).ConfigureAwait(false);
+            if (!skipRange.Valid)
+            {
+                episode.SetAnalyzed(mode, EpisodeState.NoSegments);
+                continue;
+            }
 
             episode.SetAnalyzed(mode, EpisodeState.Analyzed);
             await Plugin.Instance!.UpdateTimestampAsync(skipRange, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -127,6 +127,7 @@ public partial class ChapterAnalyzer(
             skipRange = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, skipRange, false, cancellationToken).ConfigureAwait(false);
             if (!skipRange.Valid)
             {
+                await Plugin.DeleteAutomaticTimestampAsync(episode.EpisodeId, mode, cancellationToken).ConfigureAwait(false);
                 episode.SetAnalyzed(mode, EpisodeState.NoSegments);
                 continue;
             }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -176,6 +176,7 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
                 var adjustedIntro = await timeAdjustmentHelper.AdjustIntroTimesAsync(currentEpisode, intro, cancellationToken: cancellationToken).ConfigureAwait(false);
                 if (!adjustedIntro.Valid)
                 {
+                    await Plugin.DeleteAutomaticTimestampAsync(currentEpisode.EpisodeId, mode, cancellationToken).ConfigureAwait(false);
                     currentEpisode.SetAnalyzed(mode, EpisodeState.NoSegments);
                     continue;
                 }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -174,6 +174,12 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             if (seasonIntros.TryGetValue(currentEpisode.EpisodeId, out var intro))
             {
                 var adjustedIntro = await timeAdjustmentHelper.AdjustIntroTimesAsync(currentEpisode, intro, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (!adjustedIntro.Valid)
+                {
+                    currentEpisode.SetAnalyzed(mode, EpisodeState.NoSegments);
+                    continue;
+                }
+
                 currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
                 await Plugin.Instance!.UpdateTimestampAsync(adjustedIntro, mode, configHash: currentEpisode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
             }

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -70,6 +70,13 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
                 }
 
                 credit = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, credit, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (!credit.Valid)
+                {
+                    LogNoValidCreditsFound(episode.Name);
+                    episode.SetAnalyzed(mode, EpisodeState.NoSegments);
+                    continue;
+                }
+
                 LogFoundCredits(episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -73,6 +73,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
                 if (!credit.Valid)
                 {
                     LogNoValidCreditsFound(episode.Name);
+                    await Plugin.DeleteAutomaticTimestampAsync(episode.EpisodeId, mode, cancellationToken).ConfigureAwait(false);
                     episode.SetAnalyzed(mode, EpisodeState.NoSegments);
                     continue;
                 }

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -137,7 +137,11 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
         // Ensure start < end after all adjustments
         if (adjustedStart >= adjustedEnd)
         {
-            return new Segment(episode.EpisodeId) { Start = originalIntro.Start, End = originalIntro.End };
+            LogAdjustedStartAfterEnd(_logger, episode.EpisodeId, episode.Name, adjustedStart, adjustedEnd);
+
+            // The adjusted range is unusable, so do not restore the original range and silently
+            // discard a configured start offset. Return an invalid segment so callers can ignore it.
+            return new Segment(episode.EpisodeId);
         }
 
         LogAdjustedIntro(_logger, episode.EpisodeId, episode.Name, adjustedStart, adjustedEnd);
@@ -268,7 +272,7 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
     [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name}: No suitable silence found for intro end in range {Start}-{End}")]
     private static partial void LogNoSilenceFound(ILogger logger, Guid episodeId, string name, double start, double end);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: Adjusted start time {Start} >= end time {End}, reverting to original")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: Adjusted start time {Start} >= end time {End}, discarding segment")]
     private static partial void LogAdjustedStartAfterEnd(ILogger logger, Guid episodeId, string name, double start, double end);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name} adjusted intro: {Start} - {End}")]

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -83,13 +83,16 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
 
         if (snapToEpisodeStart)
         {
-            // When snapping to episode start, do NOT apply IntroStartOffset
+            // Snap the detected boundary first; IntroStartOffset is applied below so it also
+            // takes effect when the detected intro starts at (or near) the episode start.
             LogSnappingIntroStart(_logger, episode.EpisodeId, episode.Name, _config.EndSnapThreshold);
             adjustedStart = 0;
         }
-        else
+
+        // Apply the configured playback offset after all other start adjustments. Snapped starts
+        // are opt-in because the default behavior is to preserve the episode boundary.
+        if (!snapToEpisodeStart || _config.IncludeIntroStartOffsetWhenSnapping)
         {
-            // Apply configurable start offset only if we are not snapping to the episode start
             adjustedStart = Math.Clamp(adjustedStart + _config.IntroStartOffset, 0, duration);
         }
 
@@ -259,7 +262,7 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
     [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: Negative intro start {Start}, resetting to 0")]
     private static partial void LogNegativeIntroStart(ILogger logger, Guid episodeId, string name, double start);
 
-    [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name}: Snapping intro start to 0 (within threshold {Threshold}), skipping IntroStartOffset")]
+    [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name}: Snapping intro start to 0 (within threshold {Threshold})")]
     private static partial void LogSnappingIntroStart(ILogger logger, Guid episodeId, string name, double threshold);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name}: No suitable silence found for intro end in range {Start}-{End}")]

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -395,6 +395,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public int IntroStartOffset { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to apply <see cref="IntroStartOffset" /> when the
+    /// intro start is snapped to the beginning of the episode.
+    /// </summary>
+    public bool IncludeIntroStartOffsetWhenSnapping { get; set; }
+
     // ===== Internal algorithm settings =====
 
     /// <summary>

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -119,7 +119,7 @@ public static class ConfigHasher
             $"|chapAdjust={config.AdjustIntroBasedOnChapters}|silence={config.AdjustIntroBasedOnSilence}|keyframe={config.SnapToKeyframe}",
             $"|endSnap={config.EndSnapThreshold}|winIn={config.AdjustWindowInward}|winOut={config.AdjustWindowOutward}",
             $"|noise={config.SilenceDetectionMaximumNoise}|silDur={config.SilenceDetectionMinimumDuration}",
-            $"|startOffset={config.IntroStartOffset}|endOffset={config.IntroEndOffset}");
+            $"|startOffset={config.IntroStartOffset}|includeStartOffsetWhenSnapping={config.IncludeIntroStartOffsetWhenSnapping}|endOffset={config.IntroEndOffset}");
 
     private static string Invariant(params FormattableString[] parts)
         => string.Concat(parts.Select(FormattableString.Invariant));

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -724,7 +724,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         // Invalid rows can exist from older analysis runs where an offset collapsed a segment.
         // They must not make an episode look analyzed or appear in queue snapshots.
-        var segments = allSegments.Where(s => s.End > 0.0 && s.End > s.Start).ToList();
+        var segments = [.. allSegments.Where(s => s.End > 0.0 && s.End > s.Start)];
 
         return new SeasonQueueSnapshot(
             seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),
@@ -835,6 +835,26 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             db.DbSegment.RemoveRange(entries);
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Deletes all automatic timestamps for the specified item and analysis mode.
+    /// User-provided timestamps are preserved.
+    /// </summary>
+    /// <param name="itemId">The item id whose automatic timestamp should be removed.</param>
+    /// <param name="mode">The analysis mode representing the segment type.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    internal static async Task DeleteAutomaticTimestampAsync(
+        Guid itemId,
+        AnalysisMode mode,
+        CancellationToken cancellationToken = default)
+    {
+        using var db = CreateDbContext();
+        await db.DbSegment
+            .Where(s => s.ItemId == itemId && s.Type == mode && !s.IsUserProvided)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private void MigrateLegacyExcludeSeries()

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -724,7 +724,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         // Invalid rows can exist from older analysis runs where an offset collapsed a segment.
         // They must not make an episode look analyzed or appear in queue snapshots.
-        var segments = [.. allSegments.Where(s => s.End > 0.0 && s.End > s.Start)];
+        List<DbSegment> segments = [.. allSegments.Where(s => s.End > 0.0 && s.End > s.Start)];
 
         return new SeasonQueueSnapshot(
             seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -313,7 +313,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         using var db = CreateDbContext();
         var segments = await db.DbSegment
             .AsNoTracking()
-            .Where(s => s.ItemId == id)
+            .Where(s => s.ItemId == id && s.End > 0.0 && s.End > s.Start)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -548,7 +548,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 .Where(s => batch.Contains(s.ItemId)
                     && s.Type == mode
                     && !s.IsUserProvided
-                    && s.ConfigHash != configHash)
+                    && (s.ConfigHash != configHash || s.End <= 0.0 || s.End <= s.Start))
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -722,7 +722,9 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
                 .ConfigureAwait(false));
         }
 
-        var segments = allSegments;
+        // Invalid rows can exist from older analysis runs where an offset collapsed a segment.
+        // They must not make an episode look analyzed or appear in queue snapshots.
+        var segments = allSegments.Where(s => s.End > 0.0 && s.End > s.Start).ToList();
 
         return new SeasonQueueSnapshot(
             seasonStates.ToDictionary(s => s.Type, s => (IReadOnlySet<Guid>)s.EpisodeIds.ToHashSet()),

--- a/web/src/tabs/detection.ts
+++ b/web/src/tabs/detection.ts
@@ -96,6 +96,12 @@ export const detectionTab: Tab = {
                     description:
                         "Default: 0. Example: If set to 3, the first 3 seconds of the intro will play before skipping.",
                 }),
+                checkboxField({
+                    id: "IncludeIntroStartOffsetWhenSnapping",
+                    label: "Include start offset when snapping to episode start",
+                    description:
+                        "When enabled, Intro Start Offset is also applied when the detected intro start is snapped to the beginning of the episode.",
+                }),
                 numberField({
                     id: "IntroEndOffset",
                     label: "Intro End Offset (seconds)",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -69,6 +69,7 @@ export interface PluginConfig {
     SnapToKeyframe: boolean;
     AdjustIntroBasedOnSilence: boolean;
     AdjustIntroBasedOnChapters: boolean;
+    IncludeIntroStartOffsetWhenSnapping: boolean;
     UseFileTransformationPlugin: boolean;
 
     // Server-managed flag exposed to the dashboard.


### PR DESCRIPTION
Closes https://github.com/intro-skipper/intro-skipper/issues/929

## Summary by Sourcery

Allow users to apply the configured intro start offset to episode-start-snapped intros while safely discarding invalid automatic segments.

New Features:
- Add an option to apply the intro start offset when the detected intro boundary is snapped to the episode start.

Bug Fixes:
- Prevent invalid adjusted segments from being retained or treated as analyzed, while preserving user-provided timestamps when automatic segments are removed.
- Exclude invalid timestamp ranges from timestamp and queue results.

Enhancements:
- Include the new snapping behavior in analysis configuration hashing so changes trigger appropriate reprocessing.

Tests:
- Cover start-offset behavior for snapped intros, disabled configuration, collapsed segments, and preservation of user-provided timestamps.