### PR TITLE
Drop the legacy ExcludeSeries setting

### DIFF
--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -20,7 +20,6 @@ public class TestPluginConfiguration
         var serializer = new XmlSerializer(typeof(PluginConfiguration));
         var config = new PluginConfiguration
         {
-            ExcludeSeries = "Legacy Show",
             SeriesExclusions = { "Show, With Comma", "The Office" },
             MovieExclusions = { "Movie, Part 1" },
             PathExclusions = { @"C:\Media, Remote" }
@@ -30,7 +29,6 @@ public class TestPluginConfiguration
         serializer.Serialize(writer, config);
 
         var xml = writer.ToString();
-        Assert.Contains("<ExcludeSeries>Legacy Show</ExcludeSeries>", xml, StringComparison.Ordinal);
         Assert.Contains("<string>Show, With Comma</string>", xml, StringComparison.Ordinal);
         Assert.Contains("<string>Movie, Part 1</string>", xml, StringComparison.Ordinal);
         Assert.Contains(@"<string>C:\Media, Remote</string>", xml, StringComparison.Ordinal);
@@ -38,7 +36,6 @@ public class TestPluginConfiguration
         using var reader = new StringReader(xml);
         var roundTripped = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
 
-        Assert.Equal(config.ExcludeSeries, roundTripped.ExcludeSeries);
         Assert.Equal(config.SeriesExclusions, roundTripped.SeriesExclusions);
         Assert.Equal(config.MovieExclusions, roundTripped.MovieExclusions);
         Assert.Equal(config.PathExclusions, roundTripped.PathExclusions);
@@ -50,7 +47,6 @@ public class TestPluginConfiguration
         var config = JsonSerializer.Deserialize<PluginConfiguration>(
             """
             {
-              "ExcludeSeries": "Legacy Show",
               "SeriesExclusions": ["The Office", "Show, With Comma", null],
               "MovieExclusions": ["The Matrix"],
               "PathExclusions": ["/mnt/remote"]
@@ -58,7 +54,6 @@ public class TestPluginConfiguration
             """);
 
         Assert.NotNull(config);
-        Assert.Equal("Legacy Show", config.ExcludeSeries);
         Assert.Equal(["The Office", "Show, With Comma"], config.SeriesExclusions);
         Assert.Equal(["The Matrix"], config.MovieExclusions);
         Assert.Equal(["/mnt/remote"], config.PathExclusions);
@@ -118,7 +113,6 @@ public class TestPluginConfiguration
     {
         var config = new PluginConfiguration
         {
-            ExcludeSeries = "Legacy Show",
             SeriesExclusions = { "The Office" },
             MovieExclusions = { "The Matrix" },
             PathExclusions = { "/mnt/remote" }
@@ -128,7 +122,6 @@ public class TestPluginConfiguration
         using var document = JsonDocument.Parse(json);
         var root = document.RootElement;
 
-        Assert.Equal("Legacy Show", root.GetProperty("ExcludeSeries").GetString());
         Assert.Equal(JsonValueKind.Array, root.GetProperty("SeriesExclusions").ValueKind);
         Assert.Equal("The Office", root.GetProperty("SeriesExclusions")[0].GetString());
         Assert.Equal(JsonValueKind.Array, root.GetProperty("MovieExclusions").ValueKind);

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -71,11 +71,6 @@ public class PluginConfiguration : BasePluginConfiguration
     // ===== Analysis settings =====
 
     /// <summary>
-    /// Gets or sets the comma separated list of series names to exclude from analysis.
-    /// </summary>
-    public string ExcludeSeries { get; set; } = string.Empty;
-
-    /// <summary>
     /// Gets the structured list of series names to exclude from analysis.
     /// </summary>
     public ExclusionList SeriesExclusions { get; init; } = [];

--- a/IntroSkipper/Helper/ExclusionListJsonConverter.cs
+++ b/IntroSkipper/Helper/ExclusionListJsonConverter.cs
@@ -8,24 +8,19 @@ using IntroSkipper.Data;
 namespace IntroSkipper.Helper;
 
 /// <summary>
-/// JSON converter that writes structured exclusion arrays and reads legacy string values for resilience.
+/// JSON converter that reads and writes an exclusion list as a string array, skipping null items.
 /// </summary>
 public sealed class ExclusionListJsonConverter : JsonConverter<ExclusionList>
 {
     /// <inheritdoc />
     public override ExclusionList Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var list = new ExclusionList();
-        if (reader.TokenType == JsonTokenType.String)
-        {
-            AddLegacyItems(list, reader.GetString());
-            return list;
-        }
-
         if (reader.TokenType != JsonTokenType.StartArray)
         {
-            throw new JsonException("Expected an exclusion list array or legacy comma-separated string.");
+            throw new JsonException("Expected an exclusion list array.");
         }
+
+        var list = new ExclusionList();
 
         while (reader.Read())
         {
@@ -60,18 +55,5 @@ public sealed class ExclusionListJsonConverter : JsonConverter<ExclusionList>
         }
 
         writer.WriteEndArray();
-    }
-
-    private static void AddLegacyItems(ExclusionList list, string? value)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            return;
-        }
-
-        foreach (var item in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            list.Add(item);
-        }
     }
 }

--- a/IntroSkipper/Plugin.cs
+++ b/IntroSkipper/Plugin.cs
@@ -69,8 +69,6 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // Creates the plugin data directory when missing.
         IntroSkipperDatabasePaths.GetPluginDirectory(applicationPaths);
 
-        MigrateLegacyExcludeSeries();
-
         Configuration.FileTransformationPluginEnabled = _pluginManager
             .Plugins
             .Any(p => p.Id == Guid.Parse("5e87cc92-571a-4d8d-8d98-d2d4147f9f90")); // File Transformation plugin ID
@@ -134,24 +132,4 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     internal BaseItem? GetItem(Guid id) => id != Guid.Empty ? _libraryManager.GetItemById(id) : null;
 
     internal IReadOnlyList<ChapterInfo> GetChapters(Guid id) => _chapterRepository.GetChapters(id) ?? Array.Empty<ChapterInfo>();
-
-    private void MigrateLegacyExcludeSeries()
-    {
-        var legacy = Configuration.ExcludeSeries;
-        if (string.IsNullOrWhiteSpace(legacy))
-        {
-            return;
-        }
-
-        if (Configuration.SeriesExclusions.Count == 0)
-        {
-            foreach (var item in legacy.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                Configuration.SeriesExclusions.Add(item);
-            }
-        }
-
-        Configuration.ExcludeSeries = string.Empty;
-        SaveConfiguration();
-    }
 }

--- a/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
+++ b/IntroSkipper/Services/IntroSkipperDatabaseInitializer.cs
@@ -9,7 +9,7 @@ namespace IntroSkipper.Services;
 
 /// <summary>
 /// Eagerly initializes both plugin databases at server startup so migrations and the
-/// legacy schema repair run before regular traffic. This is an optimization only:
+/// one-time legacy import run before regular traffic. This is an optimization only:
 /// correctness is guaranteed by the initialization gate inside the database facades,
 /// which every operation awaits before touching the database.
 /// </summary>
@@ -46,7 +46,7 @@ internal sealed partial class IntroSkipperDatabaseInitializer : IHostedService
 
         // Segment initialization can fail and must not abort Jellyfin startup. Cancellation
         // or the timeout only abandons this wait; the shared initialization task keeps
-        // running so legacy repair or migration work is never interrupted halfway through.
+        // running so the legacy import or a migration is never interrupted halfway through.
         try
         {
             if (!await WaitForStartupInitializationAsync(

--- a/web/src/tabs/information.ts
+++ b/web/src/tabs/information.ts
@@ -12,7 +12,7 @@ async function copyText(text: string): Promise<boolean> {
             return true;
         }
     } catch {
-        /* fall through to the legacy path */
+        /* fall through to the textarea fallback */
     }
 
     const scratch = el("textarea", { readonly: "", "aria-hidden": "true" });


### PR DESCRIPTION
`ExcludeSeries` was the comma-separated exclusion string replaced by the structured exclusion lists in #795. A one-shot migration on plugin load copied it into `SeriesExclusions` and cleared it. That migration has shipped in every release since, so the property and `MigrateLegacyExcludeSeries` go. The config tests that asserted the legacy value round-tripped are trimmed to the structured lists.

Also from #795: `ExclusionListJsonConverter` accepted a comma-separated string for a structured list so an old dashboard could still post the pre-#795 shape. The web UI has posted arrays since June and the XML config never used it, so the string branch goes too.

Two comment fixes ride along: the database initializer called the one-time import a "legacy schema repair", and the dashboard clipboard fallback called a live browser limitation a legacy path.

## Summary by Sourcery

Remove legacy exclusion configuration and compatibility handling in favor of structured exclusion lists.

Enhancements:
- Remove the obsolete ExcludeSeries configuration and its one-time migration now that structured exclusion lists are established.
- Require structured exclusion lists to use JSON arrays instead of accepting the retired comma-separated format.
- Clarify comments describing the one-time database import and clipboard fallback behavior.

Tests:
- Update configuration serialization tests to cover structured exclusion lists without the removed legacy setting.