### PR TITLE
Share the Introduction fingerprint cache row with Recap

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -134,6 +134,33 @@ public sealed class TestCacheOperations
         Assert.Equal(fingerprint, result);
     }
 
+    /// <summary>
+    /// Upgrade scenario. A release that cached Recap under its own key fingerprinted this
+    /// episode with intro scanning disabled, so only a Recap row exists. The read must serve
+    /// it and copy it under the shared Introduction key so later reads take the fast path.
+    /// </summary>
+    [Fact]
+    public async Task CachedFingerprint_RecapReadsAndUpgradesRecapOnlyRow()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Path = "/does/not/exist.mkv",
+            IntroFingerprintEnd = 600,
+        };
+        var fingerprint = new uint[] { 111u, 222u, 333u };
+        using var scope = new CachingPluginScope();
+        scope.SeedRow(episode.EpisodeId, AnalysisMode.Recap, CacheEntryType.Chromaprint, DetectionCacheService.CompressBrotli(fingerprint), 0, 600, scope.LegacyHash(AnalysisMode.Recap));
+
+        var result = await scope.CreateFFmpegService().FingerprintAsync(episode, AnalysisMode.Recap);
+
+        Assert.Equal(fingerprint, result);
+        var upgraded = scope.CacheDatabase.FindEntry(episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 600);
+        Assert.NotNull(upgraded);
+        Assert.Equal(fingerprint, DetectionCacheService.DecompressBrotli<uint[]>(upgraded.Data));
+        Assert.Equal(fingerprint, await scope.CreateFFmpegService().FingerprintAsync(episode, AnalysisMode.Introduction));
+    }
+
     [Fact]
     public async Task CachedFingerprint_ReadsPreStreamSelectionRow()
     {
@@ -201,14 +228,18 @@ public sealed class TestCacheOperations
         Assert.Equal(expected, scope.CacheService.HasCachedFingerprint(episode, mode));
     }
 
-    [Fact]
-    public void HasCachedFingerprint_AcceptsPreStreamSelectionRow()
+    // The Recap case covers an episode fingerprinted by a release that cached Recap under its
+    // own key with no Introduction row; it must stay in the Recap comparison pool.
+    [Theory]
+    [InlineData(AnalysisMode.Introduction, AnalysisMode.Introduction)]
+    [InlineData(AnalysisMode.Recap, AnalysisMode.Recap)]
+    public void HasCachedFingerprint_AcceptsPreStreamSelectionRow(AnalysisMode mode, AnalysisMode rowMode)
     {
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), IntroFingerprintEnd = 600 };
         using var scope = new CachingPluginScope();
-        scope.SeedRow(episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, 0, 600, scope.LegacyHash(AnalysisMode.Introduction));
+        scope.SeedRow(episode.EpisodeId, rowMode, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, 0, 600, scope.LegacyHash(rowMode));
 
-        Assert.True(scope.CacheService.HasCachedFingerprint(episode, AnalysisMode.Introduction));
+        Assert.True(scope.CacheService.HasCachedFingerprint(episode, mode));
     }
 
     /// <summary>

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -117,6 +117,24 @@ public sealed class TestCacheOperations
     }
 
     [Fact]
+    public async Task CachedFingerprint_RecapReadsIntroductionRow()
+    {
+        var episode = new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Path = "/does/not/exist.mkv",
+            IntroFingerprintEnd = 600,
+        };
+        var fingerprint = new uint[] { 111u, 222u, 333u };
+        using var scope = new CachingPluginScope();
+        scope.SeedRow(episode.EpisodeId, AnalysisMode.Introduction, CacheEntryType.Chromaprint, DetectionCacheService.CompressBrotli(fingerprint), 0, 600);
+
+        var result = await scope.CreateFFmpegService().FingerprintAsync(episode, AnalysisMode.Recap);
+
+        Assert.Equal(fingerprint, result);
+    }
+
+    [Fact]
     public async Task CachedFingerprint_ReadsPreStreamSelectionRow()
     {
         var episode = new QueuedEpisode
@@ -157,12 +175,14 @@ public sealed class TestCacheOperations
     }
 
     // The episode expects an intro fingerprint over 0-600 s and a credits fingerprint
-    // over 1560-1800 s; a row counts only when its range matches.
+    // over 1560-1800 s; a row counts only when its range matches. Recap reads the
+    // Introduction row, so the seeded mode is Introduction for the Recap case.
     [Theory]
     [InlineData(AnalysisMode.Introduction, false, 0, 0, false)]
     [InlineData(AnalysisMode.Introduction, true, 0, 900, false)]
     [InlineData(AnalysisMode.Introduction, true, 0, 600, true)]
     [InlineData(AnalysisMode.Credits, true, 1560, 1800, true)]
+    [InlineData(AnalysisMode.Recap, true, 0, 600, true)]
     public void HasCachedFingerprint_MatchesRowsByRange(AnalysisMode mode, bool seedRow, double rowStart, double rowEnd, bool expected)
     {
         var episode = new QueuedEpisode
@@ -175,7 +195,7 @@ public sealed class TestCacheOperations
         using var scope = new CachingPluginScope();
         if (seedRow)
         {
-            scope.SeedRow(episode.EpisodeId, mode, CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, rowStart, rowEnd);
+            scope.SeedRow(episode.EpisodeId, QueuedEpisode.FingerprintCacheMode(mode), CacheEntryType.Chromaprint, EntrypointTestHelpers.EmptyJsonArray, rowStart, rowEnd);
         }
 
         Assert.Equal(expected, scope.CacheService.HasCachedFingerprint(episode, mode));

--- a/IntroSkipper/Data/QueuedEpisode.cs
+++ b/IntroSkipper/Data/QueuedEpisode.cs
@@ -149,7 +149,8 @@ public sealed class QueuedEpisode
     /// <summary>
     /// Maps an analysis mode to the mode its Chromaprint fingerprint is cached under. Recap
     /// fingerprints the same opening window as Introduction, so both read and write one row
-    /// instead of decoding the same audio twice.
+    /// instead of decoding the same audio twice. Rows older releases wrote under the Recap key
+    /// are still read and copied under the shared key on first use.
     /// </summary>
     /// <param name="mode">Analysis mode.</param>
     /// <returns>The mode used for the fingerprint cache key.</returns>

--- a/IntroSkipper/Data/QueuedEpisode.cs
+++ b/IntroSkipper/Data/QueuedEpisode.cs
@@ -145,4 +145,14 @@ public sealed class QueuedEpisode
             _ => throw new ArgumentException("Unknown analysis mode " + mode),
         };
     }
+
+    /// <summary>
+    /// Maps an analysis mode to the mode its Chromaprint fingerprint is cached under. Recap
+    /// fingerprints the same opening window as Introduction, so both read and write one row
+    /// instead of decoding the same audio twice.
+    /// </summary>
+    /// <param name="mode">Analysis mode.</param>
+    /// <returns>The mode used for the fingerprint cache key.</returns>
+    public static AnalysisMode FingerprintCacheMode(AnalysisMode mode)
+        => mode == AnalysisMode.Recap ? AnalysisMode.Introduction : mode;
 }

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -143,18 +143,19 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
             return false;
         }
 
-        var (start, end) = episode.GetFingerprintRange(mode);
+        var cacheMode = QueuedEpisode.FingerprintCacheMode(mode);
+        var (start, end) = episode.GetFingerprintRange(cacheMode);
 
         try
         {
-            var entry = _cacheDatabase.FindEntry(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end);
+            var entry = _cacheDatabase.FindEntry(episode.EpisodeId, cacheMode, CacheEntryType.Chromaprint, start, end);
             if (entry is null)
             {
                 return false;
             }
 
             var config = Plugin.Instance?.Configuration ?? new();
-            var expectedHash = ConfigHasher.DetectionCache(config, CacheEntryType.Chromaprint, mode);
+            var expectedHash = ConfigHasher.DetectionCache(config, CacheEntryType.Chromaprint, cacheMode);
 
             // Stream-scoped and pre-stream-selection rows are accepted optimistically: whether
             // the effective stream still matches is only decided at read time, and a mismatch
@@ -165,11 +166,11 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
             return string.IsNullOrEmpty(entry.ConfigHash)
                 || string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal)
                 || ConfigHasher.IsStreamScopedDetectionCacheHash(entry.ConfigHash)
-                || string.Equals(entry.ConfigHash, ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, mode), StringComparison.Ordinal);
+                || string.Equals(entry.ConfigHash, ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, cacheMode), StringComparison.Ordinal);
         }
         catch (DbException ex)
         {
-            LogDetectionCacheReadError(_logger, ex, episode.EpisodeId, mode, CacheEntryType.Chromaprint);
+            LogDetectionCacheReadError(_logger, ex, episode.EpisodeId, cacheMode, CacheEntryType.Chromaprint);
         }
 
         return false;

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -130,7 +130,10 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
     }
 
     /// <summary>
-    /// Checks if a fingerprint cache entry exists for the episode.
+    /// Checks if a fingerprint cache entry exists for the episode. A mode that shares another
+    /// mode's row (see <see cref="QueuedEpisode.FingerprintCacheMode"/>) also counts a row an
+    /// older release wrote under its own key, so episodes fingerprinted before the rows were
+    /// shared keep their place in the comparison pool.
     /// </summary>
     /// <param name="episode">The queued episode to check.</param>
     /// <param name="mode">One of the enumeration values that specifies the analysis mode.</param>
@@ -146,16 +149,22 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         var cacheMode = QueuedEpisode.FingerprintCacheMode(mode);
         var (start, end) = episode.GetFingerprintRange(cacheMode);
 
+        return HasReadableFingerprintRow(episode.EpisodeId, cacheMode, start, end)
+            || (cacheMode != mode && HasReadableFingerprintRow(episode.EpisodeId, mode, start, end));
+    }
+
+    private bool HasReadableFingerprintRow(Guid itemId, AnalysisMode rowMode, double start, double end)
+    {
         try
         {
-            var entry = _cacheDatabase.FindEntry(episode.EpisodeId, cacheMode, CacheEntryType.Chromaprint, start, end);
+            var entry = _cacheDatabase.FindEntry(itemId, rowMode, CacheEntryType.Chromaprint, start, end);
             if (entry is null)
             {
                 return false;
             }
 
             var config = Plugin.Instance?.Configuration ?? new();
-            var expectedHash = ConfigHasher.DetectionCache(config, CacheEntryType.Chromaprint, cacheMode);
+            var expectedHash = ConfigHasher.DetectionCache(config, CacheEntryType.Chromaprint, rowMode);
 
             // Stream-scoped and pre-stream-selection rows are accepted optimistically: whether
             // the effective stream still matches is only decided at read time, and a mismatch
@@ -166,11 +175,11 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
             return string.IsNullOrEmpty(entry.ConfigHash)
                 || string.Equals(entry.ConfigHash, expectedHash, StringComparison.Ordinal)
                 || ConfigHasher.IsStreamScopedDetectionCacheHash(entry.ConfigHash)
-                || string.Equals(entry.ConfigHash, ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, cacheMode), StringComparison.Ordinal);
+                || string.Equals(entry.ConfigHash, ConfigHasher.LegacyChromaprintCacheWithoutLanguage(config, rowMode), StringComparison.Ordinal);
         }
         catch (DbException ex)
         {
-            LogDetectionCacheReadError(_logger, ex, episode.EpisodeId, cacheMode, CacheEntryType.Chromaprint);
+            LogDetectionCacheReadError(_logger, ex, itemId, rowMode, CacheEntryType.Chromaprint);
         }
 
         return false;

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -125,8 +125,9 @@ internal sealed partial class FFmpegService : IFFmpegService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var (start, end) = episode.GetFingerprintRange(mode);
-        return FingerprintAsync(episode, mode, start, end, cancellationToken);
+        var cacheMode = QueuedEpisode.FingerprintCacheMode(mode);
+        var (start, end) = episode.GetFingerprintRange(cacheMode);
+        return FingerprintAsync(episode, cacheMode, start, end, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -121,16 +121,6 @@ internal sealed partial class FFmpegService : IFFmpegService
     }
 
     /// <inheritdoc/>
-    public Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var cacheMode = QueuedEpisode.FingerprintCacheMode(mode);
-        var (start, end) = episode.GetFingerprintRange(cacheMode);
-        return FingerprintAsync(episode, cacheMode, start, end, cancellationToken);
-    }
-
-    /// <inheritdoc/>
     public Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
         // -vn, -sn, -dn: ignore video, subtitle, and data tracks
@@ -537,19 +527,13 @@ internal sealed partial class FFmpegService : IFFmpegService
         return null;
     }
 
-    /// <summary>
-    /// Fingerprint a queued episode.
-    /// </summary>
-    /// <param name="episode">Queued episode to fingerprint.</param>
-    /// <param name="mode">Portion of media file to fingerprint.</param>
-    /// <param name="start">Time (in seconds) relative to the start of the file to start fingerprinting from.</param>
-    /// <param name="end">Time (in seconds) relative to the start of the file to stop fingerprinting at.</param>
-    /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    /// <returns>Numerical fingerprint points.</returns>
-    private async Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, double start, double end, CancellationToken cancellationToken)
+    /// <inheritdoc/>
+    public async Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        var cacheMode = QueuedEpisode.FingerprintCacheMode(mode);
+        var (start, end) = episode.GetFingerprintRange(cacheMode);
         var configuration = Plugin.Instance?.Configuration;
         var preferredLanguage = ConfigHasher.NormalizeAudioLanguage(configuration?.PreferredAudioLanguage);
         var streamSelection = await FindAudioStreamSelectionAsync(
@@ -561,15 +545,25 @@ internal sealed partial class FFmpegService : IFFmpegService
 
         // Rows written before stream selection existed came from FFmpeg's default stream, so
         // they are only reusable when that is still the effective stream.
-        var legacyConfigHash = streamSelection?.SelectsDefaultStream == true
-            ? ConfigHasher.LegacyChromaprintCacheWithoutLanguage(configuration ?? new(), mode)
+        string? LegacyConfigHash(AnalysisMode rowMode) => streamSelection?.SelectsDefaultStream == true
+            ? ConfigHasher.LegacyChromaprintCacheWithoutLanguage(configuration ?? new(), rowMode)
             : null;
 
         // Resolve the stream before reading the cache so a language preference can reuse a fingerprint
         // generated with the same effective stream under the default selection.
-        if (_cacheService.TryRead(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, out uint[] cachedFingerprint, cacheVariant, legacyConfigHash))
+        if (_cacheService.TryRead(episode.EpisodeId, cacheMode, CacheEntryType.Chromaprint, start, end, out uint[] cachedFingerprint, cacheVariant, LegacyConfigHash(cacheMode)))
         {
             cancellationToken.ThrowIfCancellationRequested();
+            return cachedFingerprint;
+        }
+
+        // A row under the mode's own key was written before the row was shared. Copy it under
+        // the shared key so the next read is one lookup; the old row stays until its item is deleted.
+        if (cacheMode != mode
+            && _cacheService.TryRead(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, out cachedFingerprint, cacheVariant, LegacyConfigHash(mode)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _cacheService.Write(episode.EpisodeId, cacheMode, CacheEntryType.Chromaprint, start, end, cachedFingerprint, cacheVariant);
             return cachedFingerprint;
         }
 
@@ -617,7 +611,7 @@ internal sealed partial class FFmpegService : IFFmpegService
 
         // Try to cache this fingerprint.
         cancellationToken.ThrowIfCancellationRequested();
-        _cacheService.Write(episode.EpisodeId, mode, CacheEntryType.Chromaprint, start, end, results, cacheVariant);
+        _cacheService.Write(episode.EpisodeId, cacheMode, CacheEntryType.Chromaprint, start, end, results, cacheVariant);
 
         return results;
     }


### PR DESCRIPTION
Recap fingerprints the same opening window as Introduction (0 to `IntroFingerprintEnd`) but caches it under its own mode and config hash, so every episode decodes that audio twice when both scans are on.

The public fingerprint entry point in `FFmpegService` and `HasCachedFingerprint` in `DetectionCacheService` now map Recap to Introduction before computing the range, hash and lookup. Nothing else keys the Chromaprint cache by mode.

Two consequences worth knowing:

- Episodes that already have an Introduction fingerprint now count as "cached" for Recap, so they join the Recap comparison pool the same way they join the intro pool.
- Rows already written under the Recap mode are still read when no Introduction row exists, both by the eligibility check and by the fingerprint read, so episodes fingerprinted with intro scanning off keep their place in the Recap comparison pool. On first use the fingerprint is copied under the Introduction key; the old row stays on disk until its item is deleted, and the hash sweep leaves it alone.

First of two follow-ups from the closed recap RFCs (#805-#810). The second anchors the recap start to the cold open instead of 0.

## Summary by Sourcery

Share Chromaprint cache entries between Introduction and Recap scans while preserving access to fingerprints generated by earlier releases.

Bug Fixes:
- Reuse Introduction fingerprint cache entries for Recap scans to avoid decoding the same opening audio twice.
- Preserve compatibility with existing Recap-only cache entries by serving them and migrating them to the shared Introduction cache key.

Enhancements:
- Treat Introduction and Recap as sharing the same Chromaprint cache row and comparison-pool eligibility.

Tests:
- Add coverage for shared Introduction/Recap cache reads, legacy Recap-row migration, range matching, and pre-stream-selection entries.
