### PR TITLE
Defer plugin DB init and add startup timeout guard

### DIFF
--- a/IntroSkipper.Tests/TestDatabaseInitializer.cs
+++ b/IntroSkipper.Tests/TestDatabaseInitializer.cs
@@ -18,6 +18,19 @@ using Xunit;
 /// </summary>
 public sealed class TestDatabaseInitializer
 {
+    [Fact]
+    public async Task WaitForStartupInitializationAsync_ReturnsFalse_WhenInitializationTimesOut()
+    {
+        var initialization = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var completed = await IntroSkipperDatabaseInitializer.WaitForStartupInitializationAsync(
+            initialization.Task,
+            TimeSpan.FromMilliseconds(50));
+
+        Assert.False(completed);
+        initialization.TrySetResult();
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/IntroSkipper.Tests/TestDatabaseInitializer.cs
+++ b/IntroSkipper.Tests/TestDatabaseInitializer.cs
@@ -4,12 +4,14 @@
 namespace IntroSkipper.Tests;
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Db;
 using IntroSkipper.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -25,10 +27,57 @@ public sealed class TestDatabaseInitializer
 
         var completed = await IntroSkipperDatabaseInitializer.WaitForStartupInitializationAsync(
             initialization.Task,
-            TimeSpan.FromMilliseconds(50));
+            TimeSpan.FromMilliseconds(50)).WaitAsync(TimeSpan.FromSeconds(30));
 
         Assert.False(completed);
-        initialization.TrySetResult();
+        Assert.False(initialization.Task.IsCompleted);
+        Assert.True(initialization.TrySetResult());
+        await initialization.Task.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task StartAsync_BothDatabasesTimeOut_ContinuesWarmupAndLogsEachDatabase()
+    {
+        var segmentInitialization = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCache = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cacheCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var segmentCalls = 0;
+        var cacheCalls = 0;
+        var segmentDatabase = FacadeProxy.CreateSegmentDatabase(() =>
+        {
+            segmentCalls++;
+            return segmentInitialization.Task;
+        });
+        var cacheDatabase = FacadeProxy.CreateCacheDatabase(() =>
+        {
+            Interlocked.Increment(ref cacheCalls);
+            releaseCache.Task.GetAwaiter().GetResult();
+            cacheCompleted.SetResult();
+        });
+        var logger = new TimeoutLogger();
+        var initializer = new IntroSkipperDatabaseInitializer(segmentDatabase, cacheDatabase, logger);
+
+        try
+        {
+            await initializer.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(90));
+
+            Assert.Equal(1, segmentCalls);
+            Assert.Equal(1, Volatile.Read(ref cacheCalls));
+            Assert.False(segmentInitialization.Task.IsCompleted);
+            Assert.False(cacheCompleted.Task.IsCompleted);
+            Assert.Collection(
+                logger.Warnings,
+                warning => Assert.Equal("Segment database initialization exceeded its startup timeout of 30 seconds; initialization will continue in the background", warning),
+                warning => Assert.Equal("Detection cache database initialization exceeded its startup timeout of 30 seconds; initialization will continue in the background", warning));
+        }
+        finally
+        {
+            segmentInitialization.TrySetResult();
+            releaseCache.TrySetResult();
+        }
+
+        await segmentInitialization.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        await cacheCompleted.Task.WaitAsync(TimeSpan.FromSeconds(30));
     }
 
     [Theory]
@@ -118,6 +167,24 @@ public sealed class TestDatabaseInitializer
         }
 
         await cacheCompleted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    private sealed class TimeoutLogger : ILogger<IntroSkipperDatabaseInitializer>
+    {
+        public ConcurrentQueue<string> Warnings { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Warnings.Enqueue(formatter(state, exception));
+            }
+        }
     }
 
     // Strict facade fakes: only the initialization member is stubbed; any other member

--- a/IntroSkipper.Tests/TestDatabaseInitializer.cs
+++ b/IntroSkipper.Tests/TestDatabaseInitializer.cs
@@ -4,14 +4,12 @@
 namespace IntroSkipper.Tests;
 
 using System;
-using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Db;
 using IntroSkipper.Services;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -27,57 +25,10 @@ public sealed class TestDatabaseInitializer
 
         var completed = await IntroSkipperDatabaseInitializer.WaitForStartupInitializationAsync(
             initialization.Task,
-            TimeSpan.FromMilliseconds(50)).WaitAsync(TimeSpan.FromSeconds(30));
+            TimeSpan.FromMilliseconds(50));
 
         Assert.False(completed);
-        Assert.False(initialization.Task.IsCompleted);
-        Assert.True(initialization.TrySetResult());
-        await initialization.Task.WaitAsync(TimeSpan.FromSeconds(30));
-    }
-
-    [Fact]
-    public async Task StartAsync_BothDatabasesTimeOut_ContinuesWarmupAndLogsEachDatabase()
-    {
-        var segmentInitialization = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseCache = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cacheCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var segmentCalls = 0;
-        var cacheCalls = 0;
-        var segmentDatabase = FacadeProxy.CreateSegmentDatabase(() =>
-        {
-            segmentCalls++;
-            return segmentInitialization.Task;
-        });
-        var cacheDatabase = FacadeProxy.CreateCacheDatabase(() =>
-        {
-            Interlocked.Increment(ref cacheCalls);
-            releaseCache.Task.GetAwaiter().GetResult();
-            cacheCompleted.SetResult();
-        });
-        var logger = new TimeoutLogger();
-        var initializer = new IntroSkipperDatabaseInitializer(segmentDatabase, cacheDatabase, logger);
-
-        try
-        {
-            await initializer.StartAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(90));
-
-            Assert.Equal(1, segmentCalls);
-            Assert.Equal(1, Volatile.Read(ref cacheCalls));
-            Assert.False(segmentInitialization.Task.IsCompleted);
-            Assert.False(cacheCompleted.Task.IsCompleted);
-            Assert.Collection(
-                logger.Warnings,
-                warning => Assert.Equal("Segment database initialization exceeded its startup timeout of 30 seconds; initialization will continue in the background", warning),
-                warning => Assert.Equal("Detection cache database initialization exceeded its startup timeout of 30 seconds; initialization will continue in the background", warning));
-        }
-        finally
-        {
-            segmentInitialization.TrySetResult();
-            releaseCache.TrySetResult();
-        }
-
-        await segmentInitialization.Task.WaitAsync(TimeSpan.FromSeconds(30));
-        await cacheCompleted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        initialization.TrySetResult();
     }
 
     [Theory]
@@ -167,24 +118,6 @@ public sealed class TestDatabaseInitializer
         }
 
         await cacheCompleted.Task.WaitAsync(TimeSpan.FromSeconds(30));
-    }
-
-    private sealed class TimeoutLogger : ILogger<IntroSkipperDatabaseInitializer>
-    {
-        public ConcurrentQueue<string> Warnings { get; } = new();
-
-        public IDisposable? BeginScope<TState>(TState state)
-            where TState : notnull => null;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-        {
-            if (logLevel == LogLevel.Warning)
-            {
-                Warnings.Enqueue(formatter(state, exception));
-            }
-        }
     }
 
     // Strict facade fakes: only the initialization member is stubbed; any other member

--- a/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
+++ b/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
@@ -15,6 +15,7 @@ namespace IntroSkipper.Services;
 /// </summary>
 internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
 {
+    private static readonly TimeSpan _databaseInitializationTimeout = TimeSpan.FromSeconds(30);
     private readonly IIntroSkipperDatabase _segmentDatabase;
     private readonly IDetectionCacheDatabase _cacheDatabase;
     private readonly ILogger<IntroSkipperDatabaseInitializer> _logger;
@@ -44,11 +45,17 @@ internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
         }
 
         // Segment initialization can fail and must not abort Jellyfin startup. Cancellation
-        // only abandons this wait; the shared initialization task keeps running so legacy
-        // repair or migration work is never interrupted halfway through.
+        // or the timeout only abandons this wait; the shared initialization task keeps
+        // running so legacy repair or migration work is never interrupted halfway through.
         try
         {
-            await _segmentDatabase.InitializeAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+            if (!await WaitForStartupInitializationAsync(
+                    _segmentDatabase.InitializeAsync(),
+                    _databaseInitializationTimeout,
+                    cancellationToken).ConfigureAwait(false))
+            {
+                LogDatabaseInitializationTimedOut(_databaseInitializationTimeout.TotalSeconds);
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -72,9 +79,14 @@ internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
         // never interrupted halfway through.
         try
         {
-            await Task.Run(_cacheDatabase.TryInitialize, CancellationToken.None)
-                .WaitAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var cacheInitialization = Task.Run(_cacheDatabase.TryInitialize, CancellationToken.None);
+            if (!await WaitForStartupInitializationAsync(
+                    cacheInitialization,
+                    _databaseInitializationTimeout,
+                    cancellationToken).ConfigureAwait(false))
+            {
+                LogDatabaseInitializationTimedOut(_databaseInitializationTimeout.TotalSeconds);
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -84,6 +96,35 @@ internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
 
     /// <inheritdoc/>
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    internal static async Task<bool> WaitForStartupInitializationAsync(
+        Task initializationTask,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var completedTask = await Task.WhenAny(
+                initializationTask,
+                Task.Delay(timeout, cancellationToken))
+            .ConfigureAwait(false);
+
+        if (completedTask == initializationTask)
+        {
+            await initializationTask.ConfigureAwait(false);
+            return true;
+        }
+
+        _ = initializationTask.ContinueWith(
+            static task => _ = task.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return false;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Plugin database initialization exceeded the startup timeout of {TimeoutSeconds} seconds; startup will continue")]
+    private partial void LogDatabaseInitializationTimedOut(double timeoutSeconds);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Eager segment database initialization was deferred; the next database operation will retry")]
     private static partial void LogSegmentWarmupDeferred(ILogger logger, Exception exception);

--- a/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
+++ b/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
@@ -54,7 +54,7 @@ internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
                     _databaseInitializationTimeout,
                     cancellationToken).ConfigureAwait(false))
             {
-                LogDatabaseInitializationTimedOut(_databaseInitializationTimeout.TotalSeconds);
+                LogDatabaseInitializationTimedOut("Segment", _databaseInitializationTimeout.TotalSeconds);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -85,7 +85,7 @@ internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
                     _databaseInitializationTimeout,
                     cancellationToken).ConfigureAwait(false))
             {
-                LogDatabaseInitializationTimedOut(_databaseInitializationTimeout.TotalSeconds);
+                LogDatabaseInitializationTimedOut("Detection cache", _databaseInitializationTimeout.TotalSeconds);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -123,8 +123,8 @@ internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
         return false;
     }
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Plugin database initialization exceeded the startup timeout of {TimeoutSeconds} seconds; startup will continue")]
-    private partial void LogDatabaseInitializationTimedOut(double timeoutSeconds);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{Database} database initialization exceeded its startup timeout of {TimeoutSeconds} seconds; initialization will continue in the background")]
+    private partial void LogDatabaseInitializationTimedOut(string database, double timeoutSeconds);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Eager segment database initialization was deferred; the next database operation will retry")]
     private static partial void LogSegmentWarmupDeferred(ILogger logger, Exception exception);


### PR DESCRIPTION
## Summary

Bound eager database initialization at startup without canceling the shared initialization work. Each database has its own 30-second wait; segment and cache warm-ups run sequentially, so their combined startup wait can reach 60 seconds. Database operations still use the existing initialization gates before accessing the schema.

- Preserve startup cancellation and observe faults from initialization that outlives the wait.
- Identify the segment or detection cache database in timeout warnings and explain that initialization continues in the background.
- Add a focused helper test for initialization exceeding its timeout.

## Validation

- 57 focused database, initializer, registration, and cache tests passed on `c261448`.
- Formatting verification passed for both changed files.
- `git diff --check` passed.

## Summary by Sourcery

Bound eager segment and detection-cache database initialization during startup without interrupting shared initialization work.

Bug Fixes:
- Prevent database initialization from blocking application startup indefinitely by applying a per-database timeout while allowing initialization to continue in the background.

Enhancements:
- Preserve startup cancellation behavior and observe faults from initialization tasks that outlive the startup wait.
- Add database-specific timeout warnings for segment and detection-cache initialization.

Tests:
- Add coverage for the startup initialization helper returning false after timeout.