### PR TITLE
Invalidate automatic analysis when media items change

### DIFF
--- a/IntroSkipper.Tests/EntrypointTestHelpers.cs
+++ b/IntroSkipper.Tests/EntrypointTestHelpers.cs
@@ -99,6 +99,9 @@ internal static class EntrypointTestHelpers
     internal static HashSet<Guid> GetSeasonsToAnalyze(Entrypoint entrypoint)
         => (HashSet<Guid>)GetPrivateField(entrypoint, "_seasonsToAnalyze");
 
+    internal static Dictionary<Guid, Guid> GetItemsToReset(Entrypoint entrypoint)
+        => (Dictionary<Guid, Guid>)GetPrivateField(entrypoint, "_itemsToReset");
+
     internal static ItemChangeEventArgs CreateItemChangeEventArgs(object item, ItemUpdateType updateReason)
     {
 #pragma warning disable SYSLIB0050 // FormatterServices is obsolete; used only for test scaffolding.

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.IO;
 using System.Linq;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -55,6 +55,74 @@ public sealed class TestEntrypointEvents
     }
 
     [Fact]
+    public void OnItemChanged_InvalidatesChangedEpisodeAnalysisAndCache()
+    {
+        var itemId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var otherId = Guid.NewGuid();
+        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
+        var dbPath = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid() + ".db");
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+
+        var episode = new Episode();
+        EntrypointTestHelpers.SetPropertyOrField(episode, "Id", itemId);
+        EntrypointTestHelpers.SetPropertyOrField(episode, "SeasonId", seasonId);
+        EntrypointTestHelpers.EnsureNonVirtual(episode);
+
+        try
+        {
+            using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+
+                using (var db = Plugin.CreateDbContext())
+                {
+                    db.Database.EnsureCreated();
+                    db.DbSegment.Add(new DbSegment(new Segment(itemId, new TimeRange(0, 30)), AnalysisMode.Introduction));
+                    db.DbSegment.Add(new DbSegment(new Segment(itemId, new TimeRange(120, 150)), AnalysisMode.Credits, isUserProvided: true));
+                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, [itemId]));
+                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Credits, AnalyzerAction.Default, [itemId]));
+                    db.SaveChanges();
+                }
+
+                using (var cacheDb = Plugin.CreateCacheDbContext())
+                {
+                    cacheDb.DetectionCache.Add(new DbDetectionCache(itemId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));
+                    cacheDb.DetectionCache.Add(new DbDetectionCache(otherId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));
+                    cacheDb.SaveChanges();
+                }
+
+                var args = EntrypointTestHelpers.CreateItemChangeEventArgs(episode, ItemUpdateType.None);
+                EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemChanged", args);
+
+                using (var db = Plugin.CreateDbContext())
+                {
+                    Assert.False(db.DbSegment.Any(s => s.ItemId == itemId && !s.IsUserProvided));
+                    Assert.True(db.DbSegment.Any(s => s.ItemId == itemId && s.IsUserProvided));
+                    Assert.Empty(db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction).EpisodeIds);
+                    Assert.Empty(db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Credits).EpisodeIds);
+                }
+
+                using var verificationCache = Plugin.CreateCacheDbContext();
+                Assert.False(verificationCache.DetectionCache.Any(e => e.ItemId == itemId));
+                Assert.True(verificationCache.DetectionCache.Any(e => e.ItemId == otherId));
+            }
+        }
+        finally
+        {
+            foreach (var suffix in new[] { "", "-wal", "-shm" })
+            {
+                var path = dbPath + suffix;
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+
+    [Fact]
     public void OnItemChanged_DoesNothing_WhenAutoDetectDisabled()
     {
         var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
-using System.IO;
 using System.Linq;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
@@ -60,73 +59,20 @@ public sealed class TestEntrypointEvents
     {
         var itemId = Guid.NewGuid();
         var seasonId = Guid.NewGuid();
-        var otherId = Guid.NewGuid();
-        var cacheDir = EntrypointTestHelpers.CreateTempCacheDir();
-        var dbPath = Path.Combine(Path.GetTempPath(), "IntroSkipper.Tests", Guid.NewGuid() + ".db");
-        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
+        using var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: true);
 
         var episode = new Episode();
         EntrypointTestHelpers.SetPropertyOrField(episode, "Id", itemId);
         EntrypointTestHelpers.SetPropertyOrField(episode, "SeasonId", seasonId);
         EntrypointTestHelpers.EnsureNonVirtual(episode);
 
-        try
+        using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
         {
-            using (new EntrypointTestHelpers.PluginInstanceScope(cacheDir))
-            {
-                var plugin = Plugin.Instance!;
-                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+            var args = EntrypointTestHelpers.CreateItemChangeEventArgs(episode, ItemUpdateType.None);
+            EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemChanged", args);
 
-                using (var db = Plugin.CreateDbContext())
-                {
-                    db.Database.EnsureCreated();
-                    db.DbSegment.Add(new DbSegment(new Segment(itemId, new TimeRange(0, 30)), AnalysisMode.Introduction));
-                    db.DbSegment.Add(new DbSegment(new Segment(itemId, new TimeRange(120, 150)), AnalysisMode.Credits, isUserProvided: true));
-                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, [itemId], string.Empty, [itemId]));
-                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Credits, AnalyzerAction.Default, [itemId], string.Empty, [itemId]));
-                    db.SaveChanges();
-                }
-
-                using (var cacheDb = Plugin.CreateCacheDbContext())
-                {
-                    cacheDb.DetectionCache.Add(new DbDetectionCache(itemId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));
-                    cacheDb.DetectionCache.Add(new DbDetectionCache(otherId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray));
-                    cacheDb.SaveChanges();
-                }
-
-                var args = EntrypointTestHelpers.CreateItemChangeEventArgs(episode, ItemUpdateType.None);
-                EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemChanged", args);
-
-                var itemsToReset = EntrypointTestHelpers.GetItemsToReset(entrypoint);
-                Assert.Equal(seasonId, itemsToReset[itemId]);
-
-                using (var db = Plugin.CreateDbContext())
-                {
-                    // Invalidation is deferred until the coordinated analysis pass so an
-                    // already-running analyzer cannot repopulate the old state after the reset.
-                    Assert.True(db.DbSegment.Any(s => s.ItemId == itemId && !s.IsUserProvided));
-                    Assert.True(db.DbSegment.Any(s => s.ItemId == itemId && s.IsUserProvided));
-                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction).EpisodeIds);
-                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Credits).EpisodeIds);
-                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction).SettledReanalysisEpisodeIds);
-                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Credits).SettledReanalysisEpisodeIds);
-                }
-
-                using var verificationCache = Plugin.CreateCacheDbContext();
-                Assert.True(verificationCache.DetectionCache.Any(e => e.ItemId == itemId));
-                Assert.True(verificationCache.DetectionCache.Any(e => e.ItemId == otherId));
-            }
-        }
-        finally
-        {
-            foreach (var suffix in new[] { "", "-wal", "-shm" })
-            {
-                var path = dbPath + suffix;
-                if (File.Exists(path))
-                {
-                    File.Delete(path);
-                }
-            }
+            Assert.Equal(seasonId, EntrypointTestHelpers.GetItemsToReset(entrypoint)[itemId]);
+            Assert.Contains(seasonId, EntrypointTestHelpers.GetSeasonsToAnalyze(entrypoint));
         }
     }
 

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -55,7 +55,7 @@ public sealed class TestEntrypointEvents
     }
 
     [Fact]
-    public void OnItemChanged_InvalidatesChangedEpisodeAnalysisAndCache()
+    public void OnItemChanged_QueuesChangedEpisodeForCoordinatedInvalidation()
     {
         var itemId = Guid.NewGuid();
         var seasonId = Guid.NewGuid();
@@ -81,8 +81,8 @@ public sealed class TestEntrypointEvents
                     db.Database.EnsureCreated();
                     db.DbSegment.Add(new DbSegment(new Segment(itemId, new TimeRange(0, 30)), AnalysisMode.Introduction));
                     db.DbSegment.Add(new DbSegment(new Segment(itemId, new TimeRange(120, 150)), AnalysisMode.Credits, isUserProvided: true));
-                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, [itemId]));
-                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Credits, AnalyzerAction.Default, [itemId]));
+                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Introduction, AnalyzerAction.Default, [itemId], string.Empty, [itemId]));
+                    db.DbSeasonState.Add(new DbSeasonState(seasonId, AnalysisMode.Credits, AnalyzerAction.Default, [itemId], string.Empty, [itemId]));
                     db.SaveChanges();
                 }
 
@@ -96,16 +96,23 @@ public sealed class TestEntrypointEvents
                 var args = EntrypointTestHelpers.CreateItemChangeEventArgs(episode, ItemUpdateType.None);
                 EntrypointTestHelpers.InvokePrivate(entrypoint, "OnItemChanged", args);
 
+                var itemsToReset = EntrypointTestHelpers.GetItemsToReset(entrypoint);
+                Assert.Equal(seasonId, itemsToReset[itemId]);
+
                 using (var db = Plugin.CreateDbContext())
                 {
-                    Assert.False(db.DbSegment.Any(s => s.ItemId == itemId && !s.IsUserProvided));
+                    // Invalidation is deferred until the coordinated analysis pass so an
+                    // already-running analyzer cannot repopulate the old state after the reset.
+                    Assert.True(db.DbSegment.Any(s => s.ItemId == itemId && !s.IsUserProvided));
                     Assert.True(db.DbSegment.Any(s => s.ItemId == itemId && s.IsUserProvided));
-                    Assert.Empty(db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction).EpisodeIds);
-                    Assert.Empty(db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Credits).EpisodeIds);
+                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction).EpisodeIds);
+                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Credits).EpisodeIds);
+                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Introduction).SettledReanalysisEpisodeIds);
+                    Assert.Equal(new[] { itemId }, db.DbSeasonState.Single(s => s.SeasonId == seasonId && s.Type == AnalysisMode.Credits).SettledReanalysisEpisodeIds);
                 }
 
                 using var verificationCache = Plugin.CreateCacheDbContext();
-                Assert.False(verificationCache.DetectionCache.Any(e => e.ItemId == itemId));
+                Assert.True(verificationCache.DetectionCache.Any(e => e.ItemId == itemId));
                 Assert.True(verificationCache.DetectionCache.Any(e => e.ItemId == otherId));
             }
         }

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -516,20 +516,12 @@ public sealed class TestSeasonReanalysisReset
         var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
         var seasonId = Guid.NewGuid();
         var itemId = Guid.NewGuid();
-        var userItemId = Guid.NewGuid();
 
         try
         {
             using (var db = new IntroSkipperDbContext(dbPath))
             {
                 db.Database.EnsureCreated();
-                db.DbSegment.Add(new DbSegment(
-                    new Segment(itemId, new TimeRange(0, 30)),
-                    AnalysisMode.Introduction));
-                db.DbSegment.Add(new DbSegment(
-                    new Segment(userItemId, new TimeRange(40, 60)),
-                    AnalysisMode.Introduction,
-                    isUserProvided: true));
                 db.DbSeasonState.Add(new DbSeasonState(
                     seasonId,
                     AnalysisMode.Introduction,
@@ -548,9 +540,6 @@ public sealed class TestSeasonReanalysisReset
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
-                Assert.False(db.DbSegment.Any(s => s.ItemId == itemId && !s.IsUserProvided));
-                Assert.True(db.DbSegment.Any(s => s.ItemId == userItemId && s.IsUserProvided));
-
                 var state = db.DbSeasonState.Single();
                 Assert.Empty(state.EpisodeIds);
                 Assert.Empty(state.SettledReanalysisEpisodeIds);

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -516,6 +516,7 @@ public sealed class TestSeasonReanalysisReset
         var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
         var seasonId = Guid.NewGuid();
         var itemId = Guid.NewGuid();
+        var userItemId = Guid.NewGuid();
 
         try
         {
@@ -526,7 +527,7 @@ public sealed class TestSeasonReanalysisReset
                     new Segment(itemId, new TimeRange(0, 30)),
                     AnalysisMode.Introduction));
                 db.DbSegment.Add(new DbSegment(
-                    new Segment(itemId, new TimeRange(40, 60)),
+                    new Segment(userItemId, new TimeRange(40, 60)),
                     AnalysisMode.Introduction,
                     isUserProvided: true));
                 db.DbSeasonState.Add(new DbSeasonState(
@@ -548,7 +549,7 @@ public sealed class TestSeasonReanalysisReset
             using (var db = new IntroSkipperDbContext(dbPath))
             {
                 Assert.False(db.DbSegment.Any(s => s.ItemId == itemId && !s.IsUserProvided));
-                Assert.True(db.DbSegment.Any(s => s.ItemId == itemId && s.IsUserProvided));
+                Assert.True(db.DbSegment.Any(s => s.ItemId == userItemId && s.IsUserProvided));
 
                 var state = db.DbSeasonState.Single();
                 Assert.Empty(state.EpisodeIds);

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -509,6 +509,59 @@ public sealed class TestSeasonReanalysisReset
     }
 
     [Fact]
+    public void ResetItemForReanalysis_RemovesItemFromSettledSeasonState()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var seasonId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                db.Database.EnsureCreated();
+                db.DbSegment.Add(new DbSegment(
+                    new Segment(itemId, new TimeRange(0, 30)),
+                    AnalysisMode.Introduction));
+                db.DbSegment.Add(new DbSegment(
+                    new Segment(itemId, new TimeRange(40, 60)),
+                    AnalysisMode.Introduction,
+                    isUserProvided: true));
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Chromaprint,
+                    [itemId],
+                    "hash",
+                    [itemId]));
+                db.SaveChanges();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
+                Plugin.ResetItemForReanalysis(seasonId, itemId, [AnalysisMode.Introduction]);
+            }
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                Assert.False(db.DbSegment.Any(s => s.ItemId == itemId && !s.IsUserProvided));
+                Assert.True(db.DbSegment.Any(s => s.ItemId == itemId && s.IsUserProvided));
+
+                var state = db.DbSeasonState.Single();
+                Assert.Empty(state.EpisodeIds);
+                Assert.Empty(state.SettledReanalysisEpisodeIds);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task ResetSeasonForReanalysisAsync_DeletesCreditsDerivedAutomaticPreview()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -102,17 +102,19 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
     }
 
     /// <inheritdoc/>
-    public void DeleteForItem(Guid itemId)
+    public bool DeleteForItem(Guid itemId)
     {
         try
         {
             // Delete from the SQLite cache database.
             using var db = Plugin.CreateCacheDbContext();
             db.DetectionCache.Where(e => e.ItemId == itemId).ExecuteDelete();
+            return true;
         }
         catch (Exception ex) when (ex is DbUpdateException or DbException)
         {
             LogDetectionCacheDeleteError(_logger, ex, itemId.ToString("N"));
+            return false;
         }
     }
 

--- a/IntroSkipper/FFmpeg/IDetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/IDetectionCacheService.cs
@@ -56,7 +56,8 @@ public interface IDetectionCacheService
     /// Deletes all cache entries for a media item.
     /// </summary>
     /// <param name="itemId">The media item ID whose cache entries should be deleted.</param>
-    void DeleteForItem(Guid itemId);
+    /// <returns><see langword="true"/> if deletion completed; otherwise, <see langword="false"/>.</returns>
+    bool DeleteForItem(Guid itemId);
 
     /// <summary>
     /// Deletes cache entries by analysis mode.

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -534,7 +534,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             return;
         }
 
-        var modeArray = modes.Distinct().ToArray();
+        AnalysisMode[] modeArray = [.. modes.Distinct()];
         if (modeArray.Length == 0)
         {
             return;

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -521,6 +521,56 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     }
 
     /// <summary>
+    /// Clears automatic analysis state for one media item after Jellyfin reports that its file
+    /// changed. User-provided segments are preserved.
+    /// </summary>
+    /// <param name="seasonId">Season containing the item, or <see cref="Guid.Empty"/> when unknown.</param>
+    /// <param name="itemId">Media item identifier.</param>
+    /// <param name="modes">Analysis modes to reset.</param>
+    internal static void ResetItemForReanalysis(Guid seasonId, Guid itemId, IEnumerable<AnalysisMode> modes)
+    {
+        if (itemId == Guid.Empty)
+        {
+            return;
+        }
+
+        var modeArray = modes.Distinct().ToArray();
+        if (modeArray.Length == 0)
+        {
+            return;
+        }
+
+        using var db = CreateDbContext();
+        using var transaction = db.Database.BeginTransaction();
+        try
+        {
+            db.DbSegment
+                .Where(s => s.ItemId == itemId && modeArray.Contains(s.Type) && !s.IsUserProvided)
+                .ExecuteDelete();
+
+            var seasonStates = db.DbSeasonState
+                .Where(s => modeArray.Contains(s.Type) && (seasonId == Guid.Empty || s.SeasonId == seasonId))
+                .ToList();
+
+            foreach (var state in seasonStates)
+            {
+                var episodeIds = state.EpisodeIds.ToList();
+                if (episodeIds.Remove(itemId))
+                {
+                    db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
+                }
+            }
+
+            db.SaveChanges();
+            transaction.Commit();
+        }
+        finally
+        {
+            transaction.Dispose();
+        }
+    }
+
+    /// <summary>
     /// Removes stale automatic segments for the supplied items and mode.
     /// User-provided segments are intentionally preserved.
     /// </summary>

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -555,9 +555,15 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             foreach (var state in seasonStates)
             {
                 var episodeIds = state.EpisodeIds.ToList();
+                var settledReanalysisEpisodeIds = state.SettledReanalysisEpisodeIds.ToList();
                 if (episodeIds.Remove(itemId))
                 {
                     db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
+                }
+
+                if (settledReanalysisEpisodeIds.Remove(itemId))
+                {
+                    db.Entry(state).Property(s => s.SettledReanalysisEpisodeIds).CurrentValue = settledReanalysisEpisodeIds;
                 }
             }
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -181,6 +181,27 @@ namespace IntroSkipper.Services
                 return;
             }
 
+            // Jellyfin uses ItemUpdateType.None for filesystem-driven item updates. A replacement
+            // at the same path retains the Jellyfin item ID, so the normal queue would otherwise
+            // treat the old automatic analysis and fingerprint cache as still valid. Invalidate
+            // only this item before queueing its season for the debounced analysis pass.
+            if (itemChangeEventArgs.UpdateReason == ItemUpdateType.None &&
+                item.Id != Guid.Empty &&
+                Plugin.Instance is not null)
+            {
+                try
+                {
+                    var seasonId = item is Episode episode ? episode.SeasonId : item.Id;
+                    Plugin.ResetItemForReanalysis(seasonId, item.Id, Enum.GetValues<AnalysisMode>());
+                    _cacheService.DeleteForItem(item.Id);
+                    LogMediaItemChanged(_logger, item.Id);
+                }
+                catch (Exception ex)
+                {
+                    LogErrorResettingChangedMediaItem(_logger, ex, item.Id);
+                }
+            }
+
             Guid? id = item switch
             {
                 Episode episode => episode.SeasonId,
@@ -414,6 +435,12 @@ namespace IntroSkipper.Services
 
         [LoggerMessage(Level = LogLevel.Debug, Message = "Media item removed, deleting fingerprint cache for {Id}")]
         private partial void LogMediaItemRemoved(Guid id);
+
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Media item changed, invalidating automatic analysis and fingerprint cache for {Id}")]
+        private static partial void LogMediaItemChanged(ILogger logger, Guid id);
+
+        [LoggerMessage(Level = LogLevel.Warning, Message = "Unable to invalidate automatic analysis for changed media item {Id}")]
+        private static partial void LogErrorResettingChangedMediaItem(ILogger logger, Exception ex, Guid id);
 
         [LoggerMessage(Level = LogLevel.Warning, Message = "Error deleting fingerprint cache on item removal")]
         private partial void LogErrorDeletingFingerprintCache(Exception ex);

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Loader;
 using IntroSkipper.Configuration;
+using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -43,6 +43,7 @@ namespace IntroSkipper.Services
         private readonly ILoggerFactory _loggerFactory;
         private readonly IMediaSegmentRefresher _mediaSegmentRefresher;
         private readonly HashSet<Guid> _seasonsToAnalyze = [];
+        private readonly Dictionary<Guid, Guid> _itemsToReset = [];
         private readonly object _seasonsLock = new();
         private readonly Timer _queueTimer;
         private static readonly SemaphoreSlim _analysisSemaphore = new(1, 1);
@@ -182,27 +183,6 @@ namespace IntroSkipper.Services
                 return;
             }
 
-            // Jellyfin uses ItemUpdateType.None for filesystem-driven item updates. A replacement
-            // at the same path retains the Jellyfin item ID, so the normal queue would otherwise
-            // treat the old automatic analysis and fingerprint cache as still valid. Invalidate
-            // only this item before queueing its season for the debounced analysis pass.
-            if (itemChangeEventArgs.UpdateReason == ItemUpdateType.None &&
-                item.Id != Guid.Empty &&
-                Plugin.Instance is not null)
-            {
-                try
-                {
-                    var seasonId = item is Episode episode ? episode.SeasonId : item.Id;
-                    Plugin.ResetItemForReanalysis(seasonId, item.Id, Enum.GetValues<AnalysisMode>());
-                    _cacheService.DeleteForItem(item.Id);
-                    LogMediaItemChanged(_logger, item.Id);
-                }
-                catch (Exception ex)
-                {
-                    LogErrorResettingChangedMediaItem(_logger, ex, item.Id);
-                }
-            }
-
             Guid? id = item switch
             {
                 Episode episode => episode.SeasonId,
@@ -216,6 +196,18 @@ namespace IntroSkipper.Services
 
                 lock (_seasonsLock)
                 {
+                    // Jellyfin uses ItemUpdateType.None for filesystem-driven item updates. A
+                    // replacement at the same path retains the Jellyfin item ID, so the normal
+                    // queue would otherwise treat the old automatic analysis and fingerprint
+                    // cache as still valid. Defer invalidation until the coordinated analysis
+                    // pass, after any currently running analysis has finished writing its state.
+                    if (itemChangeEventArgs.UpdateReason == ItemUpdateType.None &&
+                        item.Id != Guid.Empty &&
+                        Plugin.Instance is not null)
+                    {
+                        _itemsToReset[item.Id] = id.Value;
+                    }
+
                     _seasonsToAnalyze.Add(id.Value);
                 }
 
@@ -326,7 +318,10 @@ namespace IntroSkipper.Services
         {
             if (AutomaticTaskState == TaskState.Running)
             {
-                _analyzeAgain = true;
+                lock (_seasonsLock)
+                {
+                    _analyzeAgain = true;
+                }
             }
             else if (AutomaticTaskState == TaskState.Idle)
             {
@@ -367,35 +362,80 @@ namespace IntroSkipper.Services
                     {
                         LogInitiatingAutomaticAnalysis();
                         HashSet<Guid> seasonIds;
+                        Dictionary<Guid, Guid> itemsToReset;
                         lock (_seasonsLock)
                         {
                             seasonIds = new HashSet<Guid>(_seasonsToAnalyze);
+                            itemsToReset = new Dictionary<Guid, Guid>(_itemsToReset);
                             _seasonsToAnalyze.Clear();
+                            _itemsToReset.Clear();
+                            _analyzeAgain = false;
                         }
 
-                        _analyzeAgain = false;
+                        var failedResetSeasonIds = new HashSet<Guid>();
+                        foreach (var (itemId, seasonId) in itemsToReset)
+                        {
+                            try
+                            {
+                                Plugin.ResetItemForReanalysis(seasonId, itemId, Enum.GetValues<AnalysisMode>());
+                                _cacheService.DeleteForItem(itemId);
+                                LogMediaItemChanged(_logger, itemId);
+                            }
+                            catch (Exception ex)
+                            {
+                                lock (_seasonsLock)
+                                {
+                                    _itemsToReset[itemId] = seasonId;
+                                    _seasonsToAnalyze.Add(seasonId);
+                                    _analyzeAgain = true;
+                                }
+
+                                failedResetSeasonIds.Add(seasonId);
+                                LogErrorResettingChangedMediaItem(_logger, ex, itemId);
+                            }
+                        }
+
+                        seasonIds.ExceptWith(failedResetSeasonIds);
 
                         var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentRefresher, _ffmpegService, _cacheService);
                         await analyzer.AnalyzeItemsAsync(new Progress<double>(), cts.Token, seasonIds).ConfigureAwait(false);
-
-                        if (_analyzeAgain && !cts.IsCancellationRequested)
-                        {
-                            LogAnalyzingEndedNeedsRestart();
-                            _queueTimer.Change(TimeSpan.FromSeconds(60), Timeout.InfiniteTimeSpan);
-                        }
                     }
                 }
                 finally
                 {
+                    var wasCancelled = cts.IsCancellationRequested;
                     // Null the field BEFORE disposing to prevent other threads
                     // from reading a disposed CancellationTokenSource via Volatile.Read.
                     Interlocked.Exchange(ref _cancellationTokenSource, null);
                     cts.Dispose();
+
+                    // Do this after making the task idle. An item update can arrive between the
+                    // analysis completion check and clearing _cancellationTokenSource; checking
+                    // the queues here closes that race and guarantees another pass is scheduled.
+                    if (!wasCancelled)
+                    {
+                        ScheduleAnalysisIfNeeded();
+                    }
                 }
             }
             finally
             {
                 _analysisSemaphore.Release();
+            }
+        }
+
+        private void ScheduleAnalysisIfNeeded()
+        {
+            bool needsRestart;
+            lock (_seasonsLock)
+            {
+                needsRestart = _analyzeAgain || _seasonsToAnalyze.Count > 0 || _itemsToReset.Count > 0;
+            }
+
+            if (needsRestart && AutomaticTaskState == TaskState.Idle)
+            {
+                LogAnalyzingEndedNeedsRestart();
+                _queueTimer.Change(TimeSpan.FromSeconds(60), Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -389,14 +389,14 @@ namespace IntroSkipper.Services
                         }
 
                         var failedResetSeasonIds = new HashSet<Guid>();
-                        var successfullyResetItemIds = new HashSet<Guid>();
+                        var successfullyResetItems = new Dictionary<Guid, Guid>();
                         foreach (var (itemId, seasonId) in itemsToReset)
                         {
                             try
                             {
                                 Plugin.ResetItemForReanalysis(seasonId, itemId, Enum.GetValues<AnalysisMode>());
                                 _cacheService.DeleteForItem(itemId);
-                                successfullyResetItemIds.Add(itemId);
+                                successfullyResetItems[itemId] = seasonId;
                                 LogMediaItemChanged(_logger, itemId);
                             }
                             catch (Exception ex)
@@ -413,12 +413,28 @@ namespace IntroSkipper.Services
                             }
                         }
 
-                        if (_config.UpdateMediaSegments && successfullyResetItemIds.Count > 0)
+                        var failedRefreshSeasonIds = new HashSet<Guid>();
+                        if (_config.UpdateMediaSegments && successfullyResetItems.Count > 0)
                         {
-                            await _mediaSegmentRefresher.RefreshAsync(successfullyResetItemIds, cts.Token).ConfigureAwait(false);
+                            try
+                            {
+                                await _mediaSegmentRefresher.RefreshAsync(successfullyResetItems.Keys, cts.Token).ConfigureAwait(false);
+                            }
+                            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+                            {
+                                RequeueResetItems(successfullyResetItems);
+                                throw;
+                            }
+                            catch (Exception ex)
+                            {
+                                RequeueResetItems(successfullyResetItems);
+                                failedRefreshSeasonIds.UnionWith(successfullyResetItems.Values);
+                                LogErrorRefreshingChangedMediaItems(_logger, ex, successfullyResetItems.Count);
+                            }
                         }
 
                         seasonIds.ExceptWith(failedResetSeasonIds);
+                        seasonIds.ExceptWith(failedRefreshSeasonIds);
 
                         var analyzer = new BaseItemAnalyzerTask(_loggerFactory.CreateLogger<Entrypoint>(), _loggerFactory, _libraryManager, _providerManager, _fileSystem, _mediaSegmentRefresher, _ffmpegService, _cacheService);
                         await analyzer.AnalyzeItemsAsync(new Progress<double>(), cts.Token, seasonIds).ConfigureAwait(false);
@@ -458,6 +474,20 @@ namespace IntroSkipper.Services
                     LogAnalyzingEndedNeedsRestart();
                     _queueTimer.Change(TimeSpan.FromSeconds(60), Timeout.InfiniteTimeSpan);
                 }
+            }
+        }
+
+        private void RequeueResetItems(IReadOnlyDictionary<Guid, Guid> itemsToReset)
+        {
+            lock (_seasonsLock)
+            {
+                foreach (var (itemId, seasonId) in itemsToReset)
+                {
+                    _itemsToReset[itemId] = seasonId;
+                    _seasonsToAnalyze.Add(seasonId);
+                }
+
+                _analyzeAgain = true;
             }
         }
 
@@ -504,6 +534,9 @@ namespace IntroSkipper.Services
 
         [LoggerMessage(Level = LogLevel.Warning, Message = "Unable to invalidate automatic analysis for changed media item {Id}")]
         private static partial void LogErrorResettingChangedMediaItem(ILogger logger, Exception ex, Guid id);
+
+        [LoggerMessage(Level = LogLevel.Warning, Message = "Unable to refresh media segments for {Count} changed media items")]
+        private static partial void LogErrorRefreshingChangedMediaItems(ILogger logger, Exception ex, int count);
 
         [LoggerMessage(Level = LogLevel.Warning, Message = "Error deleting fingerprint cache on item removal")]
         private partial void LogErrorDeletingFingerprintCache(Exception ex);

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -49,6 +49,7 @@ namespace IntroSkipper.Services
         private static readonly SemaphoreSlim _analysisSemaphore = new(1, 1);
         private PluginConfiguration _config;
         private volatile bool _analyzeAgain;
+        private volatile bool _isStopping;
         private static CancellationTokenSource? _cancellationTokenSource;
 
         /// <summary>
@@ -112,6 +113,11 @@ namespace IntroSkipper.Services
         /// <inheritdoc />
         public async Task StartAsync(CancellationToken cancellationToken)
         {
+            lock (_seasonsLock)
+            {
+                _isStopping = false;
+            }
+
             _libraryManager.ItemAdded += OnItemChanged;
             _libraryManager.ItemUpdated += OnItemChanged;
             _libraryManager.ItemRemoved += OnItemRemoved;
@@ -130,13 +136,18 @@ namespace IntroSkipper.Services
         /// <inheritdoc />
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            lock (_seasonsLock)
+            {
+                _isStopping = true;
+                _queueTimer.Change(Timeout.Infinite, 0);
+            }
+
             _libraryManager.ItemAdded -= OnItemChanged;
             _libraryManager.ItemUpdated -= OnItemChanged;
             _libraryManager.ItemRemoved -= OnItemRemoved;
             _taskManager.TaskCompleted -= OnLibraryRefresh;
             Plugin.Instance!.ConfigurationChanged -= OnSettingsChanged;
 
-            _queueTimer.Change(Timeout.Infinite, 0);
             await CancelAutomaticTaskAsync(cancellationToken).ConfigureAwait(false);
         }
 
@@ -316,17 +327,22 @@ namespace IntroSkipper.Services
         /// </summary>
         private void StartTimer(int delay = 60)
         {
-            if (AutomaticTaskState == TaskState.Running)
+            lock (_seasonsLock)
             {
-                lock (_seasonsLock)
+                if (_isStopping)
+                {
+                    return;
+                }
+
+                if (AutomaticTaskState == TaskState.Running)
                 {
                     _analyzeAgain = true;
                 }
-            }
-            else if (AutomaticTaskState == TaskState.Idle)
-            {
-                LogMediaLibraryChanged();
-                _queueTimer.Change(TimeSpan.FromSeconds(delay), Timeout.InfiniteTimeSpan);
+                else if (AutomaticTaskState == TaskState.Idle)
+                {
+                    LogMediaLibraryChanged();
+                    _queueTimer.Change(TimeSpan.FromSeconds(delay), Timeout.InfiniteTimeSpan);
+                }
             }
         }
 
@@ -410,19 +426,15 @@ namespace IntroSkipper.Services
                 }
                 finally
                 {
-                    var wasCancelled = cts.IsCancellationRequested;
                     // Null the field BEFORE disposing to prevent other threads
                     // from reading a disposed CancellationTokenSource via Volatile.Read.
                     Interlocked.Exchange(ref _cancellationTokenSource, null);
                     cts.Dispose();
 
-                    // Do this after making the task idle. An item update can arrive between the
-                    // analysis completion check and clearing _cancellationTokenSource; checking
-                    // the queues here closes that race and guarantees another pass is scheduled.
-                    if (!wasCancelled)
-                    {
-                        ScheduleAnalysisIfNeeded();
-                    }
+                    // Do this after making the task idle. An item update can arrive while the
+                    // task is cancelling; checking the queues here ensures that update is not
+                    // stranded. ScheduleAnalysisIfNeeded suppresses this during shutdown.
+                    ScheduleAnalysisIfNeeded();
                 }
             }
             finally
@@ -433,16 +445,19 @@ namespace IntroSkipper.Services
 
         private void ScheduleAnalysisIfNeeded()
         {
-            bool needsRestart;
             lock (_seasonsLock)
             {
-                needsRestart = _analyzeAgain || _seasonsToAnalyze.Count > 0 || _itemsToReset.Count > 0;
-            }
+                if (_isStopping)
+                {
+                    return;
+                }
 
-            if (needsRestart && AutomaticTaskState == TaskState.Idle)
-            {
-                LogAnalyzingEndedNeedsRestart();
-                _queueTimer.Change(TimeSpan.FromSeconds(60), Timeout.InfiniteTimeSpan);
+                var needsRestart = _analyzeAgain || _seasonsToAnalyze.Count > 0 || _itemsToReset.Count > 0;
+                if (needsRestart && AutomaticTaskState == TaskState.Idle)
+                {
+                    LogAnalyzingEndedNeedsRestart();
+                    _queueTimer.Change(TimeSpan.FromSeconds(60), Timeout.InfiniteTimeSpan);
+                }
             }
         }
 

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -395,7 +395,11 @@ namespace IntroSkipper.Services
                             try
                             {
                                 Plugin.ResetItemForReanalysis(seasonId, itemId, Enum.GetValues<AnalysisMode>());
-                                _cacheService.DeleteForItem(itemId);
+                                if (!_cacheService.DeleteForItem(itemId))
+                                {
+                                    throw new InvalidOperationException($"Unable to delete detection cache for changed media item {itemId:N}.");
+                                }
+
                                 successfullyResetItems[itemId] = seasonId;
                                 LogMediaItemChanged(_logger, itemId);
                             }

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -373,12 +373,14 @@ namespace IntroSkipper.Services
                         }
 
                         var failedResetSeasonIds = new HashSet<Guid>();
+                        var successfullyResetItemIds = new HashSet<Guid>();
                         foreach (var (itemId, seasonId) in itemsToReset)
                         {
                             try
                             {
                                 Plugin.ResetItemForReanalysis(seasonId, itemId, Enum.GetValues<AnalysisMode>());
                                 _cacheService.DeleteForItem(itemId);
+                                successfullyResetItemIds.Add(itemId);
                                 LogMediaItemChanged(_logger, itemId);
                             }
                             catch (Exception ex)
@@ -393,6 +395,11 @@ namespace IntroSkipper.Services
                                 failedResetSeasonIds.Add(seasonId);
                                 LogErrorResettingChangedMediaItem(_logger, ex, itemId);
                             }
+                        }
+
+                        if (_config.UpdateMediaSegments && successfullyResetItemIds.Count > 0)
+                        {
+                            await _mediaSegmentRefresher.RefreshAsync(successfullyResetItemIds, cts.Token).ConfigureAwait(false);
                         }
 
                         seasonIds.ExceptWith(failedResetSeasonIds);


### PR DESCRIPTION
## Summary by Sourcery

Invalidate and coordinate reanalysis for media items whose underlying files change.

New Features:
- Invalidate automatic analysis results and detection caches when Jellyfin reports filesystem-driven media item changes.
- Refresh media segments for successfully invalidated items before reanalyzing affected seasons.

Bug Fixes:
- Prevent changed media files retaining stale automatic analysis, fingerprints, and settled season state.
- Ensure failed invalidation or refresh operations are retried instead of losing queued work.
- Prevent analysis updates from being stranded during shutdown or task cancellation.

Enhancements:
- Preserve user-provided segments while resetting automatic analysis state for changed items.

Tests:
- Add coverage for queuing changed episodes for coordinated invalidation.
- Add coverage verifying item resets remove affected items from settled season state.