### PR TITLE
Align test fakes with current IDetectionCacheService and IFFmpegService interfaces

### DIFF
--- a/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
+++ b/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
@@ -93,9 +93,7 @@ public sealed class TestChromaprintFailureHandling
 
         public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items) => false;
 
-        public void DeleteForItem(Guid itemId)
-        {
-        }
+        public bool DeleteForItem(Guid itemId) => false;
 
         public void DeleteByMode(AnalysisMode mode)
         {

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -262,6 +262,8 @@ public sealed class TestCleanCacheTask
             => throw new IOException("probe failed");
 
         public string GetChromaprintLogs() => string.Empty;
+
+        public FFmpegCheckResult GetCheckResult() => FFmpegCheckResult.NotRun;
     }
 
     private sealed class NullMediaSegmentRefresher : IMediaSegmentRefresher

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -329,13 +329,15 @@ public sealed class TestVisualizationController
         public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
             => inner.Write(itemId, mode, type, start, end, items);
 
-        public void DeleteForItem(Guid itemId)
+        public bool DeleteForItem(Guid itemId)
         {
-            inner.DeleteForItem(itemId);
+            var deleted = inner.DeleteForItem(itemId);
             if (Interlocked.Increment(ref _deleteCount) == 1)
             {
                 cancellationTokenSource.Cancel();
             }
+
+            return deleted;
         }
 
         public void DeleteByMode(AnalysisMode mode) => inner.DeleteByMode(mode);


### PR DESCRIPTION
The batch merge of #898, #900, and #901 landed test fakes authored against an older base, leaving `craptastic` unbuildable (3 × CS0738/CS0535 in `IntroSkipper.Tests`):

- #933 (cherry-picked as 9d763e0) changed `IDetectionCacheService.DeleteForItem` to return `bool`, but `CancelAfterFirstDeleteCacheService` (#898) and `NoOpDetectionCacheService` (#900) still declared it `void`.
- The support-log rework added `IFFmpegService.GetCheckResult()`, which `ProbeFailureFfmpegService` (#901) never implemented.

This updates the three fakes to the current interface shapes: the cancellation fake forwards the inner service's deletion result, the no-op fake reports `false`, and the probe-failure fake returns `FFmpegCheckResult.NotRun`. No production code changes.

Verified with `dotnet build` (0 warnings, 0 errors) and `dotnet test`: 412/413 pass; the one failure, `TestAudioFingerprinting.TestSilenceDetection`, is a local ffmpeg 6.1 vs CI jellyfin-ffmpeg 7.1.3 silencedetect precision difference unrelated to this change.

## Summary by Sourcery

Bug Fixes:
- Update test fakes to match the current cache and FFmpeg service interfaces, restoring successful compilation of the test project.