### PR TITLE
Anchor Chromaprint recaps to the cold open behind a toggle

### DIFF
--- a/IntroSkipper.Tests/StubFFmpegService.cs
+++ b/IntroSkipper.Tests/StubFFmpegService.cs
@@ -26,6 +26,8 @@ internal class StubFFmpegService : IFFmpegService
 
     public Func<bool>? VersionCheck { get; init; }
 
+    public Func<QueuedEpisode, AnalysisMode, uint[]>? Fingerprints { get; init; }
+
     public Func<QueuedEpisode, TimeRange, int, int, AnalysisMode, BlackFrame[]>? RangeBlackFrames { get; init; }
 
     public Func<QueuedEpisode, int, BlackFrame[]>? CreditsBlackFrames { get; init; }
@@ -58,7 +60,10 @@ internal class StubFFmpegService : IFFmpegService
     }
 
     public virtual Task<uint[]> FingerprintAsync(QueuedEpisode episode, AnalysisMode mode, CancellationToken cancellationToken = default)
-        => throw new NotSupportedException();
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Hook(Fingerprints)(episode, mode));
+    }
 
     public virtual Task<TimeRange[]> DetectSilenceAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
         => throw new NotSupportedException();

--- a/IntroSkipper.Tests/TestAnalysisConfigHash.cs
+++ b/IntroSkipper.Tests/TestAnalysisConfigHash.cs
@@ -16,6 +16,7 @@ public sealed class TestAnalysisConfigHash
         { AnalysisMode.Credits, new PluginConfiguration { MinimumIntroDuration = 15 }, new PluginConfiguration { MinimumIntroDuration = 30 }, AnalyzerAction.Default },
         { AnalysisMode.Preview, new PluginConfiguration { AnimePreviewFromCreditsEnd = false }, new PluginConfiguration { AnimePreviewFromCreditsEnd = true }, AnalyzerAction.Default },
         { AnalysisMode.Recap, new PluginConfiguration(), new PluginConfiguration { MaximumFingerprintPointDifferences = new PluginConfiguration().MaximumFingerprintPointDifferences + 1 }, AnalyzerAction.Default },
+        { AnalysisMode.Recap, new PluginConfiguration(), new PluginConfiguration { AnchorRecapToColdOpen = true }, AnalyzerAction.Default },
         { AnalysisMode.Introduction, new PluginConfiguration(), new PluginConfiguration(), AnalyzerAction.Chapter },
     };
 

--- a/IntroSkipper.Tests/TestChapterAnalyzer.cs
+++ b/IntroSkipper.Tests/TestChapterAnalyzer.cs
@@ -62,7 +62,7 @@ public class TestChapterAnalyzer
         var episodeId = Guid.NewGuid();
         var frames = frameTimes.Select((time, i) => new BlackFrame(90, time, i)).ToList();
 
-        var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(episodeId, frames, minimumRecapDuration: 5, maximumRecapBoundary);
+        var recap = RecapDetectionHelper.BuildRecapFromBlackFrames(episodeId, frames, minimumRecapEnd: 5, maximumRecapBoundary);
 
         if (expectedEnd is null)
         {
@@ -97,7 +97,7 @@ public class TestChapterAnalyzer
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 200, Path = "episode.mkv" };
 
         var blackFrames = await RecapDetectionHelper.DetectAdaptiveBlackFramesAsync(ffmpeg, episode, 120, config, CancellationToken.None);
-        var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120);
+        var recap = RecapDetectionHelper.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120);
 
         // Baseline (1st percentile) is 2, so the normalized minimum stays at the configured 85.
         Assert.Equal(new[] { 95, 88 }, blackFrames.Select(frame => frame.Percentage));
@@ -124,7 +124,7 @@ public class TestChapterAnalyzer
         var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 1200, Path = "episode.mkv" };
 
         var blackFrames = await RecapDetectionHelper.DetectAdaptiveBlackFramesAsync(RecapScan(scan), episode, 120, config, CancellationToken.None);
-        var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120);
+        var recap = RecapDetectionHelper.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120);
 
         var frame = Assert.Single(blackFrames);
         Assert.Equal(87, frame.Percentage);
@@ -147,7 +147,7 @@ public class TestChapterAnalyzer
         var blackFrames = await RecapDetectionHelper.DetectAdaptiveBlackFramesAsync(RecapScan(scan), episode, 120, config, CancellationToken.None);
 
         Assert.Empty(blackFrames);
-        Assert.Null(ChapterAnalyzer.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120));
+        Assert.Null(RecapDetectionHelper.BuildRecapFromBlackFrames(episode.EpisodeId, blackFrames, config.MinimumRecapDetectionDuration, 120));
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestRecapDetection.cs
+++ b/IntroSkipper.Tests/TestRecapDetection.cs
@@ -5,6 +5,8 @@ namespace IntroSkipper.Tests;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
 using IntroSkipper.Configuration;
@@ -193,6 +195,77 @@ public class TestRecapDetection
             anchorToColdOpen: true);
 
         Assert.Null(recap);
+    }
+
+    // Episode A opens with a logo that B also has at 0:00 and, after a cold open, a sting at 35 s
+    // that C also has. Black frames sit at 28 s (the fade before the sting), 50 s and 90 s.
+    // Whichever pair the analyzer meets first, the recap saved for A must start at the fade.
+    [Theory]
+    [InlineData("A,B,C")]
+    [InlineData("A,C,B")]
+    public async Task AnalyzeMediaFiles_AnchoredRecapSurvivesAnEarlierPairMatchingAtEpisodeStart(string order)
+    {
+        var fingerprints = new Dictionary<string, uint[]>
+        {
+            ["A"] = Fingerprint(0x10000, (0, 5, 0x1000), (35, 40, 0x2000)),
+            ["B"] = Fingerprint(0x20000, (0, 5, 0x1000)),
+            ["C"] = Fingerprint(0x30000, (35, 40, 0x2000)),
+        };
+        var episodes = order.Split(',').Select((name, index) => new QueuedEpisode
+        {
+            EpisodeId = Guid.NewGuid(),
+            Name = name,
+            EpisodeNumber = index + 1,
+            Duration = 1800,
+            IntroFingerprintEnd = 240,
+        }).ToList();
+        var ffmpeg = new StubFFmpegService
+        {
+            Fingerprints = (episode, _) => fingerprints[episode.Name],
+            RangeBlackFrames = (_, _, _, _, _) => [new BlackFrame(100, 28, 0), new BlackFrame(100, 50, 1), new BlackFrame(100, 90, 2)],
+        };
+        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        var analyzer = new ChromaprintAnalyzer(
+            NullLogger<ChromaprintAnalyzer>.Instance,
+            ffmpeg,
+            DatabaseTestHelpers.CreateTempCacheService(),
+            database,
+            new PluginConfiguration
+            {
+                AnchorRecapToColdOpen = true,
+                MaximumFingerprintPointDifferences = 0,
+                MaximumTimeSkip = 0.2,
+                InvertedIndexShift = 0,
+                AdjustIntroBasedOnChapters = false,
+                AdjustIntroBasedOnSilence = false,
+                SnapToKeyframe = false,
+            });
+
+        await analyzer.AnalyzeMediaFiles(episodes, AnalysisMode.Recap, CancellationToken.None);
+
+        var a = episodes.Single(episode => episode.Name == "A");
+        Assert.Equal(EpisodeState.Analyzed, a.GetAnalyzed(AnalysisMode.Recap));
+        var recap = Assert.Single(await database.GetSegmentsAsync(a.EpisodeId));
+        Assert.Equal(28, TickConversions.ToSeconds(recap.StartTicks));
+        Assert.Equal(90, TickConversions.ToSeconds(recap.EndTicks));
+
+        // Sixty seconds of Chromaprint points unique to one episode, overlaid with runs shared
+        // with other episodes at the given seconds.
+        static uint[] Fingerprint(uint unique, params (double Start, double End, uint Shared)[] runs)
+        {
+            var points = Enumerable.Range(0, Position(60)).Select(i => unique + (uint)i).ToArray();
+            foreach (var (start, end, shared) in runs)
+            {
+                for (var i = Position(start); i < Position(end); i++)
+                {
+                    points[i] = shared + (uint)(i - Position(start));
+                }
+            }
+
+            return points;
+        }
+
+        static int Position(double seconds) => (int)Math.Round(seconds / ChromaprintConstants.SampleDuration);
     }
 
     [Fact]

--- a/IntroSkipper.Tests/TestRecapDetection.cs
+++ b/IntroSkipper.Tests/TestRecapDetection.cs
@@ -64,6 +64,63 @@ public class TestRecapDetection
         Assert.False(rhsSegment.Valid);
     }
 
+    [Theory]
+    [InlineData(AnalysisMode.Introduction, 0)]
+    [InlineData(AnalysisMode.Recap, 3)]
+    public void SelectSharedRegion_SnapsNearZeroStart_ExceptForRecap(AnalysisMode mode, double expectedStart)
+    {
+        var (lhsSegment, rhsSegment) = ChromaprintAnalyzer.SelectSharedRegion(
+            Guid.NewGuid(),
+            [new TimeRange(3, 20)],
+            Guid.NewGuid(),
+            [new TimeRange(3, 20)],
+            mode);
+
+        Assert.Equal(expectedStart, lhsSegment.Start);
+        Assert.Equal(expectedStart, rhsSegment.Start);
+    }
+
+    // Black frames at 28 s (fade after a cold open), 50 s (inside the recap) and 90 s (montage
+    // end); the sting is 5 s long and the scan window ends at 120 s.
+    [Theory]
+    [InlineData(true, 35, 28)]
+    [InlineData(false, 35, 0)]
+    [InlineData(true, 4, 0)]
+    [InlineData(true, 75, 75)]
+    public void BuildRecapFromSting_StartsAtColdOpenFadeOnlyWhenAnchored(bool anchor, double stingStart, double expectedStart)
+    {
+        var episodeId = Guid.NewGuid();
+        BlackFrame[] frames = [new(100, 28, 0), new(100, 50, 1), new(100, 90, 2)];
+
+        var recap = RecapDetectionHelper.BuildRecapFromSting(
+            episodeId,
+            new Segment(episodeId, new TimeRange(stingStart, stingStart + 5)),
+            frames,
+            minimumRecapDuration: 15,
+            maximumRecapBoundary: 120,
+            anchor);
+
+        Assert.NotNull(recap);
+        Assert.Equal(expectedStart, recap.Start);
+        Assert.Equal(90, recap.End);
+    }
+
+    [Fact]
+    public void BuildRecapFromSting_ReturnsNull_WhenNoBlackFrameClosesTheRecap()
+    {
+        var episodeId = Guid.NewGuid();
+
+        var recap = RecapDetectionHelper.BuildRecapFromSting(
+            episodeId,
+            new Segment(episodeId, new TimeRange(35, 40)),
+            [new BlackFrame(100, 28, 0)],
+            minimumRecapDuration: 15,
+            maximumRecapBoundary: 120,
+            anchorToColdOpen: true);
+
+        Assert.Null(recap);
+    }
+
     [Fact]
     public void RecapFingerprintRange_UsesIntroFingerprintWindow()
     {

--- a/IntroSkipper.Tests/TestRecapDetection.cs
+++ b/IntroSkipper.Tests/TestRecapDetection.cs
@@ -5,8 +5,11 @@ namespace IntroSkipper.Tests;
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using IntroSkipper.Analyzers;
+using IntroSkipper.Configuration;
 using IntroSkipper.Data;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 public class TestRecapDetection
@@ -83,9 +86,55 @@ public class TestRecapDetection
             new Segment(episodeId, new TimeRange(candidateStart, 90)),
             new Segment(episodeId, new TimeRange(savedStart, 90)),
             mode,
-            anchor);
+            anchor,
+            endSnapThreshold: 2);
 
         Assert.Equal(expected, better);
+    }
+
+    [Theory]
+    [InlineData(2, 1, 0, false, 0)]
+    [InlineData(2, 0, 1, true, 0)]
+    [InlineData(2, 2, 0, false, 0)]
+    [InlineData(2, 2.001, 0, false, 0)]
+    [InlineData(2, 2.002, 0, true, 2.002)]
+    [InlineData(2, 0, 2.002, false, 2.002)]
+    [InlineData(5, 4, 0, false, 0)]
+    [InlineData(0, 0.001, 0, false, 0)]
+    [InlineData(0, 0.002, 0, true, 0.002)]
+    [InlineData(2, 28, 1, true, 28)]
+    [InlineData(2, 1, 28, false, 28)]
+    [InlineData(2, 28, 35, true, 28)]
+    [InlineData(2, 35, 28, false, 28)]
+    public async Task IsBetterCandidate_PrefersOnlyAnchorsThatSurviveStartSnapping(
+        double snapThreshold,
+        double candidateStart,
+        double savedStart,
+        bool expectedBetter,
+        double expectedAdjustedStart)
+    {
+        var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Duration = 300 };
+        var candidate = new Segment(episode.EpisodeId, new TimeRange(candidateStart, 90));
+        var saved = new Segment(episode.EpisodeId, new TimeRange(savedStart, 90));
+        var config = new PluginConfiguration
+        {
+            AnchorRecapToColdOpen = true,
+            EndSnapThreshold = snapThreshold,
+            AdjustIntroBasedOnChapters = false,
+            AdjustIntroBasedOnSilence = false,
+            SnapToKeyframe = false,
+            IntroStartOffset = 0,
+            IntroEndOffset = 0,
+        };
+
+        var better = ChromaprintAnalyzer.IsBetterCandidate(
+            candidate, saved, AnalysisMode.Recap, config.AnchorRecapToColdOpen, config.EndSnapThreshold);
+        var helper = new TimeAdjustmentHelper(NullLogger.Instance, config, AnalysisMode.Recap, null!);
+        var adjusted = await helper.AdjustIntroTimesAsync(episode, better ? candidate : saved);
+
+        Assert.Equal(expectedBetter, better);
+        Assert.Equal(expectedAdjustedStart, adjusted.Start);
+        Assert.Equal(90, adjusted.End);
     }
 
     // Black frames at 28 s (fade after a cold open), 50 s (inside the recap) and 90 s (montage

--- a/IntroSkipper.Tests/TestRecapDetection.cs
+++ b/IntroSkipper.Tests/TestRecapDetection.cs
@@ -64,20 +64,28 @@ public class TestRecapDetection
         Assert.False(rhsSegment.Valid);
     }
 
+    // An anchored recap (start 28) and a 0:00 recap for the same episode share their end at 90.
     [Theory]
-    [InlineData(AnalysisMode.Introduction, 0)]
-    [InlineData(AnalysisMode.Recap, 3)]
-    public void SelectSharedRegion_SnapsNearZeroStart_ExceptForRecap(AnalysisMode mode, double expectedStart)
+    [InlineData(AnalysisMode.Recap, true, 28, 0, true)]
+    [InlineData(AnalysisMode.Recap, true, 0, 28, false)]
+    [InlineData(AnalysisMode.Recap, false, 28, 0, false)]
+    [InlineData(AnalysisMode.Introduction, true, 28, 0, false)]
+    public void IsBetterCandidate_PrefersAnchoredRecapOnlyWhenAnchoring(
+        AnalysisMode mode,
+        bool anchor,
+        double candidateStart,
+        double savedStart,
+        bool expected)
     {
-        var (lhsSegment, rhsSegment) = ChromaprintAnalyzer.SelectSharedRegion(
-            Guid.NewGuid(),
-            [new TimeRange(3, 20)],
-            Guid.NewGuid(),
-            [new TimeRange(3, 20)],
-            mode);
+        var episodeId = Guid.NewGuid();
 
-        Assert.Equal(expectedStart, lhsSegment.Start);
-        Assert.Equal(expectedStart, rhsSegment.Start);
+        var better = ChromaprintAnalyzer.IsBetterCandidate(
+            new Segment(episodeId, new TimeRange(candidateStart, 90)),
+            new Segment(episodeId, new TimeRange(savedStart, 90)),
+            mode,
+            anchor);
+
+        Assert.Equal(expected, better);
     }
 
     // Black frames at 28 s (fade after a cold open), 50 s (inside the recap) and 90 s (montage
@@ -114,6 +122,23 @@ public class TestRecapDetection
             episodeId,
             new Segment(episodeId, new TimeRange(35, 40)),
             [new BlackFrame(100, 28, 0)],
+            minimumRecapDuration: 15,
+            maximumRecapBoundary: 120,
+            anchorToColdOpen: true);
+
+        Assert.Null(recap);
+    }
+
+    // Black frames at 28 and 41 close a 0-41 recap, but anchoring to 28 leaves 13 s, under the minimum.
+    [Fact]
+    public void BuildRecapFromSting_ReturnsNull_WhenAnchoredRecapIsShorterThanMinimum()
+    {
+        var episodeId = Guid.NewGuid();
+
+        var recap = RecapDetectionHelper.BuildRecapFromSting(
+            episodeId,
+            new Segment(episodeId, new TimeRange(35, 40)),
+            [new BlackFrame(100, 28, 0), new BlackFrame(100, 41, 1)],
             minimumRecapDuration: 15,
             maximumRecapBoundary: 120,
             anchorToColdOpen: true);

--- a/IntroSkipper.Tests/TestRecapDetection.cs
+++ b/IntroSkipper.Tests/TestRecapDetection.cs
@@ -199,10 +199,15 @@ public class TestRecapDetection
 
     // Episode A opens with a logo that B also has at 0:00 and, after a cold open, a sting at 35 s
     // that C also has. Black frames sit at 28 s (the fade before the sting), 50 s and 90 s.
-    // Whichever pair the analyzer meets first, the recap saved for A must start at the fade.
+    // Whichever pair the analyzer meets first, the recap saved for A must start at the fade, and
+    // each episode's black-frame scan must run once however many pairs it takes part in.
     [Theory]
     [InlineData("A,B,C")]
     [InlineData("A,C,B")]
+    [InlineData("B,A,C")]
+    [InlineData("B,C,A")]
+    [InlineData("C,A,B")]
+    [InlineData("C,B,A")]
     public async Task AnalyzeMediaFiles_AnchoredRecapSurvivesAnEarlierPairMatchingAtEpisodeStart(string order)
     {
         var fingerprints = new Dictionary<string, uint[]>
@@ -224,12 +229,12 @@ public class TestRecapDetection
             Fingerprints = (episode, _) => fingerprints[episode.Name],
             RangeBlackFrames = (_, _, _, _, _) => [new BlackFrame(100, 28, 0), new BlackFrame(100, 50, 1), new BlackFrame(100, 90, 2)],
         };
-        var database = DatabaseTestHelpers.CreateTempSegmentDatabase();
+        using var db = new TempSegmentDb();
         var analyzer = new ChromaprintAnalyzer(
             NullLogger<ChromaprintAnalyzer>.Instance,
             ffmpeg,
             DatabaseTestHelpers.CreateTempCacheService(),
-            database,
+            db.Database,
             new PluginConfiguration
             {
                 AnchorRecapToColdOpen = true,
@@ -245,9 +250,10 @@ public class TestRecapDetection
 
         var a = episodes.Single(episode => episode.Name == "A");
         Assert.Equal(EpisodeState.Analyzed, a.GetAnalyzed(AnalysisMode.Recap));
-        var recap = Assert.Single(await database.GetSegmentsAsync(a.EpisodeId));
+        var recap = Assert.Single(await db.Database.GetSegmentsAsync(a.EpisodeId));
         Assert.Equal(28, TickConversions.ToSeconds(recap.StartTicks));
         Assert.Equal(90, TickConversions.ToSeconds(recap.EndTicks));
+        Assert.Equal(3, ffmpeg.RangeScanCalls);
 
         // Sixty seconds of Chromaprint points unique to one episode, overlaid with runs shared
         // with other episodes at the given seconds.

--- a/IntroSkipper/Analyzers/ChapterAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChapterAnalyzer.cs
@@ -293,39 +293,11 @@ internal sealed partial class ChapterAnalyzer(
             _config,
             cancellationToken).ConfigureAwait(false);
 
-        return BuildRecapFromBlackFrames(
+        return RecapDetectionHelper.BuildRecapFromBlackFrames(
             episode.EpisodeId,
             blackFrames,
             _config.MinimumRecapDetectionDuration,
             maxRecapBoundary);
-    }
-
-    internal static Segment? BuildRecapFromBlackFrames(
-        Guid episodeId,
-        IReadOnlyList<BlackFrame> blackFrames,
-        int minimumRecapDuration,
-        double maximumRecapBoundary)
-    {
-        BlackFrame? selectedBlackFrame = null;
-        foreach (var blackFrame in blackFrames)
-        {
-            if (blackFrame.Time < minimumRecapDuration || blackFrame.Time > maximumRecapBoundary)
-            {
-                continue;
-            }
-
-            if (selectedBlackFrame is null || blackFrame.Time > selectedBlackFrame.Time)
-            {
-                selectedBlackFrame = blackFrame;
-            }
-        }
-
-        if (selectedBlackFrame is null)
-        {
-            return null;
-        }
-
-        return new Segment(episodeId, new TimeRange(0, selectedBlackFrame.Time));
     }
 
     private (double Min, double Max) GetBounds(AnalysisMode mode, QueuedEpisode episode)

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -171,14 +171,14 @@ internal sealed partial class ChromaprintAnalyzer(
                 // beats the saved one (see IsBetterCandidate).
                 if (
                     !seasonIntros.TryGetValue(currentIntro.EpisodeId, out var savedCurrentIntro) ||
-                    IsBetterCandidate(currentIntro, savedCurrentIntro, _analysisMode, _config.AnchorRecapToColdOpen))
+                    IsBetterCandidate(currentIntro, savedCurrentIntro, _analysisMode, _config.AnchorRecapToColdOpen, _config.EndSnapThreshold))
                 {
                     seasonIntros[currentIntro.EpisodeId] = currentIntro;
                 }
 
                 if (
                     !seasonIntros.TryGetValue(remainingIntro.EpisodeId, out var savedRemainingIntro) ||
-                    IsBetterCandidate(remainingIntro, savedRemainingIntro, _analysisMode, _config.AnchorRecapToColdOpen))
+                    IsBetterCandidate(remainingIntro, savedRemainingIntro, _analysisMode, _config.AnchorRecapToColdOpen, _config.EndSnapThreshold))
                 {
                     seasonIntros[remainingIntro.EpisodeId] = remainingIntro;
                 }
@@ -299,19 +299,25 @@ internal sealed partial class ChromaprintAnalyzer(
     /// Decides whether a candidate found in a later episode pair replaces the one already saved
     /// for the same episode. Longer wins. The exception is an anchored recap: recap candidates
     /// for one episode share their end (the last black frame before the boundary), so a start
-    /// off 0 means a sting past the cold open was found, and it beats a candidate whose sting
-    /// sat at 0:00 even though that one is longer.
+    /// beyond the start snap threshold means a sting past the cold open was found, and it beats
+    /// a candidate that snaps to 0:00 even though that one is longer.
     /// </summary>
     /// <param name="candidate">Newly found segment.</param>
     /// <param name="saved">Segment already saved for the same episode.</param>
     /// <param name="mode">Analysis mode.</param>
     /// <param name="anchorRecapToColdOpen">Whether recaps are anchored to the cold open.</param>
+    /// <param name="endSnapThreshold">Configured episode boundary snap threshold in seconds.</param>
     /// <returns><see langword="true"/> when <paramref name="candidate"/> should replace <paramref name="saved"/>.</returns>
-    internal static bool IsBetterCandidate(Segment candidate, Segment saved, AnalysisMode mode, bool anchorRecapToColdOpen)
+    internal static bool IsBetterCandidate(Segment candidate, Segment saved, AnalysisMode mode, bool anchorRecapToColdOpen, double endSnapThreshold)
     {
-        if (mode == AnalysisMode.Recap && anchorRecapToColdOpen && (candidate.Start > 0) != (saved.Start > 0))
+        if (mode == AnalysisMode.Recap && anchorRecapToColdOpen)
         {
-            return candidate.Start > 0;
+            var candidateSnaps = TimeAdjustmentHelper.IsWithinStartSnapThreshold(candidate.Start, endSnapThreshold);
+            var savedSnaps = TimeAdjustmentHelper.IsWithinStartSnapThreshold(saved.Start, endSnapThreshold);
+            if (candidateSnaps != savedSnaps)
+            {
+                return !candidateSnaps;
+            }
         }
 
         return candidate.Duration > saved.Duration;

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -246,7 +246,8 @@ internal sealed partial class ChromaprintAnalyzer(
     /// <summary>
     /// Selects which shared audio region should be returned for the given analysis mode.
     /// Recap uses the earliest qualifying shared card/sting; other modes use the longest region.
-    /// A region starting within 5 s of the episode start is snapped to 0.
+    /// A region starting within 5 s of the episode start is snapped to 0, except for Recap, where
+    /// the sting start anchors the recap behind a cold open.
     /// </summary>
     /// <param name="lhsId">First episode id.</param>
     /// <param name="lhsRanges">First episode shared timecodes.</param>
@@ -283,14 +284,17 @@ internal sealed partial class ChromaprintAnalyzer(
 
         var lhs = new TimeRange(lhsRanges[selected]);
         var rhs = new TimeRange(rhsRanges[selected]);
-        if (lhs.Start <= 5)
+        if (mode != AnalysisMode.Recap)
         {
-            lhs.Start = 0;
-        }
+            if (lhs.Start <= 5)
+            {
+                lhs.Start = 0;
+            }
 
-        if (rhs.Start <= 5)
-        {
-            rhs.Start = 0;
+            if (rhs.Start <= 5)
+            {
+                rhs.Start = 0;
+            }
         }
 
         return (new Segment(lhsId, lhs), new Segment(rhsId, rhs));
@@ -345,11 +349,13 @@ internal sealed partial class ChromaprintAnalyzer(
             _recapBlackFrameCache[episode.EpisodeId] = blackFrames;
         }
 
-        return ChapterAnalyzer.BuildRecapFromBlackFrames(
+        return RecapDetectionHelper.BuildRecapFromSting(
             episode.EpisodeId,
+            card,
             blackFrames,
-            Math.Max(_config.MinimumRecapDetectionDuration, (int)Math.Ceiling(card.End)),
-            maximumBoundary);
+            _config.MinimumRecapDetectionDuration,
+            maximumBoundary,
+            _config.AnchorRecapToColdOpen);
     }
 
     /// <summary>

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -183,7 +183,13 @@ internal sealed partial class ChromaprintAnalyzer(
                     seasonIntros[remainingIntro.EpisodeId] = remainingIntro;
                 }
 
-                break;
+                // One shared region settles most modes. An anchored recap keeps comparing: the
+                // first pair may have matched an opening logo at 0:00 while a later pair holds
+                // the sting after the cold open, which IsBetterCandidate prefers.
+                if (_analysisMode != AnalysisMode.Recap || !_config.AnchorRecapToColdOpen)
+                {
+                    break;
+                }
             }
 
             // If an intro is found for this episode, adjust its times and save it else add it to the list of episodes without intros.

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -167,19 +167,18 @@ internal sealed partial class ChromaprintAnalyzer(
                     remainingIntro.End += remainingEpisode.CreditsFingerprintStart;
                 }
 
-                // Only save the discovered intro if it is:
-                // - the first intro discovered for this episode
-                // - longer than the previously discovered intro
+                // Only save the discovered intro if it is the first one for this episode or
+                // beats the saved one (see IsBetterCandidate).
                 if (
                     !seasonIntros.TryGetValue(currentIntro.EpisodeId, out var savedCurrentIntro) ||
-                    currentIntro.Duration > savedCurrentIntro.Duration)
+                    IsBetterCandidate(currentIntro, savedCurrentIntro, _analysisMode, _config.AnchorRecapToColdOpen))
                 {
                     seasonIntros[currentIntro.EpisodeId] = currentIntro;
                 }
 
                 if (
                     !seasonIntros.TryGetValue(remainingIntro.EpisodeId, out var savedRemainingIntro) ||
-                    remainingIntro.Duration > savedRemainingIntro.Duration)
+                    IsBetterCandidate(remainingIntro, savedRemainingIntro, _analysisMode, _config.AnchorRecapToColdOpen))
                 {
                     seasonIntros[remainingIntro.EpisodeId] = remainingIntro;
                 }
@@ -246,9 +245,7 @@ internal sealed partial class ChromaprintAnalyzer(
     /// <summary>
     /// Selects which shared audio region should be returned for the given analysis mode.
     /// Recap uses the earliest qualifying shared card/sting; other modes use the longest region.
-    /// A region starting within 5 s of the episode start is snapped to 0, except for Recap, which
-    /// keeps the raw sting start so <see cref="RecapDetectionHelper.BuildRecapFromSting"/> can
-    /// anchor the recap behind a cold open when that option is enabled.
+    /// A region starting within 5 s of the episode start is snapped to 0.
     /// </summary>
     /// <param name="lhsId">First episode id.</param>
     /// <param name="lhsRanges">First episode shared timecodes.</param>
@@ -285,20 +282,39 @@ internal sealed partial class ChromaprintAnalyzer(
 
         var lhs = new TimeRange(lhsRanges[selected]);
         var rhs = new TimeRange(rhsRanges[selected]);
-        if (mode != AnalysisMode.Recap)
+        if (lhs.Start <= 5)
         {
-            if (lhs.Start <= 5)
-            {
-                lhs.Start = 0;
-            }
+            lhs.Start = 0;
+        }
 
-            if (rhs.Start <= 5)
-            {
-                rhs.Start = 0;
-            }
+        if (rhs.Start <= 5)
+        {
+            rhs.Start = 0;
         }
 
         return (new Segment(lhsId, lhs), new Segment(rhsId, rhs));
+    }
+
+    /// <summary>
+    /// Decides whether a candidate found in a later episode pair replaces the one already saved
+    /// for the same episode. Longer wins. The exception is an anchored recap: recap candidates
+    /// for one episode share their end (the last black frame before the boundary), so a start
+    /// off 0 means a sting past the cold open was found, and it beats a candidate whose sting
+    /// sat at 0:00 even though that one is longer.
+    /// </summary>
+    /// <param name="candidate">Newly found segment.</param>
+    /// <param name="saved">Segment already saved for the same episode.</param>
+    /// <param name="mode">Analysis mode.</param>
+    /// <param name="anchorRecapToColdOpen">Whether recaps are anchored to the cold open.</param>
+    /// <returns><see langword="true"/> when <paramref name="candidate"/> should replace <paramref name="saved"/>.</returns>
+    internal static bool IsBetterCandidate(Segment candidate, Segment saved, AnalysisMode mode, bool anchorRecapToColdOpen)
+    {
+        if (mode == AnalysisMode.Recap && anchorRecapToColdOpen && (candidate.Start > 0) != (saved.Start > 0))
+        {
+            return candidate.Start > 0;
+        }
+
+        return candidate.Duration > saved.Duration;
     }
 
     private int GetMaximumSegmentDuration(QueuedEpisode episode)

--- a/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -246,8 +246,9 @@ internal sealed partial class ChromaprintAnalyzer(
     /// <summary>
     /// Selects which shared audio region should be returned for the given analysis mode.
     /// Recap uses the earliest qualifying shared card/sting; other modes use the longest region.
-    /// A region starting within 5 s of the episode start is snapped to 0, except for Recap, where
-    /// the sting start anchors the recap behind a cold open.
+    /// A region starting within 5 s of the episode start is snapped to 0, except for Recap, which
+    /// keeps the raw sting start so <see cref="RecapDetectionHelper.BuildRecapFromSting"/> can
+    /// anchor the recap behind a cold open when that option is enabled.
     /// </summary>
     /// <param name="lhsId">First episode id.</param>
     /// <param name="lhsRanges">First episode shared timecodes.</param>

--- a/IntroSkipper/Analyzers/RecapDetectionHelper.cs
+++ b/IntroSkipper/Analyzers/RecapDetectionHelper.cs
@@ -86,19 +86,40 @@ internal static class RecapDetectionHelper
     }
 
     /// <summary>
+    /// Builds a recap from 0 to the latest black frame within the allowed end window.
+    /// </summary>
+    /// <param name="episodeId">Episode id.</param>
+    /// <param name="blackFrames">Black frames from the recap scan window.</param>
+    /// <param name="minimumRecapEnd">Earliest allowed recap end in seconds.</param>
+    /// <param name="maximumRecapBoundary">Latest allowed recap end in seconds.</param>
+    /// <returns>The recap, or <see langword="null"/> when no black frame closes it.</returns>
+    internal static Segment? BuildRecapFromBlackFrames(
+        Guid episodeId,
+        IReadOnlyList<BlackFrame> blackFrames,
+        double minimumRecapEnd,
+        double maximumRecapBoundary)
+    {
+        var end = LatestBlackFrameTime(blackFrames, minimumRecapEnd, maximumRecapBoundary);
+        return end is null ? null : new Segment(episodeId, new TimeRange(0, end.Value));
+    }
+
+    /// <summary>
     /// Builds a recap around a shared Chromaprint sting. The end is the latest black frame before
     /// the boundary, as for the black-frame fallback. The start is 0 unless
     /// <paramref name="anchorToColdOpen"/> is set and the sting begins after
     /// <see cref="ColdOpenStartThreshold"/>; then it is the latest black frame within
     /// <see cref="ColdOpenLeadInWindow"/> before the sting, or the sting start when there is none.
+    /// An anchored recap shorter than <paramref name="minimumRecapDuration"/> is rejected.
+    /// The caller still runs the result through <see cref="TimeAdjustmentHelper"/>, so a start
+    /// within the configured snap threshold of 0 snaps back to 0 and the intro start offset applies.
     /// </summary>
     /// <param name="episodeId">Episode id.</param>
     /// <param name="sting">Shared sting region for this episode.</param>
     /// <param name="blackFrames">Black frames from the recap scan window.</param>
-    /// <param name="minimumRecapDuration">Earliest allowed recap end in seconds.</param>
+    /// <param name="minimumRecapDuration">Minimum recap length in seconds.</param>
     /// <param name="maximumRecapBoundary">Latest allowed recap end in seconds.</param>
     /// <param name="anchorToColdOpen">Whether a leading cold open moves the start off 0.</param>
-    /// <returns>The recap, or <see langword="null"/> when no black frame closes it.</returns>
+    /// <returns>The recap, or <see langword="null"/> when no black frame closes it or it is too short.</returns>
     internal static Segment? BuildRecapFromSting(
         Guid episodeId,
         Segment sting,
@@ -107,21 +128,32 @@ internal static class RecapDetectionHelper
         double maximumRecapBoundary,
         bool anchorToColdOpen)
     {
-        var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(
+        var recap = BuildRecapFromBlackFrames(
             episodeId,
             blackFrames,
-            Math.Max(minimumRecapDuration, (int)Math.Ceiling(sting.End)),
+            Math.Max(minimumRecapDuration, Math.Ceiling(sting.End)),
             maximumRecapBoundary);
         if (recap is null || !anchorToColdOpen || sting.Start <= ColdOpenStartThreshold)
         {
             return recap;
         }
 
-        var fade = blackFrames
-            .Where(frame => frame.Time <= sting.Start && frame.Time >= sting.Start - ColdOpenLeadInWindow)
-            .Select(frame => (double?)frame.Time)
-            .Max();
-        recap.Start = fade ?? sting.Start;
-        return recap;
+        recap.Start = LatestBlackFrameTime(blackFrames, sting.Start - ColdOpenLeadInWindow, sting.Start) ?? sting.Start;
+        return recap.Duration < minimumRecapDuration ? null : recap;
+    }
+
+    // The latest black frame time in the closed interval [minimum, maximum], if any.
+    private static double? LatestBlackFrameTime(IReadOnlyList<BlackFrame> blackFrames, double minimum, double maximum)
+    {
+        double? latest = null;
+        foreach (var frame in blackFrames)
+        {
+            if (frame.Time >= minimum && frame.Time <= maximum && (latest is null || frame.Time > latest))
+            {
+                latest = frame.Time;
+            }
+        }
+
+        return latest;
     }
 }

--- a/IntroSkipper/Analyzers/RecapDetectionHelper.cs
+++ b/IntroSkipper/Analyzers/RecapDetectionHelper.cs
@@ -13,6 +13,12 @@ namespace IntroSkipper.Analyzers;
 /// </summary>
 internal static class RecapDetectionHelper
 {
+    // A sting starting this close to 0:00 opens the episode, so there is no cold open to keep.
+    private const double ColdOpenStartThreshold = 5;
+
+    // The fade between a cold open and the recap is looked for this many seconds before the sting.
+    private const double ColdOpenLeadInWindow = 10;
+
     /// <summary>
     /// Gets the latest timestamp that recap boundary detection should scan.
     /// </summary>
@@ -77,5 +83,45 @@ internal static class RecapDetectionHelper
 
         var (minimum, _) = BlackFrameThresholdHelper.NormalizeThreshold(blackFrames, config.BlackFrameMinimumPercentage);
         return [.. blackFrames.Where(frame => frame.Percentage >= minimum)];
+    }
+
+    /// <summary>
+    /// Builds a recap around a shared Chromaprint sting. The end is the latest black frame before
+    /// the boundary, as for the black-frame fallback. The start is 0 unless
+    /// <paramref name="anchorToColdOpen"/> is set and the sting begins after
+    /// <see cref="ColdOpenStartThreshold"/>; then it is the latest black frame within
+    /// <see cref="ColdOpenLeadInWindow"/> before the sting, or the sting start when there is none.
+    /// </summary>
+    /// <param name="episodeId">Episode id.</param>
+    /// <param name="sting">Shared sting region for this episode.</param>
+    /// <param name="blackFrames">Black frames from the recap scan window.</param>
+    /// <param name="minimumRecapDuration">Earliest allowed recap end in seconds.</param>
+    /// <param name="maximumRecapBoundary">Latest allowed recap end in seconds.</param>
+    /// <param name="anchorToColdOpen">Whether a leading cold open moves the start off 0.</param>
+    /// <returns>The recap, or <see langword="null"/> when no black frame closes it.</returns>
+    internal static Segment? BuildRecapFromSting(
+        Guid episodeId,
+        Segment sting,
+        IReadOnlyList<BlackFrame> blackFrames,
+        int minimumRecapDuration,
+        double maximumRecapBoundary,
+        bool anchorToColdOpen)
+    {
+        var recap = ChapterAnalyzer.BuildRecapFromBlackFrames(
+            episodeId,
+            blackFrames,
+            Math.Max(minimumRecapDuration, (int)Math.Ceiling(sting.End)),
+            maximumRecapBoundary);
+        if (recap is null || !anchorToColdOpen || sting.Start <= ColdOpenStartThreshold)
+        {
+            return recap;
+        }
+
+        var fade = blackFrames
+            .Where(frame => frame.Time <= sting.Start && frame.Time >= sting.Start - ColdOpenLeadInWindow)
+            .Select(frame => (double?)frame.Time)
+            .Max();
+        recap.Start = fade ?? sting.Start;
+        return recap;
     }
 }

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -64,7 +64,7 @@ internal sealed partial class TimeAdjustmentHelper(ILogger logger, PluginConfigu
             LogNegativeIntroStart(_logger, episode.EpisodeId, episode.Name, rawStart);
             snapToEpisodeStart = true;
         }
-        else if (rawStart <= _config.EndSnapThreshold + Epsilon)
+        else if (IsWithinStartSnapThreshold(rawStart, _config.EndSnapThreshold))
         {
             // If the detected start is within threshold of episode start, snap
             snapToEpisodeStart = true;
@@ -139,6 +139,9 @@ internal sealed partial class TimeAdjustmentHelper(ILogger logger, PluginConfigu
             End = adjustedEnd
         };
     }
+
+    internal static bool IsWithinStartSnapThreshold(double start, double endSnapThreshold) =>
+        start <= endSnapThreshold + Epsilon;
 
     /// <summary>
     /// Finds the chapter boundary (start time in seconds) within the given search range.

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -312,6 +312,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool DetectRecapUsingBlackFrames { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether a Chromaprint recap starts at the fade before the
+    /// shared sting instead of 0:00, so a cold open ahead of the recap is not skipped.
+    /// </summary>
+    public bool AnchorRecapToColdOpen { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets the minimum length of similar audio that will be considered a preview.
     /// </summary>
     public int MinimumPreviewDuration { get; set; } = 15;

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -313,7 +313,9 @@ public class PluginConfiguration : BasePluginConfiguration
 
     /// <summary>
     /// Gets or sets a value indicating whether a Chromaprint recap starts at the fade before the
-    /// shared sting instead of 0:00, so a cold open ahead of the recap is not skipped.
+    /// shared sting instead of 0:00, so a cold open ahead of the recap is not skipped. Only takes
+    /// effect for episodes that reach <see cref="Analyzers.ChromaprintAnalyzer"/> still unanalyzed,
+    /// so with <see cref="DetectRecapUsingBlackFrames"/> it needs <see cref="PreferChromaprint"/>.
     /// </summary>
     public bool AnchorRecapToColdOpen { get; set; } = false;
 

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -52,7 +52,7 @@ internal static class ConfigHasher
             AnalysisMode.Recap => Invariant(
                 $"analysis|v3|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerRecapPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}|min={config.MinimumRecapDuration}|max={config.MaximumRecapDuration}",
                 $"|detMin={config.MinimumRecapDetectionDuration}|detMax={config.MaximumRecapDetectionDuration}",
-                $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}",
+                $"|recapBlackFrames={config.DetectRecapUsingBlackFrames}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}{RecapColdOpenToken(config)}",
                 $"|pct={config.AnalysisPercent}|limit={config.AnalysisLengthLimit}|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
                 $"{AdjustmentHash(config)}"),
 
@@ -167,6 +167,11 @@ internal static class ConfigHasher
         => !config.UseLegacyBlackFrameAnalyzer
             ? FormattableString.Invariant($"|nonblack={config.DetectNonBlackCredits}")
             : string.Empty;
+
+    // Only present when enabled so the default-off configuration keeps the hash it had before
+    // the option existed and does not re-analyze every recap on upgrade.
+    private static string RecapColdOpenToken(PluginConfiguration config)
+        => config.AnchorRecapToColdOpen ? "|coldOpen=True" : string.Empty;
 
     private static string ChromaprintStreamToken(PluginConfiguration config)
         => FormattableString.Invariant(

--- a/web/src/tabs/black-frame.ts
+++ b/web/src/tabs/black-frame.ts
@@ -22,7 +22,7 @@ export const blackFrameTab: Tab = {
                 id: "AnchorRecapToColdOpen",
                 label: "Keep the cold open before a recap",
                 description:
-                    "Start a Chromaprint recap at the black frame just before the shared \"previously on\" sting instead of 0:00, so a scene played before the recap is not skipped. Chapter and black-frame-only recaps still start at 0:00.",
+                    "Start a Chromaprint recap at the black frame just before the shared \"previously on\" sting instead of 0:00, so a scene played before the recap is not skipped. Chapter and black-frame-only recaps still start at 0:00. With the option above also enabled, Chromaprint must run first (Prefer Chromaprint Analysis on the Analysis tab), or the black-frame recap claims the episode at 0:00 before Chromaprint sees it.",
             }),
             inputField({
                 kind: "checkbox",

--- a/web/src/tabs/black-frame.ts
+++ b/web/src/tabs/black-frame.ts
@@ -19,6 +19,13 @@ export const blackFrameTab: Tab = {
             }),
             inputField({
                 kind: "checkbox",
+                id: "AnchorRecapToColdOpen",
+                label: "Keep the cold open before a recap",
+                description:
+                    "Start a Chromaprint recap at the black frame just before the shared \"previously on\" sting instead of 0:00, so a scene played before the recap is not skipped. Chapter and black-frame-only recaps still start at 0:00.",
+            }),
+            inputField({
+                kind: "checkbox",
                 id: "RefineCreditsBoundary",
                 label: "Refine credits boundary",
                 description:

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -62,6 +62,7 @@ export interface PluginConfig {
     ScanCredits: boolean;
     ScanRecap: boolean;
     DetectRecapUsingBlackFrames: boolean;
+    AnchorRecapToColdOpen: boolean;
     ScanPreview: boolean;
     ScanCommercial: boolean;
     EnableMainMenu: boolean;


### PR DESCRIPTION
A recap built around a shared Chromaprint sting always started at 0:00. The black-frame builder returns a range from 0, and `SelectSharedRegion` snapped any start under 5 s to 0 for every mode. On shows with a scene before the "previously on" sting, the skip removed the scene.

New option `AnchorRecapToColdOpen`, off by default, on the black-frame settings tab. When enabled, a Chromaprint recap starts at the latest black frame within 10 s before the sting, or at the sting when there is no fade. A sting within 5 s of 0:00 still starts at 0. The end is unchanged.

Details:

- `SelectSharedRegion` still snaps any start under 5 s to 0 for every mode. Anchoring happens later, in `RecapDetectionHelper.BuildRecapFromSting`, once the black frames are known.
- With the option on, the Chromaprint pair loop compares every pair in Recap mode instead of stopping at the first match. Otherwise an opening logo shared at 0:00 could hide the sting a later pair would find, and the saved start would depend on queue order.
- The option only enters the Recap analysis hash when enabled, so upgrading does not re-analyze recaps for anyone who leaves it off.
- The chapter-analyzer black-frame fallback has no sting to anchor to and still starts at 0:00.
- Downstream, `TimeAdjustmentHelper` applies the same start rules recaps already got (snap within `EndSnapThreshold`, chapter adjustment).

Second follow-up from the closed recap RFCs (#805-#810), after #954.

## Summary by Sourcery

Preserve cold-open scenes before shared Chromaprint recaps behind an opt-in configuration setting.

New Features:
- Add an opt-in setting to preserve cold-open content before Chromaprint-detected recaps by anchoring them near the shared sting.

Bug Fixes:
- Prevent recap detection from skipping scenes before a previously-on sting and make anchored recap selection independent of episode pair ordering.

Enhancements:
- Apply existing start snapping and adjustment behavior to anchored recaps while keeping chapter and black-frame-only recaps at 0:00.

Tests:
- Add coverage for recap anchoring, snapping, minimum durations, fallback behavior, candidate preference, and pair-order independence.