### PR TITLE
Make the FFmpeg scan timeout configurable

### DIFF
--- a/IntroSkipper.Tests/TestFFmpegService.cs
+++ b/IntroSkipper.Tests/TestFFmpegService.cs
@@ -64,6 +64,21 @@ public class TestFFmpegService
     }
 
     [Fact]
+    public async Task ProcessTimeout_Disabled_WaitsForExit()
+    {
+        var processPath = OperatingSystem.IsWindows() ? "powershell.exe" : "/bin/sh";
+        string[] args = OperatingSystem.IsWindows()
+            ? ["-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 1; Write-Output done"]
+            : ["-c", "sleep 1; echo done"];
+
+        var output = await new FFmpegProcessRunner(NullLogger.Instance)
+            .RunAsync(processPath, args, timeout: 0)
+            .WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.Contains("done", System.Text.Encoding.UTF8.GetString(output), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task CheckFFmpegVersionAsync_MemoizesSuccess()
     {
         var probeCount = 0;

--- a/IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/IntroSkipper/Configuration/PluginConfiguration.cs
@@ -452,6 +452,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public int ProcessThreads { get; set; }
 
     /// <summary>
+    /// Gets or sets the number of seconds a single ffmpeg scan may run before it is killed.
+    /// 0 disables the timeout, so a scan only ends with the process or with task cancellation.
+    /// </summary>
+    public int ProcessTimeoutSeconds { get; set; } = 60;
+
+    /// <summary>
     /// Gets or sets the relative priority for a ffmpeg process.
     /// </summary>
     public ProcessPriorityClass ProcessPriority { get; set; } = ProcessPriorityClass.BelowNormal;

--- a/IntroSkipper/FFmpeg/FFmpegProcessRunner.cs
+++ b/IntroSkipper/FFmpeg/FFmpegProcessRunner.cs
@@ -21,7 +21,7 @@ internal sealed partial class FFmpegProcessRunner(ILogger logger)
     /// <param name="processPath">Executable to start.</param>
     /// <param name="args">Arguments, one token each.</param>
     /// <param name="stderr"><see langword="true"/> to return standard error; otherwise standard output is returned.</param>
-    /// <param name="timeout">Milliseconds to wait for the process to exit before killing it.</param>
+    /// <param name="timeout">Milliseconds to wait for the process to exit before killing it; zero or a negative value waits indefinitely.</param>
     /// <param name="cancellationToken">Cancels the wait and kills the process.</param>
     /// <returns>The raw bytes of the selected stream.</returns>
     /// <exception cref="TimeoutException">The process did not exit within <paramref name="timeout"/> and was killed.</exception>
@@ -75,7 +75,7 @@ internal sealed partial class FFmpegProcessRunner(ILogger logger)
             var stdoutTask = DrainAsync(process.StandardOutput.BaseStream, stderr ? null : ms);
             var stderrTask = DrainAsync(process.StandardError.BaseStream, stderr ? ms : null);
 
-            using var timeoutCts = new CancellationTokenSource(timeout);
+            using var timeoutCts = new CancellationTokenSource(timeout > 0 ? timeout : Timeout.Infinite);
             using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
             var timedOut = false;
             try

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -389,7 +389,7 @@ internal sealed partial class FFmpegService : IFFmpegService
 
         LogDetectionScan(_logger, entryType, start, end, episode.Path, episode.EpisodeId);
 
-        var raw = Encoding.UTF8.GetString(await GetOutputAsync(args, stderr: true, infoQuery: false, timeout: 60 * 1000, cancellationToken).ConfigureAwait(false));
+        var raw = Encoding.UTF8.GetString(await GetOutputAsync(args, stderr: true, infoQuery: false, timeout: GetScanTimeoutMs(), cancellationToken).ConfigureAwait(false));
         var result = parse(raw);
         cancellationToken.ThrowIfCancellationRequested();
         _cacheService.Write(episode.EpisodeId, mode, entryType, start, end, result);
@@ -444,6 +444,18 @@ internal sealed partial class FFmpegService : IFFmpegService
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Returns the configured limit for one fingerprint or detection scan, in milliseconds, or
+    /// <see cref="Timeout.Infinite"/> when the user disabled it. Version probes and ffprobe
+    /// queries keep their own short limits.
+    /// </summary>
+    /// <returns>The scan timeout in milliseconds.</returns>
+    private static int GetScanTimeoutMs()
+    {
+        var seconds = Plugin.Instance?.Configuration.ProcessTimeoutSeconds ?? 60;
+        return seconds > 0 ? (int)Math.Min((long)seconds * 1000, int.MaxValue) : Timeout.Infinite;
     }
 
     /// <summary>
@@ -650,7 +662,7 @@ internal sealed partial class FFmpegService : IFFmpegService
         byte[] rawPoints;
         try
         {
-            rawPoints = await GetOutputAsync(args, stderr: false, infoQuery: false, timeout: 60 * 1000, cancellationToken).ConfigureAwait(false);
+            rawPoints = await GetOutputAsync(args, stderr: false, infoQuery: false, timeout: GetScanTimeoutMs(), cancellationToken).ConfigureAwait(false);
         }
         catch (TimeoutException ex)
         {

--- a/web/src/tabs/ffmpeg.ts
+++ b/web/src/tabs/ffmpeg.ts
@@ -38,6 +38,16 @@ export const ffmpegTab: Tab = {
                     "Number of simultaneous processes to use for FFmpeg operations. Setting 0 (default) uses the maximum threads available.",
             }),
             inputField({
+                kind: "number",
+                id: "ProcessTimeoutSeconds",
+                label: "FFmpeg scan timeout (seconds)",
+                min: 0,
+                max: 3600,
+                description:
+                    "How long one fingerprint or black-frame scan may run before it is killed and the season is skipped. " +
+                    "Raise it for high-bitrate remuxes on slow storage. Setting 0 disables the timeout.",
+            }),
+            inputField({
                 kind: "checkbox",
                 id: "ProbeAudioDuration",
                 label: "Probe audio duration for credits",

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -19,6 +19,7 @@ export interface PluginConfig {
     MinimumCommercialDuration: number;
     MaximumCommercialDuration: number;
     ProcessThreads: number;
+    ProcessTimeoutSeconds: number;
     IntroEndOffset: number;
     IntroStartOffset: number;
     SkipbuttonHideDelay: number;

--- a/web/src/validation/rules.ts
+++ b/web/src/validation/rules.ts
@@ -47,6 +47,7 @@ export const validationRules: Partial<Record<keyof PluginConfig, ValidationRule<
     BlackFrameThreshold: [range(16, 255)],
     MaxParallelism: [minValue(1)],
     ProcessThreads: [range(0, 16)],
+    ProcessTimeoutSeconds: [range(0, 3600)],
     SkipbuttonHideDelay: [range(0, 1000)],
     SkipButtonVisibleSeconds: [range(0, 600)],
     SilenceDetectionMaximumNoise: [range(-90, 0)],


### PR DESCRIPTION
## Summary

Fixes #972.

The 60 s limit on fingerprint and detection scans is hard-coded in `FFmpegService` (and as the `FFmpegProcessRunner.RunAsync` default). A 25 min Chromaprint window on a high-bitrate remux, or the 120 s black-frame decode of a 4K HEVC episode, cannot finish in 60 s on many setups, so `BaseItemAnalyzerTask` skips the season at every run and it never completes.

This PR exposes the limit as a plugin setting:

- `PluginConfiguration.ProcessTimeoutSeconds`, default **60** (behaviour unchanged for existing installs), **0 disables the timeout** so a scan only ends with the process or with task cancellation.
- `FFmpegService.GetScanTimeoutMs()` feeds it to the two scan call sites (`RunCachedScanAsync`, i.e. black frames / silence / keyframe scans, and `FingerprintAsync`). Version probes and ffprobe queries keep their own short limits.
- `FFmpegProcessRunner.RunAsync` treats a non-positive timeout as `Timeout.Infinite`; the cancellation token still kills the process tree.
- New field **"FFmpeg scan timeout (seconds)"** on the FFmpeg tab (0–3600), next to "FFmpeg Threads".
- Test `ProcessTimeout_Disabled_WaitsForExit` covers the disabled path; the existing `ProcessTimeout_KillsProcessWhileDrainingOutput` still covers the kill path.

## Testing

- `dotnet test` in a .NET 10 SDK container with ffmpeg: 752 passed, 0 failed.
- Installed the built 12.0.3.0 DLL on a Jellyfin 12 Docker server and set the timeout to 300 s. *The Last of Us* S02 (7 × 4K remux, 65–97 Mbit/s on a mergerfs HDD array) had been killed at 60 s on every run for two days; with the new setting all 7 intro fingerprints completed and 7 Intro segments were written on the next run, with zero `ffmpeg did not exit within` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make FFmpeg fingerprint and detection scan timeouts configurable, including support for unlimited execution.

New Features:
- Add a configurable FFmpeg scan timeout with a default of 60 seconds and an option to disable it.
- Expose the scan timeout setting in the FFmpeg configuration UI with validation from 0 to 3600 seconds.

Bug Fixes:
- Allow long-running fingerprint and detection scans to complete instead of being prematurely terminated by the fixed timeout.

Enhancements:
- Preserve cancellation-based process termination while allowing disabled timeouts to wait indefinitely.
- Keep independent limits for FFmpeg version probes and ffprobe queries.

Tests:
- Add coverage for scans configured without a timeout waiting for the process to exit.