### PR TITLE
Reset season state for every row referencing a changed item

### DIFF
--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -523,7 +523,7 @@ public sealed class TestSeasonReanalysisReset
             }
 
             var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
-            await database.ResetItemForReanalysisAsync(seasonId, itemId, [AnalysisMode.Introduction]);
+            await database.ResetItemForReanalysisAsync(itemId, [AnalysisMode.Introduction]);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
@@ -539,17 +539,17 @@ public sealed class TestSeasonReanalysisReset
     }
 
     [Fact]
-    public async Task ResetItemForReanalysis_RemovesItemFromSeasonStateKeyedByResolvedSeasonId()
+    public async Task ResetItemForReanalysis_RemovesItemFromEverySeasonStateReferencingIt()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
         Directory.CreateDirectory(tempDir);
         var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
 
-        // In-season specials are queued under the resolved regular season, so their season-state
-        // rows are keyed by a season id that differs from the raw SeasonId reported with the item
-        // change event.
-        var rawSeasonId = Guid.NewGuid();
+        // In-season specials are stored under a resolved queue key that differs from their raw
+        // SeasonId and can vary between scoped and full passes, so the same item can be referenced
+        // by season-state rows keyed under different season ids.
         var resolvedSeasonId = Guid.NewGuid();
+        var rawSeasonId = Guid.NewGuid();
         var itemId = Guid.NewGuid();
         var siblingId = Guid.NewGuid();
 
@@ -568,19 +568,42 @@ public sealed class TestSeasonReanalysisReset
                     [itemId, siblingId],
                     "hash",
                     [itemId, siblingId]));
+                db.DbSeasonState.Add(new DbSeasonState(
+                    rawSeasonId,
+                    AnalysisMode.Credits,
+                    AnalyzerAction.Default,
+                    [itemId],
+                    "credits-hash",
+                    [itemId]));
+                db.DbSeasonState.Add(new DbSeasonState(
+                    rawSeasonId,
+                    AnalysisMode.Recap,
+                    AnalyzerAction.Default,
+                    [itemId],
+                    "recap-hash",
+                    [itemId]));
                 await db.SaveChangesAsync();
             }
 
             var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
-            await database.ResetItemForReanalysisAsync(rawSeasonId, itemId, [AnalysisMode.Introduction]);
+            await database.ResetItemForReanalysisAsync(itemId, [AnalysisMode.Introduction, AnalysisMode.Credits]);
 
             using (var db = new IntroSkipperDbContext(dbPath))
             {
                 Assert.False(db.DbSegment.Any(s => s.ItemId == itemId));
 
-                var state = db.DbSeasonState.Single();
-                Assert.Equal([siblingId], state.EpisodeIds);
-                Assert.Equal([siblingId], state.SettledReanalysisEpisodeIds);
+                var introState = await db.DbSeasonState.SingleAsync(s => s.Type == AnalysisMode.Introduction);
+                Assert.Equal([siblingId], introState.EpisodeIds);
+                Assert.Equal([siblingId], introState.SettledReanalysisEpisodeIds);
+
+                var creditsState = await db.DbSeasonState.SingleAsync(s => s.Type == AnalysisMode.Credits);
+                Assert.Empty(creditsState.EpisodeIds);
+                Assert.Empty(creditsState.SettledReanalysisEpisodeIds);
+
+                // Modes outside the requested set stay untouched.
+                var recapState = await db.DbSeasonState.SingleAsync(s => s.Type == AnalysisMode.Recap);
+                Assert.Equal([itemId], recapState.EpisodeIds);
+                Assert.Equal([itemId], recapState.SettledReanalysisEpisodeIds);
             }
         }
         finally

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -539,6 +539,57 @@ public sealed class TestSeasonReanalysisReset
     }
 
     [Fact]
+    public async Task ResetItemForReanalysis_RemovesItemFromSeasonStateKeyedByResolvedSeasonId()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+
+        // In-season specials are queued under the resolved regular season, so their season-state
+        // rows are keyed by a season id that differs from the raw SeasonId reported with the item
+        // change event.
+        var rawSeasonId = Guid.NewGuid();
+        var resolvedSeasonId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var siblingId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSegment.Add(new DbSegment(
+                    new Segment(itemId, new TimeRange(0, 30)),
+                    AnalysisMode.Introduction));
+                db.DbSeasonState.Add(new DbSeasonState(
+                    resolvedSeasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Chromaprint,
+                    [itemId, siblingId],
+                    "hash",
+                    [itemId, siblingId]));
+                await db.SaveChangesAsync();
+            }
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.ResetItemForReanalysisAsync(rawSeasonId, itemId, [AnalysisMode.Introduction]);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                Assert.False(db.DbSegment.Any(s => s.ItemId == itemId));
+
+                var state = db.DbSeasonState.Single();
+                Assert.Equal(new[] { siblingId }, state.EpisodeIds);
+                Assert.Equal(new[] { siblingId }, state.SettledReanalysisEpisodeIds);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task ResetSeasonForReanalysisAsync_DeletesCreditsDerivedAutomaticPreview()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -579,8 +579,8 @@ public sealed class TestSeasonReanalysisReset
                 Assert.False(db.DbSegment.Any(s => s.ItemId == itemId));
 
                 var state = db.DbSeasonState.Single();
-                Assert.Equal(new[] { siblingId }, state.EpisodeIds);
-                Assert.Equal(new[] { siblingId }, state.SettledReanalysisEpisodeIds);
+                Assert.Equal([siblingId], state.EpisodeIds);
+                Assert.Equal([siblingId], state.SettledReanalysisEpisodeIds);
             }
         }
         finally

--- a/IntroSkipper/Db/IIntroSkipperDatabase.cs
+++ b/IntroSkipper/Db/IIntroSkipperDatabase.cs
@@ -174,14 +174,14 @@ public interface IIntroSkipperDatabase
 
     /// <summary>
     /// Clears automatic analysis state for one media item while preserving user-provided segments.
+    /// The item is removed from every season-state row that references it, because the resolved
+    /// queue key an item is stored under can differ from its raw SeasonId.
     /// </summary>
-    /// <param name="seasonId">Season containing the item, or <see cref="Guid.Empty"/> when unknown.</param>
     /// <param name="itemId">Media item ID.</param>
     /// <param name="modes">Analysis modes to reset.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     Task ResetItemForReanalysisAsync(
-        Guid seasonId,
         Guid itemId,
         IReadOnlyCollection<AnalysisMode> modes,
         CancellationToken cancellationToken = default);

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -152,7 +152,6 @@ public sealed partial class IntroSkipperDatabase
     /// failed reset cannot leave stale state marked as analyzed.
     /// </remarks>
     public async Task ResetItemForReanalysisAsync(
-        Guid seasonId,
         Guid itemId,
         IReadOnlyCollection<AnalysisMode> modes,
         CancellationToken cancellationToken = default)
@@ -176,25 +175,16 @@ public sealed partial class IntroSkipperDatabase
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
 
+            // Season-state rows are keyed by the resolved queue key, which can differ from the raw
+            // SeasonId reported with the item change (in-season specials, unresolved-SeasonId
+            // fallbacks) and can even vary between scoped and full passes for the same item, so no
+            // single season id reliably locates the rows that reference the item. Scan all rows for
+            // the requested modes instead; otherwise the item stays cached as analyzed under another
+            // key while its segments were just deleted, and it is never re-analyzed.
             var seasonStates = await db.DbSeasonState
-                .Where(s => modeArray.Contains(s.Type) && (seasonId == Guid.Empty || s.SeasonId == seasonId))
+                .Where(s => modeArray.Contains(s.Type))
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
-
-            // The queue keys in-season specials (and episodes with unresolved SeasonIds) under a
-            // resolved season id that differs from the raw SeasonId reported with the item change,
-            // so the narrow lookup can miss the rows that actually reference the item. Widen the
-            // scan in that case; otherwise the item stays cached as analyzed in the season state
-            // while its segments were just deleted, and it is never re-analyzed.
-            if (seasonId != Guid.Empty &&
-                modeArray.Any(mode => !seasonStates.Any(s => s.Type == mode &&
-                    (s.EpisodeIds.Contains(itemId) || s.SettledReanalysisEpisodeIds.Contains(itemId)))))
-            {
-                seasonStates.AddRange(await db.DbSeasonState
-                    .Where(s => modeArray.Contains(s.Type) && s.SeasonId != seasonId)
-                    .ToListAsync(cancellationToken)
-                    .ConfigureAwait(false));
-            }
 
             foreach (var state in seasonStates)
             {

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -181,6 +181,20 @@ public sealed partial class IntroSkipperDatabase
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
+            // The queue keys in-season specials (and episodes with unresolved SeasonIds) under a
+            // resolved season id that differs from the raw SeasonId reported with the item change,
+            // so the narrow lookup can miss the rows that actually reference the item. Widen the
+            // scan in that case; otherwise the item stays cached as analyzed in the season state
+            // while its segments were just deleted, and it is never re-analyzed.
+            if (seasonId != Guid.Empty &&
+                !seasonStates.Any(s => s.EpisodeIds.Contains(itemId) || s.SettledReanalysisEpisodeIds.Contains(itemId)))
+            {
+                seasonStates = await db.DbSeasonState
+                    .Where(s => modeArray.Contains(s.Type) && s.SeasonId != seasonId)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
             foreach (var state in seasonStates)
             {
                 var episodeIds = state.EpisodeIds.ToList();

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -187,12 +187,13 @@ public sealed partial class IntroSkipperDatabase
             // scan in that case; otherwise the item stays cached as analyzed in the season state
             // while its segments were just deleted, and it is never re-analyzed.
             if (seasonId != Guid.Empty &&
-                !seasonStates.Any(s => s.EpisodeIds.Contains(itemId) || s.SettledReanalysisEpisodeIds.Contains(itemId)))
+                modeArray.Any(mode => !seasonStates.Any(s => s.Type == mode &&
+                    (s.EpisodeIds.Contains(itemId) || s.SettledReanalysisEpisodeIds.Contains(itemId)))))
             {
-                seasonStates = await db.DbSeasonState
+                seasonStates.AddRange(await db.DbSeasonState
                     .Where(s => modeArray.Contains(s.Type) && s.SeasonId != seasonId)
                     .ToListAsync(cancellationToken)
-                    .ConfigureAwait(false);
+                    .ConfigureAwait(false));
             }
 
             foreach (var state in seasonStates)

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -409,7 +409,6 @@ namespace IntroSkipper.Services
                             try
                             {
                                 await _database.ResetItemForReanalysisAsync(
-                                    seasonId,
                                     itemId,
                                     Enum.GetValues<AnalysisMode>(),
                                     cts.Token).ConfigureAwait(false);


### PR DESCRIPTION
## Problem

Since #933, a filesystem-driven item replacement defers to `ResetItemForReanalysisAsync`, which deletes the item's automatic segments and removes it from the season-state episode sets so the next pass re-analyzes it. The season-state lookup filtered by the raw `episode.SeasonId` captured in `Entrypoint.OnItemChanged`.

Season-state rows are keyed by the *resolved* queue key, which can differ from that raw id, and can even differ per mode for the same item across runs:

- `QueueManager.GetSeasonId` redirects an in-season special (`ParentIndexNumber == 0`, aired season ≠ 0) into its aired season — but only when that season is already in the queue. A full pass keys the special under the regular season's id; a scoped pass triggered by a change event on the specials season keys it under the raw season-0 id.
- Episodes whose `SeasonId` never resolves fall back to `episode.Id` as the queue key.

For those items the reset deleted the segments but missed the season-state rows, so the item stayed in `EpisodeIds` with an unchanged config hash. `VerifyQueueAsync` then negative-caches it as `EpisodeState.NoSegments`, and the replaced file is never re-analyzed until an unrelated config change or settled-season reanalysis.

## Fix

No single season id reliably locates the rows referencing an item, so `ResetItemForReanalysisAsync` now loads all season-state rows for the requested modes and removes the item from every row that references it. The `seasonId` parameter is dropped from the interface and the `Entrypoint` call site since nothing narrows on it anymore. Both queries stay inside the existing transaction, so segments and season state still commit together and a cancelled reset rolls back atomically; the operation stays idempotent for the requeue-and-retry paths (`RequeueResetItems`, failed-reset requeue), and all writers remain serialized behind `ScheduledTaskSemaphore`, so no concurrent pass can observe or produce a torn state.

## Testing

- New `ResetItemForReanalysis_RemovesItemFromEverySeasonStateReferencingIt` covers rows keyed under different season ids and asserts sibling episodes and non-requested modes stay cached; it fails without the fix.
- `dotnet build` clean, full suite green: 516 passed, 0 failed.