### PR TITLE
Keep the credits hash at v3 so the credits pass does not rescan settled seasons

### DIFF
--- a/IntroSkipper.Tests/TestConfigHasher.cs
+++ b/IntroSkipper.Tests/TestConfigHasher.cs
@@ -75,9 +75,10 @@ public sealed class TestConfigHasher
         // the chapter-only modes never consult it.
         Case("Introduction analysis changes with chromaprint availability", Analysis(defaults, AnalysisMode.Introduction), Analysis(defaults, AnalysisMode.Introduction, ffmpegValid: false), false);
         Case("Credits analysis changes with chromaprint availability", Analysis(defaults, AnalysisMode.Credits), Analysis(defaults, AnalysisMode.Credits, ffmpegValid: false), false);
-        Case("Credits analysis treats the Chapter action as Default", Analysis(defaults, AnalysisMode.Credits), ConfigHasher.Analysis(defaults, AnalysisMode.Credits, AnalyzerAction.Chapter, ffmpegValid: true), true);
         Case("Credits analysis changes with a BlackFrame action", Analysis(defaults, AnalysisMode.Credits), ConfigHasher.Analysis(defaults, AnalysisMode.Credits, AnalyzerAction.BlackFrame, ffmpegValid: true), false);
-        Case("Credits analysis ignores PreferChromaprint", Analysis(defaults, AnalysisMode.Credits), Analysis(new PluginConfiguration { PreferChromaprint = true }, AnalysisMode.Credits), true);
+        // The string is frozen to what releases before the credits pass wrote, so seasons the
+        // first-wins chain settled stay settled after the upgrade instead of re-scanning.
+        Case("Credits analysis hash is pinned", Analysis(defaults, AnalysisMode.Credits), "353008E48A5F559E", true);
         Case("Credits analysis ignores the preview minimum; the Preview hash carries it", Analysis(defaults, AnalysisMode.Credits), Analysis(new PluginConfiguration { MinimumPreviewDuration = 30 }, AnalysisMode.Credits), true);
         Case("Preview analysis changes with the preview minimum", Analysis(defaults, AnalysisMode.Preview), Analysis(new PluginConfiguration { MinimumPreviewDuration = 30 }, AnalysisMode.Preview), false);
         Case("Recap analysis changes with chromaprint availability", Analysis(defaults, AnalysisMode.Recap), Analysis(defaults, AnalysisMode.Recap, ffmpegValid: false), false);

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -39,7 +39,7 @@ internal static class ConfigHasher
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
                 $"{AdjustmentHash(config)}"),
 
-            // Frozen at v3 on purpose: the credits pass (ADR-0002) replaced the first-wins chain
+            // Frozen at v3 on purpose: the credits pass replaced the first-wins chain
             // without a bump, because a bump re-fingerprints and re-scans every season a chapter
             // or black frame settled. Seasons analyzed by the chain keep their result until they
             // are rescanned. The prefer token stays for the same reason although the pass does

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -39,12 +39,13 @@ internal static class ConfigHasher
                 $"|fpbits={config.MaximumFingerprintPointDifferences}|skip={config.MaximumTimeSkip}|shift={config.InvertedIndexShift}|chromaprint={ffmpegValid}{ChromaprintStreamToken(config)}",
                 $"{AdjustmentHash(config)}"),
 
-            // v4: credits combine every analyzer's candidate, so seasons settled under the
-            // first-wins chain are re-analyzed once after the upgrade. PreferChromaprint is
-            // left out because the credits pass does not read it, and a Chapter action hashes
-            // as Default because chapters always take part in the pass.
+            // Frozen at v3 on purpose: the credits pass (ADR-0002) replaced the first-wins chain
+            // without a bump, because a bump re-fingerprints and re-scans every season a chapter
+            // or black frame settled. Seasons analyzed by the chain keep their result until they
+            // are rescanned. The prefer token stays for the same reason although the pass does
+            // not read PreferChromaprint. A pinned-hash test guards the string.
             AnalysisMode.Credits => Invariant(
-                $"analysis|v4|mode={mode}|action={(action == AnalyzerAction.Chapter ? AnalyzerAction.Default : action)}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
+                $"analysis|v3|mode={mode}|action={action}|prefer={config.PreferChromaprint}|chap={config.ChapterAnalyzerEndCreditsPattern}|fullchap={config.FullLengthChapters}|sbchap={config.EnableSponsorBlockChapterDetection}",
                 $"|pct={config.AnalysisPercent}|maxCredits={config.MaximumCreditsDuration}|maxMovie={config.MaximumMovieCreditsDuration}|probe={config.ProbeAudioDuration}",
                 $"|minRegion={config.MinimumIntroDuration}",
                 $"|min={config.MinimumCreditsDuration}|bfmin={config.BlackFrameMinimumPercentage}|bfthr={config.BlackFrameThreshold}|bfchap={config.UseChapterMarkersBlackFrame}",

--- a/docs/segment-database-v2.md
+++ b/docs/segment-database-v2.md
@@ -66,4 +66,4 @@ The rules, all in `CreditsCandidateCombiner` and `CreditsPass`:
 - Every stored segment goes through the same time adjustment once, including the legacy black-frame analyzer's result, which the chain used to store verbatim.
 - An already-analyzed sibling that the chromaprint comparison re-derives a candidate for is re-scanned only when that candidate reaches outside its stored credits.
 - Per-season BlackFrame and Chromaprint actions restrict the pass to that analyzer. Chapter changes nothing, and PreferChromaprint has no effect on credits.
-- The credits config hash token was bumped (v3 to v4) so seasons settled under the chain re-analyze once after the upgrade. Black-frame scans and adjustment probes replay from the detection cache where the window matches; the new cost is one audio decode per episode for the fingerprint.
+- The credits config hash token stays at v3. A bump would re-fingerprint and re-scan every season a chapter or black frame settled, most of an anime library. Seasons analyzed by the chain keep their result until they are rescanned; new episodes and rescanned seasons go through the pass.


### PR DESCRIPTION
#958 bumped the credits config hash to v4 so every season settled under the first-wins chain re-analyzed once. A prerelease run on a large library showed what that costs. An episode a chapter or black frame settled never had a credits fingerprint or a keyframe scan cached, because the analyzer that would have produced them never got a turn. The rescan is therefore a fingerprint plus a keyframe decode for most of an anime library, days of background ffmpeg on a 30k-item server, and prerelease users had already paid one such rescan from an earlier token change the same day.

This puts the token back to v3 with exactly the inputs releases before #958 wrote, including the `prefer` token the pass no longer reads, and pins the default-config hash in a test so it stays frozen. Seasons analyzed by the chain keep their result until an admin rescans them; new episodes and rescanned seasons go through the credits pass. The design doc is amended to say so.

Who this affects: 12.0.2.0 users, who otherwise re-analyze every credits season on the next release. 10.11 upgraders are unaffected either way, since the 10.11 credits hash string differs from 12.0's and their imported records never match. Prerelease users who already re-analyzed under v4 will see those seasons queued once more; their fingerprints and keyframe scans are cached now, so that pass is cache hits and adjustment probes, seconds per season rather than minutes.

## Summary by Sourcery

Preserve the v3 credits hash to avoid triggering a library-wide rescan of previously settled seasons.

Bug Fixes:
- Prevent settled credits seasons from being unnecessarily re-analyzed after upgrading to the new credits pass.

Enhancements:
- Keep the credits configuration hash at v3 with its pre-upgrade inputs so existing season results remain valid until explicitly rescanned.
- Pin the credits hash in tests to prevent accidental future changes.
- Update the segment database documentation to describe the preserved hash and rescan behavior.

Documentation:
- Clarify that new episodes and rescanned seasons use the credits pass while previously settled seasons retain their results.

Tests:
- Replace behavioral credits hash cases with a pinned default-config hash assertion.