### PR TITLE
Stop carrying the 10.11 analyzer flag into the legacy opt-in

### DIFF
--- a/IntroSkipper.Tests/TestPluginConfiguration.cs
+++ b/IntroSkipper.Tests/TestPluginConfiguration.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using System.Text.Json;
-using System.Xml;
 using System.Xml.Serialization;
 using IntroSkipper.Configuration;
 using Xunit;
@@ -62,55 +61,6 @@ public class TestPluginConfiguration
         Assert.Equal(["The Office", "Show, With Comma"], config.SeriesExclusions);
         Assert.Equal(["The Matrix"], config.MovieExclusions);
         Assert.Equal(["/mnt/remote"], config.PathExclusions);
-    }
-
-    [Theory]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    public void JsonDeserialization_MigratesFormerAlternativeAnalyzerSetting(
-        bool oldValue,
-        bool expectedLegacyValue)
-    {
-        var config = JsonSerializer.Deserialize<PluginConfiguration>(
-            $$"""{"UseAlternativeBlackFrameAnalyzer":{{oldValue.ToString().ToLowerInvariant()}}}""");
-
-        Assert.NotNull(config);
-        Assert.Equal(expectedLegacyValue, config.UseLegacyBlackFrameAnalyzer);
-    }
-
-    [Fact]
-    public void JsonSerialization_DoesNotWriteFormerAlternativeAnalyzerSetting()
-    {
-        var json = JsonSerializer.Serialize(new PluginConfiguration { UseLegacyBlackFrameAnalyzer = true });
-
-        Assert.DoesNotContain("UseAlternativeBlackFrameAnalyzer", json, StringComparison.Ordinal);
-        Assert.Contains("UseLegacyBlackFrameAnalyzer", json, StringComparison.Ordinal);
-    }
-
-    [Theory]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    public void XmlDeserialization_MigratesFormerAlternativeAnalyzerSetting(
-        bool oldValue,
-        bool expectedLegacyValue)
-    {
-        using var reader = new StringReader(
-            $"<PluginConfiguration><UseAlternativeBlackFrameAnalyzer>{XmlConvert.ToString(oldValue)}</UseAlternativeBlackFrameAnalyzer></PluginConfiguration>");
-        var config = Assert.IsType<PluginConfiguration>(new XmlSerializer(typeof(PluginConfiguration)).Deserialize(reader));
-
-        Assert.Equal(expectedLegacyValue, config.UseLegacyBlackFrameAnalyzer);
-    }
-
-    [Fact]
-    public void XmlSerialization_DoesNotWriteFormerAlternativeAnalyzerSetting()
-    {
-        using var writer = new StringWriter();
-        new XmlSerializer(typeof(PluginConfiguration)).Serialize(
-            writer,
-            new PluginConfiguration { UseLegacyBlackFrameAnalyzer = true });
-
-        Assert.DoesNotContain("UseAlternativeBlackFrameAnalyzer", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("<UseLegacyBlackFrameAnalyzer>true</UseLegacyBlackFrameAnalyzer>", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -9,10 +9,8 @@
 // SPDX-FileCopyrightText: 2024 CasuallyFilthy
 // SPDX-License-Identifier: GPL-3.0-only
 
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO.Compression;
-using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 using IntroSkipper.Data;
 using MediaBrowser.Model.Plugins;
@@ -139,21 +137,6 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether to use the legacy black frame analyzer.
     /// </summary>
     public bool UseLegacyBlackFrameAnalyzer { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the former alternative analyzer was enabled for configuration migration.
-    /// The old setting selected the modern analyzer, so its value is inverted when mapped to
-    /// <see cref="UseLegacyBlackFrameAnalyzer"/>.
-    /// </summary>
-    [JsonPropertyName("UseAlternativeBlackFrameAnalyzer")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [DefaultValue(false)]
-    [XmlElement("UseAlternativeBlackFrameAnalyzer")]
-    public bool UseAlternativeBlackFrameAnalyzer
-    {
-        get => false;
-        set => UseLegacyBlackFrameAnalyzer = !value;
-    }
 
     /// <summary>
     /// Gets or sets a value indicating whether to refine credits boundaries with frame-level analysis.


### PR DESCRIPTION
On 10.11 the modern black frame analyzer is opt-in and the stored `UseAlternativeBlackFrameAnalyzer` flag defaults to false. The 12.0 shim from #907 inverts that on load, so every upgrader who never touched the setting lands on the legacy analyzer as if they had chosen it. That is most 12.0 users, and it defeats the point of making the modern analyzer the default.

This drops the bridge property, so the old key in an upgraded config is ignored and upgraders get the 12.0 default. `UseLegacyBlackFrameAnalyzer` stays for anyone who wants the old detector back. The four migration tests for the shim go with it.

Effects on upgrade:

- Libraries that were on the legacy path through the shim rescan credits once, since the cache hash includes the flag. Fresh 12.0 installs already paid that.
- Manual credits edits are unaffected: tombstones and the admission policy block automatic writes over recorded intent.
- Anyone who upgraded to 12.0.2.0 and saved settings already has `UseLegacyBlackFrameAnalyzer=true` under the new name and stays on legacy. That cohort is small and can flip the checkbox.

## Summary by Sourcery

Remove the obsolete analyzer-setting migration so upgraded configurations follow the modern analyzer default while preserving explicit legacy opt-in.

Bug Fixes:
- Stop migrating the former alternative analyzer setting so upgraded configurations use the 12.0 default analyzer behavior instead of being incorrectly forced onto the legacy analyzer.

Enhancements:
- Remove the obsolete analyzer migration bridge property from plugin configuration while retaining the explicit legacy analyzer option.

Tests:
- Remove migration-specific JSON and XML tests for the obsolete analyzer setting.