### PR TITLE
Make analysis reprocessing durable and selective while hardening failure handling, cache cleanup, and FFmpeg execution.

### DIFF
--- a/IntroSkipper.Tests/TestAnalysisConfigHash.cs
+++ b/IntroSkipper.Tests/TestAnalysisConfigHash.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Helper;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+/// <summary>
+/// The per-season config hash is the only thing that retires stale automatic segments, so every
+/// setting an analyzer reads has to change the hash of the mode it affects. These tests cover the
+/// settings that are named for one mode but change the result of another, which is where that
+/// property is easiest to break.
+/// </summary>
+public sealed class TestAnalysisConfigHash
+{
+    private static string Hash(PluginConfiguration config, AnalysisMode mode)
+        => ConfigHasher.Analysis(config, mode, AnalyzerAction.Default, ffmpegValid: true);
+
+    [Theory]
+    [InlineData(AnalysisMode.Introduction)]
+    [InlineData(AnalysisMode.Credits)]
+    public void MinimumIntroDuration_ChangesHash_ForEveryModeChromaprintAppliesItTo(AnalysisMode mode)
+    {
+        // ChromaprintAnalyzer.GetMinimumRegionDuration feeds MinimumIntroDuration to every mode except
+        // Recap, so raising it has to invalidate credits as well as introductions.
+        var before = new PluginConfiguration { MinimumIntroDuration = 15 };
+        var after = new PluginConfiguration { MinimumIntroDuration = 30 };
+
+        Assert.NotEqual(Hash(before, mode), Hash(after, mode));
+    }
+
+    [Fact]
+    public void MinimumIntroDuration_DoesNotChangeRecapHash()
+    {
+        // Recap uses a fixed card duration instead, so folding the setting in would retire recaps for
+        // a change that cannot affect them.
+        var before = new PluginConfiguration { MinimumIntroDuration = 15 };
+        var after = new PluginConfiguration { MinimumIntroDuration = 30 };
+
+        Assert.Equal(Hash(before, AnalysisMode.Recap), Hash(after, AnalysisMode.Recap));
+    }
+
+    [Theory]
+    [InlineData(AnalysisMode.Credits)]
+    [InlineData(AnalysisMode.Preview)]
+    public void AnimePreviewFromCreditsEnd_ChangesHash_ForBothModesItProduces(AnalysisMode mode)
+    {
+        // The setting is read while analyzing Credits but writes a Preview segment, so turning it off
+        // has to invalidate the previews it created.
+        var before = new PluginConfiguration { AnimePreviewFromCreditsEnd = true };
+        var after = new PluginConfiguration { AnimePreviewFromCreditsEnd = false };
+
+        Assert.NotEqual(Hash(before, mode), Hash(after, mode));
+    }
+
+    [Fact]
+    public void AnalyzerAction_ChangesHash()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Chapter, ffmpegValid: true));
+    }
+}

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1185,19 +1185,64 @@ public class TestBlackFrames
     [Fact]
     public async Task TestAnalyzeMediaFiles_DetectionException_Continues()
     {
-        var episode = CreateQueuedCreditsEpisode();
+        var failedEpisode = CreateQueuedCreditsEpisode();
+        var noCreditsEpisode = CreateQueuedCreditsEpisode();
         var ffmpeg = new FakeFFmpegService([])
         {
             CreditsScanException = new InvalidOperationException("test failure"),
+            CreditsScanExceptionOnCall = 1,
         };
         var analyzer = CreateCreditsBlackFrameAnalyzer(ffmpeg);
         using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
 
-        var result = await analyzer.AnalyzeMediaFiles([episode], AnalysisMode.Credits, CancellationToken.None);
+        var result = await analyzer.AnalyzeMediaFiles([failedEpisode, noCreditsEpisode], AnalysisMode.Credits, CancellationToken.None);
 
-        Assert.Same(episode, result[0]);
+        Assert.Same(failedEpisode, result[0]);
+        Assert.Equal(EpisodeState.AnalysisFailed, failedEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.True(failedEpisode.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.Equal(EpisodeState.NotAnalyzed, noCreditsEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.Equal(2, ffmpeg.CreditsScanCalls);
+    }
+
+    [Fact]
+    public async Task TestBlackFrameAnalyzer_BinarySearchException_MarksFailureAndContinues()
+    {
+        var failedEpisode = CreateQueuedCreditsEpisode();
+        var noCreditsEpisode = CreateQueuedCreditsEpisode();
+        var ffmpeg = new FakeFFmpegService([])
+        {
+            RangeScanException = new InvalidOperationException("test failure"),
+            RangeScanExceptionOnCall = 2,
+        };
+        var analyzer = new BlackFrameAnalyzer(NullLogger<BlackFrameAnalyzer>.Instance, ffmpeg);
+        var config = (PluginConfiguration)EntrypointTestHelpers.GetPrivateField(analyzer, "_config");
+        config.UseChapterMarkersBlackFrame = false;
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        await analyzer.AnalyzeMediaFiles([failedEpisode, noCreditsEpisode], AnalysisMode.Credits, CancellationToken.None);
+
+        Assert.Equal(EpisodeState.AnalysisFailed, failedEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.True(failedEpisode.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.Equal(EpisodeState.NotAnalyzed, noCreditsEpisode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.True(ffmpeg.RangeScanCalls > 2);
+    }
+
+    [Fact]
+    public async Task TestAnalyzeMediaFiles_OptionalIntervalException_RemainsDegradable()
+    {
+        var episode = CreateQueuedCreditsEpisode();
+        var ffmpeg = new FakeFFmpegService(CreateLowDensitySingleCandidateFrames())
+        {
+            IntervalScanException = new InvalidOperationException("test failure"),
+        };
+        var analyzer = CreateCreditsBlackFrameAnalyzer(ffmpeg);
+        SetDetectNonBlackCredits(analyzer, value: false);
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        await analyzer.AnalyzeMediaFiles([episode], AnalysisMode.Credits, CancellationToken.None);
+
         Assert.Equal(EpisodeState.NotAnalyzed, episode.GetAnalyzed(AnalysisMode.Credits));
-        Assert.Equal(1, ffmpeg.CreditsScanCalls);
+        Assert.Equal(1, ffmpeg.IntervalScanCalls);
     }
 
     // ── Non-black (entropy/saturation) credit fallback ───────────────────
@@ -1991,6 +2036,12 @@ public class TestBlackFrames
 
         public Exception? CreditsScanException { get; init; }
 
+        public int? CreditsScanExceptionOnCall { get; init; }
+
+        public Exception? RangeScanException { get; init; }
+
+        public int? RangeScanExceptionOnCall { get; init; }
+
         public Exception? IntervalScanException { get; init; }
 
         public int CreditsScanCalls { get; private set; }
@@ -2036,6 +2087,12 @@ public class TestBlackFrames
             LastProbeThreshold = threshold;
             LastProbeMode = mode;
             cancellationToken.ThrowIfCancellationRequested();
+            if (RangeScanException is not null &&
+                (RangeScanExceptionOnCall is null || RangeScanCalls == RangeScanExceptionOnCall))
+            {
+                throw RangeScanException;
+            }
+
             return Task.FromResult(_probeFrames);
         }
 
@@ -2043,7 +2100,8 @@ public class TestBlackFrames
         {
             CreditsScanCalls++;
             cancellationToken.ThrowIfCancellationRequested();
-            if (CreditsScanException is not null)
+            if (CreditsScanException is not null &&
+                (CreditsScanExceptionOnCall is null || CreditsScanCalls == CreditsScanExceptionOnCall))
             {
                 throw CreditsScanException;
             }

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -335,6 +335,59 @@ public class TestChapterAnalyzer
     }
 
     [Fact]
+    public async Task AnalyzeMediaFiles_RecapBlackFrameException_MarksFailureAndContinues()
+    {
+        var tempDir = System.IO.Path.Join(System.IO.Path.GetTempPath(), "IntroSkipper.Tests");
+        System.IO.Directory.CreateDirectory(tempDir);
+        var dbPath = System.IO.Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var config = new PluginConfiguration
+        {
+            ChapterAnalyzerRecapPattern = string.Empty,
+            EnableSponsorBlockChapterDetection = false,
+            DetectRecapUsingBlackFrames = true,
+        };
+        var ffmpeg = new RecapBlackFrameFfmpeg([])
+        {
+            BlackFrameException = new InvalidOperationException("test failure"),
+        };
+        var analyzer = new ChapterAnalyzer(NullLogger<ChapterAnalyzer>.Instance, ffmpeg, config);
+        var failedEpisode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 1200, Path = "episode1.mkv", Name = "S01E01" };
+        var secondEpisode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 1200, Path = "episode2.mkv", Name = "S01E02" };
+
+        try
+        {
+            using (var db = new Db.IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                EntrypointTestHelpers.SetPrivateField(Plugin.Instance!, "_dbPath", dbPath);
+
+                // A per-episode ffmpeg failure in the recap black-frame fallback must mark the
+                // episode retriable and continue with the season instead of aborting the pass.
+                await analyzer.AnalyzeMediaFiles([failedEpisode, secondEpisode], AnalysisMode.Recap, CancellationToken.None);
+            }
+
+            Assert.Equal(EpisodeState.AnalysisFailed, failedEpisode.GetAnalyzed(AnalysisMode.Recap));
+            Assert.Equal(EpisodeState.AnalysisFailed, secondEpisode.GetAnalyzed(AnalysisMode.Recap));
+            Assert.Equal(2, ffmpeg.ScanCalls);
+        }
+        finally
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+            {
+                if (System.IO.File.Exists(path))
+                {
+                    System.IO.File.Delete(path);
+                }
+            }
+        }
+    }
+
+    [Fact]
     public void PluginGetChapters_ReturnsEmptyList_WhenChapterManagerReturnsNull()
     {
         using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
@@ -408,6 +461,10 @@ public class TestChapterAnalyzer
 
     private sealed class RecapBlackFrameFfmpeg(BlackFrame[] frames) : IFFmpegService
     {
+        public Exception? BlackFrameException { get; init; }
+
+        public int ScanCalls { get; private set; }
+
         public TimeRange? LastRange { get; private set; }
 
         public int? LastMinimum { get; private set; }
@@ -433,6 +490,12 @@ public class TestChapterAnalyzer
             AnalysisMode mode,
             CancellationToken cancellationToken = default)
         {
+            ScanCalls++;
+            if (BlackFrameException is not null)
+            {
+                throw BlackFrameException;
+            }
+
             LastRange = range;
             LastMinimum = minimum;
             LastThreshold = threshold;

--- a/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
+++ b/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
@@ -93,9 +93,7 @@ public sealed class TestChromaprintFailureHandling
 
         public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items) => false;
 
-        public void DeleteForItem(Guid itemId)
-        {
-        }
+        public bool DeleteForItem(Guid itemId) => false;
 
         public void DeleteByMode(AnalysisMode mode)
         {

--- a/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
+++ b/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Analyzers;
+using IntroSkipper.Data;
+using IntroSkipper.FFmpeg;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestChromaprintFailureHandling
+{
+    [Fact]
+    public async Task AnalyzeMediaFiles_FingerprintException_MarksFailureAndContinues()
+    {
+        var episodes = new[] { CreateEpisode(1), CreateEpisode(2) };
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            new ThrowingFingerprintService(),
+            new NoOpDetectionCacheService());
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        var result = await analyzer.AnalyzeMediaFiles(episodes, AnalysisMode.Introduction, CancellationToken.None);
+
+        // A fingerprint that could not be produced is a failed attempt, not a "nothing found" verdict.
+        // Left as NotAnalyzed the episode is persisted in the season's analyzed-episode list and cached
+        // as NoSegments on the next run, so a one-off ffmpeg failure becomes permanent.
+        Assert.Same(episodes, result);
+        Assert.All(episodes, e => Assert.Equal(EpisodeState.AnalysisFailed, e.GetAnalyzed(AnalysisMode.Introduction)));
+    }
+
+    private static QueuedEpisode CreateEpisode(int number) => new()
+    {
+        EpisodeId = Guid.NewGuid(),
+        SeasonId = Guid.Empty,
+        SeriesName = "Rick and Morty",
+        SeasonNumber = 1,
+        EpisodeNumber = number,
+        Name = $"S01E0{number}",
+        Duration = 1800,
+        IntroFingerprintEnd = 600,
+    };
+
+    private sealed class ThrowingFingerprintService : IFFmpegService
+    {
+        public Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new FingerprintException("chromaprint output was malformed");
+
+        public Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, TimeRange range, int minimum, int threshold, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<KeyframeVisual[]> DetectKeyframeVisualsAsync(QueuedEpisode episode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackInterval[]> DetectBlackIntervalsAsync(QueuedEpisode episode, TimeRange range, int threshold, int minimum, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public FFmpegCheckResult GetCheckResult() => FFmpegCheckResult.NotRun;
+    }
+
+    private sealed class NoOpDetectionCacheService : IDetectionCacheService
+    {
+        public bool IsEnabled => false;
+
+        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode) => false;
+
+        public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
+        {
+            result = [];
+            return false;
+        }
+
+        public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items) => false;
+
+        public void DeleteForItem(Guid itemId)
+        {
+        }
+
+        public void DeleteByMode(AnalysisMode mode)
+        {
+        }
+    }
+}

--- a/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
+++ b/IntroSkipper.Tests/TestChromaprintFailureHandling.cs
@@ -35,6 +35,48 @@ public sealed class TestChromaprintFailureHandling
         Assert.All(episodes, e => Assert.Equal(EpisodeState.AnalysisFailed, e.GetAnalyzed(AnalysisMode.Introduction)));
     }
 
+    [Fact]
+    public async Task AnalyzeMediaFiles_FingerprintException_DoesNotDowngradeAnalyzedEpisode()
+    {
+        var unanalyzed = CreateEpisode(1);
+        var analyzed = CreateEpisode(2);
+        analyzed.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.Analyzed);
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            new ThrowingFingerprintService(),
+            new NoOpDetectionCacheService { HasCachedFingerprintResult = true });
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        // The cached fingerprint pulls the analyzed episode into the re-analysis queue; a failed
+        // fingerprint there must not discard its completed verdict.
+        await analyzer.AnalyzeMediaFiles([unanalyzed, analyzed], AnalysisMode.Introduction, CancellationToken.None);
+
+        Assert.Equal(EpisodeState.AnalysisFailed, unanalyzed.GetAnalyzed(AnalysisMode.Introduction));
+        Assert.Equal(EpisodeState.Analyzed, analyzed.GetAnalyzed(AnalysisMode.Introduction));
+    }
+
+    [Fact]
+    public async Task AnalyzeMediaFiles_FingerprintException_DoesNotDowngradeUserProvidedNeighbor()
+    {
+        var unanalyzed = CreateEpisode(1);
+        var userProvided = CreateEpisode(2);
+        userProvided.SetAnalyzed(AnalysisMode.Introduction, EpisodeState.UserProvided);
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            new ThrowingFingerprintService(),
+            new NoOpDetectionCacheService());
+
+        using var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+
+        // With a single unanalyzed episode the adjacent user-provided episode is pulled in as a
+        // fingerprint pairing partner; a failed fingerprint there must not strip its protection.
+        await analyzer.AnalyzeMediaFiles([unanalyzed, userProvided], AnalysisMode.Introduction, CancellationToken.None);
+
+        Assert.Equal(EpisodeState.AnalysisFailed, unanalyzed.GetAnalyzed(AnalysisMode.Introduction));
+        Assert.Equal(EpisodeState.UserProvided, userProvided.GetAnalyzed(AnalysisMode.Introduction));
+    }
+
     private static QueuedEpisode CreateEpisode(int number) => new()
     {
         EpisodeId = Guid.NewGuid(),
@@ -81,9 +123,11 @@ public sealed class TestChromaprintFailureHandling
 
     private sealed class NoOpDetectionCacheService : IDetectionCacheService
     {
+        public bool HasCachedFingerprintResult { get; init; }
+
         public bool IsEnabled => false;
 
-        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode) => false;
+        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode) => HasCachedFingerprintResult;
 
         public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
         {

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -223,9 +223,9 @@ public sealed class TestCleanCacheTask
         {
             return targetMethod?.Name switch
             {
-                nameof(ILibraryManager.GetVirtualFolders) => [.. _folders],
+                nameof(ILibraryManager.GetVirtualFolders) => (List<VirtualFolderInfo>)[.. _folders],
                 nameof(ILibraryManager.GetItemList) when _throwOnItemList => throw new IOException("library unavailable"),
-                nameof(ILibraryManager.GetItemList) => [.. _items],
+                nameof(ILibraryManager.GetItemList) => (List<BaseItem>)[.. _items],
                 nameof(ILibraryManager.GetItemById) => null,
                 _ => throw new NotImplementedException(targetMethod?.Name),
             };

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -262,6 +262,8 @@ public sealed class TestCleanCacheTask
             => throw new IOException("probe failed");
 
         public string GetChromaprintLogs() => string.Empty;
+
+        public FFmpegCheckResult GetCheckResult() => FFmpegCheckResult.NotRun;
     }
 
     private sealed class NullMediaSegmentRefresher : IMediaSegmentRefresher

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -223,9 +223,9 @@ public sealed class TestCleanCacheTask
         {
             return targetMethod?.Name switch
             {
-                nameof(ILibraryManager.GetVirtualFolders) => _folders.ToList(),
+                nameof(ILibraryManager.GetVirtualFolders) => [.. _folders],
                 nameof(ILibraryManager.GetItemList) when _throwOnItemList => throw new IOException("library unavailable"),
-                nameof(ILibraryManager.GetItemList) => _items.ToList(),
+                nameof(ILibraryManager.GetItemList) => [.. _items],
                 nameof(ILibraryManager.GetItemById) => null,
                 _ => throw new NotImplementedException(targetMethod?.Name),
             };

--- a/IntroSkipper.Tests/TestCleanCacheTask.cs
+++ b/IntroSkipper.Tests/TestCleanCacheTask.cs
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: 2026 intro-skipper contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Db;
+using IntroSkipper.FFmpeg;
+using IntroSkipper.Manager;
+using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestCleanCacheTask
+{
+    [Fact]
+    public async Task ExecuteAsync_IncompleteInventory_PreservesStoredData()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var dbPath = CreateTempDbPath();
+        using var scope = CreatePluginScope(dbPath);
+        await SeedStoredDataAsync(dbPath, seasonId, episodeId);
+        var task = CreateTask(EntrypointTestHelpers.CreateLibraryManager());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => task.ExecuteAsync(new Progress<double>(), CancellationToken.None));
+
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.True(await db.DbSegment.AnyAsync(s => s.ItemId == episodeId));
+        Assert.True(await db.DbSeasonState.AnyAsync(s => s.SeasonId == seasonId));
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        Assert.True(await cacheDb.DetectionCache.AnyAsync(e => e.ItemId == episodeId));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CompleteInventory_RemovesStoredDataForMissingItems()
+    {
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var dbPath = CreateTempDbPath();
+        using var scope = CreatePluginScope(dbPath);
+        await SeedStoredDataAsync(dbPath, seasonId, episodeId);
+        var libraryManager = InventoryLibraryManager.Create([], []);
+        var progress = new RecordingProgress();
+        var task = CreateTask(libraryManager);
+
+        await task.ExecuteAsync(progress, CancellationToken.None);
+
+        Assert.Equal(100, progress.Value);
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.False(await db.DbSegment.AnyAsync());
+        Assert.False(await db.DbSeasonState.AnyAsync());
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        Assert.False(await cacheDb.DetectionCache.AnyAsync());
+    }
+
+    [Fact]
+    public async Task GetMediaInventory_LibraryQueryFailure_IsIncomplete()
+    {
+        using var scope = CreatePluginScope(CreateTempDbPath());
+        var libraryManager = InventoryLibraryManager.Create(
+            [CreateVirtualFolder()],
+            [],
+            throwOnItemList: true);
+        var queueManager = CreateQueueManager(libraryManager);
+
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true);
+
+        Assert.False(inventory.IsComplete);
+    }
+
+    [Fact]
+    public async Task GetMediaInventory_InvalidFolderItemId_IsIncomplete()
+    {
+        using var scope = CreatePluginScope(CreateTempDbPath());
+        var folder = new VirtualFolderInfo
+        {
+            Name = "Library",
+            ItemId = "not-a-guid",
+        };
+        var libraryManager = InventoryLibraryManager.Create([folder], []);
+        var queueManager = CreateQueueManager(libraryManager);
+
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true);
+
+        Assert.False(inventory.IsComplete);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetMediaInventory_OmittedSupportedItem_IsIncomplete(bool throwDuringProbe)
+    {
+        using var scope = CreatePluginScope(CreateTempDbPath(), probeAudioDuration: throwDuringProbe);
+        var movie = new Movie
+        {
+            Name = "Movie",
+            Path = throwDuringProbe ? "/tmp/movie.mkv" : string.Empty,
+            RunTimeTicks = TimeSpan.FromMinutes(90).Ticks,
+        };
+        EntrypointTestHelpers.SetPropertyOrField(movie, "Id", Guid.NewGuid());
+        var libraryManager = InventoryLibraryManager.Create([CreateVirtualFolder()], [movie]);
+        var queueManager = CreateQueueManager(libraryManager);
+
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true);
+
+        Assert.False(inventory.IsComplete);
+    }
+
+    private static CleanCacheTask CreateTask(ILibraryManager libraryManager)
+        => new(
+            NullLogger<CleanCacheTask>.Instance,
+            NullLoggerFactory.Instance,
+            libraryManager,
+            providerManager: null!,
+            fileSystem: null!,
+            new ProbeFailureFfmpegService(),
+            new NullMediaSegmentRefresher());
+
+    private static QueueManager CreateQueueManager(ILibraryManager libraryManager)
+        => new(
+            NullLogger<QueueManager>.Instance,
+            libraryManager,
+            providerManager: null!,
+            fileSystem: null!,
+            new ProbeFailureFfmpegService());
+
+    private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(
+        string dbPath,
+        bool probeAudioDuration = false)
+    {
+        var scope = new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir());
+        var plugin = Plugin.Instance!;
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "_dbPath", dbPath);
+        EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", new PluginConfiguration
+        {
+            ProbeAudioDuration = probeAudioDuration,
+            UpdateMediaSegments = false,
+        });
+        return scope;
+    }
+
+    private static async Task SeedStoredDataAsync(string dbPath, Guid seasonId, Guid episodeId)
+    {
+        await using (var db = new IntroSkipperDbContext(dbPath))
+        {
+            await db.Database.EnsureCreatedAsync();
+            db.DbSegment.Add(new DbSegment(
+                new Segment(episodeId, new TimeRange(10, 20)),
+                AnalysisMode.Introduction));
+            db.DbSeasonState.Add(new DbSeasonState(
+                seasonId,
+                AnalysisMode.Introduction,
+                AnalyzerAction.Default,
+                [episodeId]));
+            await db.SaveChangesAsync();
+        }
+
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        cacheDb.DetectionCache.Add(new DbDetectionCache(
+            episodeId,
+            AnalysisMode.Introduction,
+            CacheEntryType.Chromaprint,
+            EntrypointTestHelpers.EmptyJsonArray));
+        await cacheDb.SaveChangesAsync();
+    }
+
+    private static VirtualFolderInfo CreateVirtualFolder()
+        => new()
+        {
+            Name = "Library",
+            ItemId = Guid.NewGuid().ToString("N"),
+        };
+
+    private static string CreateTempDbPath()
+    {
+        var directory = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests", "clean-cache");
+        Directory.CreateDirectory(directory);
+        return Path.Join(directory, Guid.NewGuid().ToString("N") + ".db");
+    }
+
+    private sealed class RecordingProgress : IProgress<double>
+    {
+        public double? Value { get; private set; }
+
+        public void Report(double value) => Value = value;
+    }
+
+    private class InventoryLibraryManager : DispatchProxy
+    {
+        private IReadOnlyList<VirtualFolderInfo> _folders = [];
+        private IReadOnlyList<BaseItem> _items = [];
+        private bool _throwOnItemList;
+
+        public static ILibraryManager Create(
+            IReadOnlyList<VirtualFolderInfo> folders,
+            IReadOnlyList<BaseItem> items,
+            bool throwOnItemList = false)
+        {
+            var proxy = Create<ILibraryManager, InventoryLibraryManager>();
+            var state = (InventoryLibraryManager)(object)proxy;
+            state._folders = folders;
+            state._items = items;
+            state._throwOnItemList = throwOnItemList;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.Name switch
+            {
+                nameof(ILibraryManager.GetVirtualFolders) => _folders.ToList(),
+                nameof(ILibraryManager.GetItemList) when _throwOnItemList => throw new IOException("library unavailable"),
+                nameof(ILibraryManager.GetItemList) => _items.ToList(),
+                nameof(ILibraryManager.GetItemById) => null,
+                _ => throw new NotImplementedException(targetMethod?.Name),
+            };
+        }
+    }
+
+    private sealed class ProbeFailureFfmpegService : IFFmpegService
+    {
+        public Task<bool> CheckFFmpegVersionAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<uint>());
+
+        public Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<TimeRange>());
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, TimeRange range, int minimum, int threshold, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<BlackFrame>());
+
+        public Task<BlackFrame[]> DetectBlackFramesAsync(QueuedEpisode episode, int threshold, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<BlackFrame>());
+
+        public Task<KeyframeVisual[]> DetectKeyframeVisualsAsync(QueuedEpisode episode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<KeyframeVisual>());
+
+        public Task<BlackInterval[]> DetectBlackIntervalsAsync(QueuedEpisode episode, TimeRange range, int threshold, int minimum, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<BlackInterval>());
+
+        public Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<double>());
+
+        public Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
+            => throw new IOException("probe failed");
+
+        public string GetChromaprintLogs() => string.Empty;
+    }
+
+    private sealed class NullMediaSegmentRefresher : IMediaSegmentRefresher
+    {
+        public Task RefreshAsync(BaseItem item, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task RemoveIntroSkipperSegmentsAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -139,7 +139,7 @@ public sealed class TestEntrypointEvents
     }
 
     [Fact]
-    public void OnSettingsChanged_UpdatesConfig_AndSetsAnalyzeAgain()
+    public void OnSettingsChanged_UpdatesConfig()
     {
         var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
 
@@ -147,15 +147,11 @@ public sealed class TestEntrypointEvents
 
         using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
         {
-            // Ensure AnalyzeAgain starts false.
-            var plugin = Plugin.Instance!;
-            plugin.AnalyzeAgain = false;
-
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnSettingsChanged", (BasePluginConfiguration)newConfig);
-
-            Assert.True(plugin.AnalyzeAgain);
         }
 
+        // A save records the new configuration and nothing else. Reanalysis is driven by the
+        // per-season config hash, which is durable and therefore survives an interrupted run.
         var storedConfig = (PluginConfiguration)EntrypointTestHelpers.GetPrivateField(entrypoint, "_config");
         Assert.Same(newConfig, storedConfig);
     }

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -9,6 +9,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
@@ -20,6 +22,48 @@ namespace IntroSkipper.Tests;
 
 public class TestFFmpegService
 {
+    [Fact]
+    public async Task TestProcessTimeoutKillsChildWhileDrainingOutput()
+    {
+        var pidFile = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests." + Guid.NewGuid().ToString("N") + ".pid");
+        string processPath;
+        string[] args;
+        int timeout;
+        if (OperatingSystem.IsWindows())
+        {
+            processPath = "powershell.exe";
+            args = ["-NoProfile", "-NonInteractive", "-Command", $"Set-Content -LiteralPath '{pidFile}' -Value $PID; Start-Sleep -Seconds 30"];
+            timeout = 2000;
+        }
+        else
+        {
+            processPath = "/bin/sh";
+            args = ["-c", $"echo $$ > '{pidFile}'; sleep 30"];
+            timeout = 500;
+        }
+
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(() => CreateFFmpegService()
+                .GetProcessOutputAsync(processPath, args, timeout: timeout)
+                .WaitAsync(TimeSpan.FromSeconds(15)));
+
+            var processId = int.Parse((await File.ReadAllTextAsync(pidFile)).Trim(), CultureInfo.InvariantCulture);
+            try
+            {
+                using var process = Process.GetProcessById(processId);
+                Assert.True(process.HasExited, $"Timed-out helper process {processId} is still running.");
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+        finally
+        {
+            File.Delete(pidFile);
+        }
+    }
+
     #region Info Query Tests
 
     [FactSkipFFmpegTests]

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Configuration;
@@ -14,9 +15,11 @@ using IntroSkipper.FFmpeg;
 using IntroSkipper.Helper;
 using IntroSkipper.Manager;
 using IntroSkipper.ScheduledTasks;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -859,11 +862,463 @@ public sealed class TestSeasonReanalysisReset
         }
     }
 
+    [Fact]
+    public async Task VerifyQueueAsync_LogsConfigHashChange_WhenChromaprintBecomesAvailable()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var storedHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: false);
+        var expectedHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true);
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Default,
+                    [episodeId],
+                    storedHash));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                var logger = new CapturingLogger<QueueManager>();
+                var queueManager = new QueueManager(
+                    logger,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+
+                await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+
+                var entry = Assert.Single(
+                    logger.Entries,
+                    e => e.Message.Contains("configuration hash changed", StringComparison.Ordinal));
+                Assert.Equal(LogLevel.Information, entry.Level);
+                Assert.Contains(storedHash, entry.Message, StringComparison.Ordinal);
+                Assert.Contains(expectedHash, entry.Message, StringComparison.Ordinal);
+                Assert.Contains("chromaprint available: True", entry.Message, StringComparison.Ordinal);
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyQueueAsync_DoesNotRedoSeasonsAlreadyAnalyzedUnderCurrentSettings()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var currentHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true);
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Default,
+                    [episodeId],
+                    "stale-hash"));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+
+                // A settings change leaves the season carrying a stale hash, so it is queued for work.
+                var beforeAnalysis = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+                Assert.Equal(EpisodeState.NotAnalyzed, beforeAnalysis.Single().GetAnalyzed(AnalysisMode.Introduction));
+
+                // The analyzer records the new hash for every season it finishes, so a run interrupted
+                // after this point must not queue the season again.
+                await Plugin.SetEpisodeIdsAsync(seasonId, AnalysisMode.Introduction, [episodeId], currentHash);
+
+                var afterAnalysis = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+                Assert.Equal(EpisodeState.NoSegments, afterAnalysis.Single().GetAnalyzed(AnalysisMode.Introduction));
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+    [Fact]
+    public async Task VerifyQueueAsync_IgnoresSettingsSave_WhenStoredHashStillMatches()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var currentHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true);
+
+        // Built before the plugin scope: the constructor requires Plugin.Instance to be null.
+        var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Default,
+                    [episodeId],
+                    currentHash));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                // Saving settings that leave every hash untouched must not requeue anything. This is
+                // the whole-library rescan users reported after changing a cosmetic setting, and the
+                // process-wide flag that caused it is also what made an interrupted run unresumable.
+                EntrypointTestHelpers.InvokePrivate(
+                    entrypoint,
+                    "OnSettingsChanged",
+                    (MediaBrowser.Model.Plugins.BasePluginConfiguration)config);
+
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+
+                var verified = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+
+                Assert.Equal(EpisodeState.NoSegments, verified.Single().GetAnalyzed(AnalysisMode.Introduction));
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyQueueAsync_KeepsChromaprintResults_WhenTheProbeReportsUnavailable()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var withChromaprintHash = ConfigHasher.Analysis(
+            config,
+            AnalysisMode.Introduction,
+            AnalyzerAction.Default,
+            ffmpegValid: true);
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+                db.DbSeasonState.Add(new DbSeasonState(
+                    seasonId,
+                    AnalysisMode.Introduction,
+                    AnalyzerAction.Default,
+                    [episodeId],
+                    withChromaprintHash));
+                await db.SaveChangesAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                // The probe reports false for a genuinely incapable ffmpeg and for a one-off failure to
+                // launch it alike, so losing chromaprint must never discard results produced with it.
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: false));
+
+                var verified = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(episodeId, seasonId)],
+                    [AnalysisMode.Introduction]);
+
+                Assert.Equal(EpisodeState.NoSegments, verified.Single().GetAnalyzed(AnalysisMode.Introduction));
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeItemsAsync_RecordsConfigHash_WhenAnalyzerActionIsNone()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var noneHash = ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.None, ffmpegValid: true);
+
+        try
+        {
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                await Plugin.SetAnalyzerActionAsync(
+                    seasonId,
+                    new Dictionary<AnalysisMode, AnalyzerAction>
+                    {
+                        [AnalysisMode.Introduction] = AnalyzerAction.None,
+                    });
+
+                var analyzer = new BaseItemAnalyzerTask(
+                    NullLogger.Instance,
+                    NullLoggerFactory.Instance,
+                    libraryManager: null!,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    mediaSegmentRefresher: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true),
+                    cacheService: null!);
+
+                var episode = CreateQueuedEpisode(episodeId, seasonId);
+                var method = typeof(BaseItemAnalyzerTask).GetMethod(
+                    "AnalyzeItemsAsync",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(method);
+
+                var analyzed = await (Task<int>)method!.Invoke(
+                    analyzer,
+                    [plugin, (IReadOnlyList<QueuedEpisode>)[episode], AnalysisMode.Introduction, true, CancellationToken.None])!;
+                Assert.Equal(0, analyzed);
+            }
+
+            // The action is part of the hash, so a mode switched off must still record the new hash.
+            // Without it the season mismatches on every run forever: queued, skipped, never written.
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                var state = await db.DbSeasonState.SingleAsync();
+                Assert.Equal(AnalyzerAction.None, state.Action);
+                Assert.Equal(noneHash, state.ConfigHash);
+                Assert.Equal(new[] { episodeId }, state.EpisodeIds);
+            }
+        }
+        finally
+        {
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task VerifyQueueAsync_StaysSilent_ForSpecialsWhenSeasonZeroIsOptedOut()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var mediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+
+        var seasonId = Guid.NewGuid();
+        var episodeId = Guid.NewGuid();
+
+        // Analysis never writes season state for opted-out specials, so without the guard this season
+        // would report NoStoredState at information level on every scheduled run, forever.
+        var config = new PluginConfiguration { AnalyzeSeasonZero = false };
+
+        try
+        {
+            await File.WriteAllTextAsync(mediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var episode = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Id", episodeId);
+                EntrypointTestHelpers.SetPropertyOrField(episode, "Path", mediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(episode);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                var logger = new CapturingLogger<QueueManager>();
+                var queueManager = new QueueManager(
+                    logger,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+
+                var special = CreateQueuedEpisode(episodeId, seasonId);
+                special.SeasonNumber = 0;
+
+                var verified = await queueManager.VerifyQueueAsync([special], [AnalysisMode.Introduction]);
+
+                Assert.Equal(EpisodeState.NotAnalyzed, verified.Single().GetAnalyzed(AnalysisMode.Introduction));
+                Assert.DoesNotContain(
+                    logger.Entries,
+                    e => e.Message.Contains("for analysis", StringComparison.Ordinal));
+            }
+        }
+        finally
+        {
+            if (File.Exists(mediaPath))
+            {
+                File.Delete(mediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+
     private static QueuedEpisode CreateQueuedEpisode(Guid episodeId, Guid seasonId)
         => new()
         {
             EpisodeId = episodeId,
             SeasonId = seasonId,
+            SeasonNumber = 1,
             Name = "S01E01",
             SeriesName = "Rick and Morty",
         };

--- a/IntroSkipper.Tests/TestSeasonReanalysis.cs
+++ b/IntroSkipper.Tests/TestSeasonReanalysis.cs
@@ -331,6 +331,106 @@ public sealed class TestSeasonReanalysisPlanner
 public sealed class TestSeasonReanalysisReset
 {
     [Fact]
+    public async Task PersistableEpisodeIds_ExcludeFailuresWithoutDiscardingNegativeCacheResults()
+    {
+        var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".db");
+        var failedMediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+        var noSegmentsMediaPath = Path.Join(tempDir, Guid.NewGuid().ToString("N") + ".mkv");
+        var seasonId = Guid.NewGuid();
+        var failedId = Guid.NewGuid();
+        var noSegmentsId = Guid.NewGuid();
+        var analyzedId = Guid.NewGuid();
+        var userProvidedId = Guid.NewGuid();
+        var config = new PluginConfiguration();
+        var configHash = ConfigHasher.Analysis(
+            config,
+            AnalysisMode.Credits,
+            AnalyzerAction.Default,
+            ffmpegValid: true);
+
+        var failed = CreateQueuedEpisode(failedId, seasonId);
+        failed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
+        var noSegments = CreateQueuedEpisode(noSegmentsId, seasonId);
+        var analyzed = CreateQueuedEpisode(analyzedId, seasonId);
+        analyzed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
+        Assert.True(analyzed.NeedsAnalysis(AnalysisMode.Credits));
+        analyzed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.Analyzed);
+        var userProvided = CreateQueuedEpisode(userProvidedId, seasonId);
+        userProvided.SetAnalyzed(AnalysisMode.Credits, EpisodeState.UserProvided);
+
+        var persistableIds = BaseItemAnalyzerTask.GetPersistableEpisodeIds(
+            [failed, noSegments, analyzed, userProvided],
+            AnalysisMode.Credits);
+
+        Assert.Equal([noSegmentsId, analyzedId, userProvidedId], persistableIds);
+        Assert.True(failed.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.False(analyzed.NeedsAnalysis(AnalysisMode.Credits));
+        Assert.False(userProvided.NeedsAnalysis(AnalysisMode.Credits));
+
+        try
+        {
+            await File.WriteAllTextAsync(failedMediaPath, string.Empty);
+            await File.WriteAllTextAsync(noSegmentsMediaPath, string.Empty);
+
+            using (var db = new IntroSkipperDbContext(dbPath))
+            {
+                await db.Database.EnsureCreatedAsync();
+            }
+
+            using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
+            {
+                var plugin = Plugin.Instance!;
+                EntrypointTestHelpers.SetPrivateField(plugin, "_dbPath", dbPath);
+                EntrypointTestHelpers.SetPropertyOrField(plugin, "Configuration", config);
+
+                var failedItem = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(failedItem, "Id", failedId);
+                EntrypointTestHelpers.SetPropertyOrField(failedItem, "Path", failedMediaPath);
+                var noSegmentsItem = new Episode();
+                EntrypointTestHelpers.SetPropertyOrField(noSegmentsItem, "Id", noSegmentsId);
+                EntrypointTestHelpers.SetPropertyOrField(noSegmentsItem, "Path", noSegmentsMediaPath);
+                var libraryManager = EntrypointTestHelpers.CreateLibraryManager(failedItem, noSegmentsItem);
+                EntrypointTestHelpers.SetPrivateField(plugin, "_libraryManager", libraryManager);
+
+                await Plugin.SetEpisodeIdsAsync(
+                    seasonId,
+                    AnalysisMode.Credits,
+                    persistableIds,
+                    configHash);
+
+                var queueManager = new QueueManager(
+                    NullLogger<QueueManager>.Instance,
+                    libraryManager,
+                    providerManager: null!,
+                    fileSystem: null!,
+                    ffmpegService: new FakeFfmpegService(ffmpegValid: true));
+                var nextRun = await queueManager.VerifyQueueAsync(
+                    [CreateQueuedEpisode(failedId, seasonId), CreateQueuedEpisode(noSegmentsId, seasonId)],
+                    [AnalysisMode.Credits]);
+
+                Assert.Equal(EpisodeState.NotAnalyzed, nextRun[0].GetAnalyzed(AnalysisMode.Credits));
+                Assert.Equal(EpisodeState.NoSegments, nextRun[1].GetAnalyzed(AnalysisMode.Credits));
+            }
+        }
+        finally
+        {
+            if (File.Exists(failedMediaPath))
+            {
+                File.Delete(failedMediaPath);
+            }
+
+            if (File.Exists(noSegmentsMediaPath))
+            {
+                File.Delete(noSegmentsMediaPath);
+            }
+
+            DeleteSqliteFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public async Task SettleReanalysisGuard_PersistsCompletedEpisodeSet()
     {
         var tempDir = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests");

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -329,13 +329,15 @@ public sealed class TestVisualizationController
         public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
             => inner.Write(itemId, mode, type, start, end, items);
 
-        public void DeleteForItem(Guid itemId)
+        public bool DeleteForItem(Guid itemId)
         {
-            inner.DeleteForItem(itemId);
+            var deleted = inner.DeleteForItem(itemId);
             if (Interlocked.Increment(ref _deleteCount) == 1)
             {
                 cancellationTokenSource.Cancel();
             }
+
+            return deleted;
         }
 
         public void DeleteByMode(AnalysisMode mode) => inner.DeleteByMode(mode);

--- a/IntroSkipper.Tests/TestVisualizationController.cs
+++ b/IntroSkipper.Tests/TestVisualizationController.cs
@@ -76,6 +76,34 @@ public sealed class TestVisualizationController
     }
 
     [Fact]
+    public async Task EraseSeasonAsync_CancellationAfterCacheDeletion_LeavesDatabaseConsistent()
+    {
+        var seriesId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+        var episodeIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var dbPath = CreateTempDbPath();
+        using var pluginScope = CreatePluginScope(dbPath, seriesId, seasonId, episodeIds, updateMediaSegments: true);
+        await SeedSeasonAsync(dbPath, seasonId, episodeIds);
+        await SeedCacheAsync(episodeIds[0], episodeIds[1]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+        var cacheService = new CancelAfterFirstDeleteCacheService(
+            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance),
+            cancellationTokenSource);
+        var controller = CreateController(new RecordingMediaSegmentRefresher(), loggerFactory, cacheService);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            controller.EraseSeasonAsync(seriesId, seasonId, eraseCache: true, cancellationTokenSource.Token));
+
+        await using var db = new IntroSkipperDbContext(dbPath);
+        Assert.False(await db.DbSegment.AnyAsync(s => episodeIds.Contains(s.ItemId)));
+        var seasonStates = await db.DbSeasonState.Where(s => s.SeasonId == seasonId).ToListAsync();
+        Assert.All(seasonStates, state => Assert.Empty(state.EpisodeIds));
+        using var cacheDb = Plugin.CreateCacheDbContext();
+        Assert.False(await cacheDb.DetectionCache.AnyAsync(e => episodeIds.Contains(e.ItemId)));
+    }
+
+    [Fact]
     public async Task ClearExcludedTimestampsAsync_RemovesOnlyCurrentlyExcludedState()
     {
         var seriesId = Guid.NewGuid();
@@ -169,7 +197,10 @@ public sealed class TestVisualizationController
         }
     }
 
-    private static VisualizationController CreateController(RecordingMediaSegmentRefresher refresher, ILoggerFactory loggerFactory)
+    private static VisualizationController CreateController(
+        RecordingMediaSegmentRefresher refresher,
+        ILoggerFactory loggerFactory,
+        IDetectionCacheService? cacheService = null)
     {
         return new VisualizationController(
             NullLogger<VisualizationController>.Instance,
@@ -179,7 +210,7 @@ public sealed class TestVisualizationController
             fileSystem: null!,
             loggerFactory,
             ffmpegService: null!,
-            new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
+            cacheService ?? new DetectionCacheService(NullLogger<DetectionCacheService>.Instance));
     }
 
     private static EntrypointTestHelpers.PluginInstanceScope CreatePluginScope(string dbPath, Guid seriesId, Guid seasonId, IReadOnlyList<Guid> episodeIds, bool updateMediaSegments)
@@ -270,6 +301,7 @@ public sealed class TestVisualizationController
 
         public Task RefreshAsync(IEnumerable<Guid> itemIds, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             RefreshCallCount++;
             CollectionCallCount++;
             LastItemIds = [.. itemIds];
@@ -281,5 +313,34 @@ public sealed class TestVisualizationController
             RemoveCallCount++;
             return RefreshAsync(itemIds, cancellationToken);
         }
+    }
+
+    private sealed class CancelAfterFirstDeleteCacheService(
+        IDetectionCacheService inner,
+        CancellationTokenSource cancellationTokenSource) : IDetectionCacheService
+    {
+        private int _deleteCount;
+
+        public bool IsEnabled => inner.IsEnabled;
+
+        public bool TryRead<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, out T[] result)
+            => inner.TryRead(itemId, mode, type, start, end, out result);
+
+        public bool Write<T>(Guid itemId, AnalysisMode mode, CacheEntryType type, double start, double end, T[] items)
+            => inner.Write(itemId, mode, type, start, end, items);
+
+        public void DeleteForItem(Guid itemId)
+        {
+            inner.DeleteForItem(itemId);
+            if (Interlocked.Increment(ref _deleteCount) == 1)
+            {
+                cancellationTokenSource.Cancel();
+            }
+        }
+
+        public void DeleteByMode(AnalysisMode mode) => inner.DeleteByMode(mode);
+
+        public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode)
+            => inner.HasCachedFingerprint(episode, mode);
     }
 }

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -119,6 +119,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
             }
             catch (Exception ex)
             {
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
                 LogErrorAnalyzingCredits(_logger, ex, episode.Name);
             }
         }
@@ -214,6 +215,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
         }
         catch (Exception ex)
         {
+            episode.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
             LogErrorDuringAnalysis(_logger, ex, episode.Name);
             return null;
         }

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -114,7 +114,23 @@ public partial class ChapterAnalyzer(
                 : null;
             if ((skipRange is null || !skipRange.Valid) && enableRecapBlackFrameFallback)
             {
-                skipRange = await DetectRecapUsingBlackFramesAsync(episode, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    skipRange = await DetectRecapUsingBlackFramesAsync(episode, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // A hard per-episode failure (e.g. an ffmpeg timeout) must not abort the whole
+                    // season pass. Mark the episode as failed so it stays retriable and is not
+                    // persisted as a completed no-segment result.
+                    episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                    LogErrorDetectingRecapBlackFrames(ex, episode.Name);
+                    continue;
+                }
             }
 
             if (skipRange is null || !skipRange.Valid)
@@ -358,4 +374,7 @@ public partial class ChapterAnalyzer(
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{Base}: okay")]
     private partial void LogChapterOk(string @base);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error detecting recap black frames for {Episode}")]
+    private partial void LogErrorDetectingRecapBlackFrames(Exception ex, string episode);
 }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -84,8 +84,15 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
                 // Fallback to an empty fingerprint on any error, and record the failure so the episode
                 // is retried on the next run. Without this it is persisted as a completed no-segment
                 // result, and an ffmpeg hiccup on one episode becomes a permanent verdict.
+                // Episodes that already carry a completed result (re-analysis of an Analyzed episode
+                // with a cached fingerprint, or an Analyzed/UserProvided neighbor pulled in to pair
+                // with a lone unanalyzed episode) keep that result: a failed fingerprint must not
+                // discard a valid verdict.
                 fingerprintCache[episode.EpisodeId] = [];
-                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                if (episode.NeedsAnalysis(mode))
+                {
+                    episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                }
             }
         }
 

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -81,8 +81,11 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
                 LogCaughtFingerprintError(ex);
                 WarningManager.SetFlag(PluginWarning.InvalidChromaprintFingerprint);
 
-                // Fallback to an empty fingerprint on any error
+                // Fallback to an empty fingerprint on any error, and record the failure so the episode
+                // is retried on the next run. Without this it is persisted as a completed no-segment
+                // result, and an ffmpeg hiccup on one episode becomes a permanent verdict.
                 fingerprintCache[episode.EpisodeId] = [];
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
             }
         }
 

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -90,6 +90,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
             }
             catch (Exception ex)
             {
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
                 LogErrorAnalyzingCredits(ex, episode.Name);
             }
         }

--- a/IntroSkipper/Controllers/SkipIntroController.cs
+++ b/IntroSkipper/Controllers/SkipIntroController.cs
@@ -185,11 +185,7 @@ public class SkipIntroController(IMediaSegmentRefresher mediaSegmentRefresher, I
     [HttpPost("Intros/EraseTimestamps")]
     public async Task<ActionResult> ResetIntroTimestamps([FromQuery] AnalysisMode mode, [FromQuery] bool eraseCache = false, CancellationToken cancellationToken = default)
     {
-        using var db = Plugin.CreateDbContext();
-        await db.DbSegment
-            .Where(s => s.Type == mode)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        await Plugin.EraseTimestampsForModeAsync(mode, cancellationToken).ConfigureAwait(false);
 
         if (eraseCache && mode is AnalysisMode.Introduction or AnalysisMode.Credits)
         {

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -250,27 +250,32 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
             int removedSegments;
             using (var db = Plugin.CreateDbContext())
             {
-                removedSegments = await db.DbSegment
-                    .Where(s => excludedIds.Contains(s.ItemId))
-                    .ExecuteDeleteAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                var seasonIds = excludedIdsBySeason.Keys.ToHashSet();
-                var seasonStates = await db.DbSeasonState
-                    .Where(s => seasonIds.Contains(s.SeasonId))
-                    .ToListAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                foreach (var state in seasonStates)
+                var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+                await using (transaction.ConfigureAwait(false))
                 {
-                    var currentIds = state.EpisodeIds.ToList();
-                    if (currentIds.RemoveAll(excludedIdsBySeason[state.SeasonId].Contains) > 0)
-                    {
-                        db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = currentIds;
-                    }
-                }
+                    removedSegments = await db.DbSegment
+                        .Where(s => excludedIds.Contains(s.ItemId))
+                        .ExecuteDeleteAsync(cancellationToken)
+                        .ConfigureAwait(false);
 
-                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    HashSet<Guid> seasonIds = [.. excludedIdsBySeason.Keys];
+                    var seasonStates = await db.DbSeasonState
+                        .Where(s => seasonIds.Contains(s.SeasonId))
+                        .ToListAsync(cancellationToken)
+                        .ConfigureAwait(false);
+
+                    foreach (var state in seasonStates)
+                    {
+                        List<Guid> currentIds = [.. state.EpisodeIds];
+                        if (currentIds.RemoveAll(excludedIdsBySeason[state.SeasonId].Contains) > 0)
+                        {
+                            db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = currentIds;
+                        }
+                    }
+
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
 
             int removedCacheEntries;

--- a/IntroSkipper/Controllers/VisualizationController.cs
+++ b/IntroSkipper/Controllers/VisualizationController.cs
@@ -173,36 +173,36 @@ public partial class VisualizationController(ILogger<VisualizationController> lo
         {
             using var db = Plugin.CreateDbContext();
 
-            // ExecuteDeleteAsync runs a single server-side DELETE and bypasses the change tracker.
-            // This is safe here because the tracked operations below target DbSeasonState, not DbSegment.
             var episodeIds = episodes.Select(e => e.EpisodeId).ToHashSet();
-            await db.DbSegment
-                .Where(s => episodeIds.Contains(s.ItemId))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+            await using (transaction.ConfigureAwait(false))
+            {
+                await db.DbSegment
+                    .Where(s => episodeIds.Contains(s.ItemId))
+                    .ExecuteDeleteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                var seasonStates = await db.DbSeasonState
+                    .Where(s => s.SeasonId == seasonId)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (var state in seasonStates)
+                {
+                    db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
+                }
+
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             if (eraseCache)
             {
-                // Cache deletion must run to completion — the DB rows are already gone,
-                // so aborting here would leave orphaned files with no way to clean them up.
                 foreach (var episode in episodes)
                 {
                     await Task.Run(() => _cacheService.DeleteForItem(episode.EpisodeId), CancellationToken.None).ConfigureAwait(false);
                 }
             }
-
-            // Batch-load season state and clear episode IDs.
-            var seasonStates = await db.DbSeasonState
-                .Where(s => s.SeasonId == seasonId)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            foreach (var state in seasonStates)
-            {
-                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
-            }
-
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             if (Plugin.Instance.Configuration.UpdateMediaSegments)
             {

--- a/IntroSkipper/Data/AnalysisReason.cs
+++ b/IntroSkipper/Data/AnalysisReason.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Why a season's episodes were queued for analysis instead of being restored from stored state.
+/// Logged per season and mode so a full-library rescan can be traced back to its cause.
+/// </summary>
+public enum AnalysisReason
+{
+    /// <summary>
+    /// Every episode was restored from stored state. Nothing needs analyzing.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The stored analysis configuration hash no longer matches the computed one. Caused by a changed
+    /// setting or by a change in Chromaprint availability, which is folded into the hash for the
+    /// Introduction, Credits, and Recap modes.
+    /// </summary>
+    ConfigHashChanged,
+
+    /// <summary>
+    /// No analysis state is stored for this season and mode. Expected for a season analyzed for the
+    /// first time, and also seen when stored state was deleted, for example by a cache cleanup that
+    /// ran against an incomplete library inventory.
+    /// </summary>
+    NoStoredState,
+
+    /// <summary>
+    /// Stored state matches, but it does not list these episodes. Either they joined the season after
+    /// it was last analyzed, or something deliberately cleared the recorded list, such as a season
+    /// rescan, a settled-season reset, or deleting a segment.
+    /// </summary>
+    NotRecorded,
+}

--- a/IntroSkipper/Data/EpisodeState.cs
+++ b/IntroSkipper/Data/EpisodeState.cs
@@ -30,4 +30,9 @@ public enum EpisodeState
     /// Episode segment was provided externally via the segment editor and must not be overwritten by automatic analysis.
     /// </summary>
     UserProvided,
+
+    /// <summary>
+    /// Episode analysis failed and must not be cached as a completed no-segment result.
+    /// </summary>
+    AnalysisFailed,
 }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -415,7 +415,7 @@ public sealed partial class FFmpegService(
                 }
             }
         }
-        catch (Exception ex) when (ex is IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception)
+        catch (Exception ex) when (ex is IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception or TimeoutException)
         {
             LogAudioDurationProbeFailed(_logger, ex, filePath);
         }
@@ -516,7 +516,7 @@ public sealed partial class FFmpegService(
             firstArg.StartsWith("-h", StringComparison.Ordinal);
     }
 
-    private async Task<byte[]> GetProcessOutputAsync(
+    internal async Task<byte[]> GetProcessOutputAsync(
         string processPath,
         IReadOnlyList<string> args,
         bool stderr = false,
@@ -550,39 +550,53 @@ public sealed partial class FFmpegService(
 
         try
         {
-            process.PriorityClass = Plugin.Instance?.Configuration.ProcessPriority ?? ProcessPriorityClass.BelowNormal;
-        }
-        catch (Exception e) when (e is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException)
-        {
-            _logger.LogWarning("ffmpeg priority could not be modified. {Message}", e.Message);
-        }
+            try
+            {
+                process.PriorityClass = Plugin.Instance?.Configuration.ProcessPriority ?? ProcessPriorityClass.BelowNormal;
+            }
+            catch (Exception e) when (e is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException)
+            {
+                _logger.LogWarning("ffmpeg priority could not be modified. {Message}", e.Message);
+            }
 
-        using var cancellationRegistration = cancellationToken.Register(() => KillProcessTree(process));
-        using var ms = new MemoryStream();
+            using var ms = new MemoryStream();
+            var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms, CancellationToken.None);
+            var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null, CancellationToken.None);
 
-        var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms, cancellationToken);
-        var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null, cancellationToken);
-        await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            var timedOut = false;
+            using var timeoutCts = new CancellationTokenSource(timeout);
+            using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            try
+            {
+                await process.WaitForExitAsync(waitCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                KillProcessTree(process);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            {
+                _logger.LogWarning("ffmpeg did not exit within {TimeoutMs}ms; killing process", timeout);
+                KillProcessTree(process);
+                timedOut = true;
+            }
 
-        using var timeoutCts = new CancellationTokenSource(timeout);
-        using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-        try
-        {
-            await process.WaitForExitAsync(waitCts.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+
             cancellationToken.ThrowIfCancellationRequested();
-            throw;
-        }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
-        {
-            _logger.LogWarning("ffmpeg did not exit within {TimeoutMs}ms; killing process", timeout);
-            KillProcessTree(process);
-        }
+            if (timedOut)
+            {
+                throw new TimeoutException($"ffmpeg process was killed after not exiting within {timeout}ms");
+            }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        return ms.ToArray();
+            return ms.ToArray();
+        }
+        finally
+        {
+            KillProcessTree(process);
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     private static async Task DrainAsync(Stream stream, Stream? destination, CancellationToken cancellationToken)
@@ -670,7 +684,16 @@ public sealed partial class FFmpegService(
         };
 
         // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).
-        var rawPoints = await GetOutputAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
+        byte[] rawPoints;
+        try
+        {
+            rawPoints = await GetOutputAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new FingerprintException("chromaprint fingerprinting of \"" + episode.Path + "\" timed out", ex);
+        }
+
         if (rawPoints.Length == 0 || rawPoints.Length % 4 != 0)
         {
             LogChromaprintReturnedPoints(_logger, rawPoints.Length, episode.Path);

--- a/IntroSkipper/Helper/AnalysisEligibility.cs
+++ b/IntroSkipper/Helper/AnalysisEligibility.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Helper;
+
+/// <summary>
+/// Season-level rules that decide whether analysis runs at all. Shared so the analyzer, the
+/// settled-season planner, and the queue reporting cannot drift apart on what counts as analyzable.
+/// </summary>
+internal static class AnalysisEligibility
+{
+    /// <summary>
+    /// Determines whether a whole season is skipped because it holds specials and the season-zero
+    /// opt-in is off. Movies carry season number 0 as well, so they are excluded from the rule.
+    /// </summary>
+    /// <param name="first">Any episode from the season; only its category and season number are read.</param>
+    /// <param name="config">Plugin configuration.</param>
+    /// <returns><see langword="true"/> when analysis skips the season entirely.</returns>
+    internal static bool IsSeasonZeroOptedOut(QueuedEpisode first, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(config);
+
+        return first.Category is not QueuedMediaCategory.Movie
+            && first.SeasonNumber == 0
+            && !config.AnalyzeSeasonZero;
+    }
+}

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -19,6 +19,13 @@ public static class ConfigHasher
     /// <param name="config">Plugin configuration.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="action">Analyzer priority/action used for the season.</param>
+    /// <remarks>
+    /// Two settings are folded into a mode other than the one they are named for, because that is where
+    /// they change the result: <see cref="PluginConfiguration.MinimumIntroDuration"/> is the minimum
+    /// shared-region duration Chromaprint applies to Credits as well, and
+    /// <see cref="PluginConfiguration.AnimePreviewFromCreditsEnd"/> is what creates anime Preview
+    /// segments. Leaving either out means turning it off never retires the segments it produced.
+    /// </remarks>
     /// <param name="ffmpegValid">Whether the current FFmpeg build supports Chromaprint. Folded into the
     /// hash for Chromaprint-capable modes so a settled <see cref="EpisodeState.NoSegments"/> season is
     /// re-analyzed once when Chromaprint becomes available instead of being skipped forever.</param>
@@ -36,8 +43,9 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
-                $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v3|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
+                $"|minRegion={config.MinimumIntroDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bfalt={config.UseAlternativeBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfaltVersion=2{CreditsNonBlackToken(config)}",
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}",
@@ -52,7 +60,8 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Preview => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"analysis|v2|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"|animePreview={config.AnimePreviewFromCreditsEnd}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Commercial => Invariant(

--- a/IntroSkipper/Helper/SeasonReanalysisPlanner.cs
+++ b/IntroSkipper/Helper/SeasonReanalysisPlanner.cs
@@ -45,7 +45,7 @@ internal static class SeasonReanalysisPlanner
         }
 
         // Respect the season-zero (specials) opt-in.
-        if (first.SeasonNumber == 0 && !config.AnalyzeSeasonZero)
+        if (AnalysisEligibility.IsSeasonZeroOptedOut(first, config))
         {
             return false;
         }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -481,15 +481,40 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         // The expected config hash depends on the season-level analyzer action and mode, not on the
         // individual episode, so compute it once per mode instead of once per episode and mode.
-        var hashMatchesByMode = new Dictionary<AnalysisMode, bool>(modes.Count);
+        var stateByMode = new Dictionary<AnalysisMode, ModeCacheState>(modes.Count);
         foreach (var mode in modes)
         {
             var action = snapshot.AnalyzerActionByMode.TryGetValue(mode, out var savedAction)
                 ? savedAction
                 : AnalyzerAction.Default;
             var expectedHash = ConfigHasher.Analysis(plugin.Configuration, mode, action, ffmpegValid);
-            hashMatchesByMode[mode] = snapshot.ConfigHashByMode.TryGetValue(mode, out var savedHash) &&
-                string.Equals(savedHash, expectedHash, StringComparison.Ordinal);
+
+            // A season-state row is created by the analyzer preference editor as well as by analysis,
+            // so an empty hash means "never analyzed", not "analyzed under a different configuration".
+            var hasStoredHash = snapshot.ConfigHashByMode.TryGetValue(mode, out var savedHash) &&
+                !string.IsNullOrEmpty(savedHash);
+            var hashMatches = hasStoredHash && string.Equals(savedHash, expectedHash, StringComparison.Ordinal);
+
+            // Chromaprint availability invalidates upward only. Gaining it reopens seasons that settled
+            // without it, which is why it is in the hash at all. Losing it must not: the probe reports
+            // false for a genuinely incapable build and for a one-off failure to launch ffmpeg alike,
+            // and discarding good results because a probe failed once re-analyzed whole libraries.
+            if (!hashMatches && !ffmpegValid && hasStoredHash)
+            {
+                var withChromaprint = ConfigHasher.Analysis(plugin.Configuration, mode, action, ffmpegValid: true);
+                if (string.Equals(savedHash, withChromaprint, StringComparison.Ordinal))
+                {
+                    hashMatches = true;
+                    expectedHash = withChromaprint;
+                }
+            }
+
+            // A missing state row is reported instead of the hash comparison it would have lost anyway.
+            var reason = !hasStoredHash ? AnalysisReason.NoStoredState
+                : !hashMatches ? AnalysisReason.ConfigHashChanged
+                : AnalysisReason.None;
+
+            stateByMode[mode] = new ModeCacheState(reason, action, savedHash ?? string.Empty, expectedHash);
         }
 
         foreach (var candidate in candidates)
@@ -519,7 +544,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
                 foreach (var mode in modes)
                 {
-                    var hashMatches = hashMatchesByMode[mode];
+                    var hashMatches = stateByMode[mode].HashMatches;
 
                     if (snapshot.SegmentsByEpisodeId.TryGetValue(candidate.EpisodeId, out var hasSegments) &&
                         hasSegments.TryGetValue(mode, out _))
@@ -527,15 +552,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                         var isUserProvided = snapshot.UserProvidedByMode.TryGetValue(mode, out var userProvided) &&
                                              userProvided.Contains(candidate.EpisodeId);
 
-                        // Always preserve user-provided segments. When AnalyzeAgain is true (settings
-                        // changed), leave automatically-analyzed segments as NotAnalyzed so they are
-                        // re-analyzed and their timestamps updated to reflect the new settings.
-                        if (isUserProvided || (!plugin.AnalyzeAgain && hashMatches))
+                        // Always preserve user-provided segments. Automatic ones are reusable only
+                        // while the stored hash still describes the current configuration.
+                        if (isUserProvided || hashMatches)
                         {
                             candidate.SetAnalyzed(mode, isUserProvided ? EpisodeState.UserProvided : EpisodeState.Analyzed);
                         }
                     }
-                    else if (!plugin.AnalyzeAgain && hashMatches &&
+                    else if (hashMatches &&
                              snapshot.EpisodeIdsByMode.TryGetValue(mode, out var ids) &&
                              ids.Contains(candidate.EpisodeId))
                     {
@@ -553,8 +577,110 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
         }
 
+        LogAnalysisReasons(verified, modes, stateByMode, ffmpegValid, plugin.Configuration);
+
         return verified;
     }
+
+    /// <summary>
+    /// Reports why each mode still has episodes to analyze, so a full-library rescan can be traced
+    /// back to its cause. Losing a whole season's stored state is logged at information level, since
+    /// that is the case users need explained. Picking up newly added episodes happens on most runs of
+    /// an active library, so it stays at debug level.
+    /// </summary>
+    /// <param name="verified">Episodes that survived verification, with their analyzed state set.</param>
+    /// <param name="modes">Analysis modes being processed.</param>
+    /// <param name="stateByMode">Stored-state comparison for each mode.</param>
+    /// <param name="ffmpegValid">Whether the current FFmpeg build supports Chromaprint.</param>
+    /// <param name="config">Plugin configuration.</param>
+    private void LogAnalysisReasons(
+        IReadOnlyList<QueuedEpisode> verified,
+        IReadOnlyCollection<AnalysisMode> modes,
+        IReadOnlyDictionary<AnalysisMode, ModeCacheState> stateByMode,
+        bool ffmpegValid,
+        PluginConfiguration config)
+    {
+        if (verified.Count == 0)
+        {
+            return;
+        }
+
+        var first = verified[0];
+
+        // Analysis skips specials wholesale when the opt-in is off, so these episodes stay unanalyzed
+        // with no stored state. Reporting a reason to analyze them would repeat on every run and never
+        // come true.
+        if (AnalysisEligibility.IsSeasonZeroOptedOut(first, config))
+        {
+            return;
+        }
+
+        foreach (var mode in modes)
+        {
+            var state = stateByMode[mode];
+
+            // Switching a mode off changes the hash, so the season is queued once to settle its new
+            // state and then skipped. The analyzer logs that skip itself, so announcing analysis that
+            // will not happen would only be confusing.
+            if (state.Action == AnalyzerAction.None)
+            {
+                continue;
+            }
+
+            // AnalysisReason.None means the stored state matched, so the pending episodes are ones the
+            // stored state does not list. Only a hash change means something moved under the user, so
+            // it is the one cause worth reporting by default.
+            var (reason, level) = state.Reason switch
+            {
+                AnalysisReason.None => (AnalysisReason.NotRecorded, LogLevel.Debug),
+                AnalysisReason.ConfigHashChanged => (AnalysisReason.ConfigHashChanged, LogLevel.Information),
+                _ => (state.Reason, LogLevel.Debug)
+            };
+
+            if (!_logger.IsEnabled(level))
+            {
+                continue;
+            }
+
+            // Counts what the analyzer chain will process, which is every episode NeedsAnalysis()
+            // admits, not just the NotAnalyzed ones that trigger the pass.
+            var pending = verified.Count(e => e.NeedsAnalysis(mode));
+            if (pending == 0 || !verified.Any(e => e.GetAnalyzed(mode) == EpisodeState.NotAnalyzed))
+            {
+                continue;
+            }
+
+            if (reason == AnalysisReason.ConfigHashChanged)
+            {
+                LogSeasonConfigHashChanged(
+                    _logger,
+                    mode,
+                    pending,
+                    verified.Count,
+                    first.SeriesName,
+                    first.SeasonNumber,
+                    state.StoredHash,
+                    state.ExpectedHash,
+                    ChromaprintAffectsMode(mode) ? ffmpegValid.ToString() : "n/a");
+                continue;
+            }
+
+            LogSeasonQueuedForAnalysis(
+                _logger,
+                level,
+                mode,
+                pending,
+                verified.Count,
+                first.SeriesName,
+                first.SeasonNumber,
+                reason);
+        }
+    }
+
+    // Only the Chromaprint-capable modes fold Chromaprint availability into their hash, so naming it
+    // for Preview or Commercial would point at a cause that cannot apply.
+    private static bool ChromaprintAffectsMode(AnalysisMode mode)
+        => mode is AnalysisMode.Introduction or AnalysisMode.Credits or AnalysisMode.Recap;
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Plugin instance is null in GetMediaItems()")]
     private static partial void LogPluginInstanceNull(ILogger logger);
@@ -627,6 +753,32 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping analysis of {Name} ({Id})")]
     private static partial void LogSkippingAnalysisException(ILogger logger, string name, Guid id, Exception exception);
+
+    [LoggerMessage(Message = "[Mode: {Mode}] Queuing {Count} of {Total} items in {Name} season {Season} for analysis: {Reason}")]
+    private static partial void LogSeasonQueuedForAnalysis(ILogger logger, LogLevel level, AnalysisMode mode, int count, int total, string name, int season, AnalysisReason reason);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "[Mode: {Mode}] Queuing {Count} of {Total} items in {Name} season {Season} for analysis: analysis configuration hash changed from \"{StoredHash}\" to \"{ExpectedHash}\" (chromaprint available: {ChromaprintAvailable})")]
+    private static partial void LogSeasonConfigHashChanged(ILogger logger, AnalysisMode mode, int count, int total, string name, int season, string storedHash, string expectedHash, string chromaprintAvailable);
+
+    /// <summary>
+    /// Stored analysis state for one mode, compared against the current configuration.
+    /// </summary>
+    /// <param name="Reason">Why the season's stored state cannot be reused, if it cannot.</param>
+    /// <param name="Action">Analyzer action stored for the season, which decides whether the mode runs at all.</param>
+    /// <param name="StoredHash">Hash recorded when the season was last analyzed, empty when none is stored.</param>
+    /// <param name="ExpectedHash">Hash computed from the current configuration.</param>
+    private readonly record struct ModeCacheState(
+        AnalysisReason Reason,
+        AnalyzerAction Action,
+        string StoredHash,
+        string ExpectedHash)
+    {
+        /// <summary>
+        /// Gets a value indicating whether stored analysis state can be reused for this mode. Derived
+        /// from <see cref="Reason"/> so the queue decision and the logged explanation cannot drift.
+        /// </summary>
+        public bool HashMatches => Reason is AnalysisReason.None;
+    }
 
     internal sealed record MediaInventoryResult(
         IReadOnlyDictionary<Guid, List<QueuedEpisode>> Items,

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -45,6 +45,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private double _analysisPercent;
     private ExclusionPolicy _exclusionPolicy = ExclusionPolicy.Empty;
 
+    private enum QueueItemResult
+    {
+        Queued,
+        Excluded,
+        Failed,
+    }
+
     /// <summary>
     /// Gets all media items on the server.
     /// </summary>
@@ -396,13 +403,6 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
 
         return QueueItemResult.Queued;
-    }
-
-    private enum QueueItemResult
-    {
-        Queued,
-        Excluded,
-        Failed,
     }
 
     private async Task<double> ResolveCreditsFingerprintEndAsync(string path, double duration, CancellationToken cancellationToken)

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -205,7 +205,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             return false;
         }
 
-        var items = libraryItems.DistinctBy(e => e.Id).ToList();
+        IReadOnlyList<BaseItem> items = [.. libraryItems.DistinctBy(e => e.Id)];
 
         // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
@@ -218,22 +218,24 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             {
                 if (item is Episode episode)
                 {
-                    if (await QueueEpisode(episode, includeExcluded, cancellationToken).ConfigureAwait(false))
+                    var result = await QueueEpisode(episode, includeExcluded, cancellationToken).ConfigureAwait(false);
+                    if (result == QueueItemResult.Queued)
                     {
                         queuedCount++;
                     }
-                    else if (includeExcluded)
+                    else if (result == QueueItemResult.Failed)
                     {
                         isComplete = false;
                     }
                 }
                 else if (item is Movie movie)
                 {
-                    if (await QueueMovieAsync(movie, includeExcluded, cancellationToken).ConfigureAwait(false))
+                    var result = await QueueMovieAsync(movie, includeExcluded, cancellationToken).ConfigureAwait(false);
+                    if (result == QueueItemResult.Queued)
                     {
                         queuedCount++;
                     }
-                    else if (includeExcluded)
+                    else if (result == QueueItemResult.Failed)
                     {
                         isComplete = false;
                     }
@@ -258,21 +260,21 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return isComplete;
     }
 
-    private async Task<bool> QueueEpisode(Episode episode, bool includeExcluded, CancellationToken cancellationToken)
+    private async Task<QueueItemResult> QueueEpisode(Episode episode, bool includeExcluded, CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
         if (string.IsNullOrEmpty(episode.Path))
         {
             LogNotQueuingEpisodeNoPath(_logger, episode.Name, episode.SeriesName, episode.Id);
-            return false;
+            return QueueItemResult.Failed;
         }
 
         var decision = _exclusionPolicy.EvaluateSeries(episode.SeriesName, episode.SeriesId, episode.Path);
         if (decision.IsExcluded && !includeExcluded)
         {
             LogSkippingExcludedItem(_logger, episode.Name, decision.RuleLabel);
-            return false;
+            return QueueItemResult.Excluded;
         }
 
         // Allocate a new list for each new season
@@ -324,7 +326,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             pluginInstance.TotalQueued++;
         }
 
-        return true;
+        return QueueItemResult.Queued;
     }
 
     private static QueuedMediaCategory ResolveEpisodeCategory(Episode episode, IReadOnlyList<QueuedEpisode> seasonEpisodes, Plugin pluginInstance)
@@ -348,21 +350,21 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return episode.DateCreated != default ? episode.DateCreated : episode.DateLastSaved;
     }
 
-    private async Task<bool> QueueMovieAsync(Movie movie, bool includeExcluded, CancellationToken cancellationToken)
+    private async Task<QueueItemResult> QueueMovieAsync(Movie movie, bool includeExcluded, CancellationToken cancellationToken)
     {
         var pluginInstance = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance was null");
 
         if (string.IsNullOrEmpty(movie.Path))
         {
             LogNotQueuingMovieNoPath(_logger, movie.Name, movie.Id);
-            return false;
+            return QueueItemResult.Failed;
         }
 
         var decision = _exclusionPolicy.EvaluateMovie(movie.Name, movie.Id, movie.Path);
         if (decision.IsExcluded && !includeExcluded)
         {
             LogSkippingExcludedItem(_logger, movie.Name, decision.RuleLabel);
-            return false;
+            return QueueItemResult.Excluded;
         }
 
         // Allocate a new list for each movie.
@@ -393,7 +395,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             pluginInstance.TotalQueued++;
         }
 
-        return true;
+        return QueueItemResult.Queued;
+    }
+
+    private enum QueueItemResult
+    {
+        Queued,
+        Excluded,
+        Failed,
     }
 
     private async Task<double> ResolveCreditsFingerprintEndAsync(string path, double duration, CancellationToken cancellationToken)

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -50,8 +50,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
-    public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
-        => GetMediaItems(includeExcluded: false, cancellationToken);
+    public async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
+        => (await GetMediaInventory(includeExcluded: false, cancellationToken).ConfigureAwait(false)).Items;
 
     internal async Task<bool> GetFfmpegValidAsync(CancellationToken cancellationToken = default)
     {
@@ -66,12 +66,15 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     }
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
+        => (await GetMediaInventory(includeExcluded, cancellationToken).ConfigureAwait(false)).Items;
+
+    internal async Task<MediaInventoryResult> GetMediaInventory(bool includeExcluded, CancellationToken cancellationToken = default)
     {
         var plugin = Plugin.Instance;
         if (plugin is null)
         {
             LogPluginInstanceNull(_logger);
-            return _queuedEpisodes;
+            return new MediaInventoryResult(_queuedEpisodes, false);
         }
 
         if (!includeExcluded)
@@ -81,43 +84,60 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         LoadAnalysisSettings(plugin);
 
-        // For all selected libraries, enqueue all contained episodes.
-        var virtualFolders = _libraryManager.GetVirtualFolders();
-        if (virtualFolders is null)
+        var isComplete = true;
+        try
         {
-            LogLibraryManagerNull(_logger);
-            return _queuedEpisodes;
+            var virtualFolders = _libraryManager.GetVirtualFolders();
+            if (virtualFolders is null)
+            {
+                LogLibraryManagerNull(_logger);
+                return new MediaInventoryResult(_queuedEpisodes, false);
+            }
+
+            foreach (var folder in virtualFolders)
+            {
+                if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true)
+                {
+                    LogLibraryDisabled(_logger, folder.Name);
+                    continue;
+                }
+
+                LogRunningEnqueueLibrary(_logger, folder.Name);
+
+                // Some virtual folders don't have a proper item id.
+                if (!Guid.TryParse(folder.ItemId, out var folderId))
+                {
+                    isComplete = false;
+                    LogInvalidFolderId(_logger, folder.Name);
+                    continue;
+                }
+
+                try
+                {
+                    if (!await QueueLibraryContents(folderId, includeExcluded, cancellationToken).ConfigureAwait(false))
+                    {
+                        isComplete = false;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    isComplete = false;
+                    LogFailedEnqueueLibrary(_logger, folder.Name, ex);
+                }
+            }
         }
-
-        foreach (var folder in virtualFolders)
+        catch (OperationCanceledException)
         {
-            // If libraries have been selected for analysis, ensure this library was selected.
-            if (folder.LibraryOptions?.DisabledMediaSegmentProviders?.Contains(plugin.Name) == true)
-            {
-                LogLibraryDisabled(_logger, folder.Name);
-                continue;
-            }
-
-            LogRunningEnqueueLibrary(_logger, folder.Name);
-
-            // Some virtual folders don't have a proper item id.
-            if (!Guid.TryParse(folder.ItemId, out var folderId))
-            {
-                continue;
-            }
-
-            try
-            {
-                await QueueLibraryContents(folderId, includeExcluded, cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                LogFailedEnqueueLibrary(_logger, folder.Name, ex);
-            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            isComplete = false;
+            LogFailedEnumerateLibraries(_logger, ex);
         }
 
         if (_refreshedEpisodes.Count > 0)
@@ -135,7 +155,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
         }
 
-        return _queuedEpisodes;
+        return new MediaInventoryResult(_queuedEpisodes, isComplete);
     }
 
     /// <summary>
@@ -164,7 +184,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
     }
 
-    private async Task QueueLibraryContents(Guid id, bool includeExcluded, CancellationToken cancellationToken)
+    private async Task<bool> QueueLibraryContents(Guid id, bool includeExcluded, CancellationToken cancellationToken)
     {
         LogConstructingQuery(_logger);
 
@@ -178,20 +198,20 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             IsVirtualItem = false
         };
 
-        var items = _libraryManager.GetItemList(query, false)
-            .DistinctBy(e => e.Id)
-            .ToList();
-
-        if (items is null)
+        var libraryItems = _libraryManager.GetItemList(query, false);
+        if (libraryItems is null)
         {
             LogLibraryQueryNull(_logger);
-            return;
+            return false;
         }
+
+        var items = libraryItems.DistinctBy(e => e.Id).ToList();
 
         // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
 
         var queuedCount = 0;
+        var isComplete = true;
         foreach (var item in items)
         {
             try
@@ -202,12 +222,20 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                     {
                         queuedCount++;
                     }
+                    else if (includeExcluded)
+                    {
+                        isComplete = false;
+                    }
                 }
                 else if (item is Movie movie)
                 {
                     if (await QueueMovieAsync(movie, includeExcluded, cancellationToken).ConfigureAwait(false))
                     {
                         queuedCount++;
+                    }
+                    else if (includeExcluded)
+                    {
+                        isComplete = false;
                     }
                 }
                 else
@@ -221,11 +249,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
             catch (Exception ex)
             {
+                isComplete = false;
                 LogErrorProcessingItem(_logger, ex, item.Name, item.Id);
             }
         }
 
         LogQueuedEpisodes(_logger, queuedCount);
+        return isComplete;
     }
 
     private async Task<bool> QueueEpisode(Episode episode, bool includeExcluded, CancellationToken cancellationToken)
@@ -532,6 +562,12 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     [LoggerMessage(Level = LogLevel.Error, Message = "Library manager returned null when requesting virtual folders")]
     private static partial void LogLibraryManagerNull(ILogger logger);
 
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to enumerate virtual folders")]
+    private static partial void LogFailedEnumerateLibraries(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping library \"{Name}\": virtual folder does not have a valid item id")]
+    private static partial void LogInvalidFolderId(ILogger logger, string name);
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Not analyzing library \"{Name}\": Intro Skipper is disabled in library settings. To enable, check library configuration > Media Segment Providers")]
     private static partial void LogLibraryDisabled(ILogger logger, string name);
 
@@ -591,4 +627,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping analysis of {Name} ({Id})")]
     private static partial void LogSkippingAnalysisException(ILogger logger, string name, Guid id, Exception exception);
+
+    internal sealed record MediaInventoryResult(
+        IReadOnlyDictionary<Guid, List<QueuedEpisode>> Items,
+        bool IsComplete);
 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -466,8 +466,8 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         AnalysisMode mode,
         IEnumerable<Guid> episodeIds,
         string configHash = "",
-        CancellationToken cancellationToken = default,
-        AnalyzerAction action = AnalyzerAction.Default)
+        AnalyzerAction action = AnalyzerAction.Default,
+        CancellationToken cancellationToken = default)
     {
         using var db = CreateDbContext();
         var seasonState = await db.DbSeasonState

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -461,7 +461,13 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             .ConfigureAwait(false);
     }
 
-    internal static async Task SetEpisodeIdsAsync(Guid id, AnalysisMode mode, IEnumerable<Guid> episodeIds, string configHash = "", CancellationToken cancellationToken = default)
+    internal static async Task SetEpisodeIdsAsync(
+        Guid id,
+        AnalysisMode mode,
+        IEnumerable<Guid> episodeIds,
+        string configHash = "",
+        CancellationToken cancellationToken = default,
+        AnalyzerAction action = AnalyzerAction.Default)
     {
         using var db = CreateDbContext();
         var seasonState = await db.DbSeasonState
@@ -470,7 +476,7 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
         if (seasonState is null)
         {
-            seasonState = new DbSeasonState(id, mode, AnalyzerAction.Default, episodeIds, configHash);
+            seasonState = new DbSeasonState(id, mode, action, episodeIds, configHash);
             db.DbSeasonState.Add(seasonState);
         }
         else

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -130,11 +130,6 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public string CacheDbPath => _cacheDbPath;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to analyze again.
-    /// </summary>
-    public bool AnalyzeAgain { get; set; }
-
-    /// <summary>
     /// Gets the most recent media item queue.
     /// </summary>
     public ConcurrentDictionary<Guid, List<QueuedEpisode>> QueuedMediaItems { get; } = new();
@@ -740,6 +735,50 @@ public partial class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
             // on this pass or a later one) instead of being stranded as NoSegments.
             var seasonStates = await db.DbSeasonState
                 .Where(s => s.SeasonId == seasonId && modeArray.Contains(s.Type))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var state in seasonStates)
+            {
+                db.Entry(state).Property(s => s.EpisodeIds).CurrentValue = [];
+            }
+
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await transaction.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Deletes every stored segment for one analysis mode across the whole library and clears the
+    /// analyzed-episode lists that referenced them.
+    /// </summary>
+    /// <remarks>
+    /// Clearing the lists is what makes the erase recoverable. Leaving them in place would let
+    /// <c>VerifyQueueAsync</c> restore each episode as <see cref="EpisodeState.NoSegments"/> on the
+    /// next run, because the stored config hash still matches, so analysis would skip the mode and the
+    /// erased timestamps would never come back. Mirrors the per-season path in
+    /// <see cref="ResetSeasonForReanalysisAsync"/>.
+    /// </remarks>
+    /// <param name="mode">Analysis mode to erase.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    internal static async Task EraseTimestampsForModeAsync(AnalysisMode mode, CancellationToken cancellationToken = default)
+    {
+        using var db = CreateDbContext();
+        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await db.DbSegment
+                .Where(s => s.Type == mode)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var seasonStates = await db.DbSeasonState
+                .Where(s => s.Type == mode)
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -211,6 +211,10 @@ public partial class BaseItemAnalyzerTask(
             {
                 LogFingerprintExceptionDuringAnalysis(_logger, ex);
             }
+            catch (TimeoutException ex)
+            {
+                LogFfmpegTimeoutDuringAnalysis(_logger, ex);
+            }
             catch (Exception ex)
             {
                 LogUnexpectedAnalysisError(_logger, ex);
@@ -595,6 +599,9 @@ public partial class BaseItemAnalyzerTask(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Fingerprint exception during analysis.")]
     private static partial void LogFingerprintExceptionDuringAnalysis(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "An ffmpeg scan timed out during analysis; skipping this season.")]
+    private static partial void LogFfmpegTimeoutDuringAnalysis(ILogger logger, Exception ex);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "An unexpected error occurred during analysis.")]
     private static partial void LogUnexpectedAnalysisError(ILogger logger, Exception ex);

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -428,10 +428,21 @@ public partial class BaseItemAnalyzerTask(
         }
 
         // Set the episode IDs for the analyzed items
-        await Plugin.SetEpisodeIdsAsync(first.SeasonId, mode, items.Select(i => i.EpisodeId), configHash, cancellationToken).ConfigureAwait(false);
+        await Plugin.SetEpisodeIdsAsync(first.SeasonId, mode, GetPersistableEpisodeIds(items, mode), configHash, cancellationToken).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
     }
+
+    /// <summary>
+    /// Gets episode IDs whose analysis result can be persisted for the current configuration.
+    /// </summary>
+    /// <param name="items">Episodes in the current season pass.</param>
+    /// <param name="mode">Analysis mode being processed.</param>
+    /// <returns>Episode IDs excluding transient analysis failures.</returns>
+    internal static IReadOnlyList<Guid> GetPersistableEpisodeIds(IReadOnlyList<QueuedEpisode> items, AnalysisMode mode)
+        => [.. items
+            .Where(item => item.GetAnalyzed(mode) != EpisodeState.AnalysisFailed)
+            .Select(item => item.EpisodeId)];
 
     /// <summary>
     /// Decide whether an anime Preview segment needs to be written for an episode, and build it.

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -345,8 +345,8 @@ public partial class BaseItemAnalyzerTask(
                 mode,
                 items.Select(i => i.EpisodeId),
                 configHash,
-                cancellationToken,
-                action).ConfigureAwait(false);
+                action,
+                cancellationToken).ConfigureAwait(false);
 
             return 0;
         }
@@ -450,7 +450,7 @@ public partial class BaseItemAnalyzerTask(
         }
 
         // Set the episode IDs for the analyzed items
-        await Plugin.SetEpisodeIdsAsync(first.SeasonId, mode, GetPersistableEpisodeIds(items, mode), configHash, cancellationToken).ConfigureAwait(false);
+        await Plugin.SetEpisodeIdsAsync(first.SeasonId, mode, GetPersistableEpisodeIds(items, mode), configHash, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
     }

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -57,7 +57,13 @@ public partial class BaseItemAnalyzerTask(
     private readonly IMediaSegmentRefresher _mediaSegmentRefresher = mediaSegmentRefresher;
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
-    private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+
+    /// <summary>
+    /// Gets the live plugin configuration. Jellyfin replaces the configuration object on save, so a
+    /// snapshot taken when the task was constructed would let this class stamp a hash computed from
+    /// the old settings while <c>VerifyQueueAsync</c> and the analyzers read the new ones.
+    /// </summary>
+    private static PluginConfiguration Config => Plugin.Instance?.Configuration ?? new PluginConfiguration();
 
     /// <summary>
     /// Analyze all media items on the server.
@@ -72,11 +78,11 @@ public partial class BaseItemAnalyzerTask(
         IReadOnlyCollection<Guid>? seasonsToAnalyze = null)
     {
         List<AnalysisMode> modes = [
-            .. _config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
+            .. Config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
         if (seasonsToAnalyze?.Count == 0)
@@ -120,7 +126,7 @@ public partial class BaseItemAnalyzerTask(
         int totalProcessed = 0;
         var options = new ParallelOptions
         {
-            MaxDegreeOfParallelism = Math.Max(1, _config.MaxParallelism),
+            MaxDegreeOfParallelism = Math.Max(1, Config.MaxParallelism),
             CancellationToken = cancellationToken
         };
 
@@ -143,13 +149,13 @@ public partial class BaseItemAnalyzerTask(
             // Reuses the cached fingerprints, so this only re-runs the comparison, not the decode.
             var utcNow = DateTime.UtcNow;
             var episodeIds = episodes.Select(e => e.EpisodeId).ToArray();
-            if (_config.ReanalyzeSettledSeasons &&
-                SeasonReanalysisPlanner.IsSettledForReanalysis(episodes, _config, utcNow))
+            if (Config.ReanalyzeSettledSeasons &&
+                SeasonReanalysisPlanner.IsSettledForReanalysis(episodes, Config, utcNow))
             {
                 settledResetModes = await GetSettleReanalysisModesAsync(first.SeasonId, episodeIds, modes, ffmpegValid, ct).ConfigureAwait(false);
                 if (settledResetModes.Count > 0)
                 {
-                    var resetModes = ExpandSettledResetModesForDerivedSegments(settledResetModes, _config.AnimePreviewFromCreditsEnd);
+                    var resetModes = ExpandSettledResetModesForDerivedSegments(settledResetModes, Config.AnimePreviewFromCreditsEnd);
                     LogReanalyzingSettledSeason(_logger, first.SeasonNumber, first.SeriesName, episodes.Count);
                     await Plugin.ResetSeasonForReanalysisAsync(first.SeasonId, episodeIds, resetModes, ct).ConfigureAwait(false);
                     foreach (var episode in episodes)
@@ -211,7 +217,7 @@ public partial class BaseItemAnalyzerTask(
                 throw;
             }
 
-            if (updateMediaSegments && _config.UpdateMediaSegments)
+            if (updateMediaSegments && Config.UpdateMediaSegments)
             {
                 await _mediaSegmentRefresher.RefreshAsync(episodes.Select(e => e.EpisodeId), ct).ConfigureAwait(false);
             }
@@ -221,7 +227,6 @@ public partial class BaseItemAnalyzerTask(
                 await Plugin.RecordSettleReanalysisAsync(first.SeasonId, completedSettledModes, episodeIds, ct).ConfigureAwait(false);
             }
         }).ConfigureAwait(false);
-        plugin.AnalyzeAgain = false;
     }
 
     private static async Task<IReadOnlyList<AnalysisMode>> GetSettleReanalysisModesAsync(
@@ -314,18 +319,30 @@ public partial class BaseItemAnalyzerTask(
         var isMovie = category == QueuedMediaCategory.Movie;
         var isAnime = category == QueuedMediaCategory.AnimeEpisode;
 
-        if (!isMovie && first.SeasonNumber == 0 && !_config.AnalyzeSeasonZero)
+        if (AnalysisEligibility.IsSeasonZeroOptedOut(first, Config))
         {
             return 0;
         }
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
         var action = await Plugin.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
-        var configHash = ConfigHasher.Analysis(_config, mode, action, ffmpegValid);
+        var configHash = ConfigHasher.Analysis(Config, mode, action, ffmpegValid);
 
         if (action == AnalyzerAction.None)
         {
             LogSkippingNoneAction(_logger, mode, first.SeriesName, first.SeasonNumber);
+
+            // The action is part of the hash, so switching a mode off already invalidates the stored
+            // one. Record the new hash even though nothing was analyzed, or the season mismatches on
+            // every run forever: queued, skipped here, never written back. Existing segments stay put;
+            // switching the mode back on changes the hash again and re-analyzes them.
+            await Plugin.SetEpisodeIdsAsync(
+                first.SeasonId,
+                mode,
+                items.Select(i => i.EpisodeId),
+                configHash,
+                cancellationToken).ConfigureAwait(false);
+
             return 0;
         }
 
@@ -405,7 +422,7 @@ public partial class BaseItemAnalyzerTask(
                 PromoteAnalyzer(analyzers, static a => a is BlackFrameAnalyzer or CreditsBlackFrameAnalyzer);
                 break;
             default:
-                if (_config.PreferChromaprint && ffmpegValid)
+                if (Config.PreferChromaprint && ffmpegValid)
                 {
                     PromoteAnalyzer(analyzers, static a => a is ChromaprintAnalyzer);
                 }
@@ -422,7 +439,7 @@ public partial class BaseItemAnalyzerTask(
         }
 
         // For anime, optionally create a Preview segment from the end of credits to the end of the episode.
-        if (mode == AnalysisMode.Credits && isAnime && _config.AnimePreviewFromCreditsEnd)
+        if (mode == AnalysisMode.Credits && isAnime && Config.AnimePreviewFromCreditsEnd)
         {
             await CreateAnimePreviewFromCreditsAsync(plugin, items, cancellationToken).ConfigureAwait(false);
         }
@@ -491,7 +508,7 @@ public partial class BaseItemAnalyzerTask(
     /// Creates the configured black frame analyzer variant.
     /// </summary>
     /// <returns>A <see cref="BlackFrameAnalyzer"/> or <see cref="CreditsBlackFrameAnalyzer"/> based on configuration.</returns>
-    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => _config.UseAlternativeBlackFrameAnalyzer
+    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => Config.UseAlternativeBlackFrameAnalyzer
         ? new CreditsBlackFrameAnalyzer(_loggerFactory.CreateLogger<CreditsBlackFrameAnalyzer>(), _ffmpegService)
         : new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>(), _ffmpegService);
 

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -345,7 +345,8 @@ public partial class BaseItemAnalyzerTask(
                 mode,
                 items.Select(i => i.EpisodeId),
                 configHash,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                action).ConfigureAwait(false);
 
             return 0;
         }

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -87,9 +87,16 @@ public partial class CleanCacheTask(
             _fileSystem,
             _ffmpegService);
 
-        // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
+        // QueueManager.GetMediaInventory() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders.
-        var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true, cancellationToken).ConfigureAwait(false);
+        if (!inventory.IsComplete)
+        {
+            LogIncompleteInventory(_logger);
+            throw new InvalidOperationException("Cannot clean the Intro Skipper cache because the media inventory is incomplete");
+        }
+
+        var queue = inventory.Items;
         var enabledLibraryEpisodeIds = queue.Values
             .SelectMany(static episodes => episodes)
             .Select(static episode => episode.EpisodeId)
@@ -160,6 +167,9 @@ public partial class CleanCacheTask(
     {
         return [];
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Aborting cache cleanup: the media inventory is incomplete, so cached data cannot be safely removed. Check the preceding log entries for the libraries or items that failed to enumerate")]
+    private static partial void LogIncompleteInventory(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting detection cache rows for episode ID: {EpisodeId}")]
     private static partial void LogDeletingDetectionCacheRows(ILogger logger, Guid episodeId);

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -313,14 +313,11 @@ namespace IntroSkipper.Services
             }
         }
 
+        // Settings that change analysis output are folded into the per-season config hash, so a save
+        // needs no reanalysis trigger of its own. The next run re-analyzes exactly the seasons whose
+        // stored hash no longer matches.
         private void OnSettingsChanged(object? sender, BasePluginConfiguration e)
-        {
-            _config = (PluginConfiguration)e;
-            if (Plugin.Instance is { } plugin)
-            {
-                plugin.AnalyzeAgain = true;
-            }
-        }
+            => _config = (PluginConfiguration)e;
 
         /// <summary>
         /// Start timer to debounce analyzing.


### PR DESCRIPTION
## Summary by Sourcery

Make analysis reprocessing durable and selective while safely handling per-item failures, incomplete inventories, cache cleanup, and FFmpeg timeouts.

New Features:
- Persist per-season analysis configuration and action state so reprocessing resumes durably and only affected seasons are reanalyzed.
- Add analysis failure tracking that keeps failed episodes retriable without overwriting completed or user-provided results.
- Add media inventory completeness checks to prevent cache cleanup from deleting data after partial library enumeration.
- Add structured logging for analysis queue reasons, including configuration hash changes.

Bug Fixes:
- Prevent stale automatic segments and negative results from surviving relevant configuration changes.
- Preserve database consistency when erasing timestamps or seasons is cancelled during cache cleanup.
- Ensure FFmpeg timeouts terminate child processes and are surfaced as retryable analysis failures.
- Avoid discarding valid Chromaprint-derived results when FFmpeg availability checks temporarily fail.

Enhancements:
- Centralize season eligibility rules and use live configuration values throughout analysis tasks.
- Make analyzer exceptions degradable per episode so one media failure does not abort an entire season pass.
- Expand configuration hashing to cover settings that affect derived analysis modes and analyzer actions.

Tests:
- Add coverage for configuration hash invalidation, durable season reanalysis, analyzer failure handling, cache cleanup safety, transactional erasure, and FFmpeg process termination.