### PR TITLE
Always cache detection results

### DIFF
--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -420,7 +420,7 @@ public sealed class TestCacheOperations
 
         public CachingPluginScope()
         {
-            _inner = EntrypointTestHelpers.CreatePluginScope(new PluginConfiguration { CacheFingerprints = true });
+            _inner = EntrypointTestHelpers.CreatePluginScope(new PluginConfiguration());
             CacheDatabase = DatabaseTestHelpers.CreateCacheDatabase(_inner.CacheDbPath);
             CacheService = new DetectionCacheService(NullLogger<DetectionCacheService>.Instance, CacheDatabase);
         }

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -125,11 +125,6 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool PreferChromaprint { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the episode's fingerprint should be cached to the filesystem.
-    /// </summary>
-    public bool CacheFingerprints { get; set; } = true;
-
-    /// <summary>
     /// Gets or sets the Brotli compression level used for the detection cache.
     /// Higher compression reduces disk usage but increases CPU time during analysis.
     /// </summary>

--- a/IntroSkipper/FFmpeg/DetectionCacheService.cs
+++ b/IntroSkipper/FFmpeg/DetectionCacheService.cs
@@ -27,8 +27,6 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
     private readonly ILogger<DetectionCacheService> _logger = logger;
     private readonly IDetectionCacheDatabase _cacheDatabase = cacheDatabase;
 
-    private static bool IsEnabled => Plugin.Instance?.Configuration.CacheFingerprints ?? false;
-
     /// <summary>
     /// Tries to read a cached detection result from the SQLite DB.
     /// </summary>
@@ -53,11 +51,6 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         string? legacyConfigHash = null)
     {
         result = [];
-
-        if (!IsEnabled)
-        {
-            return false;
-        }
 
         try
         {
@@ -111,11 +104,6 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
         T[] items,
         string? cacheVariant = null)
     {
-        if (!IsEnabled)
-        {
-            return;
-        }
-
         var data = CompressBrotli(items);
         var configHash = ConfigHasher.DetectionCache(Plugin.Instance?.Configuration ?? new(), type, mode, cacheVariant);
 
@@ -141,11 +129,6 @@ public sealed partial class DetectionCacheService(ILogger<DetectionCacheService>
     /// <returns><see langword="true"/> if a fingerprint cache entry exists; otherwise, <see langword="false"/>.</returns>
     public bool HasCachedFingerprint(QueuedEpisode episode, AnalysisMode mode)
     {
-        if (!IsEnabled)
-        {
-            return false;
-        }
-
         var cacheMode = QueuedEpisode.FingerprintCacheMode(mode);
         var (start, end) = episode.GetFingerprintRange(cacheMode);
 


### PR DESCRIPTION
The `CacheFingerprints` checkbox was removed from the settings page in December 2025 (744af17e), but the setting stayed in the config. Anyone who unchecked it before then has been running without the cache since, with no way back except editing the XML.

The pipeline now depends on the cache for correctness, not just speed:

- Chromaprint builds its comparison set from episodes needing analysis plus analyzed siblings with a cached fingerprint. With the cache off, a single new episode in an analyzed season has nothing to compare against and gets no intro.
- Settled-season reanalysis re-decodes every episode instead of re-running the comparison.
- Recap sharing and the credits pass read through the same cache rows.

This drops the property, so a stale `false` in an existing config is ignored on load, and removes the three gates in `DetectionCacheService`. No migration needed. `CacheCompressionLevel` stays.

## Summary by Sourcery

Make detection-result caching mandatory by removing the obsolete opt-out configuration and disabling gates.

Bug Fixes:
- Ensure detection caching is always available so fingerprint comparisons, reanalysis, recap sharing, and credits processing remain correct for existing and newly analyzed episodes.

Enhancements:
- Remove the obsolete CacheFingerprints configuration property and its runtime gating while retaining cache compression settings.

Tests:
- Update cache operation tests to verify caching with the default plugin configuration.