### PR TITLE
Filter season-state reset query to rows referencing the item

### DIFF
--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -539,6 +539,49 @@ public sealed class TestSeasonReanalysisReset
     }
 
     [Fact]
+    public async Task ResetItemForReanalysis_RemovesItemStoredWithLowercaseGuidJson()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var seasonId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var siblingId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+
+                // RecordSettleReanalysisAsync and rows migrated from DbSeasonInfo store episode-id
+                // JSON with lowercase GUIDs, while EF's primitive-collection mapping writes
+                // uppercase. The reset must find the item regardless of the stored casing.
+                var lowercaseJson = System.Text.Json.JsonSerializer.Serialize(new[] { itemId, siblingId });
+                await db.Database.ExecuteSqlInterpolatedAsync(
+                    $"""
+                    INSERT INTO "DbSeasonState" ("SeasonId", "Type", "Action", "EpisodeIds", "ConfigHash", "SettledReanalysisEpisodeIds")
+                    VALUES ({seasonId}, {(int)AnalysisMode.Introduction}, {(int)AnalyzerAction.Chromaprint}, {lowercaseJson}, {"hash"}, {lowercaseJson})
+                    """);
+            }
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.ResetItemForReanalysisAsync(itemId, [AnalysisMode.Introduction]);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var state = db.DbSeasonState.Single();
+                Assert.Equal([siblingId], state.EpisodeIds);
+                Assert.Equal([siblingId], state.SettledReanalysisEpisodeIds);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task ResetItemForReanalysis_RemovesItemReferencedOnlyInSettledReanalysisSet()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -554,9 +554,8 @@ public sealed class TestSeasonReanalysisReset
             {
                 await db.Database.EnsureCreatedAsync();
 
-                // RecordSettleReanalysisAsync and rows migrated from DbSeasonInfo store episode-id
-                // JSON with lowercase GUIDs, while EF's primitive-collection mapping writes
-                // uppercase. The reset must find the item regardless of the stored casing.
+                // RecordSettleReanalysisAsync and migrated rows store lowercase GUID JSON;
+                // the reset must find the item regardless of the stored casing.
                 Guid[] lowercaseIds = [itemId, siblingId];
                 var lowercaseJson = System.Text.Json.JsonSerializer.Serialize(lowercaseIds);
                 await db.Database.ExecuteSqlInterpolatedAsync(

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -557,7 +557,8 @@ public sealed class TestSeasonReanalysisReset
                 // RecordSettleReanalysisAsync and rows migrated from DbSeasonInfo store episode-id
                 // JSON with lowercase GUIDs, while EF's primitive-collection mapping writes
                 // uppercase. The reset must find the item regardless of the stored casing.
-                var lowercaseJson = System.Text.Json.JsonSerializer.Serialize(new[] { itemId, siblingId });
+                Guid[] lowercaseIds = [itemId, siblingId];
+                var lowercaseJson = System.Text.Json.JsonSerializer.Serialize(lowercaseIds);
                 await db.Database.ExecuteSqlInterpolatedAsync(
                     $"""
                     INSERT INTO "DbSeasonState" ("SeasonId", "Type", "Action", "EpisodeIds", "ConfigHash", "SettledReanalysisEpisodeIds")

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -539,6 +539,47 @@ public sealed class TestSeasonReanalysisReset
     }
 
     [Fact]
+    public async Task ResetItemForReanalysis_RemovesItemReferencedOnlyInSettledReanalysisSet()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var seasonId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var siblingId = Guid.NewGuid();
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Chromaprint,
+                    [siblingId],
+                    "hash",
+                    [itemId, siblingId]));
+                await db.SaveChangesAsync();
+            }
+
+            var database = DatabaseTestHelpers.CreateSegmentDatabase(dbPath);
+            await database.ResetItemForReanalysisAsync(itemId, [AnalysisMode.Introduction]);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var state = db.DbSeasonState.Single();
+                Assert.Equal([siblingId], state.EpisodeIds);
+                Assert.Equal([siblingId], state.SettledReanalysisEpisodeIds);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task ResetItemForReanalysis_RemovesItemFromEverySeasonStateReferencingIt()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -175,15 +175,9 @@ public sealed partial class IntroSkipperDatabase
                 .ExecuteDeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            // Season-state rows are keyed by the resolved queue key, which can differ from the raw
-            // SeasonId reported with the item change (in-season specials, unresolved-SeasonId
-            // fallbacks) and can even vary between scoped and full passes for the same item, so no
-            // single season id reliably locates the rows that reference the item. Match on the
-            // episode-id lists themselves instead; otherwise the item stays cached as analyzed
-            // under another key while its segments were just deleted, and it is never re-analyzed.
-            // The json_each lookups compare with NOCASE because the stored GUID casing is mixed:
-            // EF's primitive-collection mapping writes uppercase, while SerializeEpisodeIds
-            // (RecordSettleReanalysisAsync) and rows migrated from DbSeasonInfo are lowercase.
+            // No single season id reliably locates the rows referencing an item (see #936), so
+            // match on the episode-id lists themselves. NOCASE is required because EF writes
+            // uppercase GUID JSON while SerializeEpisodeIds and migrated rows are lowercase.
             var itemIdText = itemId.ToString();
             var seasonStates = await db.DbSeasonState
                 .FromSqlInterpolated(

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -178,11 +178,13 @@ public sealed partial class IntroSkipperDatabase
             // Season-state rows are keyed by the resolved queue key, which can differ from the raw
             // SeasonId reported with the item change (in-season specials, unresolved-SeasonId
             // fallbacks) and can even vary between scoped and full passes for the same item, so no
-            // single season id reliably locates the rows that reference the item. Scan all rows for
-            // the requested modes instead; otherwise the item stays cached as analyzed under another
-            // key while its segments were just deleted, and it is never re-analyzed.
+            // single season id reliably locates the rows that reference the item. Match on the
+            // episode-id lists themselves instead (translated to json_each lookups by SQLite);
+            // otherwise the item stays cached as analyzed under another key while its segments
+            // were just deleted, and it is never re-analyzed.
             var seasonStates = await db.DbSeasonState
-                .Where(s => modeArray.Contains(s.Type))
+                .Where(s => modeArray.Contains(s.Type)
+                    && (s.EpisodeIds.Contains(itemId) || s.SettledReanalysisEpisodeIds.Contains(itemId)))
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 

--- a/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.Maintenance.cs
@@ -179,12 +179,20 @@ public sealed partial class IntroSkipperDatabase
             // SeasonId reported with the item change (in-season specials, unresolved-SeasonId
             // fallbacks) and can even vary between scoped and full passes for the same item, so no
             // single season id reliably locates the rows that reference the item. Match on the
-            // episode-id lists themselves instead (translated to json_each lookups by SQLite);
-            // otherwise the item stays cached as analyzed under another key while its segments
-            // were just deleted, and it is never re-analyzed.
+            // episode-id lists themselves instead; otherwise the item stays cached as analyzed
+            // under another key while its segments were just deleted, and it is never re-analyzed.
+            // The json_each lookups compare with NOCASE because the stored GUID casing is mixed:
+            // EF's primitive-collection mapping writes uppercase, while SerializeEpisodeIds
+            // (RecordSettleReanalysisAsync) and rows migrated from DbSeasonInfo are lowercase.
+            var itemIdText = itemId.ToString();
             var seasonStates = await db.DbSeasonState
-                .Where(s => modeArray.Contains(s.Type)
-                    && (s.EpisodeIds.Contains(itemId) || s.SettledReanalysisEpisodeIds.Contains(itemId)))
+                .FromSqlInterpolated(
+                    $"""
+                    SELECT * FROM "DbSeasonState"
+                    WHERE EXISTS (SELECT 1 FROM json_each("EpisodeIds") WHERE "value" = {itemIdText} COLLATE NOCASE)
+                       OR EXISTS (SELECT 1 FROM json_each("SettledReanalysisEpisodeIds") WHERE "value" = {itemIdText} COLLATE NOCASE)
+                    """)
+                .Where(s => modeArray.Contains(s.Type))
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 


### PR DESCRIPTION
## Problem

Since #936, `ResetItemForReanalysisAsync` loads every season-state row for the requested modes into a tracked context to find the rows referencing a changed item. `Entrypoint` calls it with all analysis modes once per changed item, so a batch of item-change events (a season re-mux, a library scan touching many files) loads the entire `DbSeasonState` table — episode-id lists included — once per item, only to no-op on almost every row.

## Fix

Push the reference check into the query with `json_each` lookups over both episode-id lists, so only the rows that actually reference the item are materialized and tracked. Semantics are unchanged: rows not referencing the item were no-ops before, both id lists are still checked, and the query stays inside the existing transaction.

The lookups compare with `COLLATE NOCASE` because the stored GUID casing is mixed: EF's primitive-collection mapping writes uppercase JSON, while `SerializeEpisodeIds` (used by `RecordSettleReanalysisAsync`) and rows migrated from `DbSeasonInfo` are lowercase. A plain translated `Contains` binds an uppercase parameter and silently misses the lowercase rows — the in-memory scan parsed GUIDs case-insensitively and was immune, so a case-sensitive query would have re-introduced the stranded-item bug #936 fixed for exactly the settled-reanalysis rows.

## Testing

- New `ResetItemForReanalysis_RemovesItemStoredWithLowercaseGuidJson` inserts a row with lowercase GUID JSON (the `RecordSettleReanalysisAsync` / migrated-row format) via raw SQL and asserts the reset still removes the item; it fails against a case-sensitive translated `Contains`.
- New `ResetItemForReanalysis_RemovesItemReferencedOnlyInSettledReanalysisSet` pins the settled-only branch of the predicate.
- The #936 test `ResetItemForReanalysis_RemovesItemFromEverySeasonStateReferencingIt` exercises the composed query end to end, including mode scoping.
- Full suite: 518/518 passing.

## Summary by Sourcery

Filter season-state reanalysis resets by item references while retaining case-insensitive matching and coverage for both episode lists.

Bug Fixes:
- Restrict season-state reanalysis resets to rows that reference the changed item in either episode list, while preserving case-insensitive GUID matching.

Enhancements:
- Improve reanalysis reset efficiency by avoiding materialization of unrelated season-state rows.

Tests:
- Add coverage for lowercase GUID JSON and items referenced only by settled reanalysis state.