### PR TITLE
Keep analysis failures from displacing completed results and isolate recap fallback errors

### DIFF
--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -335,6 +335,59 @@ public class TestChapterAnalyzer
     }
 
     [Fact]
+    public async Task AnalyzeMediaFiles_RecapBlackFrameException_MarksFailureAndContinues()
+    {
+        var tempDir = System.IO.Path.Join(System.IO.Path.GetTempPath(), "IntroSkipper.Tests");
+        System.IO.Directory.CreateDirectory(tempDir);
+        var dbPath = System.IO.Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var config = new PluginConfiguration
+        {
+            ChapterAnalyzerRecapPattern = string.Empty,
+            EnableSponsorBlockChapterDetection = false,
+            DetectRecapUsingBlackFrames = true,
+        };
+        var ffmpeg = new RecapBlackFrameFfmpeg([])
+        {
+            BlackFrameException = new InvalidOperationException("test failure"),
+        };
+        var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, ffmpeg, config);
+        var failedEpisode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 1200, Path = "episode1.mkv", Name = "S01E01" };
+        var secondEpisode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 1200, Path = "episode2.mkv", Name = "S01E02" };
+
+        try
+        {
+            using (var db = new Db.IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
+
+                // A per-episode ffmpeg failure in the recap black-frame fallback must mark the
+                // episode retriable and continue with the season instead of aborting the pass.
+                await analyzer.AnalyzeMediaFiles([failedEpisode, secondEpisode], AnalysisMode.Recap, CancellationToken.None);
+            }
+
+            Assert.Equal(EpisodeState.AnalysisFailed, failedEpisode.GetAnalyzed(AnalysisMode.Recap));
+            Assert.Equal(EpisodeState.AnalysisFailed, secondEpisode.GetAnalyzed(AnalysisMode.Recap));
+            Assert.Equal(2, ffmpeg.ScanCalls);
+        }
+        finally
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+            {
+                if (System.IO.File.Exists(path))
+                {
+                    System.IO.File.Delete(path);
+                }
+            }
+        }
+    }
+
+    [Fact]
     public void PluginGetChapters_ReturnsEmptyList_WhenChapterManagerReturnsNull()
     {
         using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
@@ -408,6 +461,10 @@ public class TestChapterAnalyzer
 
     private sealed class RecapBlackFrameFfmpeg(BlackFrame[] frames) : IFFmpegService
     {
+        public Exception? BlackFrameException { get; init; }
+
+        public int ScanCalls { get; private set; }
+
         public TimeRange? LastRange { get; private set; }
 
         public int? LastMinimum { get; private set; }
@@ -433,6 +490,12 @@ public class TestChapterAnalyzer
             AnalysisMode mode,
             CancellationToken cancellationToken = default)
         {
+            ScanCalls++;
+            if (BlackFrameException is not null)
+            {
+                throw BlackFrameException;
+            }
+
             LastRange = range;
             LastMinimum = minimum;
             LastThreshold = threshold;

--- a/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
+++ b/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
@@ -35,6 +35,48 @@ public sealed class TestChromaprintFailureHandling
         Assert.All(episodes, e => Assert.Equal(EpisodeState.AnalysisFailed, e.GetAnalyzed(AnalysisMode.Introduction)));
     }
 
+    [Fact]
+    public async Task AnalyzeMediaFiles_FingerprintException_DoesNotDowngradeAnalyzedEpisode()
+    {
+        var unanalyzed = CreateEpisode(1);
+        var analyzed = CreateEpisode(2);
+        analyzed.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.Analyzed);
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            new ThrowingFingerprintService(),
+            new NoOpDetectionCacheService { HasCachedFingerprintResult = true });
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        // The cached fingerprint pulls the analyzed episode into the re-analysis queue; a failed
+        // fingerprint there must not discard its completed verdict.
+        await analyzer.AnalyzeMediaFiles([unanalyzed, analyzed], AnalysisMode.Introduction, CancellationToken.None);
+
+        Assert.Equal(EpisodeState.AnalysisFailed, unanalyzed.GetAnalyzed(AnalysisMode.Introduction));
+        Assert.Equal(EpisodeState.Analyzed, analyzed.GetAnalyzed(AnalysisMode.Introduction));
+    }
+
+    [Fact]
+    public async Task AnalyzeMediaFiles_FingerprintException_DoesNotDowngradeUserProvidedNeighbor()
+    {
+        var unanalyzed = CreateEpisode(1);
+        var userProvided = CreateEpisode(2);
+        userProvided.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.UserProvided);
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            new ThrowingFingerprintService(),
+            new NoOpDetectionCacheService());
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        // With a single unanalyzed episode the adjacent user-provided episode is pulled in as a
+        // fingerprint pairing partner; a failed fingerprint there must not strip its protection.
+        await analyzer.AnalyzeMediaFiles([unanalyzed, userProvided], AnalysisMode.Introduction, CancellationToken.None);
+
+        Assert.Equal(EpisodeState.AnalysisFailed, unanalyzed.GetAnalyzed(AnalysisMode.Introduction));
+        Assert.Equal(EpisodeState.UserProvided, userProvided.GetAnalyzed(AnalysisMode.Introduction));
+    }
+
     private static QueuedEpisode CreateEpisode(int number) => new()
     {
         EpisodeId = Guid.NewGuid(),
@@ -81,9 +123,11 @@ public sealed class TestChromaprintFailureHandling
 
     private sealed class NoOpDetectionCacheService : IDetectionCacheService
     {
+        public bool HasCachedFingerprintResult { get; init; }
+
         public bool IsEnabled => false;
 
-        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode) => false;
+        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode) => HasCachedFingerprintResult;
 
         public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
         {
@@ -93,9 +137,7 @@ public sealed class TestChromaprintFailureHandling
 
         public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items) => false;
 
-        public void DeleteForItem(Guid itemId)
-        {
-        }
+        public bool DeleteForItem(Guid itemId) => false;
 
         public void DeleteByMode(AnalysisMode mode)
         {

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -329,13 +329,15 @@ public sealed class TestVisualizationController
         public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
             => inner.Write(itemId, mode, type, start, end, items);
 
-        public void DeleteForItem(Guid itemId)
+        public bool DeleteForItem(Guid itemId)
         {
-            inner.DeleteForItem(itemId);
+            var deleted = inner.DeleteForItem(itemId);
             if (Interlocked.Increment(ref _deleteCount) == 1)
             {
                 cancellationTokenSource.Cancel();
             }
+
+            return deleted;
         }
 
         public void DeleteByMode(AnalysisMode mode) => inner.DeleteByMode(mode);

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -114,7 +114,23 @@ public partial class ChapterAnalyzer(
                 : null;
             if ((skipRange is null || !skipRange.Valid) && enableRecapBlackFrameFallback)
             {
-                skipRange = await DetectRecapUsingBlackFramesAsync(episode, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    skipRange = await DetectRecapUsingBlackFramesAsync(episode, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // A hard per-episode failure (e.g. an ffmpeg timeout) must not abort the whole
+                    // season pass. Mark the episode as failed so it stays retriable and is not
+                    // persisted as a completed no-segment result.
+                    episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                    LogErrorDetectingRecapBlackFrames(ex, episode.Name);
+                    continue;
+                }
             }
 
             if (skipRange is null || !skipRange.Valid)
@@ -358,4 +374,7 @@ public partial class ChapterAnalyzer(
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{Base}: okay")]
     private partial void LogChapterOk(string @base);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error detecting recap black frames for {Episode}")]
+    private partial void LogErrorDetectingRecapBlackFrames(Exception ex, string episode);
 }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -84,8 +84,15 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
                 // Fallback to an empty fingerprint on any error, and record the failure so the episode
                 // is retried on the next run. Without this it is persisted as a completed no-segment
                 // result, and an ffmpeg hiccup on one episode becomes a permanent verdict.
+                // Episodes that already carry a completed result (re-analysis of an Analyzed episode
+                // with a cached fingerprint, or an Analyzed/UserProvided neighbor pulled in to pair
+                // with a lone unanalyzed episode) keep that result: a failed fingerprint must not
+                // discard a valid verdict.
                 fingerprintCache[episode.EpisodeId] = [];
-                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                if (episode.NeedsAnalysis(mode))
+                {
+                    episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                }
             }
         }
 


### PR DESCRIPTION
Follow-up to #900, which introduced the transient `AnalysisFailed` state. This closes two paths it left open and repairs the test build on this branch.

- **Chromaprint failures no longer downgrade completed episodes.** The fingerprint queue also holds episodes that already carry a verdict: `Analyzed` episodes re-fingerprinted from cache, and the `Analyzed`/`UserProvided` neighbor pulled in to pair with a lone unanalyzed episode. A `FingerprintException` there flipped that state to `AnalysisFailed`, dropping a valid result from the persisted episode IDs and — for the user-provided neighbor — letting later analyzers in the same pass treat a protected episode as needing analysis. The failure mark now applies only to episodes that still need analysis.
- **ChapterAnalyzer's recap black-frame fallback is isolated per episode.** The fallback calls FFmpeg with no per-item handling, and since #899 a hung FFmpeg surfaces as `TimeoutException` instead of truncated output, so one bad episode aborted the entire scheduled analysis task through the rethrowing season handler. Hard failures there now mark the episode `AnalysisFailed` and continue, matching the isolation #900 gave the other analyzers.
- **Fix the test-project build.** Merging #900/#898 against #933's `IDetectionCacheService.DeleteForItem` return-type change left two test fakes implementing the old `void` signature; `IntroSkipper.Tests` did not compile at branch head.

Regression tests cover the Chromaprint re-analysis and user-provided-neighbor paths and recap-fallback continuation. `TestAudioFingerprinting.TestSilenceDetection` fails locally against a non-pinned ffmpeg's output precision, unrelated to this change; all other 409 tests pass.

## Summary by Sourcery

Prevent per-episode analysis failures from overwriting valid results or stopping subsequent episode analysis.

Bug Fixes:
- Preserve completed and user-provided episode results when Chromaprint fingerprinting fails during re-analysis or neighbor pairing.
- Isolate recap black-frame detection failures per episode so failed episodes are marked retriable without aborting the remaining analysis pass.

Build:
- Update test fakes for the changed detection-cache deletion method signature so the test project builds.

Tests:
- Add regression coverage for Chromaprint failure handling and recap fallback continuation.