### PR TITLE
Publish an SPDX SBOM and attestation with each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,9 @@ jobs:
           upload-artifact: false
 
       - name: Attest SBOM
-        if: ${{ github.repository != 'intro-skipper/intro-skipper-test' && !inputs.skip_signing }}
+        # Must match the SignPath gate exactly: attesting an unsigned DLL would
+        # imply provenance the artifact does not have.
+        if: ${{ github.repository == 'intro-skipper/intro-skipper' && !inputs.skip_signing }}
         uses: actions/attest@v4
         with:
           subject-path: IntroSkipper/bin/Release/${{ env.DOTNET_TFM }}/IntroSkipper.dll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Generate SBOM
         if: ${{ github.repository != 'intro-skipper/intro-skipper-test' }}
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
         with:
           path: .
           format: spdx-json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,15 @@ jobs:
           subject-path: IntroSkipper/bin/Release/${{ env.DOTNET_TFM }}/IntroSkipper.dll
           sbom-path: intro-skipper-v${{ env.NEW_FILE_VERSION }}.spdx.json
 
+      - name: Attest build provenance
+        # Same gate as above. Omitting sbom-path/predicate-type selects the
+        # action's default SLSA provenance mode; the modes are mutually
+        # exclusive, so this cannot be folded into the step above.
+        if: ${{ github.repository == 'intro-skipper/intro-skipper' && !inputs.skip_signing }}
+        uses: actions/attest@v4
+        with:
+          subject-path: IntroSkipper/bin/Release/${{ env.DOTNET_TFM }}/IntroSkipper.dll
+
       - name: Remove old release if exits
         if: ${{ github.repository == 'intro-skipper/intro-skipper-test' }}
         run: gh release delete "${{ env.MAIN_VERSION }}/v${{ env.NEW_FILE_VERSION }}" --cleanup-tag --yes || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -73,6 +75,22 @@ jobs:
       - name: Create archive
         run: zip -j "intro-skipper-v${{ env.NEW_FILE_VERSION }}.zip" IntroSkipper/bin/Release/${{ env.DOTNET_TFM }}/IntroSkipper.dll
 
+      - name: Generate SBOM
+        if: ${{ github.repository != 'intro-skipper/intro-skipper-test' }}
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          output-file: intro-skipper-v${{ env.NEW_FILE_VERSION }}.spdx.json
+          upload-artifact: false
+
+      - name: Attest SBOM
+        if: ${{ github.repository != 'intro-skipper/intro-skipper-test' && !inputs.skip_signing }}
+        uses: actions/attest@v4
+        with:
+          subject-path: IntroSkipper/bin/Release/${{ env.DOTNET_TFM }}/IntroSkipper.dll
+          sbom-path: intro-skipper-v${{ env.NEW_FILE_VERSION }}.spdx.json
+
       - name: Remove old release if exits
         if: ${{ github.repository == 'intro-skipper/intro-skipper-test' }}
         run: gh release delete "${{ env.MAIN_VERSION }}/v${{ env.NEW_FILE_VERSION }}" --cleanup-tag --yes || true
@@ -81,7 +99,12 @@ jobs:
 
       - name: Create new release with tag
         if: github.event_name != 'pull_request'
-        run: gh release create "${{ env.MAIN_VERSION }}/v${{ env.NEW_FILE_VERSION }}" "intro-skipper-v${{ env.NEW_FILE_VERSION }}.zip" --title "v${{ env.NEW_FILE_VERSION }}" --latest --generate-notes --target ${{ env.MAIN_VERSION }}
+        run: |
+          ASSETS=("intro-skipper-v${{ env.NEW_FILE_VERSION }}.zip")
+          if [ -f "intro-skipper-v${{ env.NEW_FILE_VERSION }}.spdx.json" ]; then
+            ASSETS+=("intro-skipper-v${{ env.NEW_FILE_VERSION }}.spdx.json")
+          fi
+          gh release create "${{ env.MAIN_VERSION }}/v${{ env.NEW_FILE_VERSION }}" "${ASSETS[@]}" --title "v${{ env.NEW_FILE_VERSION }}" --latest --generate-notes --target ${{ env.MAIN_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
+        env:
+          RestorePackagesWithLockFile: 'true'
 
       - name: Bump release version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         # Must match the SignPath gate exactly: attesting an unsigned DLL would
         # imply provenance the artifact does not have.
         if: ${{ github.repository == 'intro-skipper/intro-skipper' && !inputs.skip_signing }}
-        uses: actions/attest@v4
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: IntroSkipper/bin/Release/${{ env.DOTNET_TFM }}/IntroSkipper.dll
           sbom-path: intro-skipper-v${{ env.NEW_FILE_VERSION }}.spdx.json
@@ -98,7 +98,7 @@ jobs:
         # action's default SLSA provenance mode; the modes are mutually
         # exclusive, so this cannot be folded into the step above.
         if: ${{ github.repository == 'intro-skipper/intro-skipper' && !inputs.skip_signing }}
-        uses: actions/attest@v4
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: IntroSkipper/bin/Release/${{ env.DOTNET_TFM }}/IntroSkipper.dll
 


### PR DESCRIPTION
## What

Adds two steps to `release.yml`:

- **Generate SBOM** — `anchore/sbom-action` (Syft) scans the workspace after the build and emits `intro-skipper-v<version>.spdx.json`, which is uploaded as a release asset beside the plugin zip.
- **Attest SBOM** — `actions/attest@v4` binds that document to the built DLL as a signed attestation.

Job permissions gain `id-token: write` and `attestations: write`.

## Why

We had no SBOM at all — `update-spdx.yml` only rewrites license headers. Scanning the workspace (rather than just the build output) means the SBOM covers both dependency ecosystems: the NuGet graph via `IntroSkipper/bin/Release/net10.0/IntroSkipper.deps.json`, and the pnpm graph from `web/pnpm-lock.yaml` used to build the embedded web assets.

## Notes for review

- **Attestation subject is the DLL, not the zip.** `gh attestation verify` then works against the file a user unpacks into their plugin directory. It runs after the SignPath step, so the attested digest is the signed bytes — worth keeping in mind if signing ever moves later in the job.
- **Gating.** Both steps skip on `intro-skipper/intro-skipper-test`. Attestation additionally skips when `skip_signing` is set, so unsigned builds never publish one.
- **Release step rewritten as a small bash block.** Since the SBOM is conditional, the asset list is built at runtime and the SBOM appended only if the file exists; otherwise `gh release create` would fail on the test repo with a missing file.
- `path: .` also sweeps in `IntroSkipper.Tests` dependencies. That felt like the safer supply-chain default, but scoping to the build output only is a one-line change if you'd rather the SBOM describe strictly what ships.

Untested end-to-end — `release.yml` is `workflow_dispatch`-only, so the first real run will be the first execution of these steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add SBOM publication and artifact attestations to the release workflow while preserving conditional handling for test and unsigned builds.

New Features:
- Publish an SPDX JSON software bill of materials alongside each release archive.
- Generate signed SBOM and build-provenance attestations for signed release DLLs.

Enhancements:
- Ensure release package restoration uses the lock files and include the SBOM asset only when it is generated.

CI:
- Grant the release workflow permissions required for identity tokens and attestations.