### PR TITLE
Propagate segment deletions during analysis to Jellyfin media segments

### DIFF
--- a/IntroSkipper.Tests/TestDatabaseFacades.cs
+++ b/IntroSkipper.Tests/TestDatabaseFacades.cs
@@ -688,9 +688,11 @@ public sealed class TestDatabaseFacades
             await database.UpdateTimestampAsync(new Segment(matchingHashItemId, new TimeRange(0, 30)), AnalysisMode.Introduction, configHash: "new-config");
             await database.UpdateTimestampAsync(new Segment(otherModeItemId, new TimeRange(1200, 1260)), AnalysisMode.Credits, configHash: "old-config");
 
-            await database.CleanStaleAutomaticSegmentsAsync(itemIds, AnalysisMode.Introduction, "new-config");
+            var deleted = await database.CleanStaleAutomaticSegmentsAsync(itemIds, AnalysisMode.Introduction, "new-config");
 
+            Assert.Equal(1, deleted);
             Assert.Empty(await database.GetSegmentsAsync(staleItemId));
+            Assert.Equal(0, await database.CleanStaleAutomaticSegmentsAsync(itemIds, AnalysisMode.Introduction, "new-config"));
 
             await using var db = new IntroSkipperDbContext(dbPath);
             var remaining = await db.DbSegment.AsNoTracking().ToListAsync();

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -511,7 +511,7 @@ public sealed class TestSeasonReanalysisReset
         {
             using (var db = new IntroSkipperDbContext(dbPath))
             {
-                db.Database.EnsureCreated();
+                await db.Database.EnsureCreatedAsync();
                 db.DbSeasonState.Add(new DbSeasonState(
                     seasonId,
                     AnalysisMode.Introduction,
@@ -519,7 +519,7 @@ public sealed class TestSeasonReanalysisReset
                     [itemId],
                     "hash",
                     [itemId]));
-                db.SaveChanges();
+                await db.SaveChangesAsync();
             }
 
             var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);

--- a/IntroSkipper/Db/IIntroSkipperDatabase.cs
+++ b/IntroSkipper/Db/IIntroSkipperDatabase.cs
@@ -139,8 +139,8 @@ public interface IIntroSkipperDatabase
     /// <param name="mode">Analysis mode.</param>
     /// <param name="configHash">Current configuration hash.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task CleanStaleAutomaticSegmentsAsync(IEnumerable<Guid> itemIds, AnalysisMode mode, string configHash, CancellationToken cancellationToken = default);
+    /// <returns>The number of segments that were removed.</returns>
+    Task<int> CleanStaleAutomaticSegmentsAsync(IEnumerable<Guid> itemIds, AnalysisMode mode, string configHash, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Sets the analyzer actions for a season.

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -36,7 +36,7 @@ public sealed partial class IntroSkipperDatabase
     }
 
     /// <inheritdoc/>
-    public async Task CleanStaleAutomaticSegmentsAsync(
+    public async Task<int> CleanStaleAutomaticSegmentsAsync(
         IEnumerable<Guid> itemIds,
         AnalysisMode mode,
         string configHash,
@@ -47,12 +47,12 @@ public sealed partial class IntroSkipperDatabase
         var ids = itemIds.Distinct().ToArray();
         if (ids.Length == 0)
         {
-            return;
+            return 0;
         }
 
         await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
-        await db.DbSegment
+        return await db.DbSegment
             .Where(s => EF.Parameter(ids).Contains(s.ItemId)
                 && s.Type == mode
                 && !s.IsUserProvided

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -170,7 +170,7 @@ public partial class BaseItemAnalyzerTask(
                 foreach (var mode in modes)
                 {
                     ct.ThrowIfCancellationRequested();
-                    int analyzed = await AnalyzeItemsAsync(
+                    bool segmentsChanged = await AnalyzeItemsAsync(
                         episodes,
                         mode,
                         ffmpegValid,
@@ -186,7 +186,7 @@ public partial class BaseItemAnalyzerTask(
                         completedSettledModes.Add(mode);
                     }
 
-                    updateMediaSegments = analyzed > 0 || updateMediaSegments;
+                    updateMediaSegments = segmentsChanged || updateMediaSegments;
                     progress.Report((double)totalProcessed / totalQueued * 100);
                 }
             }
@@ -289,8 +289,8 @@ public partial class BaseItemAnalyzerTask(
     /// <param name="mode">Analysis mode.</param>
     /// <param name="ffmpegValid">Whether FFmpeg supports the required Chromaprint features.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Number of items successfully analyzed.</returns>
-    private async Task<int> AnalyzeItemsAsync(
+    /// <returns>Whether any stored segments changed, either because items were analyzed or because stale or invalid automatic segments were deleted.</returns>
+    private async Task<bool> AnalyzeItemsAsync(
         IReadOnlyList<QueuedEpisode> items,
         AnalysisMode mode,
         bool ffmpegValid,
@@ -298,7 +298,7 @@ public partial class BaseItemAnalyzerTask(
     {
         if (!HasUncachedAnalysisWork(items, mode))
         {
-            return 0;
+            return false;
         }
 
         var first = items[0];
@@ -308,7 +308,7 @@ public partial class BaseItemAnalyzerTask(
 
         if (!isMovie && first.SeasonNumber == 0 && !_config.AnalyzeSeasonZero)
         {
-            return 0;
+            return false;
         }
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
@@ -318,7 +318,7 @@ public partial class BaseItemAnalyzerTask(
         if (action == AnalyzerAction.None)
         {
             LogSkippingNoneAction(_logger, mode, first.SeriesName, first.SeasonNumber);
-            return 0;
+            return false;
         }
 
         foreach (var item in items)
@@ -326,11 +326,11 @@ public partial class BaseItemAnalyzerTask(
             item.AnalysisConfigHash = configHash;
         }
 
-        await _database.CleanStaleAutomaticSegmentsAsync(
+        var staleSegmentsRemoved = await _database.CleanStaleAutomaticSegmentsAsync(
             items.Where(e => e.GetAnalyzed(mode) != EpisodeState.UserProvided).Select(e => e.EpisodeId),
             mode,
             configHash,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false) > 0;
 
         LogAnalyzingFiles(_logger, mode, items.Count, first.SeriesName, first.SeasonNumber);
 
@@ -405,6 +405,10 @@ public partial class BaseItemAnalyzerTask(
                 break;
         }
 
+        // Analyzers that adjust an existing automatic segment into an unusable range delete it and
+        // mark the episode NoSegments, so a transition into that state means stored segments changed.
+        var preAnalysisStates = items.ToDictionary(e => e.EpisodeId, e => e.GetAnalyzed(mode));
+
         // Execute each analyzer in order. Analyzers skip episodes already
         // marked as analyzed by earlier ones via NeedsAnalysis().
         foreach (var analyzer in analyzers)
@@ -422,7 +426,13 @@ public partial class BaseItemAnalyzerTask(
         // Set the episode IDs for the analyzed items
         await _database.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), configHash, cancellationToken).ConfigureAwait(false);
 
-        return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
+        var analyzed = totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
+        var invalidSegmentsRemoved = items.Any(e =>
+            e.GetAnalyzed(mode) == EpisodeState.NoSegments
+            && preAnalysisStates.TryGetValue(e.EpisodeId, out var previousState)
+            && previousState != EpisodeState.NoSegments);
+
+        return analyzed > 0 || staleSegmentsRemoved || invalidSegmentsRemoved;
     }
 
     /// <summary>

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -368,7 +368,24 @@ namespace IntroSkipper.Services
             try
             {
                 var cts = new CancellationTokenSource();
-                Interlocked.Exchange(ref _cancellationTokenSource, cts);
+
+                // A timer callback can already be in flight when StopAsync stops the timer.
+                // Starting a new analysis here would leave shutdown waiting on the semaphore
+                // until it times out, so bail out and keep the queues for the next start.
+                // Checking the flag and publishing the cancellation source under the same
+                // lock StopAsync uses to set the flag guarantees shutdown either sees the
+                // published source and cancels it, or this callback sees the flag and stops.
+                lock (_seasonsLock)
+                {
+                    if (_isStopping)
+                    {
+                        cts.Dispose();
+                        return;
+                    }
+
+                    Interlocked.Exchange(ref _cancellationTokenSource, cts);
+                }
+
                 try
                 {
                     using (await ScheduledTaskSemaphore.AcquireAsync(cts.Token).ConfigureAwait(false))


### PR DESCRIPTION
## Problem

Since #930, analyzers delete an episode's automatic segment when boundary adjustment produces an unusable range (`DeleteAutomaticTimestampAsync` + `EpisodeState.NoSegments`), and `CleanStaleAutomaticSegmentsAsync` removes stale-hash and invalid rows at the start of every mode pass. Both delete rows only from the plugin database.

The season loop in `BaseItemAnalyzerTask` triggers `IMediaSegmentRefresher.RefreshAsync` only when `analyzed > 0`, i.e. when at least one episode reached `EpisodeState.Analyzed`. When a pass only deletes segments and writes none — for example a config change (such as enabling `IncludeIntroStartOffsetWhenSnapping` with a large offset) that turns every adjusted range invalid — the refresh never runs, and Jellyfin keeps serving skip prompts for segments the plugin just deleted. The stale entries persist until some unrelated analysis result later happens to trigger a refresh.

## Fix

`AnalyzeItemsAsync` now reports whether stored segments changed instead of only how many episodes were analyzed:

- `CleanStaleAutomaticSegmentsAsync` returns the number of rows it deleted, and a non-zero count marks the pass as changed.
- Episode states are snapshotted before the analyzer chain runs; a transition into `EpisodeState.NoSegments` (the invalid-adjustment delete path) also marks the pass as changed.
- The season loop's `updateMediaSegments` now uses that combined signal, so deletions propagate to Jellyfin's media segments in the same run.

Seasons where analyzers simply find nothing (episodes stay `NotAnalyzed`, no rows deleted) still skip the refresh, so no extra refresh churn is introduced.

## Testing

- Extended `CleanStaleAutomaticSegmentsAsync_DeletesOnlyStaleAutomaticSegments_WhenItemListIsLarge` to assert the deleted count on the first pass and zero on an idempotent second pass.
- `dotnet build` clean, full suite green: 515 passed, 0 failed.

## Summary by Sourcery

Ensure analysis-driven segment deletions are reflected in Jellyfin during the same run and prevent analysis from racing with shutdown.

Bug Fixes:
- Propagate automatic segment deletions to Jellyfin immediately when analysis removes stale or invalid segments.
- Prevent a new analysis run from starting after shutdown has begun, avoiding shutdown delays and preserving queued work.

Enhancements:
- Track whether analysis changed stored segments, rather than only whether episodes were successfully analyzed, while avoiding refreshes for no-op passes.

Tests:
- Verify stale-segment cleanup reports the deleted-row count and is idempotent on subsequent runs.