### PR TITLE
Log nonzero ffmpeg exit codes

### DIFF
--- a/IntroSkipper/FFmpeg/FFmpegProcessRunner.cs
+++ b/IntroSkipper/FFmpeg/FFmpegProcessRunner.cs
@@ -105,6 +105,15 @@ internal sealed partial class FFmpegProcessRunner(ILogger logger)
                 throw new TimeoutException($"ffmpeg process was killed after not exiting within {timeout}ms");
             }
 
+            // Observed only: callers parse whatever was written and cache the result, and a
+            // nonzero exit does not yet say whether that output was usable (a file without an
+            // audio stream fails a fingerprint run this way). The line makes those cases
+            // visible in the log before any caller starts treating an exit code as a failure.
+            if (process.ExitCode != 0 && _logger.IsEnabled(LogLevel.Debug))
+            {
+                LogFfmpegExitCode(_logger, process.ExitCode, string.Join(" ", info.ArgumentList));
+            }
+
             return ms.ToArray();
         }
         finally
@@ -156,6 +165,9 @@ internal sealed partial class FFmpegProcessRunner(ILogger logger)
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ffmpeg did not exit within {TimeoutMs}ms; killing process")]
     private static partial void LogFfmpegExitTimeout(ILogger logger, int timeoutMs);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ffmpeg exited with code {ExitCode}: {Arguments}")]
+    private static partial void LogFfmpegExitCode(ILogger logger, int exitCode, string arguments);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to kill ffmpeg process tree: {Message}")]
     private static partial void LogFfmpegKillFailed(ILogger logger, string message);

--- a/IntroSkipper/FFmpeg/FFmpegProcessRunner.cs
+++ b/IntroSkipper/FFmpeg/FFmpegProcessRunner.cs
@@ -111,7 +111,7 @@ internal sealed partial class FFmpegProcessRunner(ILogger logger)
             // visible in the log before any caller starts treating an exit code as a failure.
             if (process.ExitCode != 0 && _logger.IsEnabled(LogLevel.Debug))
             {
-                LogFfmpegExitCode(_logger, process.ExitCode, string.Join(" ", info.ArgumentList));
+                _logger.LogDebug("ffmpeg exited with code {ExitCode}: {Arguments}", process.ExitCode, string.Join(" ", info.ArgumentList));
             }
 
             return ms.ToArray();
@@ -165,9 +165,6 @@ internal sealed partial class FFmpegProcessRunner(ILogger logger)
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ffmpeg did not exit within {TimeoutMs}ms; killing process")]
     private static partial void LogFfmpegExitTimeout(ILogger logger, int timeoutMs);
-
-    [LoggerMessage(Level = LogLevel.Debug, Message = "ffmpeg exited with code {ExitCode}: {Arguments}")]
-    private static partial void LogFfmpegExitCode(ILogger logger, int exitCode, string arguments);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to kill ffmpeg process tree: {Message}")]
     private static partial void LogFfmpegKillFailed(ILogger logger, string message);


### PR DESCRIPTION
The process runner never reads ffmpeg's exit code. A run that fails after writing partial output, or nothing at all, parses to an empty result and is cached like a real one. Before any caller starts treating a nonzero exit as a failure, we need to know which runs exit nonzero with usable output, for example a fingerprint run on a file without an audio stream.

This logs every nonzero exit at Debug with the exit code and the argument list, next to the existing "Starting ffmpeg" line. No behavior changes. Once a release of real libraries shows what ffmpeg returns per scan type, the runner can raise on the cases that are actual failures and the detection cache stops storing them.

## Summary by Sourcery

Enhancements:
- Add debug logging for nonzero ffmpeg exit codes, including the exit code and invoked arguments, without changing process behavior.