### PR TITLE
Guard analysis startup during shutdown and simplify item reset transaction

### DIFF
--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -542,38 +542,32 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         using var db = CreateDbContext();
         using var transaction = db.Database.BeginTransaction();
-        try
+
+        db.DbSegment
+            .Where(s => s.ItemId == itemId && modeArray.Contains(s.Type) && !s.IsUserProvided)
+            .ExecuteDelete();
+
+        var seasonStates = db.DbSeasonState
+            .Where(s => modeArray.Contains(s.Type) && (seasonId == Guid.Empty || s.SeasonId == seasonId))
+            .ToList();
+
+        foreach (var state in seasonStates)
         {
-            db.DbSegment
-                .Where(s => s.ItemId == itemId && modeArray.Contains(s.Type) && !s.IsUserProvided)
-                .ExecuteDelete();
-
-            var seasonStates = db.DbSeasonState
-                .Where(s => modeArray.Contains(s.Type) && (seasonId == Guid.Empty || s.SeasonId == seasonId))
-                .ToList();
-
-            foreach (var state in seasonStates)
+            var episodeIds = state.EpisodeIds.ToList();
+            var settledReanalysisEpisodeIds = state.SettledReanalysisEpisodeIds.ToList();
+            if (episodeIds.Remove(itemId))
             {
-                var episodeIds = state.EpisodeIds.ToList();
-                var settledReanalysisEpisodeIds = state.SettledReanalysisEpisodeIds.ToList();
-                if (episodeIds.Remove(itemId))
-                {
-                    db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
-                }
-
-                if (settledReanalysisEpisodeIds.Remove(itemId))
-                {
-                    db.Entry(state).Property(s => s.SettledReanalysisEpisodeIds).CurrentValue = settledReanalysisEpisodeIds;
-                }
+                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = episodeIds;
             }
 
-            db.SaveChanges();
-            transaction.Commit();
+            if (settledReanalysisEpisodeIds.Remove(itemId))
+            {
+                db.Entry(state).Property(s => s.SettledReanalysisEpisodeIds).CurrentValue = settledReanalysisEpisodeIds;
+            }
         }
-        finally
-        {
-            transaction.Dispose();
-        }
+
+        db.SaveChanges();
+        transaction.Commit();
     }
 
     /// <summary>

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -370,6 +370,14 @@ namespace IntroSkipper.Services
             await _analysisSemaphore.WaitAsync().ConfigureAwait(false);
             try
             {
+                // A timer callback can already be in flight when StopAsync stops the timer.
+                // Starting a new analysis here would leave shutdown waiting on the semaphore
+                // until it times out, so bail out and keep the queues for the next start.
+                if (_isStopping)
+                {
+                    return;
+                }
+
                 var cts = new CancellationTokenSource();
                 Interlocked.Exchange(ref _cancellationTokenSource, cts);
                 try


### PR DESCRIPTION
Follow-up to #933.

- `Entrypoint.PerformAnalysisAsync` now bails out after acquiring the analysis semaphore when `_isStopping` is set. A timer callback already in flight when `StopAsync` stops the queue timer could otherwise start a fresh analysis pass with a brand-new (uncancelled) token, leaving `CancelAutomaticTaskAsync` blocked on the semaphore until its 60-second timeout throws during shutdown. The queues are left intact for the next start.
- `Plugin.ResetItemForReanalysis` drops the redundant `try`/`finally { transaction.Dispose(); }` around a transaction already declared with `using var`, which disposed it twice.

`TestEntrypointEvents` and `TestSeasonReanalysis` pass locally (43/43); the full suite passes except `TestSilenceDetection`, which fails identically on the unmodified 10.11 head with the local ffmpeg 6.1.1 (silencedetect timestamp precision differs from CI's ffmpeg).

## Summary by Sourcery

Prevent shutdown races during analysis startup and simplify transaction cleanup for reanalysis resets.

Bug Fixes:
- Prevent analysis from starting during shutdown when a timer callback is already in flight, avoiding shutdown semaphore timeouts and preserving queued work for the next start.

Enhancements:
- Simplify reanalysis item reset transaction handling by relying on scoped disposal.