### PR TITLE
Allow intro start offset when snapping to episode start (#930)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -8,7 +8,7 @@ body:
     attributes:
       label: Self service debugging
       description: |
-        Jellyfin 10.11 is actively updated. Please make sure you are using the [latest](https://github.com/jellyfin/jellyfin/releases/latest) release.
+        Jellyfin 12 is actively updated. Please make sure you are using the [latest](https://github.com/jellyfin/jellyfin/releases/latest) release.
 
         If you are unable to skip segments, please see [Troubleshooting](https://github.com/intro-skipper/intro-skipper/wiki/Troubleshooting) before reporting.
 
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Jellyfin version or container image/tag
       description: The Jellyfin version or container for Docker
-      placeholder: 10.11.11, jellyfin/jellyfin:10.9.9, etc.
+      placeholder: 12.0.0, jellyfin/jellyfin:12.0.z, etc.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/detection_report.yml
+++ b/.github/ISSUE_TEMPLATE/detection_report.yml
@@ -10,7 +10,7 @@ body:
       description: |
         Detection needs a working FFmpeg with Chromaprint and an analysis run with your current settings. Rule those out first, see [Troubleshooting](https://github.com/intro-skipper/intro-skipper/wiki/Troubleshooting).
       options:
-        - label: I use Jellyfin 10.11.11 (or newer) and installed the plugin using `https://intro-skipper.org/manifest.json` or `https://manifest.intro-skipper.org/manifest.json`
+        - label: I use Jellyfin 12.0.0 (or newer) and installed the plugin using `https://intro-skipper.org/manifest.json` or `https://manifest.intro-skipper.org/manifest.json`
           required: true
         - label: "The support log below says `FFmpeg: okay`"
           required: true
@@ -28,7 +28,7 @@ body:
   - type: input
     attributes:
       label: Jellyfin version or container image/tag
-      placeholder: 10.11.11, jellyfin/jellyfin:10.11.11, etc.
+      placeholder: 12.0.0, jellyfin/jellyfin:12.0.0, etc.
     validations:
       required: true
 

--- a/IntroSkipper.Tests/TestDatabaseFacades.cs
+++ b/IntroSkipper.Tests/TestDatabaseFacades.cs
@@ -242,6 +242,30 @@ public sealed class TestDatabaseFacades
     }
 
     [Fact]
+    public async Task DeleteAutomaticTimestampAsync_PreservesUserProvidedSegments()
+    {
+        var dbPath = CreateTempDbPath();
+        var itemId = Guid.NewGuid();
+        try
+        {
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(0, 10)), AnalysisMode.Commercial);
+            await database.UpdateTimestampAsync(new Segment(itemId, new TimeRange(20, 30)), AnalysisMode.Commercial, isUserProvided: true);
+
+            await database.DeleteAutomaticTimestampAsync(itemId, AnalysisMode.Commercial);
+
+            var remaining = Assert.Single(await database.GetSegmentsAsync(itemId));
+            Assert.True(remaining.IsUserProvided);
+            Assert.Equal(20, remaining.Start);
+            Assert.Equal(30, remaining.End);
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task DeleteSegmentsByModeAsync_RemovesOnlyTheGivenMode()
     {
         var dbPath = CreateTempDbPath();

--- a/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
+++ b/IntroSkipper.Tests/TestTimeAdjustmentHelper.cs
@@ -33,18 +33,67 @@ public class TestTimeAdjustmentHelper
     }
 
     [Fact]
-    public async Task StartOffset_IsIgnored_When_SnappingToEpisodeStart()
+    public async Task StartOffset_IsApplied_When_SnappingToEpisodeStart()
     {
         var (helper, cfg) = CreateHelper();
         cfg.IntroStartOffset = 2; // user-configured offset
+        cfg.IncludeIntroStartOffsetWhenSnapping = true;
 
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
         var original = new Segment(episode.EpisodeId) { Start = 1.2, End = 10 };
 
         var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
 
+        Assert.Equal(2, adjusted.Start);
+        Assert.Equal(10, adjusted.End);
+    }
+
+    [Fact]
+    public async Task StartOffset_IsApplied_When_IntroStartsAtZero()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2;
+        cfg.IncludeIntroStartOffsetWhenSnapping = true;
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 0, End = 10 };
+
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
+
+        Assert.Equal(2, adjusted.Start);
+        Assert.Equal(10, adjusted.End);
+    }
+
+    [Fact]
+    public async Task StartOffset_IsNotApplied_When_SnappingAndOptionIsDisabled()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2;
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 0, End = 10 };
+
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
+
         Assert.Equal(0, adjusted.Start);
         Assert.Equal(10, adjusted.End);
+    }
+
+    [Fact]
+    public async Task OffsetThatConsumesSnappedIntro_ReturnsInvalidSegment()
+    {
+        var (helper, cfg) = CreateHelper();
+        cfg.IntroStartOffset = 2;
+        cfg.IncludeIntroStartOffsetWhenSnapping = true;
+
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 60 };
+        var original = new Segment(episode.EpisodeId) { Start = 1, End = 2 };
+
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, original);
+
+        Assert.False(adjusted.Valid);
+        Assert.Equal(0, adjusted.Start);
+        Assert.Equal(0, adjusted.End);
     }
 
     [Fact]

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -129,6 +129,12 @@ public partial class ChapterAnalyzer(
             // The helper is initialized with the current mode, so recap fallback segments
             // still receive the same mode-specific boundary adjustments as chapter matches.
             skipRange = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, skipRange, false, cancellationToken).ConfigureAwait(false);
+            if (!skipRange.Valid)
+            {
+                await _database.DeleteAutomaticTimestampAsync(episode.EpisodeId, mode, cancellationToken).ConfigureAwait(false);
+                episode.SetAnalyzed(mode, EpisodeState.NoSegments);
+                continue;
+            }
 
             episode.SetAnalyzed(mode, EpisodeState.Analyzed);
             await _database.UpdateTimestampAsync(skipRange, mode, configHash: episode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -177,6 +177,13 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
             if (seasonIntros.TryGetValue(currentEpisode.EpisodeId, out var intro))
             {
                 var adjustedIntro = await timeAdjustmentHelper.AdjustIntroTimesAsync(currentEpisode, intro, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (!adjustedIntro.Valid)
+                {
+                    await _database.DeleteAutomaticTimestampAsync(currentEpisode.EpisodeId, mode, cancellationToken).ConfigureAwait(false);
+                    currentEpisode.SetAnalyzed(mode, EpisodeState.NoSegments);
+                    continue;
+                }
+
                 currentEpisode.SetAnalyzed(mode, EpisodeState.Analyzed);
                 await _database.UpdateTimestampAsync(adjustedIntro, mode, configHash: currentEpisode.AnalysisConfigHash, cancellationToken: cancellationToken).ConfigureAwait(false);
             }

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -72,6 +72,14 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
                 }
 
                 credit = await timeAdjustmentHelper.AdjustIntroTimesAsync(episode, credit, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (!credit.Valid)
+                {
+                    LogNoValidCreditsFound(episode.Name);
+                    await _database.DeleteAutomaticTimestampAsync(episode.EpisodeId, mode, cancellationToken).ConfigureAwait(false);
+                    episode.SetAnalyzed(mode, EpisodeState.NoSegments);
+                    continue;
+                }
+
                 LogFoundCredits(episode.Name, credit.Start);
 
                 episode.SetAnalyzed(mode, EpisodeState.Analyzed);

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -83,13 +83,16 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
 
         if (snapToEpisodeStart)
         {
-            // When snapping to episode start, do NOT apply IntroStartOffset
+            // Snap the detected boundary first; IntroStartOffset is applied below so it also
+            // takes effect when the detected intro starts at (or near) the episode start.
             LogSnappingIntroStart(_logger, episode.EpisodeId, episode.Name, _config.EndSnapThreshold);
             adjustedStart = 0;
         }
-        else
+
+        // Apply the configured playback offset after all other start adjustments. Snapped starts
+        // are opt-in because the default behavior is to preserve the episode boundary.
+        if (!snapToEpisodeStart || _config.IncludeIntroStartOffsetWhenSnapping)
         {
-            // Apply configurable start offset only if we are not snapping to the episode start
             adjustedStart = Math.Clamp(adjustedStart + _config.IntroStartOffset, 0, duration);
         }
 
@@ -134,7 +137,11 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
         // Ensure start < end after all adjustments
         if (adjustedStart >= adjustedEnd)
         {
-            return new Segment(episode.EpisodeId) { Start = originalIntro.Start, End = originalIntro.End };
+            LogAdjustedStartAfterEnd(_logger, episode.EpisodeId, episode.Name, adjustedStart, adjustedEnd);
+
+            // The adjusted range is unusable, so do not restore the original range and silently
+            // discard a configured start offset. Return an invalid segment so callers can ignore it.
+            return new Segment(episode.EpisodeId);
         }
 
         LogAdjustedIntro(_logger, episode.EpisodeId, episode.Name, adjustedStart, adjustedEnd);
@@ -259,13 +266,13 @@ public partial class TimeAdjustmentHelper(ILogger logger, PluginConfiguration co
     [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: Negative intro start {Start}, resetting to 0")]
     private static partial void LogNegativeIntroStart(ILogger logger, Guid episodeId, string name, double start);
 
-    [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name}: Snapping intro start to 0 (within threshold {Threshold}), skipping IntroStartOffset")]
+    [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name}: Snapping intro start to 0 (within threshold {Threshold})")]
     private static partial void LogSnappingIntroStart(ILogger logger, Guid episodeId, string name, double threshold);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name}: No suitable silence found for intro end in range {Start}-{End}")]
     private static partial void LogNoSilenceFound(ILogger logger, Guid episodeId, string name, double start, double end);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: Adjusted start time {Start} >= end time {End}, reverting to original")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: Adjusted start time {Start} >= end time {End}, discarding segment")]
     private static partial void LogAdjustedStartAfterEnd(ILogger logger, Guid episodeId, string name, double start, double end);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{EpisodeId} {Name} adjusted intro: {Start} - {End}")]

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -423,6 +423,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public int IntroStartOffset { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to apply <see cref="IntroStartOffset" /> when the
+    /// intro start is snapped to the beginning of the episode.
+    /// </summary>
+    public bool IncludeIntroStartOffsetWhenSnapping { get; set; }
+
     // ===== Internal algorithm settings =====
 
     /// <summary>

--- a/IntroSkipper/Data/Segment.cs
+++ b/IntroSkipper/Data/Segment.cs
@@ -77,9 +77,9 @@ public class Segment
 
     /// <summary>
     /// Gets a value indicating whether this segment is valid or not.
-    /// Invalid results must not be returned through the API.
+    /// Invalid results must not be returned through the API. A segment must have a positive duration.
     /// </summary>
-    public bool Valid => End > 0.0;
+    public bool Valid => End > 0.0 && End > Start;
 
     /// <summary>
     /// Gets the duration of this segment.

--- a/IntroSkipper/Db/IIntroSkipperDatabase.cs
+++ b/IntroSkipper/Db/IIntroSkipperDatabase.cs
@@ -77,6 +77,15 @@ public interface IIntroSkipperDatabase
     Task<IReadOnlyList<DbSegment>> DeleteTimestampAsync(Guid itemId, AnalysisMode mode, Segment? segment = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Deletes automatic segments for an item and analysis mode while preserving user-provided segments.
+    /// </summary>
+    /// <param name="itemId">Item ID whose automatic segment should be removed.</param>
+    /// <param name="mode">Analysis mode to remove.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task DeleteAutomaticTimestampAsync(Guid itemId, AnalysisMode mode, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Deletes every stored segment of the given analysis mode.
     /// </summary>
     /// <param name="mode">Analysis mode to erase.</param>

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -56,7 +56,7 @@ public sealed partial class IntroSkipperDatabase
             .Where(s => EF.Parameter(ids).Contains(s.ItemId)
                 && s.Type == mode
                 && !s.IsUserProvided
-                && s.ConfigHash != configHash)
+                && (s.ConfigHash != configHash || s.End <= 0.0 || s.End <= s.Start))
             .ExecuteDeleteAsync(cancellationToken)
             .ConfigureAwait(false);
     }

--- a/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.SeasonStates.cs
@@ -199,7 +199,9 @@ public sealed partial class IntroSkipperDatabase
 
         var segments = await db.DbSegment
             .AsNoTracking()
-            .Where(s => EF.Parameter(episodeIdArray).Contains(s.ItemId))
+            .Where(s => EF.Parameter(episodeIdArray).Contains(s.ItemId)
+                && s.End > 0.0
+                && s.End > s.Start)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/IntroSkipper/Db/IntroSkipperDatabase.Segments.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Segments.cs
@@ -102,7 +102,7 @@ public sealed partial class IntroSkipperDatabase
     {
         var segments = await GetSegmentsAsync(id, cancellationToken).ConfigureAwait(false);
 
-        return ToCanonicalTimestamps(segments);
+        return ToCanonicalTimestamps(segments.Where(IsValid));
     }
 
     /// <summary>
@@ -118,6 +118,8 @@ public sealed partial class IntroSkipperDatabase
             .ToDictionary(
                 group => group.Key,
                 group => group.OrderBy(segment => segment.Start).First().ToSegment());
+
+    private static bool IsValid(DbSegment segment) => segment.End > 0.0 && segment.End > segment.Start;
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<DbSegment>> GetSegmentsAsync(Guid id, CancellationToken cancellationToken = default)
@@ -175,6 +177,17 @@ public sealed partial class IntroSkipperDatabase
         }
 
         return entries;
+    }
+
+    /// <inheritdoc/>
+    public async Task DeleteAutomaticTimestampAsync(Guid itemId, AnalysisMode mode, CancellationToken cancellationToken = default)
+    {
+        await InitializeAsync().ConfigureAwait(false);
+        using var db = _contextFactory.CreateDbContext();
+        await db.DbSegment
+            .Where(s => s.ItemId == itemId && s.Type == mode && !s.IsUserProvided)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -177,7 +177,7 @@ public static class ConfigHasher
             $"|chapAdjust={config.AdjustIntroBasedOnChapters}|silence={config.AdjustIntroBasedOnSilence}|keyframe={config.SnapToKeyframe}",
             $"|endSnap={config.EndSnapThreshold}|winIn={config.AdjustWindowInward}|winOut={config.AdjustWindowOutward}",
             $"|noise={config.SilenceDetectionMaximumNoise}|silDur={config.SilenceDetectionMinimumDuration}",
-            $"|startOffset={config.IntroStartOffset}|endOffset={config.IntroEndOffset}");
+            $"|startOffset={config.IntroStartOffset}|includeStartOffsetWhenSnapping={config.IncludeIntroStartOffsetWhenSnapping}|endOffset={config.IntroEndOffset}");
 
     private static string Invariant(params FormattableString[] parts)
         => string.Concat(parts.Select(FormattableString.Invariant));

--- a/IntroSkipper/Providers/SegmentDtoFactory.cs
+++ b/IntroSkipper/Providers/SegmentDtoFactory.cs
@@ -40,7 +40,7 @@ public sealed class SegmentDtoFactory(IIntroSkipperDatabase database)
                 continue;
             }
 
-            if (segment.End <= 0.0)
+            if (segment.End <= 0.0 || segment.End <= segment.Start)
             {
                 continue;
             }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
     <p>
-        <img alt="Plugin Banner" src="https://raw.githubusercontent.com/intro-skipper/intro-skipper/10.11/images/logo.png" />
+        <img alt="Plugin Banner" src="https://raw.githubusercontent.com/intro-skipper/intro-skipper/12.0/images/logo.png" />
     </p>
     <p>
         Analyzes the audio of television episodes to detect and skip over intros.
@@ -52,9 +52,9 @@ Some web UI features (for example, adjusting the skip-button timeout) require th
 ## System requirements
 
 * Jellyfin 12.0.0 (or newer)
-* Jellyfin's [fork](https://github.com/jellyfin/jellyfin-ffmpeg) of `ffmpeg` must be installed, version `7.1.1-7` or newer
-  * `jellyfin/jellyfin` 10.11.z container: preinstalled
-  * `linuxserver/jellyfin` 10.11.z container: preinstalled
+* Jellyfin's [fork](https://github.com/jellyfin/jellyfin-ffmpeg) of `ffmpeg` must be installed, version `7.1.3-1` or newer
+  * `jellyfin/jellyfin` 12.z container: preinstalled
+  * `linuxserver/jellyfin` 12.z container: preinstalled
   * Debian Linux based native installs: provided by the `jellyfin-ffmpeg7` package
   * MacOS native installs: build ffmpeg with chromaprint support ([instructions](https://github.com/intro-skipper/intro-skipper/wiki/Custom-FFMPEG-(MacOS)))
   * Gentoo Linux native installs: enable `xarblu-overlay` and install `media-video/jellyfin-ffmpeg`
@@ -65,7 +65,7 @@ Some web UI features (for example, adjusting the skip-button timeout) require th
 
 ## Disclaimer
 
-This plugin is licensed under the [GNU General Public License v3.0](https://github.com/intro-skipper/intro-skipper/blob/10.11/LICENSE).
+This plugin is licensed under the [GNU General Public License v3.0](https://github.com/intro-skipper/intro-skipper/blob/12.0/LICENSE).
 It is provided as-is, without warranty of any kind, express or implied. Use it at your own
 risk. The authors accept no liability for data loss, missed detections,
 false positives, or any other damages arising from its use.

--- a/web/src/tabs/detection.ts
+++ b/web/src/tabs/detection.ts
@@ -96,6 +96,12 @@ export const detectionTab: Tab = {
                     description:
                         "Default: 0. Example: If set to 3, the first 3 seconds of the intro will play before skipping.",
                 }),
+                checkboxField({
+                    id: "IncludeIntroStartOffsetWhenSnapping",
+                    label: "Include start offset when snapping to episode start",
+                    description:
+                        "When enabled, Intro Start Offset is also applied when the detected intro start is snapped to the beginning of the episode.",
+                }),
                 numberField({
                     id: "IntroEndOffset",
                     label: "Intro End Offset (seconds)",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -74,6 +74,7 @@ export interface PluginConfig {
     SnapToKeyframe: boolean;
     AdjustIntroBasedOnSilence: boolean;
     AdjustIntroBasedOnChapters: boolean;
+    IncludeIntroStartOffsetWhenSnapping: boolean;
     UseFileTransformationPlugin: boolean;
     AutoSkipIntro: boolean;
     AutoSkipCredits: boolean;


### PR DESCRIPTION
* Allow intro start offset when snapping to episode start

* Return invalid segments when adjusted intro range is unusable

* Handle invalid adjusted segments as unanalyzed

* Delete stale automatic segments when analysis finds no valid range

* Declare filtered segments as a concrete list

* Update segment deletion test to use commercial analysis mode

## Summary by Sourcery

Allow configurable intro offsets for episode-start snapping and ensure invalid analysis results are discarded safely.

New Features:
- Add an option to apply the intro start offset when detection snaps the intro boundary to the episode start.

Bug Fixes:
- Treat adjusted intro ranges that have no positive duration as invalid instead of restoring unusable original ranges.
- Remove stale automatically detected segments when analysis produces no valid segment while preserving user-provided segments.
- Filter invalid segments from database results, queue snapshots, and API responses.

Enhancements:
- Include the new adjustment option in analysis configuration hashing so changes trigger appropriate reanalysis.

Documentation:
- Update documented Jellyfin and FFmpeg compatibility requirements to the current supported versions.

Tests:
- Add coverage for snapped intro offset behavior, invalid adjusted ranges, and preserving user-provided segments during automatic cleanup.