### PR TITLE
Snap intro ends with Jellyfin's keyframe store instead of an ffmpeg scan

### DIFF
--- a/IntroSkipper.Tests/FakeKeyframeManager.cs
+++ b/IntroSkipper.Tests/FakeKeyframeManager.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.MediaEncoding.Keyframes;
+using MediaBrowser.Controller.IO;
+
+/// <summary>
+/// In-memory <see cref="IKeyframeManager"/>: one row per item, plus a save count so a test can
+/// tell a served row apart from a fresh extraction.
+/// </summary>
+internal sealed class FakeKeyframeManager : IKeyframeManager
+{
+    private readonly Dictionary<Guid, KeyframeData> _rows = [];
+
+    public int SaveCount { get; private set; }
+
+    public IReadOnlyList<KeyframeData> GetKeyframeData(Guid itemId)
+        => _rows.TryGetValue(itemId, out var data) ? [data] : [];
+
+    public Task SaveKeyframeDataAsync(Guid itemId, KeyframeData data, CancellationToken cancellationToken)
+    {
+        _rows[itemId] = data;
+        SaveCount++;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteKeyframeDataAsync(Guid itemId, CancellationToken cancellationToken)
+    {
+        _rows.Remove(itemId);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Seeds a row as Jellyfin's own extraction would have, without counting a save.</summary>
+    public void Seed(Guid itemId, KeyframeData data) => _rows[itemId] = data;
+}

--- a/IntroSkipper.Tests/FfmpegTestHelpers.cs
+++ b/IntroSkipper.Tests/FfmpegTestHelpers.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using IntroSkipper.Data;
 using IntroSkipper.FFmpeg;
+using MediaBrowser.Controller.IO;
 using Microsoft.Extensions.Logging.Abstractions;
 
 /// <summary>
@@ -21,9 +22,13 @@ internal static class FfmpegTestHelpers
     /// </summary>
     /// <param name="versionProbe">Replaces the ffmpeg version probe; <see langword="null"/> runs the real one.</param>
     /// <param name="versionProbeTimeout">Bounds one probe attempt.</param>
+    /// <param name="keyframeManager">Jellyfin's keyframe store; <see langword="null"/> uses an empty <see cref="FakeKeyframeManager"/>.</param>
     /// <returns>The service.</returns>
-    internal static FFmpegService CreateFFmpegService(Func<CancellationToken, Task<bool>>? versionProbe = null, TimeSpan? versionProbeTimeout = null)
-        => new(NullLogger<FFmpegService>.Instance, DatabaseTestHelpers.CreateTempCacheService(), versionProbe, versionProbeTimeout);
+    internal static FFmpegService CreateFFmpegService(
+        Func<CancellationToken, Task<bool>>? versionProbe = null,
+        TimeSpan? versionProbeTimeout = null,
+        IKeyframeManager? keyframeManager = null)
+        => new(NullLogger<FFmpegService>.Instance, DatabaseTestHelpers.CreateTempCacheService(), keyframeManager ?? new FakeKeyframeManager(), versionProbe, versionProbeTimeout);
 
     /// <summary>
     /// Queues a fixture file for analysis.

--- a/IntroSkipper.Tests/StubFFmpegService.cs
+++ b/IntroSkipper.Tests/StubFFmpegService.cs
@@ -35,7 +35,7 @@ internal class StubFFmpegService : IFFmpegService
 
     public Func<QueuedEpisode, TimeRange, AnalysisMode, TimeRange[]>? Silence { get; init; }
 
-    public Func<QueuedEpisode, TimeRange, AnalysisMode, double[]>? KeyFrames { get; init; }
+    public Func<QueuedEpisode, TimeRange, double[]>? KeyFrames { get; init; }
 
     public Func<QueuedEpisode, KeyframeVisual[]>? KeyframeVisuals { get; init; }
 
@@ -116,8 +116,8 @@ internal class StubFFmpegService : IFFmpegService
         return Task.FromResult(Hook(BlackIntervals)(episode, range, threshold, minimum));
     }
 
-    public virtual Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
-        => Task.FromResult(Hook(KeyFrames)(episode, range, mode));
+    public virtual Task<double[]> GetKeyframesAsync(QueuedEpisode episode, TimeRange range, CancellationToken cancellationToken = default)
+        => Task.FromResult(Hook(KeyFrames)(episode, range));
 
     public virtual Task<double?> ProbeAudioDurationAsync(string filePath, CancellationToken cancellationToken = default)
         => throw new NotSupportedException();

--- a/IntroSkipper.Tests/TestBlackFrames.cs
+++ b/IntroSkipper.Tests/TestBlackFrames.cs
@@ -73,17 +73,6 @@ public class TestBlackFrames
     }
 
     [FactSkipFFmpegTests]
-    public async Task TestSeekSampleKeyFrames()
-    {
-        var actual = await FfmpegTestHelpers.CreateFFmpegService().DetectKeyFramesAsync(
-            FfmpegTestHelpers.QueueFile("video/seek-sample.mp4"),
-            new(0, 8),
-            AnalysisMode.Introduction);
-
-        Assert.Equal([0, 1, 2, 3, 4, 5, 6, 7], actual);
-    }
-
-    [FactSkipFFmpegTests]
     public async Task TestDetectKeyframeVisuals_ClipsScanToCreditsWindow()
     {
         // Real FFmpeg: -skip_frame nokey + -to does NOT reliably bound the scan (it emits keyframes

--- a/IntroSkipper.Tests/TestCacheOperations.cs
+++ b/IntroSkipper.Tests/TestCacheOperations.cs
@@ -37,7 +37,6 @@ public sealed class TestCacheOperations
             (AnalysisMode.Credits, CacheEntryType.BlackFrame, 100.5, 0),
             (AnalysisMode.Introduction, CacheEntryType.Chromaprint, 0, 0),
             (AnalysisMode.Introduction, CacheEntryType.Silence, 0, 30),
-            (AnalysisMode.Introduction, CacheEntryType.Keyframe, 0, 30),
             (AnalysisMode.Introduction, CacheEntryType.BlackFrame, 0, 30),
         };
         foreach (var (entryMode, type, start, end) in entries)
@@ -486,7 +485,7 @@ public sealed class TestCacheOperations
 
         public string CacheDbPath => _inner.CacheDbPath;
 
-        public FFmpegService CreateFFmpegService(ILogger<FFmpegService>? logger = null) => new(logger ?? NullLogger<FFmpegService>.Instance, CacheService);
+        public FFmpegService CreateFFmpegService(ILogger<FFmpegService>? logger = null) => new(logger ?? NullLogger<FFmpegService>.Instance, CacheService, new FakeKeyframeManager());
 
         /// <summary>
         /// The hash a release without audio stream selection wrote on this configuration's

--- a/IntroSkipper.Tests/TestCreditsPass.cs
+++ b/IntroSkipper.Tests/TestCreditsPass.cs
@@ -734,7 +734,7 @@ public sealed class TestCreditsPass
             KeyframeVisuals = _ => [],
             RangeBlackFrames = rangeScan ?? ((_, _, _, _, _) => []),
             Silence = (_, _, _) => [],
-            KeyFrames = (_, _, _) => [],
+            KeyFrames = (_, _) => [],
         };
 
         return (episodes, ffmpeg, DatabaseTestHelpers.CreateTempSegmentDatabase());

--- a/IntroSkipper.Tests/TestKeyframeStore.cs
+++ b/IntroSkipper.Tests/TestKeyframeStore.cs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 rlauuzo
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace IntroSkipper.Tests;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using IntroSkipper.Data;
+using IntroSkipper.FFmpeg;
+using Jellyfin.MediaEncoding.Keyframes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+/// <summary>
+/// The keyframe lookup behind the intro-end snap: served from Jellyfin's keyframe store, and
+/// extracted with Jellyfin's own extractors and stored there when the store has no row.
+/// </summary>
+public sealed class TestKeyframeStore
+{
+    // seek-sample.mp4 has one keyframe per second.
+    private static readonly double[] SeekSampleKeyframes = [0, 1, 2, 3, 4, 5, 6, 7];
+
+    [FactSkipFFmpegTests]
+    public async Task ColdStore_Mp4_ExtractsWithFfprobeAndStores()
+    {
+        var store = new FakeKeyframeManager();
+        var episode = FfmpegTestHelpers.QueueFile("video/seek-sample.mp4");
+
+        var actual = await FfmpegTestHelpers.CreateFFmpegService(keyframeManager: store).GetKeyframesAsync(episode, new(0, 8));
+
+        Assert.Equal(SeekSampleKeyframes, actual);
+        var stored = Assert.Single(store.GetKeyframeData(episode.EpisodeId));
+        Assert.Equal(SeekSampleKeyframes, stored.KeyframeTicks.Select(TickConversions.ToSeconds));
+        Assert.Equal(1, store.SaveCount);
+    }
+
+    [FactSkipFFmpegTests]
+    public async Task ColdStore_Mkv_ExtractsFromCues()
+    {
+        var store = new FakeKeyframeManager();
+        var mkvPath = Path.Combine(Path.GetTempPath(), $"intro-skipper-{Guid.NewGuid():N}.mkv");
+        try
+        {
+            var source = FfmpegTestHelpers.QueueFile("video/seek-sample.mp4").Path;
+            await new FFmpegProcessRunner(NullLogger.Instance).RunAsync("ffmpeg", ["-y", "-i", source, "-c", "copy", mkvPath]);
+            var episode = new QueuedEpisode { EpisodeId = Guid.NewGuid(), Name = "seek-sample.mkv", Path = mkvPath };
+
+            var actual = await FfmpegTestHelpers.CreateFFmpegService(keyframeManager: store).GetKeyframesAsync(episode, new(0, 8));
+
+            Assert.Equal(SeekSampleKeyframes, actual);
+            Assert.Equal(1, store.SaveCount);
+        }
+        finally
+        {
+            File.Delete(mkvPath);
+        }
+    }
+
+    [Fact]
+    public async Task WarmStore_ServesStoredRowWithoutExtracting()
+    {
+        var store = new FakeKeyframeManager();
+        var episode = FfmpegTestHelpers.QueueFile("video/seek-sample.mp4");
+        store.Seed(episode.EpisodeId, new KeyframeData(TickConversions.FromSeconds(10), [TickConversions.FromSeconds(1.5), TickConversions.FromSeconds(3), TickConversions.FromSeconds(9)]));
+
+        var actual = await FfmpegTestHelpers.CreateFFmpegService(keyframeManager: store).GetKeyframesAsync(episode, new(0, 8));
+
+        Assert.Equal([1.5, 3], actual);
+        Assert.Equal(0, store.SaveCount);
+    }
+
+    [Fact]
+    public async Task FailedExtraction_ReturnsEmptyAndStoresNothing()
+    {
+        var store = new FakeKeyframeManager();
+        var episode = FfmpegTestHelpers.QueueFile("video/missing.mp4");
+
+        var actual = await FfmpegTestHelpers.CreateFFmpegService(keyframeManager: store).GetKeyframesAsync(episode, new(0, 8));
+
+        Assert.Empty(actual);
+        Assert.Equal(0, store.SaveCount);
+    }
+}

--- a/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
+++ b/IntroSkipper/Analyzers/TimeAdjustmentHelper.cs
@@ -201,7 +201,7 @@ internal sealed partial class TimeAdjustmentHelper(ILogger logger, PluginConfigu
     /// </summary>
     private async Task<double> SnapToNearestKeyframeAsync(QueuedEpisode episode, double time, TimeRange searchRange, CancellationToken cancellationToken)
     {
-        var keyframes = await _ffmpegService.DetectKeyFramesAsync(episode, searchRange, _mode, cancellationToken).ConfigureAwait(false);
+        var keyframes = await _ffmpegService.GetKeyframesAsync(episode, searchRange, cancellationToken).ConfigureAwait(false);
         return SelectNearest(keyframes, time);
     }
 

--- a/IntroSkipper/Data/CacheEntryType.cs
+++ b/IntroSkipper/Data/CacheEntryType.cs
@@ -3,40 +3,40 @@
 // SPDX-FileCopyrightText: 2026 AbandonedCart
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace IntroSkipper.Data;
 
 /// <summary>
-/// Type of detection data stored in a cache entry.
+/// Type of detection data stored in a cache entry. Stored as its integer value, so the
+/// values are pinned. Value 3 was the keyframe listing, now read from Jellyfin's keyframe
+/// store; rows of that type are never read.
 /// </summary>
+[SuppressMessage("Design", "CA1027:Mark enums with FlagsAttribute", Justification = "Pinned storage identifiers with a retired value, not flags.")]
 public enum CacheEntryType
 {
     /// <summary>
     /// Audio fingerprint data (Chromaprint).
     /// </summary>
-    Chromaprint,
+    Chromaprint = 0,
 
     /// <summary>
     /// Silence detection results.
     /// </summary>
-    Silence,
+    Silence = 1,
 
     /// <summary>
     /// Black frame detection results.
     /// </summary>
-    BlackFrame,
-
-    /// <summary>
-    /// Key frame timestamp data.
-    /// </summary>
-    Keyframe,
+    BlackFrame = 2,
 
     /// <summary>
     /// Black interval detection results.
     /// </summary>
-    BlackInterval,
+    BlackInterval = 4,
 
     /// <summary>
     /// Per-keyframe visual statistics (entropy and saturation) for non-black credit detection.
     /// </summary>
-    KeyframeVisual,
+    KeyframeVisual = 5,
 }

--- a/IntroSkipper/Db/DbDetectionCache.cs
+++ b/IntroSkipper/Db/DbDetectionCache.cs
@@ -81,8 +81,7 @@ public class DbDetectionCache
     /// <see cref="CacheEntryType.Chromaprint"/> stores <c>uint[]</c>,
     /// <see cref="CacheEntryType.Silence"/> stores <c>TimeRange[]</c>,
     /// <see cref="CacheEntryType.BlackFrame"/> stores <c>BlackFrame[]</c>,
-    /// <see cref="CacheEntryType.BlackInterval"/> stores <c>BlackInterval[]</c>,
-    /// <see cref="CacheEntryType.Keyframe"/> stores <c>double[]</c>.
+    /// <see cref="CacheEntryType.BlackInterval"/> stores <c>BlackInterval[]</c>.
     /// </value>
     [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "EF Core requires byte[] for BLOB column mapping.")]
     public byte[] Data { get; set; } = [];

--- a/IntroSkipper/FFmpeg/FFmpegOutputParser.cs
+++ b/IntroSkipper/FFmpeg/FFmpegOutputParser.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using IntroSkipper.Data;
-using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.FFmpeg;
 
@@ -47,33 +46,6 @@ internal static partial class FFmpegOutputParser
         }
 
         return [.. silenceRanges];
-    }
-
-    internal static double[] ParseKeyFrames(string raw, double rangeStart, ILogger? logger = null)
-    {
-        var keyframes = new List<double>();
-
-        foreach (var line in raw.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var ptsIndex = line.IndexOf("pts_time:", StringComparison.OrdinalIgnoreCase);
-            if (ptsIndex == -1)
-            {
-                continue;
-            }
-
-            var ptsTimeStr = line[(ptsIndex + 9)..].Split(' ', 2)[0];
-
-            if (double.TryParse(ptsTimeStr, CultureInfo.InvariantCulture, out var timestamp))
-            {
-                keyframes.Add(timestamp + rangeStart);
-            }
-            else if (logger is not null)
-            {
-                LogFailedToParseTimestamp(logger, ptsTimeStr, line);
-            }
-        }
-
-        return [.. keyframes];
     }
 
     internal static BlackFrame[] ParseBlackFrames(string raw)
@@ -207,7 +179,4 @@ internal static partial class FFmpegOutputParser
 
     [GeneratedRegex(@"lavfi\.signalstats\.SATAVG=(?<value>-?[0-9]+(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?)")]
     private static partial Regex KeyframeSaturationRegex();
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to parse timestamp: {PtsTimeStr} from line: {Line}")]
-    private static partial void LogFailedToParseTimestamp(ILogger logger, string ptsTimeStr, string line);
 }

--- a/IntroSkipper/FFmpeg/FFmpegService.cs
+++ b/IntroSkipper/FFmpeg/FFmpegService.cs
@@ -8,6 +8,10 @@ using System.Text;
 using System.Text.Json;
 using IntroSkipper.Data;
 using IntroSkipper.Helper;
+using Jellyfin.MediaEncoding.Keyframes;
+using Jellyfin.MediaEncoding.Keyframes.FfProbe;
+using Jellyfin.MediaEncoding.Keyframes.Matroska;
+using MediaBrowser.Controller.IO;
 using Microsoft.Extensions.Logging;
 
 namespace IntroSkipper.FFmpeg;
@@ -49,6 +53,7 @@ internal sealed partial class FFmpegService : IFFmpegService
 
     private readonly ILogger<FFmpegService> _logger;
     private readonly DetectionCacheService _cacheService;
+    private readonly IKeyframeManager _keyframeManager;
     private readonly FFmpegProcessRunner _processRunner;
     private readonly FFmpegVersionGate _versionGate;
 
@@ -57,8 +62,9 @@ internal sealed partial class FFmpegService : IFFmpegService
     /// </summary>
     /// <param name="logger">The logger instance.</param>
     /// <param name="cacheService">The detection cache service.</param>
-    public FFmpegService(ILogger<FFmpegService> logger, DetectionCacheService cacheService)
-        : this(logger, cacheService, null, null)
+    /// <param name="keyframeManager">Jellyfin's keyframe store.</param>
+    public FFmpegService(ILogger<FFmpegService> logger, DetectionCacheService cacheService, IKeyframeManager keyframeManager)
+        : this(logger, cacheService, keyframeManager, null, null)
     {
     }
 
@@ -67,16 +73,19 @@ internal sealed partial class FFmpegService : IFFmpegService
     /// </summary>
     /// <param name="logger">The logger instance.</param>
     /// <param name="cacheService">The detection cache service.</param>
+    /// <param name="keyframeManager">Jellyfin's keyframe store.</param>
     /// <param name="versionProbe">Replaces the ffmpeg version probe; <see langword="null"/> runs the real one.</param>
     /// <param name="versionProbeTimeout">Bounds one probe attempt; <see langword="null"/> uses the default.</param>
     internal FFmpegService(
         ILogger<FFmpegService> logger,
         DetectionCacheService cacheService,
+        IKeyframeManager keyframeManager,
         Func<CancellationToken, Task<bool>>? versionProbe,
         TimeSpan? versionProbeTimeout)
     {
         _logger = logger;
         _cacheService = cacheService;
+        _keyframeManager = keyframeManager;
         _processRunner = new FFmpegProcessRunner(logger);
         _versionGate = new FFmpegVersionGate(
             logger,
@@ -341,20 +350,68 @@ internal sealed partial class FFmpegService : IFFmpegService
     }
 
     /// <inheritdoc/>
-    public Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default)
+    public async Task<double[]> GetKeyframesAsync(QueuedEpisode episode, TimeRange range, CancellationToken cancellationToken = default)
     {
-        string[] args =
-        [
-            "-skip_frame", "nokey",
-            "-ss", range.Start.ToString(CultureInfo.InvariantCulture),
-            "-i", episode.Path,
-            "-to", range.Duration.ToString(CultureInfo.InvariantCulture),
-            "-an", "-dn", "-sn",
-            "-vf", "showinfo",
-            "-f", "null", "-",
-        ];
+        cancellationToken.ThrowIfCancellationRequested();
 
-        return RunCachedScanAsync(episode, mode, CacheEntryType.Keyframe, range.Start, range.End, args, raw => FFmpegOutputParser.ParseKeyFrames(raw, range.Start, _logger), cancellationToken);
+        var rows = _keyframeManager.GetKeyframeData(episode.EpisodeId);
+        var data = rows.Count > 0
+            ? rows[0]
+            : await ExtractAndStoreKeyframesAsync(episode, cancellationToken).ConfigureAwait(false);
+
+        return data is null
+            ? []
+            : [.. data.KeyframeTicks.Select(TickConversions.ToSeconds).Where(time => time >= range.Start && time <= range.End)];
+    }
+
+    // The row Jellyfin's own Keyframe Extractor task would have written, so HLS remuxing can reuse
+    // it. Save failures propagate: a broken Jellyfin database is not a per-episode condition.
+    private async Task<KeyframeData?> ExtractAndStoreKeyframesAsync(QueuedEpisode episode, CancellationToken cancellationToken)
+    {
+        KeyframeData data;
+        try
+        {
+            data = ExtractKeyframes(episode.Path);
+        }
+        catch (Exception ex)
+        {
+            LogKeyframeExtractionFailed(_logger, ex, episode.EpisodeId, episode.Name, episode.Path);
+            return null;
+        }
+
+        if (data.KeyframeTicks.Count == 0)
+        {
+            LogNoKeyframesFound(_logger, episode.EpisodeId, episode.Name, episode.Path);
+            return null;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await _keyframeManager.SaveKeyframeDataAsync(episode.EpisodeId, data, cancellationToken).ConfigureAwait(false);
+        LogKeyframesStored(_logger, data.KeyframeTicks.Count, episode.Path, episode.EpisodeId);
+        return data;
+    }
+
+    // Jellyfin's extractor order: container metadata first, ffprobe otherwise. Both extractors are
+    // synchronous, so this blocks for the ffprobe run, as Jellyfin's Keyframe Extractor task does.
+    private KeyframeData ExtractKeyframes(string path)
+    {
+        if (path.EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var fromCues = MatroskaKeyframeExtractor.GetKeyframeData(path);
+                if (fromCues.KeyframeTicks.Count > 0)
+                {
+                    return fromCues;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogMatroskaCuesUnreadable(_logger, ex, path);
+            }
+        }
+
+        return FfProbeKeyframeExtractor.GetKeyframeData(GetFFprobePath(), path);
     }
 
     /// <summary>
@@ -716,6 +773,18 @@ internal sealed partial class FFmpegService : IFFmpegService
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to probe preferred audio language {Language} for {File}; using FFmpeg's default audio stream selection")]
     private static partial void LogPreferredAudioLanguageProbeFailed(ILogger logger, Exception ex, string file, string language);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Stored {Count} keyframes of \"{File}\" (id {Id}) in Jellyfin's keyframe store")]
+    private static partial void LogKeyframesStored(ILogger logger, int count, string file, Guid id);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: keyframe extraction failed for \"{File}\"; the intro end will not snap to a keyframe")]
+    private static partial void LogKeyframeExtractionFailed(ILogger logger, Exception ex, Guid episodeId, string name, string file);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{EpisodeId} {Name}: no keyframes found in \"{File}\"; the intro end will not snap to a keyframe")]
+    private static partial void LogNoKeyframesFound(ILogger logger, Guid episodeId, string name, string file);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Could not read the cue index of \"{File}\"; extracting keyframes with ffprobe")]
+    private static partial void LogMatroskaCuesUnreadable(ILogger logger, Exception ex, string file);
 
     /// <summary>
     /// The audio stream a fingerprint is taken from.

--- a/IntroSkipper/FFmpeg/IFFmpegService.cs
+++ b/IntroSkipper/FFmpeg/IFFmpegService.cs
@@ -8,7 +8,8 @@ namespace IntroSkipper.FFmpeg;
 
 /// <summary>
 /// Provides FFmpeg-based media analysis operations including fingerprinting,
-/// silence detection, black frame detection, and key frame detection.
+/// silence detection and black frame detection, plus the keyframe lookup that
+/// backs onto Jellyfin's keyframe store.
 /// </summary>
 public interface IFFmpegService
 {
@@ -99,14 +100,20 @@ public interface IFFmpegService
     Task<BlackInterval[]> DetectBlackIntervalsAsync(QueuedEpisode episode, TimeRange range, int threshold, int minimum, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Detects key frames in a media file within a time range.
+    /// Lists the keyframes of a media file within a time range from Jellyfin's keyframe store.
     /// </summary>
+    /// <remarks>
+    /// An episode without a stored row is extracted once (Matroska cues for mkv, an ffprobe
+    /// packet listing otherwise) and saved through Jellyfin's keyframe manager, so later calls
+    /// and Jellyfin's own HLS remuxing reuse the row. Extraction blocks for the ffprobe run and
+    /// cannot be cancelled. A failed or empty extraction is logged, not stored, and yields an
+    /// empty list, so a snap leaves its time unchanged.
+    /// </remarks>
     /// <param name="episode">Media file to analyze.</param>
-    /// <param name="range">Time range to search.</param>
-    /// <param name="mode">Analysis mode, used to correctly key the cache entry.</param>
-    /// <param name="cancellationToken">Token used to cancel the FFmpeg process.</param>
-    /// <returns>A task that returns timestamps of key frames.</returns>
-    Task<double[]> DetectKeyFramesAsync(QueuedEpisode episode, TimeRange range, AnalysisMode mode, CancellationToken cancellationToken = default);
+    /// <param name="range">Time range to search, both ends inclusive.</param>
+    /// <param name="cancellationToken">Token checked before the store is read and before a fresh extraction is saved.</param>
+    /// <returns>A task that returns the keyframe timestamps in seconds.</returns>
+    Task<double[]> GetKeyframesAsync(QueuedEpisode episode, TimeRange range, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Probes the first audio stream's actual duration with ffprobe.

--- a/IntroSkipper/Helper/ConfigHasher.cs
+++ b/IntroSkipper/Helper/ConfigHasher.cs
@@ -133,8 +133,6 @@ internal static class ConfigHasher
             CacheEntryType.BlackInterval => Invariant(
                 $"cache|v1|{type}|{mode}|blackdetect=v1|threshold={config.BlackFrameThreshold}|bfmin={config.BlackFrameMinimumPercentage}|duration={BlackInterval.MinimumDetectionDuration}"),
 
-            CacheEntryType.Keyframe => $"cache|v1|{type}",
-
             CacheEntryType.KeyframeVisual => $"cache|v1|{type}|{mode}",
 
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)


### PR DESCRIPTION
Snapping an intro end to a keyframe ran the plugin's own ffmpeg pass over a window around the boundary, per episode and per analysis mode, and cached the list in the plugin's detection cache. Jellyfin keeps a keyframe table of its own for HLS remuxing, but it stays empty unless an admin runs the Keyframe Extractor task or plays an mkv. Two systems computed the same keyframes and the plugin's copy was useless to Jellyfin.

The snap now reads Jellyfin's keyframe store. When there is no row for the episode, the plugin extracts the keyframes with the extractors Jellyfin ships in the Jellyfin.MediaEncoding.Keyframes package (Matroska cues for mkv, an ffprobe packet listing otherwise), saves the row through Jellyfin's keyframe manager and uses it. Later analysis runs and Jellyfin's HLS remuxing reuse that row. A failed or empty extraction is logged, not stored, and leaves the end unsnapped.

Gone with it: the ffmpeg keyframe listing scan, its showinfo parser and the Keyframe detection cache type. The enum now carries explicit values so existing BlackInterval and KeyframeVisual rows keep their meaning; old Keyframe rows stay unread. The two credits keyframe scans are untouched.

An earlier attempt at this (#660) crashed on Jellyfin 10.11 because the server shipped the keyframes assembly as 10.11.0.0 while the NuGet package carried 10.11.x.0. Jellyfin PR 17582 fixed the versioning in 12.0, so the package and server now match.

Tests: a new in-memory fake of Jellyfin's keyframe manager, and TestKeyframeStore covering cold mp4, cold mkv (remuxed from the fixture at test time), warm store without extraction, and failed extraction. The 16 failures in TestLegacyAnalysisCompatibility on Windows are a file lock on the legacy fixture database and fail identically on 12.0 without this change.

Closes #981

## Summary by Sourcery

Back intro-end keyframe snapping with Jellyfin’s shared keyframe store instead of a plugin-specific scan and cache.

New Features:
- Reuse Jellyfin’s keyframe store for intro-end snapping, extracting and persisting keyframes when an episode has no stored data.

Bug Fixes:
- Leave intro ends unsnapped and log a warning when keyframe extraction fails or produces no keyframes.

Enhancements:
- Remove the plugin’s dedicated keyframe scan and detection-cache entries while preserving the meanings of existing cache records.
- Use Jellyfin’s Matroska cue and ffprobe keyframe extractors so stored data can also be reused by HLS remuxing.

Tests:
- Add keyframe-store tests covering cold MP4 and MKV extraction, warm-store reuse, and failed extraction scenarios.