### PR TITLE
Ported the applicable 10.11 fixes to 12.0 (947)

### DIFF
--- a/IntroSkipper.Tests/TestAnalysisConfigHash.cs
+++ b/IntroSkipper.Tests/TestAnalysisConfigHash.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 rlauuzo
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using IntroSkipper.Configuration;
 using IntroSkipper.Data;
 using IntroSkipper.Helper;

--- a/IntroSkipper.Tests/TestAnalysisConfigHash.cs
+++ b/IntroSkipper.Tests/TestAnalysisConfigHash.cs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+using IntroSkipper.Helper;
+using IntroSkipper.ScheduledTasks;
+using Xunit;
+
+namespace IntroSkipper.Tests;
+
+public sealed class TestAnalysisConfigHash
+{
+    [Fact]
+    public void MinimumIntroDuration_InvalidatesCreditsHash()
+    {
+        var before = new PluginConfiguration { MinimumIntroDuration = 15 };
+        var after = new PluginConfiguration { MinimumIntroDuration = 30 };
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(before, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(after, AnalysisMode.Credits, AnalyzerAction.Default, ffmpegValid: true));
+    }
+
+    [Fact]
+    public void AnimePreviewSetting_InvalidatesPreviewHash()
+    {
+        var before = new PluginConfiguration { AnimePreviewFromCreditsEnd = false };
+        var after = new PluginConfiguration { AnimePreviewFromCreditsEnd = true };
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(before, AnalysisMode.Preview, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(after, AnalysisMode.Preview, AnalyzerAction.Default, ffmpegValid: true));
+    }
+
+    [Fact]
+    public void AnalyzerAction_InvalidatesHash()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.NotEqual(
+            ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Default, ffmpegValid: true),
+            ConfigHasher.Analysis(config, AnalysisMode.Introduction, AnalyzerAction.Chapter, ffmpegValid: true));
+    }
+
+    [Fact]
+    public void FailedItemsAreNotPersistedAsAnalyzed()
+    {
+        var failed = new QueuedEpisode { EpisodeId = Guid.NewGuid() };
+        failed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
+        var completed = new QueuedEpisode { EpisodeId = Guid.NewGuid() };
+        completed.SetAnalyzed(AnalysisMode.Credits, EpisodeState.NoSegments);
+
+        var ids = BaseItemAnalyzerTask.GetPersistableEpisodeIds([failed, completed], AnalysisMode.Credits);
+
+        Assert.Equal([completed.EpisodeId], ids);
+        Assert.True(failed.NeedsAnalysis(AnalysisMode.Credits));
+    }
+}

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -1205,7 +1205,8 @@ public class TestBlackFrames
         var result = await analyzer.AnalyzeMediaFiles([episode], AnalysisMode.Credits, CancellationToken.None);
 
         Assert.Same(episode, result[0]);
-        Assert.Equal(EpisodeState.NotAnalyzed, episode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.Equal(EpisodeState.AnalysisFailed, episode.GetAnalyzed(AnalysisMode.Credits));
+        Assert.True(episode.NeedsAnalysis(AnalysisMode.Credits));
         Assert.Equal(1, ffmpeg.CreditsScanCalls);
     }
 

--- a/IntroSkipper.Tests/TestEntrypointEvents.cs
+++ b/IntroSkipper.Tests/TestEntrypointEvents.cs
@@ -140,7 +140,7 @@ public sealed class TestEntrypointEvents
     }
 
     [Fact]
-    public void OnSettingsChanged_UpdatesConfig_AndSetsAnalyzeAgain()
+    public void OnSettingsChanged_UpdatesConfig()
     {
         var entrypoint = EntrypointTestHelpers.CreateEntrypoint(autoDetectIntros: false);
 
@@ -148,15 +148,10 @@ public sealed class TestEntrypointEvents
 
         using (new EntrypointTestHelpers.PluginInstanceScope(EntrypointTestHelpers.CreateTempCacheDir()))
         {
-            // Ensure AnalyzeAgain starts false.
-            var plugin = Plugin.Instance!;
-            plugin.AnalyzeAgain = false;
-
             EntrypointTestHelpers.InvokePrivate(entrypoint, "OnSettingsChanged", (BasePluginConfiguration)newConfig);
-
-            Assert.True(plugin.AnalyzeAgain);
         }
 
+        // Reanalysis is driven by durable per-item configuration hashes, not a process-wide flag.
         var storedConfig = (PluginConfiguration)EntrypointTestHelpers.GetPrivateField(entrypoint, "_config");
         Assert.Same(newConfig, storedConfig);
     }

--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -9,6 +9,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +23,47 @@ namespace IntroSkipper.Tests;
 
 public class TestFFmpegService
 {
+    [Fact]
+    public async Task ProcessTimeout_KillsProcessWhileDrainingOutput()
+    {
+        var pidFile = Path.Join(Path.GetTempPath(), "IntroSkipper.Tests." + Guid.NewGuid().ToString("N") + ".pid");
+        var processPath = OperatingSystem.IsWindows() ? "powershell.exe" : "/bin/sh";
+        string[] args;
+        int timeout;
+        if (OperatingSystem.IsWindows())
+        {
+            args = ["-NoProfile", "-NonInteractive", "-Command", $"Set-Content -LiteralPath '{pidFile}' -Value $PID; Start-Sleep -Seconds 30"];
+            timeout = 2000;
+        }
+        else
+        {
+            args = ["-c", $"echo $$ > '{pidFile}'; sleep 30"];
+            timeout = 500;
+        }
+
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(() => CreateFFmpegService()
+                .GetProcessOutputAsync(processPath, args, timeout: timeout)
+                .WaitAsync(TimeSpan.FromSeconds(15)));
+
+            var processId = int.Parse((await File.ReadAllTextAsync(pidFile)).Trim(), CultureInfo.InvariantCulture);
+            try
+            {
+                using var process = Process.GetProcessById(processId);
+                Assert.True(process.HasExited, $"Timed-out helper process {processId} is still running.");
+            }
+            catch (ArgumentException)
+            {
+                // The process may have exited before GetProcessById observed it.
+            }
+        }
+        finally
+        {
+            File.Delete(pidFile);
+        }
+    }
+
     [Fact]
     public async Task CheckFFmpegVersionAsync_MemoizesSuccess()
     {

--- a/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -122,6 +122,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
             }
             catch (Exception ex)
             {
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
                 LogErrorAnalyzingCredits(_logger, ex, episode.Name);
             }
         }
@@ -217,6 +218,7 @@ public sealed partial class BlackFrameAnalyzer(ILogger<BlackFrameAnalyzer> logge
         }
         catch (Exception ex)
         {
+            episode.SetAnalyzed(AnalysisMode.Credits, EpisodeState.AnalysisFailed);
             LogErrorDuringAnalysis(_logger, ex, episode.Name);
             return null;
         }

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -119,7 +119,22 @@ public partial class ChapterAnalyzer(
 
             if (matches.Count == 0 && enableRecapBlackFrameFallback)
             {
-                var fallback = await DetectRecapUsingBlackFramesAsync(episode, cancellationToken).ConfigureAwait(false);
+                Segment? fallback;
+                try
+                {
+                    fallback = await DetectRecapUsingBlackFramesAsync(episode, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                    LogErrorDetectingRecapBlackFrames(ex, episode.Name);
+                    continue;
+                }
+
                 if (fallback is not null && fallback.Valid)
                 {
                     matches = [fallback];
@@ -404,4 +419,7 @@ public partial class ChapterAnalyzer(
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{Base}: okay")]
     private partial void LogChapterOk(string @base);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error detecting recap black frames for {Episode}")]
+    private partial void LogErrorDetectingRecapBlackFrames(Exception ex, string episode);
 }

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -84,8 +84,13 @@ public partial class ChromaprintAnalyzer(ILogger<ChromaprintAnalyzer> logger, IF
                 LogCaughtFingerprintError(ex);
                 WarningManager.SetFlag(PluginWarning.InvalidChromaprintFingerprint);
 
-                // Fallback to an empty fingerprint on any error
+                // Keep a transient fingerprint failure retriable. A completed neighbor may be
+                // included only to provide a comparison fingerprint; do not discard its valid result.
                 fingerprintCache[episode.EpisodeId] = [];
+                if (episode.NeedsAnalysis(mode))
+                {
+                    episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
+                }
             }
         }
 

--- a/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
+++ b/IntroSkipper/Analyzers/CreditsBlackFrameAnalyzer.cs
@@ -92,6 +92,7 @@ public sealed partial class CreditsBlackFrameAnalyzer(ILogger<CreditsBlackFrameA
             }
             catch (Exception ex)
             {
+                episode.SetAnalyzed(mode, EpisodeState.AnalysisFailed);
                 LogErrorAnalyzingCredits(ex, episode.Name);
             }
         }

--- a/IntroSkipper/Data/AnalysisReason.cs
+++ b/IntroSkipper/Data/AnalysisReason.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Data;
+
+/// <summary>
+/// Why an item remains queued for analysis instead of being restored from stored state.
+/// </summary>
+public enum AnalysisReason
+{
+    /// <summary>
+    /// Stored analysis state matches the current configuration.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The stored analysis hash differs from the current configuration hash.
+    /// </summary>
+    ConfigHashChanged,
+
+    /// <summary>
+    /// No analysis hash is stored for the item and mode.
+    /// </summary>
+    NoStoredState,
+
+    /// <summary>
+    /// The item was not included in the stored analysis state.
+    /// </summary>
+    NotRecorded,
+}

--- a/IntroSkipper/Data/EpisodeState.cs
+++ b/IntroSkipper/Data/EpisodeState.cs
@@ -30,4 +30,9 @@ public enum EpisodeState
     /// Episode segment was provided externally via the segment editor and must not be overwritten by automatic analysis.
     /// </summary>
     UserProvided,
+
+    /// <summary>
+    /// Episode analysis failed and must not be cached as a completed no-segment result.
+    /// </summary>
+    AnalysisFailed,
 }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -559,7 +559,7 @@ public sealed partial class FFmpegService(
                 }
             }
         }
-        catch (Exception ex) when (ex is IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception)
+        catch (Exception ex) when (ex is IOException or InvalidOperationException or UnauthorizedAccessException or System.ComponentModel.Win32Exception or TimeoutException)
         {
             LogAudioDurationProbeFailed(_logger, ex, filePath);
         }
@@ -660,7 +660,7 @@ public sealed partial class FFmpegService(
             firstArg.StartsWith("-h", StringComparison.Ordinal);
     }
 
-    private async Task<byte[]> GetProcessOutputAsync(
+    internal async Task<byte[]> GetProcessOutputAsync(
         string processPath,
         IReadOnlyList<string> args,
         bool stderr = false,
@@ -694,39 +694,55 @@ public sealed partial class FFmpegService(
 
         try
         {
-            process.PriorityClass = Plugin.Instance?.Configuration.ProcessPriority ?? ProcessPriorityClass.BelowNormal;
-        }
-        catch (Exception e) when (e is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException)
-        {
-            LogFfmpegPriorityNotModified(_logger, e.Message);
-        }
+            try
+            {
+                process.PriorityClass = Plugin.Instance?.Configuration.ProcessPriority ?? ProcessPriorityClass.BelowNormal;
+            }
+            catch (Exception e) when (e is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException)
+            {
+                LogFfmpegPriorityNotModified(_logger, e.Message);
+            }
 
-        using var cancellationRegistration = cancellationToken.Register(() => KillProcessTree(process));
-        using var ms = new MemoryStream();
+            using var ms = new MemoryStream();
+            // Draining must not use the caller token: on cancellation or timeout the process is
+            // killed first, then its remaining output is drained so the pipes cannot deadlock.
+            var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms, CancellationToken.None);
+            var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null, CancellationToken.None);
 
-        var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms, cancellationToken);
-        var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null, cancellationToken);
-        await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            using var timeoutCts = new CancellationTokenSource(timeout);
+            using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            var timedOut = false;
+            try
+            {
+                await process.WaitForExitAsync(waitCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                KillProcessTree(process);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+            {
+                LogFfmpegExitTimeout(_logger, timeout);
+                KillProcessTree(process);
+                timedOut = true;
+            }
 
-        using var timeoutCts = new CancellationTokenSource(timeout);
-        using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-        try
-        {
-            await process.WaitForExitAsync(waitCts.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+
             cancellationToken.ThrowIfCancellationRequested();
-            throw;
-        }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
-        {
-            LogFfmpegExitTimeout(_logger, timeout);
-            KillProcessTree(process);
-        }
+            if (timedOut)
+            {
+                throw new TimeoutException($"ffmpeg process was killed after not exiting within {timeout}ms");
+            }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        return ms.ToArray();
+            return ms.ToArray();
+        }
+        finally
+        {
+            KillProcessTree(process);
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     private static async Task DrainAsync(Stream stream, Stream? destination, CancellationToken cancellationToken)
@@ -932,7 +948,15 @@ public sealed partial class FFmpegService(
         ]);
 
         // Returns all fingerprint points as raw 32-bit unsigned integers (little endian).
-        var rawPoints = await GetOutputAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
+        byte[] rawPoints;
+        try
+        {
+            rawPoints = await GetOutputAsync(args, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new FingerprintException($"chromaprint fingerprinting of \"{episode.Path}\" timed out", ex);
+        }
         if (rawPoints.Length == 0 || rawPoints.Length % 4 != 0)
         {
             LogChromaprintReturnedPoints(_logger, rawPoints.Length, episode.Path);

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -957,6 +957,7 @@ public sealed partial class FFmpegService(
         {
             throw new FingerprintException($"chromaprint fingerprinting of \"{episode.Path}\" timed out", ex);
         }
+
         if (rawPoints.Length == 0 || rawPoints.Length % 4 != 0)
         {
             LogChromaprintReturnedPoints(_logger, rawPoints.Length, episode.Path);

--- a/IntroSkipper/Helper/AnalysisEligibility.cs
+++ b/IntroSkipper/Helper/AnalysisEligibility.cs
@@ -15,6 +15,9 @@ internal static class AnalysisEligibility
     /// Determines whether specials are opted out of analysis. Movies also use season number zero,
     /// but are not specials and must remain eligible.
     /// </summary>
+    /// <param name="first">An episode from the season being considered.</param>
+    /// <param name="config">The current plugin configuration.</param>
+    /// <returns><see langword="true"/> when the season is opted out of analysis; otherwise, <see langword="false"/>.</returns>
     internal static bool IsSeasonZeroOptedOut(QueuedEpisode first, PluginConfiguration config)
     {
         ArgumentNullException.ThrowIfNull(first);

--- a/IntroSkipper/Helper/AnalysisEligibility.cs
+++ b/IntroSkipper/Helper/AnalysisEligibility.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+using IntroSkipper.Configuration;
+using IntroSkipper.Data;
+
+namespace IntroSkipper.Helper;
+
+/// <summary>
+/// Shared season-level rules that decide whether analysis runs at all.
+/// </summary>
+internal static class AnalysisEligibility
+{
+    /// <summary>
+    /// Determines whether specials are opted out of analysis. Movies also use season number zero,
+    /// but are not specials and must remain eligible.
+    /// </summary>
+    internal static bool IsSeasonZeroOptedOut(QueuedEpisode first, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(config);
+
+        return first.Category is not QueuedMediaCategory.Movie
+            && first.SeasonNumber == 0
+            && !config.AnalyzeSeasonZero;
+    }
+}

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -42,8 +42,9 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Credits => Invariant(
-                $"analysis|v2|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v3|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
+                $"|minRegion={config.MinimumIntroDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",
                 $"|bflegacy={config.UseLegacyBlackFrameAnalyzer}|bfrefine={config.RefineCreditsBoundary}|bfVersion=3{CreditsNonBlackToken(config)}",
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
@@ -58,7 +59,8 @@ public static class ConfigHasher
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Preview => Invariant(
-                $"analysis|v1|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"analysis|v2|mode={mode}|action={action}|chap={config.ChapterAnalyzerPreviewPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumPreviewDuration}|max={config.MaximumPreviewDuration}",
+                $"|animePreview={config.AnimePreviewFromCreditsEnd}",
                 $"{AdjustmentHash(config)}"),
 
             AnalysisMode.Commercial => Invariant(

--- a/IntroSkipper/Helper/SeasonReanalysisPlanner.cs
+++ b/IntroSkipper/Helper/SeasonReanalysisPlanner.cs
@@ -45,7 +45,7 @@ internal static class SeasonReanalysisPlanner
         }
 
         // Respect the season-zero (specials) opt-in.
-        if (first.SeasonNumber == 0 && !config.AnalyzeSeasonZero)
+        if (AnalysisEligibility.IsSeasonZeroOptedOut(first, config))
         {
             return false;
         }

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -105,6 +105,9 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// Enumerates the media inventory and reports whether every library and item was inspected.
     /// Cleanup must not delete rows absent from an incomplete inventory.
     /// </summary>
+    /// <param name="includeExcluded">Whether excluded items should be included.</param>
+    /// <param name="cancellationToken">Token used to cancel enumeration.</param>
+    /// <returns>The enumerated media items and a completeness indicator.</returns>
     internal Task<MediaInventoryResult> GetMediaInventory(bool includeExcluded, CancellationToken cancellationToken = default)
         => GetMediaInventoryCore(includeExcluded, seasonIds: null, cancellationToken);
 
@@ -749,9 +752,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                     // discard results produced while it was available.
                     if (!hashMatches && !ffmpegValid && hasAnalyzedHash)
                     {
-                        var availableHash = ConfigHasher.Analysis(plugin.Configuration, mode, action: snapshot.AnalyzerActionByMode.TryGetValue(mode, out var savedAction)
-                            ? savedAction
-                            : AnalyzerAction.Default, ffmpegValid: true);
+                        var availableHash = ConfigHasher.Analysis(
+                            plugin.Configuration,
+                            mode,
+                            snapshot.AnalyzerActionByMode.TryGetValue(mode, out var savedAction)
+                                ? savedAction
+                                : AnalyzerAction.Default,
+                            ffmpegValid: true);
                         hashMatches = string.Equals(analyzedHash, availableHash, StringComparison.Ordinal);
                     }
 
@@ -862,7 +869,6 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                     reason);
             }
         }
-
     }
 
     private static bool ChromaprintAffectsMode(AnalysisMode mode)

--- a/IntroSkipper/Manager/QueueManager.cs
+++ b/IntroSkipper/Manager/QueueManager.cs
@@ -49,6 +49,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private int _enumerationFailures;
     private ExclusionPolicy _exclusionPolicy = ExclusionPolicy.Empty;
 
+    private enum QueueItemResult
+    {
+        Queued,
+        Excluded,
+        Failed,
+    }
+
     /// <summary>
     /// Gets the number of libraries or individual items that failed to enumerate or queue
     /// during the most recent <see cref="GetMediaItems(bool, CancellationToken)"/> call.
@@ -62,8 +69,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
-    public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
-        => GetMediaItems(includeExcluded: false, seasonIds: null, cancellationToken);
+    public async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(CancellationToken cancellationToken = default)
+        => (await GetMediaInventoryCore(includeExcluded: false, seasonIds: null, cancellationToken).ConfigureAwait(false)).Items;
 
     /// <summary>
     /// Gets media items belonging to the specified seasons or movies.
@@ -71,10 +78,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     /// <param name="seasonIds">Season IDs and movie IDs to enqueue, or <see langword="null"/> to enqueue everything.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Queued media items.</returns>
-    public Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(
+    public async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(
         IReadOnlyCollection<Guid>? seasonIds,
         CancellationToken cancellationToken = default)
-        => GetMediaItems(includeExcluded: false, seasonIds, cancellationToken);
+        => (await GetMediaInventoryCore(includeExcluded: false, seasonIds, cancellationToken).ConfigureAwait(false)).Items;
 
     // Per-run memo on top of the service's success-only memoization: while ffmpeg is
     // invalid the service re-probes every call, so cache the verdict here to keep an
@@ -92,9 +99,16 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     }
 
     internal async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(bool includeExcluded, CancellationToken cancellationToken = default)
-        => await GetMediaItems(includeExcluded, seasonIds: null, cancellationToken).ConfigureAwait(false);
+        => (await GetMediaInventoryCore(includeExcluded, seasonIds: null, cancellationToken).ConfigureAwait(false)).Items;
 
-    private async Task<IReadOnlyDictionary<Guid, List<QueuedEpisode>>> GetMediaItems(
+    /// <summary>
+    /// Enumerates the media inventory and reports whether every library and item was inspected.
+    /// Cleanup must not delete rows absent from an incomplete inventory.
+    /// </summary>
+    internal Task<MediaInventoryResult> GetMediaInventory(bool includeExcluded, CancellationToken cancellationToken = default)
+        => GetMediaInventoryCore(includeExcluded, seasonIds: null, cancellationToken);
+
+    private async Task<MediaInventoryResult> GetMediaInventoryCore(
         bool includeExcluded,
         IReadOnlyCollection<Guid>? seasonIds,
         CancellationToken cancellationToken)
@@ -113,7 +127,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         if (plugin is null)
         {
             LogPluginInstanceNull(_logger);
-            return _queuedEpisodes;
+            return new MediaInventoryResult(_queuedEpisodes, false);
         }
 
         if (publishQueue)
@@ -125,7 +139,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
         if (seasonIds is { Count: 0 })
         {
-            return _queuedEpisodes;
+            return new MediaInventoryResult(_queuedEpisodes, true);
         }
 
         // For selected libraries, enqueue either all contained items or only the requested seasons/movies.
@@ -133,8 +147,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         if (virtualFolders is null)
         {
             LogLibraryManagerNull(_logger);
-            return _queuedEpisodes;
+            return new MediaInventoryResult(_queuedEpisodes, false);
         }
+
+        var isComplete = true;
 
         // Resolve each requested id to its owning libraries once, so a scoped run queries only
         // the folders that can contain a requested item instead of fanning its queries out to
@@ -179,6 +195,8 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             // Some virtual folders don't have a proper item id.
             if (!Guid.TryParse(folder.ItemId, out var folderId))
             {
+                isComplete = false;
+                LogInvalidFolderId(_logger, folder.Name);
                 continue;
             }
 
@@ -192,7 +210,10 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
             try
             {
-                await QueueLibraryContents(folderId, includeExcluded, seasonIds, publishQueue, cancellationToken).ConfigureAwait(false);
+                if (!await QueueLibraryContents(folderId, includeExcluded, seasonIds, publishQueue, cancellationToken).ConfigureAwait(false))
+                {
+                    isComplete = false;
+                }
             }
             catch (OperationCanceledException)
             {
@@ -201,6 +222,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             catch (Exception ex)
             {
                 _enumerationFailures++;
+                isComplete = false;
                 LogFailedEnqueueLibrary(_logger, folder.Name, ex);
             }
         }
@@ -232,7 +254,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             plugin.TotalQueued = plugin.QueuedMediaItems.Sum(kvp => kvp.Value.Count);
         }
 
-        return _queuedEpisodes;
+        return new MediaInventoryResult(_queuedEpisodes, isComplete);
     }
 
     /// <summary>
@@ -261,7 +283,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         }
     }
 
-    private async Task QueueLibraryContents(
+    private async Task<bool> QueueLibraryContents(
         Guid id,
         bool includeExcluded,
         IReadOnlyCollection<Guid>? seasonIds,
@@ -279,29 +301,40 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         if (items is null)
         {
             LogLibraryQueryNull(_logger);
-            return;
+            return false;
         }
 
         // Queue all supported library items on the server for analysis.
         LogIteratingLibraryItems(_logger);
 
         var queuedCount = 0;
+        var isComplete = true;
         foreach (var item in items.DistinctBy(e => e.Id))
         {
             try
             {
                 if (item is Episode episode)
                 {
-                    if (await QueueEpisode(episode, includeExcluded, publishQueue, cancellationToken).ConfigureAwait(false))
+                    var result = await QueueEpisode(episode, includeExcluded, publishQueue, cancellationToken).ConfigureAwait(false);
+                    if (result == QueueItemResult.Queued)
                     {
                         queuedCount++;
+                    }
+                    else if (result == QueueItemResult.Failed)
+                    {
+                        isComplete = false;
                     }
                 }
                 else if (item is Movie movie)
                 {
-                    if (await QueueMovieAsync(movie, includeExcluded, publishQueue, cancellationToken).ConfigureAwait(false))
+                    var result = await QueueMovieAsync(movie, includeExcluded, publishQueue, cancellationToken).ConfigureAwait(false);
+                    if (result == QueueItemResult.Queued)
                     {
                         queuedCount++;
+                    }
+                    else if (result == QueueItemResult.Failed)
+                    {
+                        isComplete = false;
                     }
                 }
                 else
@@ -318,11 +351,13 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                 // Count item-level failures too: a live item that failed to queue must not be
                 // classified as stale by cleanup just because its siblings enumerated fine.
                 _enumerationFailures++;
+                isComplete = false;
                 LogErrorProcessingItem(_logger, ex, item.Name, item.Id);
             }
         }
 
         LogQueuedEpisodes(_logger, queuedCount);
+        return isComplete;
     }
 
     private IEnumerable<BaseItem> GetScopedLibraryItems(Guid libraryId, IReadOnlyCollection<Guid> seasonIds)
@@ -417,7 +452,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
     private static bool IsInSeasonSpecial(Episode episode)
         => episode.ParentIndexNumber == 0 && episode.AiredSeasonNumber != 0;
 
-    private async Task<bool> QueueEpisode(
+    private async Task<QueueItemResult> QueueEpisode(
         Episode episode,
         bool includeExcluded,
         bool publishQueue,
@@ -428,14 +463,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         if (string.IsNullOrEmpty(episode.Path))
         {
             LogNotQueuingEpisodeNoPath(_logger, episode.Name, episode.SeriesName, episode.Id);
-            return false;
+            return QueueItemResult.Failed;
         }
 
         var decision = _exclusionPolicy.EvaluateSeries(episode.SeriesName, episode.SeriesId, episode.Path);
         if (decision.IsExcluded && !includeExcluded)
         {
             LogSkippingExcludedItem(_logger, episode.Name, decision.RuleLabel);
-            return false;
+            return QueueItemResult.Excluded;
         }
 
         // Allocate a new list for each new season
@@ -490,7 +525,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             pluginInstance.TotalQueued++;
         }
 
-        return true;
+        return QueueItemResult.Queued;
     }
 
     private static QueuedMediaCategory ResolveEpisodeCategory(Episode episode, IReadOnlyList<QueuedEpisode> seasonEpisodes, Plugin pluginInstance)
@@ -514,7 +549,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         return episode.DateCreated != default ? episode.DateCreated : episode.DateLastSaved;
     }
 
-    private async Task<bool> QueueMovieAsync(
+    private async Task<QueueItemResult> QueueMovieAsync(
         Movie movie,
         bool includeExcluded,
         bool publishQueue,
@@ -525,14 +560,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         if (string.IsNullOrEmpty(movie.Path))
         {
             LogNotQueuingMovieNoPath(_logger, movie.Name, movie.Id);
-            return false;
+            return QueueItemResult.Failed;
         }
 
         var decision = _exclusionPolicy.EvaluateMovie(movie.Name, movie.Id, movie.Path);
         if (decision.IsExcluded && !includeExcluded)
         {
             LogSkippingExcludedItem(_logger, movie.Name, decision.RuleLabel);
-            return false;
+            return QueueItemResult.Excluded;
         }
 
         // Allocate a new list for each movie.
@@ -563,7 +598,7 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             pluginInstance.TotalQueued++;
         }
 
-        return true;
+        return QueueItemResult.Queued;
     }
 
     private async Task<double> ResolveCreditsFingerprintEndAsync(string path, double duration, CancellationToken cancellationToken)
@@ -653,11 +688,16 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
         // individual episode, so compute it once per mode; each episode then compares its own
         // analysis record against it.
         var expectedHashByMode = new Dictionary<AnalysisMode, string>(modes.Count);
+        var actionByMode = new Dictionary<AnalysisMode, AnalyzerAction>(modes.Count);
+        var storedHashByMode = new Dictionary<AnalysisMode, string>(modes.Count);
+        var mismatchedHashByMode = new Dictionary<AnalysisMode, string>(modes.Count);
+        var hashMismatchModes = new HashSet<AnalysisMode>();
         foreach (var mode in modes)
         {
             var action = snapshot.AnalyzerActionByMode.TryGetValue(mode, out var savedAction)
                 ? savedAction
                 : AnalyzerAction.Default;
+            actionByMode[mode] = action;
             expectedHashByMode[mode] = ConfigHasher.Analysis(plugin.Configuration, mode, action, ffmpegValid);
         }
 
@@ -691,8 +731,35 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                     // An analysis record under the current hash settles the episode for the mode
                     // (Analyzed with segments, NoSegments without); a missing or stale record
                     // leaves it NotAnalyzed.
-                    var hashMatches = snapshot.AnalyzedConfigHashes.TryGetValue((candidate.EpisodeId, mode), out var analyzedHash) &&
+                    // An empty hash is equivalent to no durable analysis state. It can be present on
+                    // rows created before hashing was recorded and must not settle an item forever.
+                    var hasAnalyzedHash = snapshot.AnalyzedConfigHashes.TryGetValue((candidate.EpisodeId, mode), out var analyzedHash)
+                        && !string.IsNullOrEmpty(analyzedHash);
+                    var hashMatches = hasAnalyzedHash &&
                         string.Equals(analyzedHash, expectedHashByMode[mode], StringComparison.Ordinal);
+
+                    if (hasAnalyzedHash)
+                    {
+                        storedHashByMode.TryAdd(mode, analyzedHash!);
+                    }
+
+                    // A failed FFmpeg capability probe must not invalidate good Chromaprint results.
+                    // Availability is an upward invalidation: a later successful probe can reopen a
+                    // season that was settled without Chromaprint, but a transient failed probe cannot
+                    // discard results produced while it was available.
+                    if (!hashMatches && !ffmpegValid && hasAnalyzedHash)
+                    {
+                        var availableHash = ConfigHasher.Analysis(plugin.Configuration, mode, action: snapshot.AnalyzerActionByMode.TryGetValue(mode, out var savedAction)
+                            ? savedAction
+                            : AnalyzerAction.Default, ffmpegValid: true);
+                        hashMatches = string.Equals(analyzedHash, availableHash, StringComparison.Ordinal);
+                    }
+
+                    if (!hashMatches && hasAnalyzedHash)
+                    {
+                        hashMismatchModes.Add(mode);
+                        mismatchedHashByMode.TryAdd(mode, analyzedHash!);
+                    }
 
                     if (snapshot.SegmentModesByEpisodeId.TryGetValue(candidate.EpisodeId, out var modesWithSegments) &&
                         modesWithSegments.Contains(mode))
@@ -700,15 +767,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
                         var isUserProvided = snapshot.UserProvidedByMode.TryGetValue(mode, out var userProvided) &&
                                              userProvided.Contains(candidate.EpisodeId);
 
-                        // Always preserve user-provided segments. When AnalyzeAgain is true (settings
-                        // changed), leave automatically-analyzed segments as NotAnalyzed so they are
-                        // re-analyzed and their timestamps updated to reflect the new settings.
-                        if (isUserProvided || (!plugin.AnalyzeAgain && hashMatches))
+                        // Always preserve user-provided segments. Automatic results are reusable only
+                        // when the stored per-item hash still describes the current configuration.
+                        if (isUserProvided || hashMatches)
                         {
                             candidate.SetAnalyzed(mode, isUserProvided ? EpisodeState.UserProvided : EpisodeState.Analyzed);
                         }
                     }
-                    else if (!plugin.AnalyzeAgain && hashMatches)
+                    else if (hashMatches)
                     {
                         candidate.SetAnalyzed(mode, EpisodeState.NoSegments);
                     }
@@ -724,14 +790,92 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
             }
         }
 
+        LogAnalysisReasons(verified, modes, actionByMode, expectedHashByMode, storedHashByMode, mismatchedHashByMode, hashMismatchModes, ffmpegValid, plugin.Configuration);
+
         return verified;
     }
+
+    /// <summary>
+    /// Logs why a verified season still contains pending work. Hash changes are information-level
+    /// events because they explain unexpected reprocessing; normal first scans and newly added items
+    /// remain debug-level noise.
+    /// </summary>
+    private void LogAnalysisReasons(
+        IReadOnlyList<QueuedEpisode> verified,
+        IReadOnlyCollection<AnalysisMode> modes,
+        IReadOnlyDictionary<AnalysisMode, AnalyzerAction> actions,
+        IReadOnlyDictionary<AnalysisMode, string> expectedHashes,
+        IReadOnlyDictionary<AnalysisMode, string> storedHashes,
+        IReadOnlyDictionary<AnalysisMode, string> mismatchedHashes,
+        IReadOnlySet<AnalysisMode> hashMismatchModes,
+        bool ffmpegValid,
+        PluginConfiguration config)
+    {
+        if (verified.Count == 0 || AnalysisEligibility.IsSeasonZeroOptedOut(verified[0], config))
+        {
+            return;
+        }
+
+        var first = verified[0];
+        foreach (var mode in modes)
+        {
+            if (actions[mode] == AnalyzerAction.None)
+            {
+                continue;
+            }
+
+            var pending = verified.Count(episode => episode.NeedsAnalysis(mode));
+            if (pending == 0 || !verified.Any(episode => episode.GetAnalyzed(mode) == EpisodeState.NotAnalyzed))
+            {
+                continue;
+            }
+
+            var reason = hashMismatchModes.Contains(mode)
+                ? AnalysisReason.ConfigHashChanged
+                : storedHashes.ContainsKey(mode)
+                    ? AnalysisReason.NotRecorded
+                    : AnalysisReason.NoStoredState;
+
+            if (reason == AnalysisReason.ConfigHashChanged)
+            {
+                LogSeasonConfigHashChanged(
+                    _logger,
+                    mode,
+                    pending,
+                    verified.Count,
+                    first.SeriesName,
+                    first.SeasonNumber,
+                    mismatchedHashes[mode],
+                    expectedHashes[mode],
+                    ChromaprintAffectsMode(mode) ? ffmpegValid.ToString() : "n/a");
+            }
+            else
+            {
+                LogSeasonQueuedForAnalysis(
+                    _logger,
+                    LogLevel.Debug,
+                    mode,
+                    pending,
+                    verified.Count,
+                    first.SeriesName,
+                    first.SeasonNumber,
+                    reason);
+            }
+        }
+
+    }
+
+    private static bool ChromaprintAffectsMode(AnalysisMode mode)
+        => mode is AnalysisMode.Introduction or AnalysisMode.Credits or AnalysisMode.Recap;
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Plugin instance is null in GetMediaItems()")]
     private static partial void LogPluginInstanceNull(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Library manager returned null when requesting virtual folders")]
     private static partial void LogLibraryManagerNull(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping library \"{Name}\": virtual folder does not have a valid item id")]
+    private static partial void LogInvalidFolderId(ILogger logger, string name);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Not analyzing library \"{Name}\": Intro Skipper is disabled in library settings. To enable, check library configuration > Media Segment Providers")]
     private static partial void LogLibraryDisabled(ILogger logger, string name);
@@ -798,4 +942,14 @@ public partial class QueueManager(ILogger<QueueManager> logger, ILibraryManager 
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping analysis of {Name} ({Id})")]
     private static partial void LogSkippingAnalysisException(ILogger logger, string name, Guid id, Exception exception);
+
+    [LoggerMessage(Message = "[Mode: {Mode}] Queuing {Count} of {Total} items in {Name} season {Season} for analysis: {Reason}")]
+    private static partial void LogSeasonQueuedForAnalysis(ILogger logger, LogLevel level, AnalysisMode mode, int count, int total, string name, int season, AnalysisReason reason);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "[Mode: {Mode}] Queuing {Count} of {Total} items in {Name} season {Season} for analysis: analysis configuration hash changed from \"{StoredHash}\" to \"{ExpectedHash}\" (chromaprint available: {ChromaprintAvailable})")]
+    private static partial void LogSeasonConfigHashChanged(ILogger logger, AnalysisMode mode, int count, int total, string name, int season, string storedHash, string expectedHash, string chromaprintAvailable);
+
+    internal sealed record MediaInventoryResult(
+        IReadOnlyDictionary<Guid, List<QueuedEpisode>> Items,
+        bool IsComplete);
 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -82,11 +82,6 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to analyze again.
-    /// </summary>
-    public bool AnalyzeAgain { get; set; }
-
-    /// <summary>
     /// Gets the most recent media item queue.
     /// </summary>
     public ConcurrentDictionary<Guid, List<QueuedEpisode>> QueuedMediaItems { get; } = new();

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -55,6 +55,7 @@ public partial class BaseItemAnalyzerTask(
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
     private readonly IIntroSkipperDatabase _database = database;
+
     /// <summary>
     /// Gets the live plugin configuration. Jellyfin replaces the configuration object on save, so
     /// retaining a constructor-time snapshot can stamp analysis with a hash that no longer matches
@@ -465,6 +466,9 @@ public partial class BaseItemAnalyzerTask(
     /// Gets episode IDs whose analysis result can be persisted. Transient failures remain without an
     /// analysis record so queue verification retries them on the next scan.
     /// </summary>
+    /// <param name="items">The queued episodes whose analysis results were evaluated.</param>
+    /// <param name="mode">The analysis mode used for the queued episodes.</param>
+    /// <returns>The IDs of episodes with persistable analysis results.</returns>
     internal static IReadOnlyList<Guid> GetPersistableEpisodeIds(IReadOnlyList<QueuedEpisode> items, AnalysisMode mode)
         => [.. items
             .Where(item => item.GetAnalyzed(mode) != EpisodeState.AnalysisFailed)

--- a/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -55,7 +55,12 @@ public partial class BaseItemAnalyzerTask(
     private readonly IFFmpegService _ffmpegService = ffmpegService;
     private readonly IDetectionCacheService _cacheService = cacheService;
     private readonly IIntroSkipperDatabase _database = database;
-    private readonly PluginConfiguration _config = Plugin.Instance?.Configuration ?? new PluginConfiguration();
+    /// <summary>
+    /// Gets the live plugin configuration. Jellyfin replaces the configuration object on save, so
+    /// retaining a constructor-time snapshot can stamp analysis with a hash that no longer matches
+    /// the analyzers or queue verifier.
+    /// </summary>
+    private static PluginConfiguration Config => Plugin.Instance?.Configuration ?? new PluginConfiguration();
 
     /// <summary>
     /// Analyze all media items on the server.
@@ -70,11 +75,11 @@ public partial class BaseItemAnalyzerTask(
         IReadOnlyCollection<Guid>? seasonsToAnalyze = null)
     {
         List<AnalysisMode> modes = [
-            .. _config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>(),
-            .. _config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
+            .. Config.ScanIntroduction ? [AnalysisMode.Introduction] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanCredits ? [AnalysisMode.Credits] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanRecap ? [AnalysisMode.Recap] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanPreview ? [AnalysisMode.Preview] : Array.Empty<AnalysisMode>(),
+            .. Config.ScanCommercial ? [AnalysisMode.Commercial] : Array.Empty<AnalysisMode>()
         ];
 
         if (seasonsToAnalyze?.Count == 0)
@@ -87,7 +92,7 @@ public partial class BaseItemAnalyzerTask(
 
         var queueManager = _analyzerFactory.CreateQueueManager();
 
-        var plugin = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
+        _ = Plugin.Instance ?? throw new InvalidOperationException("Plugin instance is null");
         var ffmpegValid = await queueManager.GetFfmpegValidAsync(cancellationToken).ConfigureAwait(false);
 
         var queue = await queueManager.GetMediaItems(seasonFilter, cancellationToken).ConfigureAwait(false);
@@ -113,7 +118,7 @@ public partial class BaseItemAnalyzerTask(
         int totalProcessed = 0;
         var options = new ParallelOptions
         {
-            MaxDegreeOfParallelism = Math.Max(1, _config.MaxParallelism),
+            MaxDegreeOfParallelism = Math.Max(1, Config.MaxParallelism),
             CancellationToken = cancellationToken
         };
 
@@ -136,13 +141,13 @@ public partial class BaseItemAnalyzerTask(
             // Reuses the cached fingerprints, so this only re-runs the comparison, not the decode.
             var utcNow = DateTime.UtcNow;
             var episodeIds = episodes.Select(e => e.EpisodeId).ToArray();
-            if (_config.ReanalyzeSettledSeasons &&
-                SeasonReanalysisPlanner.IsSettledForReanalysis(episodes, _config, utcNow))
+            if (Config.ReanalyzeSettledSeasons &&
+                SeasonReanalysisPlanner.IsSettledForReanalysis(episodes, Config, utcNow))
             {
                 settledResetModes = await GetSettleReanalysisModesAsync(first.SeasonId, episodeIds, modes, ffmpegValid, ct).ConfigureAwait(false);
                 if (settledResetModes.Count > 0)
                 {
-                    var resetModes = ExpandSettledResetModesForDerivedSegments(settledResetModes, _config.AnimePreviewFromCreditsEnd);
+                    var resetModes = ExpandSettledResetModesForDerivedSegments(settledResetModes, Config.AnimePreviewFromCreditsEnd);
                     LogReanalyzingSettledSeason(_logger, first.SeasonNumber, first.SeriesName, episodes.Count);
                     await _database.ResetItemsForReanalysisAsync(episodeIds, resetModes, ct).ConfigureAwait(false);
                     foreach (var episode in episodes)
@@ -197,13 +202,17 @@ public partial class BaseItemAnalyzerTask(
             {
                 LogFingerprintExceptionDuringAnalysis(_logger, ex);
             }
+            catch (TimeoutException ex)
+            {
+                LogFfmpegTimeoutDuringAnalysis(_logger, ex);
+            }
             catch (Exception ex)
             {
                 LogUnexpectedAnalysisError(_logger, ex);
                 throw;
             }
 
-            if (updateMediaSegments)
+            if (updateMediaSegments && Config.UpdateMediaSegments)
             {
                 await _mediaSegmentRefresher.RefreshAsync(episodes.Select(e => e.EpisodeId), ct).ConfigureAwait(false);
             }
@@ -213,7 +222,6 @@ public partial class BaseItemAnalyzerTask(
                 await _database.RecordSettleReanalysisAsync(first.SeasonId, completedSettledModes, episodeIds, ct).ConfigureAwait(false);
             }
         }).ConfigureAwait(false);
-        plugin.AnalyzeAgain = false;
     }
 
     private async Task<IReadOnlyList<AnalysisMode>> GetSettleReanalysisModesAsync(
@@ -307,18 +315,25 @@ public partial class BaseItemAnalyzerTask(
         var isMovie = category == QueuedMediaCategory.Movie;
         var isAnime = category == QueuedMediaCategory.AnimeEpisode;
 
-        if (!isMovie && first.SeasonNumber == 0 && !_config.AnalyzeSeasonZero)
+        if (AnalysisEligibility.IsSeasonZeroOptedOut(first, Config))
         {
             return false;
         }
 
         var totalItems = items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
         var action = await _database.GetAnalyzerActionAsync(first.SeasonId, mode, cancellationToken).ConfigureAwait(false);
-        var configHash = ConfigHasher.Analysis(_config, mode, action, ffmpegValid);
+        var configHash = ConfigHasher.Analysis(Config, mode, action, ffmpegValid);
 
         if (action == AnalyzerAction.None)
         {
             LogSkippingNoneAction(_logger, mode, first.SeriesName, first.SeasonNumber);
+            // The disabled action is part of the hash. Persist it as settled so the same season is not
+            // queued and skipped forever on every subsequent run.
+            await _database.MarkItemsAnalyzedAsync(
+                mode,
+                items.Select(i => i.EpisodeId),
+                configHash,
+                cancellationToken).ConfigureAwait(false);
             return false;
         }
 
@@ -343,7 +358,7 @@ public partial class BaseItemAnalyzerTask(
         var analyzers = new List<IMediaFileAnalyzer>
         {
             // ChapterAnalyzer: supports all modes and content types
-            new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>(), _ffmpegService, _database, _config)
+            new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>(), _ffmpegService, _database, Config)
         };
 
         if (mode is AnalysisMode.Credits)
@@ -400,7 +415,7 @@ public partial class BaseItemAnalyzerTask(
                 PromoteAnalyzer(analyzers, static a => a is BlackFrameAnalyzer or CreditsBlackFrameAnalyzer);
                 break;
             default:
-                if (_config.PreferChromaprint && ffmpegValid)
+                if (Config.PreferChromaprint && ffmpegValid)
                 {
                     PromoteAnalyzer(analyzers, static a => a is ChromaprintAnalyzer);
                 }
@@ -424,13 +439,18 @@ public partial class BaseItemAnalyzerTask(
         // These writes target Preview rows on items whose Credits state may not have moved, so they
         // are a third source of change the counts below cannot see.
         var previewsWritten = false;
-        if (mode == AnalysisMode.Credits && isAnime && _config.AnimePreviewFromCreditsEnd)
+        if (mode == AnalysisMode.Credits && isAnime && Config.AnimePreviewFromCreditsEnd)
         {
             previewsWritten = await CreateAnimePreviewFromCreditsAsync(items, cancellationToken).ConfigureAwait(false);
         }
 
-        // Record every item of the pass as analyzed under this hash, found segments or not.
-        await _database.MarkItemsAnalyzedAsync(mode, items.Select(i => i.EpisodeId), configHash, cancellationToken).ConfigureAwait(false);
+        // Record completed items under this hash, found segments or not. Failed items are omitted so
+        // a transient FFmpeg or analyzer failure remains eligible on the next scan.
+        await _database.MarkItemsAnalyzedAsync(
+            mode,
+            GetPersistableEpisodeIds(items, mode),
+            configHash,
+            cancellationToken).ConfigureAwait(false);
 
         var analyzed = totalItems - items.Count(e => e.GetAnalyzed(mode) != EpisodeState.Analyzed);
         var invalidSegmentsRemoved = items.Any(e =>
@@ -440,6 +460,15 @@ public partial class BaseItemAnalyzerTask(
 
         return analyzed > 0 || staleRemoved > 0 || previewsWritten || invalidSegmentsRemoved;
     }
+
+    /// <summary>
+    /// Gets episode IDs whose analysis result can be persisted. Transient failures remain without an
+    /// analysis record so queue verification retries them on the next scan.
+    /// </summary>
+    internal static IReadOnlyList<Guid> GetPersistableEpisodeIds(IReadOnlyList<QueuedEpisode> items, AnalysisMode mode)
+        => [.. items
+            .Where(item => item.GetAnalyzed(mode) != EpisodeState.AnalysisFailed)
+            .Select(item => item.EpisodeId)];
 
     /// <summary>
     /// Decide whether an anime Preview segment needs to be written for an episode, and build it.
@@ -492,7 +521,7 @@ public partial class BaseItemAnalyzerTask(
     /// Creates the configured black frame analyzer variant.
     /// </summary>
     /// <returns>A <see cref="CreditsBlackFrameAnalyzer"/> by default, or the legacy <see cref="BlackFrameAnalyzer"/> when configured.</returns>
-    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => _config.UseLegacyBlackFrameAnalyzer
+    private IMediaFileAnalyzer CreateBlackFrameAnalyzer() => Config.UseLegacyBlackFrameAnalyzer
         ? new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>(), _ffmpegService, _database)
         : new CreditsBlackFrameAnalyzer(_loggerFactory.CreateLogger<CreditsBlackFrameAnalyzer>(), _ffmpegService, _database);
 
@@ -605,6 +634,9 @@ public partial class BaseItemAnalyzerTask(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Fingerprint exception during analysis.")]
     private static partial void LogFingerprintExceptionDuringAnalysis(ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "An ffmpeg scan timed out during analysis; skipping this season.")]
+    private static partial void LogFfmpegTimeoutDuringAnalysis(ILogger logger, Exception ex);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "An unexpected error occurred during analysis.")]
     private static partial void LogUnexpectedAnalysisError(ILogger logger, Exception ex);

--- a/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
+++ b/IntroSkipper/ScheduledTasks/CleanCacheTask.cs
@@ -76,9 +76,10 @@ public partial class CleanCacheTask(
     {
         var queueManager = _analyzerFactory.CreateQueueManager();
 
-        // QueueManager.GetMediaItems() already skips libraries where the plugin is disabled via
+        // QueueManager.GetMediaInventory() already skips libraries where the plugin is disabled via
         // LibraryOptions.DisabledMediaSegmentProviders.
-        var queue = await queueManager.GetMediaItems(includeExcluded: true, cancellationToken).ConfigureAwait(false);
+        var inventory = await queueManager.GetMediaInventory(includeExcluded: true, cancellationToken).ConfigureAwait(false);
+        var queue = inventory.Items;
         var enabledLibraryEpisodeIds = queue.Values
             .SelectMany(static episodes => episodes)
             .Select(static episode => episode.EpisodeId)
@@ -87,9 +88,9 @@ public partial class CleanCacheTask(
         // Every cleanup below starts from rows that are NOT in the enumerated queue, so an
         // incomplete queue would push swathes of healthy data through the stale-candidate
         // path and lean entirely on the per-id existence check below. Bail out instead.
-        if (queueManager.EnumerationFailureCount > 0)
+        if (!inventory.IsComplete)
         {
-            LogSkippingCleanupEnumerationFailures(_logger, queueManager.EnumerationFailureCount);
+            LogSkippingCleanupEnumerationFailures(_logger, Math.Max(1, queueManager.EnumerationFailureCount));
             progress.Report(100);
             return;
         }

--- a/IntroSkipper/Services/Entrypoint.cs
+++ b/IntroSkipper/Services/Entrypoint.cs
@@ -310,13 +310,7 @@ namespace IntroSkipper.Services
         }
 
         private void OnSettingsChanged(object? sender, BasePluginConfiguration e)
-        {
-            _config = (PluginConfiguration)e;
-            if (Plugin.Instance is { } plugin)
-            {
-                plugin.AnalyzeAgain = true;
-            }
-        }
+            => _config = (PluginConfiguration)e;
 
         /// <summary>
         /// Start timer to debounce analyzing.


### PR DESCRIPTION
Enforced FFmpeg timeouts while draining output and made timeouts retryable. Preserved failed episodes as retryable instead of caching false “no segments” results. Removed the process-wide AnalyzeAgain behavior in favor of durable hashes. Fixed hash invalidation for credits, previews, analyzer actions, and FFmpeg availability. Added incomplete-inventory protection for cache cleanup. Added queue diagnostics and shared season-zero eligibility logic. Added regression tests for timeout handling, failed persistence, and hash invalidation.

## Summary by Sourcery

Improve analysis reliability and reanalysis tracking by making timeouts and failures retryable, using durable configuration hashes, and protecting cache cleanup from incomplete inventory scans.

Bug Fixes:
- Make FFmpeg process timeouts terminate processes reliably while draining output and allow timeout failures to be retried.
- Preserve failed episode analyses as retryable instead of caching them as completed no-segment results.
- Prevent cache cleanup from deleting data when media inventory enumeration is incomplete.

Enhancements:
- Replace the process-wide reanalysis flag with durable per-item configuration hashes and add diagnostics explaining queued analysis reasons.
- Expand analysis hash invalidation to cover relevant credits, preview, analyzer-action, and FFmpeg availability changes.
- Centralize season-zero analysis eligibility and improve queue inventory diagnostics.

Tests:
- Add regression coverage for FFmpeg timeout termination, failed-analysis persistence, and configuration hash invalidation.