### PR TITLE
Make projection journal completion atomic

### DIFF
--- a/IntroSkipper.Tests/TestSegmentChange.cs
+++ b/IntroSkipper.Tests/TestSegmentChange.cs
@@ -13,6 +13,7 @@ using IntroSkipper.Db;
 using IntroSkipper.Manager;
 using IntroSkipper.SegmentChanges;
 using Jellyfin.Database.Implementations.Enums;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -1013,6 +1014,38 @@ public sealed class TestSegmentChange : IDisposable
 
         Assert.True(await journal.CompleteProjectionWorkAsync(itemId, surviving.Item.Version, [], CancellationToken.None));
         Assert.Null(await journal.ReadProjectionWorkAsync(itemId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task CompleteWork_WhenQueueDeleteFails_RetainsExternalOperations()
+    {
+        var itemId = Guid.NewGuid();
+        var row = new DbSegment(itemId, AnalysisMode.Introduction, 10, 20, SegmentSource.User);
+        await SeedAsync(row);
+        var database = CreateDatabase();
+        ISegmentProjectionJournal journal = database;
+
+        Assert.Null((await database.ApplyChangeAsync(
+            new EditorDeleteSegmentIntent(itemId, row.Id, MediaSegmentType.Intro))).Outcome);
+        var work = await journal.ReadProjectionWorkAsync(itemId, CancellationToken.None);
+        Assert.NotNull(work);
+        var operation = Assert.Single(work.Operations);
+
+        await using (var db = CreateContext())
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                "CREATE TRIGGER FailProjectionCompletion BEFORE DELETE ON ProjectionQueue BEGIN SELECT RAISE(ABORT, 'completion failed'); END;");
+        }
+
+        await Assert.ThrowsAsync<SqliteException>(() => journal.CompleteProjectionWorkAsync(
+            itemId,
+            work.Item.Version,
+            [operation.Id],
+            CancellationToken.None));
+
+        await using var verify = CreateContext();
+        Assert.Single(await verify.ProjectionQueue.ToListAsync());
+        Assert.Equal(operation.Id, Assert.Single(await verify.ProjectionExternalOperations.ToListAsync()).Id);
     }
 
     [Fact]

--- a/IntroSkipper/Db/ISegmentProjectionJournal.cs
+++ b/IntroSkipper/Db/ISegmentProjectionJournal.cs
@@ -41,11 +41,10 @@ internal interface ISegmentProjectionJournal
     Task<ProjectionWork?> ReadProjectionWorkAsync(Guid itemId, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Completes applied work: deletes the processed operations, then the queue row —
-    /// the latter only when its version still matches, so work enqueued while the
-    /// apply was in flight survives. The two deletes are deliberately separate
-    /// statements: a crash between them leaves the row, which merely costs one extra
-    /// idempotent re-sync.
+    /// Completes applied work: deletes the processed operations and the queue row in
+    /// one transaction, so both commit or both roll back. The queue row is deleted
+    /// only when its version still matches, so work enqueued while the apply was in
+    /// flight survives.
     /// </summary>
     /// <param name="itemId">Item id.</param>
     /// <param name="version">The queue-row version the caller projected.</param>

--- a/IntroSkipper/Db/IntroSkipperDatabase.ProjectionJournal.cs
+++ b/IntroSkipper/Db/IntroSkipperDatabase.ProjectionJournal.cs
@@ -71,18 +71,24 @@ public sealed partial class IntroSkipperDatabase : ISegmentProjectionJournal
         await InitializeAsync().ConfigureAwait(false);
         using var db = _contextFactory.CreateDbContext();
 
-        if (processedOperationIds.Count > 0)
+        var transaction = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using (transaction.ConfigureAwait(false))
         {
-            await db.ProjectionExternalOperations
-                .Where(o => o.ItemId == itemId && EF.Parameter(processedOperationIds).Contains(o.Id))
-                .ExecuteDeleteAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
+            if (processedOperationIds.Count > 0)
+            {
+                await db.ProjectionExternalOperations
+                    .Where(o => o.ItemId == itemId && EF.Parameter(processedOperationIds).Contains(o.Id))
+                    .ExecuteDeleteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
-        return await db.ProjectionQueue
-            .Where(q => q.ItemId == itemId && q.Version == version)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false) > 0;
+            var completed = await db.ProjectionQueue
+                .Where(q => q.ItemId == itemId && q.Version == version)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false) > 0;
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return completed;
+        }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Fixes a durability gap in projection completion by deleting processed external operations and the matching queue marker in one database transaction. A crash or database failure can no longer commit only the operation deletion and silently prevent its replay.

Adds a regression test that forces the queue-marker delete to fail and verifies both the queue row and external operation remain available for retry.

Validation:
- `dotnet test IntroSkipper.Tests/IntroSkipper.Tests.csproj --no-restore --filter FullyQualifiedName~TestSegmentChange -p:NoWarn=CA1873` (46 passed)
- `dotnet test IntroSkipper.sln --no-restore -p:NoWarn=CA1873` (668 passed)

The `CA1873` suppression is limited to the verification command because the current base branch has a pre-existing analyzer error in `CleanCacheTask.cs:94`.

## Summary by Sourcery

Make projection journal completion atomic to prevent failed completions from losing replayable external operations.

Bug Fixes:
- Make projection completion atomic so processed external operations and their queue marker are committed or rolled back together, preserving both for retry when completion fails.

Tests:
- Add a regression test confirming failed queue-marker deletion retains the queue row and external operation.